### PR TITLE
[TS] LPS-118431 Restore old populateHttpHeaders code if _ddmIndexer.isLegacyDDMIndexFieldsEnabled() is true

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryIndexerIndexedFieldsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryIndexerIndexedFieldsTest.java
@@ -126,7 +126,7 @@ public class DLFileEntryIndexerIndexedFieldsTest extends BaseDLIndexerTestCase {
 		Document document = dlSearchFixture.searchOnlyOneSearchHit(
 			searchTerm, LocaleUtil.JAPAN);
 
-		indexedFieldsFixture.postProcessDocument(document);
+		document = indexedFieldsFixture.postProcessDocument(document);
 
 		Map<String, String> map = new HashMap<>();
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryIndexerIndexedFieldsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryIndexerIndexedFieldsTest.java
@@ -21,6 +21,7 @@ import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.test.util.search.FileEntryBlueprint;
 import com.liferay.document.library.test.util.search.FileEntrySearchFixture;
+import com.liferay.dynamic.data.mapping.util.DDMIndexer;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -163,6 +164,31 @@ public class DLFileEntryIndexerIndexedFieldsTest extends BaseDLIndexerTestCase {
 		return ddmStructureId;
 	}
 
+	protected void legacyPopulateHttpHeader(
+		String fieldName, String value, String ddmStructureId,
+		Map<String, String> map) {
+
+		String contentEncodingFieldName = StringBundler.concat(
+			"ddm__text__", ddmStructureId, "__HttpHeaders_", fieldName);
+
+		map.put(contentEncodingFieldName, value);
+		map.put(
+			contentEncodingFieldName + "_String_sortable",
+			StringUtil.toLowerCase(value));
+	}
+
+	protected void legacyPopulateHttpHeaders(
+			FileEntry fileEntry, Map<String, String> map)
+		throws Exception {
+
+		String ddmStructureId = String.valueOf(getDDMStructureId(fileEntry));
+
+		legacyPopulateHttpHeader(
+			"CONTENT_ENCODING", "UTF-8", ddmStructureId, map);
+		legacyPopulateHttpHeader(
+			"CONTENT_TYPE", "text/plain; charset=UTF-8", ddmStructureId, map);
+	}
+
 	protected void populateDates(FileEntry fileEntry, Map<String, String> map) {
 		indexedFieldsFixture.populateDate(
 			Field.CREATE_DATE, fileEntry.getCreateDate(), map);
@@ -222,7 +248,14 @@ public class DLFileEntryIndexerIndexedFieldsTest extends BaseDLIndexerTestCase {
 		map.put("visible", "true");
 
 		populateDates(fileEntry, map);
-		populateHttpHeaders(fileEntry, map);
+
+		if (_ddmIndexer.isLegacyDDMIndexFieldsEnabled()) {
+			legacyPopulateHttpHeaders(fileEntry, map);
+		}
+		else {
+			populateHttpHeaders(fileEntry, map);
+		}
+
 		populateLocalizedTitles(fileEntry, map);
 		populateViewCount(fileEntry, map);
 
@@ -298,6 +331,9 @@ public class DLFileEntryIndexerIndexedFieldsTest extends BaseDLIndexerTestCase {
 	}
 
 	protected FileEntrySearchFixture fileEntrySearchFixture;
+
+	@Inject
+	private static DDMIndexer _ddmIndexer;
 
 	@Inject
 	private DLFileEntryLocalService _dlFileEntryLocalService;

--- a/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserIndexerIndexedFieldsByAssociationTest.java
+++ b/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserIndexerIndexedFieldsByAssociationTest.java
@@ -312,9 +312,7 @@ public class UserIndexerIndexedFieldsByAssociationTest {
 		Document document = stream.findFirst(
 		).get();
 
-		indexedFieldsFixture.postProcessDocument(document);
-
-		return document;
+		return indexedFieldsFixture.postProcessDocument(document);
 	}
 
 	protected GroupSearchFixture groupSearchFixture;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-118431

Regression caused by [LPS-103224](https://issues.liferay.com/browse/LPS-103224): integration test DLFileEntryIndexerIndexedFieldsTest.testIndexedFields only works with Elasticsearch after LPS-103224 changes. 

To avoid that, I am restoring old populateHttpHeaders code and using it in case _ddmIndexer.isLegacyDDMIndexFieldsEnabled() is true