### PR TITLE
LPS-120795 Minimize startup logging related to sidecar Elasticsearch

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/Sidecar.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/Sidecar.java
@@ -97,7 +97,7 @@ public class Sidecar {
 
 	public void start() {
 		if (_log.isDebugEnabled()) {
-			_log.debug("Sidecar Elasticsearch liferay started");
+			_log.debug("Sidecar Elasticsearch starting");
 		}
 
 		_installElasticsearchIfNeeded();

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/Sidecar.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/Sidecar.java
@@ -96,8 +96,8 @@ public class Sidecar {
 	}
 
 	public void start() {
-		if (_log.isInfoEnabled()) {
-			_log.info("Starting sidecar Elasticsearch");
+		if (_log.isDebugEnabled()) {
+			_log.debug("Sidecar Elasticsearch liferay started");
 		}
 
 		_installElasticsearchIfNeeded();
@@ -115,7 +115,7 @@ public class Sidecar {
 		if (_log.isInfoEnabled()) {
 			_log.info(
 				StringBundler.concat(
-					"Sidecar Elasticsearch ", getNodeName(), " is at ",
+					"Sidecar Elasticsearch ", getNodeName(), " started at ",
 					address));
 		}
 
@@ -558,8 +558,8 @@ public class Sidecar {
 
 		sb.setStringAt(StringPool.CLOSE_CURLY_BRACE, sb.index() - 1);
 
-		if (_log.isInfoEnabled()) {
-			_log.info(sb.toString());
+		if (_log.isDebugEnabled()) {
+			_log.debug(sb.toString());
 		}
 
 		return arguments.toArray(new String[0]);

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/SidecarManager.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/SidecarManager.java
@@ -95,19 +95,18 @@ public class SidecarManager implements ElasticsearchConfigurationObserver {
 				ConnectionConstants.SIDECAR_CONNECTION_ID);
 		}
 		else {
-			if (_log.isDebugEnabled()) {
-				StringBundler sb = new StringBundler(8);
+			if (_log.isWarnEnabled()) {
+				StringBundler sb = new StringBundler(7);
 
-				sb.append("Liferay is configured to use Elasticsearch engine ");
-				sb.append("running in a child process of current process ");
-				sb.append("named as sidecar. Do NOT use sidecar in ");
-				sb.append("production. Sidecar is useful for development and ");
-				sb.append("demonstration purposes. Refer to the ");
+				sb.append("Liferay automatically starts a child process of ");
+				sb.append("Elasticsearch named sidecar for convenient ");
+				sb.append("development and demonstration purposes. Do NOT ");
+				sb.append("use sidecar in production. Refer to the ");
 				sb.append("documentation for details on the limitations of ");
-				sb.append("sidecar. Remote Elasticsearch connections can be ");
-				sb.append("configured in the Control Panel.");
+				sb.append("sidecar and instructions on configuring a remote ");
+				sb.append("Elasticsearch connection in the Control Panel.");
 
-				_log.debug(sb.toString());
+				_log.warn(sb.toString());
 			}
 
 			if (_sidecar != null) {

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/SidecarManager.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/SidecarManager.java
@@ -95,7 +95,7 @@ public class SidecarManager implements ElasticsearchConfigurationObserver {
 				ConnectionConstants.SIDECAR_CONNECTION_ID);
 		}
 		else {
-			if (_log.isWarnEnabled()) {
+			if (_log.isDebugEnabled()) {
 				StringBundler sb = new StringBundler(8);
 
 				sb.append("Liferay is configured to use Elasticsearch engine ");
@@ -107,7 +107,7 @@ public class SidecarManager implements ElasticsearchConfigurationObserver {
 				sb.append("sidecar. Remote Elasticsearch connections can be ");
 				sb.append("configured in the Control Panel.");
 
-				_log.warn(sb.toString());
+				_log.debug(sb.toString());
 			}
 
 			if (_sidecar != null) {

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/log4j2.properties
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/log4j2.properties
@@ -5,5 +5,5 @@ appender.console.type=Console
 logger.action.level=warn
 logger.action.name=org.elasticsearch.action
 rootLogger.appenderRef.console.ref=console
-rootLogger.level=warn
+rootLogger.level=error
 status=error

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 5.16.6
+Bundle-Version: 5.16.8
 Export-Package:\
 	com.liferay.portal.asm,\
 	com.liferay.portal.bean,\

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/elasticsearch/Elasticsearch7.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/elasticsearch/Elasticsearch7.testcase
@@ -232,7 +232,7 @@ definition {
 		property portal.acceptance = "true";
 		property test.assert.warning.exceptions = "true";
 
-		AssertConsoleTextPresent(value1 = "Sidecar Elasticsearch liferay is at 127.0.0.1:9201");
+		AssertConsoleTextPresent(value1 = "Sidecar Elasticsearch liferay started at 127.0.0.1:9201");
 
 		JSONWebcontent.addWebContent(
 			content = "WC Content",
@@ -255,11 +255,11 @@ definition {
 		Clustering.viewClusterStatusInConsole();
 
 		Clustering.viewTextPresentOnSpecificNode(
-			expectedText = "Sidecar Elasticsearch liferay is at 127.0.0.1:9201",
+			expectedText = "Sidecar Elasticsearch liferay started at 127.0.0.1:9201",
 			nodePort = "8080");
 
 		Clustering.viewTextPresentOnSpecificNode(
-			expectedText = "Sidecar Elasticsearch liferay is at 127.0.0.1:9202",
+			expectedText = "Sidecar Elasticsearch liferay started at 127.0.0.1:9202",
 			nodePort = "9080");
 
 		Elasticsearch.viewClusterStatusViaClusterHealthAPI(


### PR DESCRIPTION
Hello @wcao20170619,

Authors: @wcao20170619 @joshuacords 
Reviewer: @joshuacords 

https://issues.liferay.com/browse/LPS-120795

A few changes:
- I've improved the wording of the Warning for the Sidecar with Russell's help. Also, we still want this warning to appear if the user is using embedded mode.
- I've turned off the ES warnings with the log4j2 changes, to be refined by later tickets.