### PR TITLE
LPS-121941 Execute all tests in TestOrderHelper twice, setting DDMIndexerConfiguration.enableLegacyDDMIndexFields to true and false values

### DIFF
--- a/modules/apps/document-library/document-library-test/build.gradle
+++ b/modules/apps/document-library/document-library-test/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	testIntegrationCompile group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	testIntegrationCompile group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	testIntegrationCompile group: "org.jodd", name: "jodd-core", version: "3.6.4"
+	testIntegrationCompile group: "org.osgi", name: "org.osgi.service.cm", version: "1.5.0"
 	testIntegrationCompile project(":apps:asset:asset-auto-tagger-api")
 	testIntegrationCompile project(":apps:asset:asset-display-page-api")
 	testIntegrationCompile project(":apps:asset:asset-test-util")

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchLegacyDDMIndexFieldsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchLegacyDDMIndexFieldsTest.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.journal.search.test;
+package com.liferay.document.library.search.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.dynamic.data.mapping.configuration.DDMIndexerConfiguration;
@@ -27,8 +27,8 @@ import org.junit.runner.RunWith;
  * @author Jorge Díaz
  */
 @RunWith(Arquillian.class)
-public class JournalArticleSearchLegacyDDMIndexFieldsTest
-	extends JournalArticleSearchTest {
+public class DLFileEntrySearchLegacyDDMIndexFieldsTest
+	extends DLFileEntrySearchTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
@@ -27,6 +27,7 @@ import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLTrashServiceUtil;
 import com.liferay.document.library.test.util.DLAppTestUtil;
+import com.liferay.dynamic.data.mapping.configuration.DDMIndexerConfiguration;
 import com.liferay.dynamic.data.mapping.kernel.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.kernel.DDMFormValues;
 import com.liferay.dynamic.data.mapping.kernel.LocalizedValue;
@@ -41,6 +42,7 @@ import com.liferay.dynamic.data.mapping.util.DDMBeanTranslatorUtil;
 import com.liferay.dynamic.data.mapping.util.DDMIndexer;
 import com.liferay.dynamic.data.mapping.util.DDMUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.Group;
@@ -58,6 +60,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -71,6 +74,8 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import java.io.File;
 import java.io.InputStream;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -90,6 +95,23 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE,
 			SynchronousDestinationTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		ConfigurationTestUtil.saveConfiguration(
+			DDMIndexerConfiguration.class.getName(),
+			new HashMapDictionary() {
+				{
+					put("enableLegacyDDMIndexFields", false);
+				}
+			});
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		ConfigurationTestUtil.deleteConfiguration(
+			DDMIndexerConfiguration.class.getName());
+	}
 
 	@Override
 	@Test

--- a/modules/apps/journal/journal-test/build.gradle
+++ b/modules/apps/journal/journal-test/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationCompile group: "log4j", name: "log4j", version: "1.2.17"
+	testIntegrationCompile group: "org.osgi", name: "org.osgi.service.cm", version: "1.5.0"
 	testIntegrationCompile group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	testIntegrationCompile project(":apps:asset:asset-api")
 	testIntegrationCompile project(":apps:asset:asset-display-page-api")
@@ -30,6 +31,7 @@ dependencies {
 	testIntegrationCompile project(":apps:journal:journal-test-util")
 	testIntegrationCompile project(":apps:layout:layout-page-template-api")
 	testIntegrationCompile project(":apps:layout:layout-test-util")
+	testIntegrationCompile project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationCompile project(":apps:portal-search:portal-search-api")
 	testIntegrationCompile project(":apps:portal-security:portal-security-permission-test-util")
 	testIntegrationCompile project(":apps:portal:portal-local-service-tree-test-util")

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleSearchLegacyDDMIndexFieldsTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleSearchLegacyDDMIndexFieldsTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.configuration.DDMIndexerConfiguration;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import org.osgi.service.cm.Configuration;
+
+/**
+ * @author Jorge Díaz
+ */
+@RunWith(Arquillian.class)
+public class JournalArticleSearchLegacyDDMIndexFieldsTest
+	extends JournalArticleSearchTest {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		Configuration ddmIndexerConfiguration =
+			configurationAdmin.getConfiguration(
+				DDMIndexerConfiguration.class.getName(), StringPool.QUESTION);
+
+		ConfigurationTestUtil.saveConfiguration(
+			ddmIndexerConfiguration,
+			new HashMapDictionary() {
+				{
+					put("enableLegacyDDMIndexFields", true);
+				}
+			});
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		Configuration ddmIndexerConfiguration =
+			configurationAdmin.getConfiguration(
+				DDMIndexerConfiguration.class.getName(), StringPool.QUESTION);
+
+		ConfigurationTestUtil.deleteConfiguration(ddmIndexerConfiguration);
+	}
+
+}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleSearchTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleSearchTest.java
@@ -15,6 +15,7 @@
 package com.liferay.journal.search.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.configuration.DDMIndexerConfiguration;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormLayout;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
@@ -34,6 +35,8 @@ import com.liferay.journal.service.JournalArticleLocalServiceUtil;
 import com.liferay.journal.service.JournalArticleServiceUtil;
 import com.liferay.journal.service.JournalFolderServiceUtil;
 import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.ClassedModel;
@@ -61,11 +64,13 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.test.util.BaseSearchTestCase;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.registry.Registry;
 import com.liferay.registry.RegistryUtil;
@@ -75,13 +80,18 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
 
 /**
  * @author Juan Fernández
@@ -94,6 +104,30 @@ public class JournalArticleSearchTest extends BaseSearchTestCase {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		Configuration ddmIndexerConfiguration =
+			configurationAdmin.getConfiguration(
+				DDMIndexerConfiguration.class.getName(), StringPool.QUESTION);
+
+		ConfigurationTestUtil.saveConfiguration(
+			ddmIndexerConfiguration,
+			new HashMapDictionary() {
+				{
+					put("enableLegacyDDMIndexFields", false);
+				}
+			});
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		Configuration ddmIndexerConfiguration =
+			configurationAdmin.getConfiguration(
+				DDMIndexerConfiguration.class.getName(), StringPool.QUESTION);
+
+		ConfigurationTestUtil.deleteConfiguration(ddmIndexerConfiguration);
+	}
 
 	@Before
 	@Override
@@ -593,6 +627,9 @@ public class JournalArticleSearchTest extends BaseSearchTestCase {
 			_ddmStructure.getDescriptionMap(), ddmForm, ddmFormLayout,
 			serviceContext);
 	}
+
+	@Inject
+	protected static ConfigurationAdmin configurationAdmin;
 
 	protected class JournalArticleSearchTestOrderHelper
 		extends TestOrderHelper {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleSearchTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleSearchTest.java
@@ -35,7 +35,6 @@ import com.liferay.journal.service.JournalArticleLocalServiceUtil;
 import com.liferay.journal.service.JournalArticleServiceUtil;
 import com.liferay.journal.service.JournalFolderServiceUtil;
 import com.liferay.journal.test.util.JournalTestUtil;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
@@ -70,7 +69,6 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.test.util.BaseSearchTestCase;
-import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.registry.Registry;
 import com.liferay.registry.RegistryUtil;
@@ -90,9 +88,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.osgi.service.cm.Configuration;
-import org.osgi.service.cm.ConfigurationAdmin;
-
 /**
  * @author Juan Fernández
  * @author Tibor Lipusz
@@ -107,12 +102,8 @@ public class JournalArticleSearchTest extends BaseSearchTestCase {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		Configuration ddmIndexerConfiguration =
-			configurationAdmin.getConfiguration(
-				DDMIndexerConfiguration.class.getName(), StringPool.QUESTION);
-
 		ConfigurationTestUtil.saveConfiguration(
-			ddmIndexerConfiguration,
+			DDMIndexerConfiguration.class.getName(),
 			new HashMapDictionary() {
 				{
 					put("enableLegacyDDMIndexFields", false);
@@ -122,11 +113,8 @@ public class JournalArticleSearchTest extends BaseSearchTestCase {
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
-		Configuration ddmIndexerConfiguration =
-			configurationAdmin.getConfiguration(
-				DDMIndexerConfiguration.class.getName(), StringPool.QUESTION);
-
-		ConfigurationTestUtil.deleteConfiguration(ddmIndexerConfiguration);
+		ConfigurationTestUtil.deleteConfiguration(
+			DDMIndexerConfiguration.class.getName());
 	}
 
 	@Before
@@ -627,9 +615,6 @@ public class JournalArticleSearchTest extends BaseSearchTestCase {
 			_ddmStructure.getDescriptionMap(), ddmForm, ddmFormLayout,
 			serviceContext);
 	}
-
-	@Inject
-	protected static ConfigurationAdmin configurationAdmin;
 
 	protected class JournalArticleSearchTestOrderHelper
 		extends TestOrderHelper {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-121941

In **TestOrderHelper** we are currently testing the ddm sorting functionality.  After https://issues.liferay.com/browse/LPS-103224 changes, it is necessary to test them twice, setting the DDMIndexerConfiguration.enableLegacyDDMIndexFields to true/false.

TestOrderHelper is used in two classes: **DLFileEntrySearchTest and JournalArticleSearchTest**

**My changes:**
In that classes, I am adding a `setUpClass()` method that sets DDMIndexerConfiguration.enableLegacyDDMIndexFields configuration to false (_that is the default value for 7.3-master branches_)
So we will test the default master behavior in all branches.

In order to test the legacy behavior, I have created two new classes **DLFileEntrySearchLegacyDDMIndexFieldsTest and JournalArticleSearchLegacyDDMIndexFieldsTest** that extend existing classes but their setUpClass() method that sets DDMIndexerConfiguration.enableLegacyDDMIndexFields configuration to true (_that is the default value for 7.0-7.2 branches_)

/cc @jkappler