### PR TITLE
[7.3-must] LPS-119890 Update supported version to 7.9 in Elasticsearch 7 connector app description

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine.
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines.

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_ar.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_ar.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_bg.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_bg.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_ca.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_ca.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_cs.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_cs.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_da.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_da.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_de.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_de.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_el.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_el.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_en.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_en.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine.
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines.

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_en_AU.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_en_AU.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_en_GB.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_en_GB.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_es.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_es.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_et.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_et.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_eu.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_eu.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_fa.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_fa.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_fi.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_fi.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_fr.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_fr.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_fr_CA.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_fr_CA.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_gl.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_gl.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_hi_IN.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_hi_IN.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_hr.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_hr.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_hu.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_hu.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_in.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_in.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_it.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_it.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_iw.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_iw.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_ja.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_ja.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_kk.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_kk.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_ko.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_ko.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_lo.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_lo.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_lt.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_lt.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_nb.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_nb.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_nl.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_nl.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_nl_BE.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_nl_BE.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_pl.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_pl.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_pt_BR.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_pt_BR.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_pt_PT.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_pt_PT.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_ro.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_ro.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_ru.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_ru.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_sk.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_sk.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_sl.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_sl.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_sr_RS.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_sr_RS.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_sr_RS_latin.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_sr_RS_latin.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_sv.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_sv.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_ta_IN.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_ta_IN.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_th.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_th.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_tr.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_tr.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_uk.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_uk.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_vi.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_vi.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_zh_CN.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_zh_CN.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)

--- a/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_zh_TW.properties
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd-localization/bundle_zh_TW.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to the Elasticsearch 7.3.x through 7.7.x search engine. (Automatic Copy)
+liferay-releng-app-description=${liferay.releng.app.title.prefix} Connector to Elasticsearch 7 connects Liferay Portal or Liferay DXP to Elasticsearch 7.9+ search engines. (Automatic Copy)


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-119890

Background:
* In 7.3 we are using the Java REST Client of Elasticsearch 7 (LPS-85208)
* The connector dependencies have been upgraded to 7.9.0 (LPS-115774) 
* The REST Client is compatible with greater minor versions so we are adding "7.9.+". See https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.3/java-rest-high-compatibility.html
  > The High Level Client is guaranteed to be able to communicate with any Elasticsearch node running on the same major version and greater or equal minor version. It doesn’t need to be in the same minor version as the Elasticsearch nodes it communicates with, as it is forward compatible meaning that it supports communicating with later versions of Elasticsearch than the one it was developed for.
* The minimum required minor version for 7.3 CE GA6 and DXP 7.3 GA1 will be 7.9
* We change from singular ("to the ES 7.9+ search engine") to plural ("to ES 7.9+ search engines") since 7.3 supports multiple ES connections

/cc @dejuknow

/cc @jpince fyi too because I've seen your update in product-dev regarding the lang keys