### PR TITLE
[Multi-Tenant] LPS-117703 + LPS-117704: Update Synonyms & Result Rankings

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/name/RankingIndexNameBuilderImpl.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/name/RankingIndexNameBuilderImpl.java
@@ -28,11 +28,11 @@ public class RankingIndexNameBuilderImpl implements RankingIndexNameBuilder {
 	@Override
 	public RankingIndexName getRankingIndexName(String companyIndexName) {
 		return new RankingIndexNameImpl(
-			companyIndexName + StringPool.MINUS + INDEX_NAME_SUFFIX);
+			companyIndexName + StringPool.MINUS + RANKINGS_INDEX_NAME);
 	}
 
-	protected static final String INDEX_NAME_SUFFIX =
-		"liferay-search-tuning-rankings";
+	protected static final String RANKINGS_INDEX_NAME =
+		"search-tuning-rankings";
 
 	protected class RankingIndexNameImpl implements RankingIndexName {
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/name/SynonymSetIndexNameBuilderImpl.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/name/SynonymSetIndexNameBuilderImpl.java
@@ -28,11 +28,11 @@ public class SynonymSetIndexNameBuilderImpl
 	@Override
 	public SynonymSetIndexName getSynonymSetIndexName(String companyIndexName) {
 		return new SynonymSetIndexNameImpl(
-			INDEX_NAME_PREFIX + StringPool.MINUS + companyIndexName);
+			companyIndexName + StringPool.MINUS + SYNONYMS_INDEX_NAME);
 	}
 
-	protected static final String INDEX_NAME_PREFIX =
-		"liferay-search-tuning-synonyms";
+	protected static final String SYNONYMS_INDEX_NAME =
+		"search-tuning-synonyms";
 
 	private static class SynonymSetIndexNameImpl
 		implements SynonymSetIndexName {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-117703
https://issues.liferay.com/browse/LPS-117704

Also performed upgrade scenario described on the Epic (https://issues.liferay.com/browse/LPS-117702).

:information_source: **Notes**: I was thinking about to consolidate the index name creation logic completely to the respective builder impls so we could eliminate the need (and remove some code) to inject `IndexNameBuilder` to multiple DS services in the code: instead, the `*IndexNameBuilderImpl`-s would receive just a `companyId` and the rest would be constructed within the builders.
However, to do this, we'd need to use `CompanyThreadLocal` in `SynonymSetIndexCreationIndexContributor` because there we don't have the `companyId` available in the context. (And there may be other locations in the SS code with the same need.)