### PR TITLE
LPS-116907 - Search bar with federated search key returns no results

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortlet.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.search.web.internal.search.bar.portlet;
 
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Http;
@@ -118,6 +119,12 @@ public class SearchBarPortlet extends MVCPortlet {
 			portletSharedSearchResponse.getSearchSettings(),
 			searchBarPortletPreferences, themeDisplay);
 
+		SearchResponse searchResponse = getSearchResponse(
+			portletSharedSearchResponse, searchBarPortletPreferences);
+
+		String keywords = searchResponse.withSearchContextGet(
+			SearchContext::getKeywords);
+
 		return searchBarPortletDisplayBuilder.setDestination(
 			searchBarPortletPreferences.getDestinationString()
 		).setEmptySearchEnabled(
@@ -125,7 +132,7 @@ public class SearchBarPortlet extends MVCPortlet {
 		).setInvisible(
 			searchBarPortletPreferences.isInvisible()
 		).setKeywords(
-			portletSharedSearchResponse.getKeywordsOptional()
+			Optional.ofNullable(keywords)
 		).setKeywordsParameterName(
 			keywordsParameterName
 		).setPaginationStartParameterName(
@@ -185,6 +192,14 @@ public class SearchBarPortlet extends MVCPortlet {
 
 		return optional.orElse(
 			searchBarPortletPreferences.getScopeParameterName());
+	}
+
+	protected SearchResponse getSearchResponse(
+		PortletSharedSearchResponse portletSharedSearchResponse,
+		SearchBarPortletPreferences searchBarPortletPreferences) {
+
+		return portletSharedSearchResponse.getFederatedSearchResponse(
+			searchBarPortletPreferences.getFederatedSearchKeyOptional());
 	}
 
 	protected boolean isEmptySearchEnabled(

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortlet.java
@@ -16,7 +16,6 @@ package com.liferay.portal.search.web.internal.search.results.portlet;
 
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.util.AssetRendererFactoryLookup;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.DisplayTerms;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.language.Language;
@@ -25,6 +24,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.IndexerRegistry;
+import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -55,7 +55,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import javax.portlet.Portlet;
@@ -152,12 +151,6 @@ public class SearchResultsPortlet extends MVCPortlet {
 
 		searchResultsPortletDisplayContext.setDocuments(documents);
 
-		Optional<String> keywordsOptional =
-			portletSharedSearchResponse.getKeywordsOptional();
-
-		searchResultsPortletDisplayContext.setKeywords(
-			keywordsOptional.orElse(StringPool.BLANK));
-
 		SearchResultsPortletPreferences searchResultsPortletPreferences =
 			new SearchResultsPortletPreferencesImpl(
 				portletSharedSearchResponse.getPortletPreferences(
@@ -166,8 +159,11 @@ public class SearchResultsPortlet extends MVCPortlet {
 		SearchResponse searchResponse = getSearchResponse(
 			portletSharedSearchResponse, searchResultsPortletPreferences);
 
+		searchResultsPortletDisplayContext.setKeywords(
+			searchResponse.withSearchContextGet(SearchContext::getKeywords));
+
 		searchResultsPortletDisplayContext.setRenderNothing(
-			isRenderNothing(portletSharedSearchResponse, searchResponse));
+			isRenderNothing(searchResponse));
 
 		searchResultsPortletDisplayContext.setSearchContainer(
 			buildSearchContainer(
@@ -410,14 +406,11 @@ public class SearchResultsPortlet extends MVCPortlet {
 		return http.removeParameter(urlString, paginationStartParameterName);
 	}
 
-	protected boolean isRenderNothing(
-		PortletSharedSearchResponse portletSharedSearchResponse,
-		SearchResponse searchResponse) {
+	protected boolean isRenderNothing(SearchResponse searchResponse) {
+		String keywords = searchResponse.withSearchContextGet(
+			SearchContext::getKeywords);
 
-		Optional<String> keywordsOptional =
-			portletSharedSearchResponse.getKeywordsOptional();
-
-		if (keywordsOptional.isPresent()) {
+		if (keywords != null) {
 			return false;
 		}
 


### PR DESCRIPTION
http://issues.liferay.com/browse/LPS-116907

I'm not sure if `searchResponse.withSearchContextGet(SearchContext::getKeywords)` [`9a6a700` (#4)](https://github.com/liferay-search/liferay-portal/pull/4/commits/9a6a700da152685c793e3d2dc6a160988c4ad0d6#diff-7734d4af1d36dcd68ab0c0de0cc5fe07R125-R126) is the best way to get the `keywords` from the `searchContext`, but it seemed like the only option, unless we made a change to `portal-search-api`'s `SearchResponse`.