### PR TITLE
LPS-120168 Use Sites and Libraries as default title like other places.

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/site/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/site/facet/view.jsp
@@ -82,7 +82,7 @@ List<ScopeSearchFacetTermDisplayContext> scopeSearchFacetTermDisplayContexts = s
 						id='<%= liferayPortletResponse.getNamespace() + "facetScopePanel" %>'
 						markupView="lexicon"
 						persistState="<%= true %>"
-						title="site"
+						title="sites-and-libraries"
 					>
 						<aui:fieldset>
 							<ul class="list-unstyled">


### PR DESCRIPTION
Notes from @brianikim
> https://issues.liferay.com/browse/LPS-120168
> 
> The issue is a straightforward issue of the wrong language key being used.
> 
> The title should, by default, be Sites and Libraries like other places such as the following:
> 
> https://github.com/liferay/liferay-portal/blob/b91a0ad886e23c94e043899ebe6af9ca6415872d/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java#L597
> 
> 
> Sincerely,
> Brian Kim