### PR TITLE
[TS] LPS-118240 Not possible to set a "_score" sort in asc

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/sort/DefaultSortTranslator.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/sort/DefaultSortTranslator.java
@@ -69,14 +69,12 @@ public class DefaultSortTranslator implements SortTranslator {
 
 			SortOrder sortOrder = SortOrder.ASC;
 
-			if (sort.isReverse() || sortFieldName.equals("_score")) {
-				sortOrder = SortOrder.DESC;
-			}
-
 			SortBuilder<?> sortBuilder = null;
 
 			if (sortFieldName.equals("_score")) {
 				sortBuilder = SortBuilders.scoreSort();
+
+				sortOrder = SortOrder.DESC;
 			}
 			else if (sort.getType() == Sort.GEO_DISTANCE_TYPE) {
 				GeoDistanceSort geoDistanceSort = (GeoDistanceSort)sort;
@@ -116,6 +114,10 @@ public class DefaultSortTranslator implements SortTranslator {
 				sortBuilder = fieldSortBuilder;
 			}
 
+			if (sort.isReverse()) {
+				sortOrder = reverseSortOrder(sortOrder);
+			}
+
 			sortBuilder.order(sortOrder);
 
 			searchRequestBuilder.addSort(sortBuilder);
@@ -129,7 +131,19 @@ public class DefaultSortTranslator implements SortTranslator {
 			return sortFieldName;
 		}
 
+		if (Objects.equals(sortFieldName, "_score")) {
+			return sortFieldName;
+		}
+
 		return Field.getSortFieldName(sort, scoreFieldName);
+	}
+
+	protected SortOrder reverseSortOrder(SortOrder sortOrder) {
+		if (Objects.equals(sortOrder, SortOrder.ASC)) {
+			return SortOrder.DESC;
+		}
+
+		return SortOrder.ASC;
 	}
 
 }

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/sort/ElasticsearchSortTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/sort/ElasticsearchSortTest.java
@@ -28,4 +28,8 @@ public class ElasticsearchSortTest extends BaseSortTestCase {
 		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
 	}
 
+	protected String getScoreParameter() {
+		return "_score";
+	}
+
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sort/DefaultSortTranslator.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sort/DefaultSortTranslator.java
@@ -69,14 +69,12 @@ public class DefaultSortTranslator implements SortTranslator {
 
 			SortOrder sortOrder = SortOrder.ASC;
 
-			if (sort.isReverse() || sortFieldName.equals("_score")) {
-				sortOrder = SortOrder.DESC;
-			}
-
 			SortBuilder<?> sortBuilder = null;
 
 			if (sortFieldName.equals("_score")) {
 				sortBuilder = SortBuilders.scoreSort();
+
+				sortOrder = SortOrder.DESC;
 			}
 			else if (sort.getType() == Sort.GEO_DISTANCE_TYPE) {
 				GeoDistanceSort geoDistanceSort = (GeoDistanceSort)sort;
@@ -116,6 +114,10 @@ public class DefaultSortTranslator implements SortTranslator {
 				sortBuilder = fieldSortBuilder;
 			}
 
+			if (sort.isReverse()) {
+				sortOrder = reverseSortOrder(sortOrder);
+			}
+
 			sortBuilder.order(sortOrder);
 
 			searchSourceBuilder.sort(sortBuilder);
@@ -129,7 +131,19 @@ public class DefaultSortTranslator implements SortTranslator {
 			return sortFieldName;
 		}
 
+		if (Objects.equals(sortFieldName, "_score")) {
+			return sortFieldName;
+		}
+
 		return Field.getSortFieldName(sort, scoreFieldName);
+	}
+
+	protected SortOrder reverseSortOrder(SortOrder sortOrder) {
+		if (Objects.equals(sortOrder, SortOrder.ASC)) {
+			return SortOrder.DESC;
+		}
+
+		return SortOrder.ASC;
 	}
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/sort/ElasticsearchSortTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/sort/ElasticsearchSortTest.java
@@ -28,4 +28,8 @@ public class ElasticsearchSortTest extends BaseSortTestCase {
 		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
 	}
 
+	protected String getScoreParameter() {
+		return "_score";
+	}
+
 }

--- a/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/main/java/com/liferay/portal/search/solr7/internal/search/engine/adapter/search/SearchSolrQueryAssemblerImpl.java
+++ b/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/main/java/com/liferay/portal/search/solr7/internal/search/engine/adapter/search/SearchSolrQueryAssemblerImpl.java
@@ -86,7 +86,19 @@ public class SearchSolrQueryAssemblerImpl implements SearchSolrQueryAssembler {
 			return sortFieldName;
 		}
 
+		if (Objects.equals(sortFieldName, "score")) {
+			return sortFieldName;
+		}
+
 		return Field.getSortFieldName(sort, scoreFieldName);
+	}
+
+	protected SolrQuery.ORDER reverseSortOrder(SolrQuery.ORDER sortOrder) {
+		if (Objects.equals(sortOrder, SolrQuery.ORDER.asc)) {
+			return SolrQuery.ORDER.desc;
+		}
+
+		return SolrQuery.ORDER.asc;
 	}
 
 	@Reference(unbind = "-")
@@ -251,10 +263,12 @@ public class SearchSolrQueryAssemblerImpl implements SearchSolrQueryAssembler {
 
 			sortFieldNames.add(sortFieldName);
 
-			SolrQuery.ORDER order = SolrQuery.ORDER.asc;
+			SolrQuery.ORDER order =
+				!Objects.equals(sortFieldName, "score") ? SolrQuery.ORDER.asc :
+					SolrQuery.ORDER.desc;
 
-			if (sort.isReverse() || sortFieldName.equals("score")) {
-				order = SolrQuery.ORDER.desc;
+			if (sort.isReverse()) {
+				order = reverseSortOrder(order);
 			}
 
 			solrQuery.addSort(new SolrQuery.SortClause(sortFieldName, order));

--- a/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/test/java/com/liferay/portal/search/solr7/internal/sort/SolrSortTest.java
+++ b/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/test/java/com/liferay/portal/search/solr7/internal/sort/SolrSortTest.java
@@ -28,4 +28,8 @@ public class SolrSortTest extends BaseSortTestCase {
 		return new SolrIndexingFixture();
 	}
 
+	protected String getScoreParameter() {
+		return "score";
+	}
+
 }

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseSortTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseSortTestCase.java
@@ -14,16 +14,21 @@
 
 package com.liferay.portal.search.test.util.sort;
 
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.SortFactory;
+import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
 import com.liferay.portal.search.internal.SortFactoryImpl;
 import com.liferay.portal.search.test.util.DocumentsAssert;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
 import com.liferay.portal.search.test.util.indexing.DocumentCreationHelper;
 import com.liferay.portal.search.test.util.indexing.DocumentCreationHelpers;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.function.Function;
 
 import org.junit.Test;
@@ -33,6 +38,32 @@ import org.junit.Test;
  * @author André de Oliveira
  */
 public abstract class BaseSortTestCase extends BaseIndexingTestCase {
+
+	@Test
+	public void testCustomScoreSorting() throws Exception {
+		List<String> stringValues = new ArrayList<>();
+
+		stringValues.add("value");
+		stringValues.add("no matches");
+
+		String fieldName = "testField";
+
+		addDocuments(
+			value -> DocumentCreationHelpers.singleText(fieldName, value),
+			stringValues.stream());
+
+		assertKeywordSearchOrder(
+			fieldName,
+			new Sort[] {new Sort(getScoreParameter(), Sort.CUSTOM_TYPE, false)},
+			stringValues);
+
+		Collections.reverse(stringValues);
+
+		assertKeywordSearchOrder(
+			fieldName,
+			new Sort[] {new Sort(getScoreParameter(), Sort.SCORE_TYPE, true)},
+			stringValues);
+	}
 
 	@Test
 	public void testDefaultSorts() throws Exception {
@@ -71,6 +102,32 @@ public abstract class BaseSortTestCase extends BaseIndexingTestCase {
 		}
 	}
 
+	protected void assertKeywordSearchOrder(
+		String fieldName, Sort[] sorts, List<String> expectedValues) {
+
+		assertSearch(
+			indexingTestHelper -> {
+				indexingTestHelper.define(
+					searchContext -> searchContext.setSorts(sorts));
+
+				BooleanQueryImpl booleanQueryImpl = new BooleanQueryImpl();
+
+				booleanQueryImpl.addExactTerm(fieldName, "value");
+
+				booleanQueryImpl.add(
+					getDefaultQuery(), BooleanClauseOccur.SHOULD);
+
+				indexingTestHelper.setQuery(booleanQueryImpl);
+
+				indexingTestHelper.search();
+
+				indexingTestHelper.verify(
+					hits -> DocumentsAssert.assertValues(
+						indexingTestHelper.getRequestString(), hits.getDocs(),
+						fieldName, expectedValues));
+			});
+	}
+
 	protected void assertOrder(Sort[] sorts, String fieldName, String expected)
 		throws Exception {
 
@@ -95,6 +152,8 @@ public abstract class BaseSortTestCase extends BaseIndexingTestCase {
 			new Sort[] {new Sort(fieldName, sortType, false)}, fieldName,
 			expected);
 	}
+
+	protected abstract String getScoreParameter();
 
 	protected void testDoubleField(String fieldName) throws Exception {
 		testDoubleField(


### PR DESCRIPTION
[ci:test:search - 57 out of 70 jobs passed in 1 hour 33 minutes
](https://github.com/joshuacords/liferay-portal/pull/93#issuecomment-666876905) (All test failures are known to be unrelated)
[ci:test:stable - 21 out of 21 jobs passed
ci:test:relevant - 40 out of 40 jobs passed in 2 hours 6 minutes](https://github.com/joshuacords/liferay-portal/pull/93#issuecomment-666843094)

Author: @joshuacords

LPS-118240 Not possible to set a "_score" sort in asc
https://issues.liferay.com/browse/LPS-118240