### PR TITLE
[TS] LPS-119230 Ghost facets - permissions error

### DIFF
--- a/modules/apps/alloy/alloy-mvc/bnd.bnd
+++ b/modules/apps/alloy/alloy-mvc/bnd.bnd
@@ -5,6 +5,6 @@ Export-Package:\
 	com.liferay.alloy.mvc,\
 	com.liferay.alloy.mvc.json.web.service
 Import-Package:\
-	com.liferay.portal.kernel.portlet;version="[10.2.0,10.3)",\
+	com.liferay.portal.kernel.portlet;version="[10.2.0,11.1)",\
 	\
 	*

--- a/modules/apps/asset/asset-publisher-web/bnd.bnd
+++ b/modules/apps/asset/asset-publisher-web/bnd.bnd
@@ -2,7 +2,7 @@ Bundle-Name: Liferay Asset Publisher Web
 Bundle-SymbolicName: com.liferay.asset.publisher.web
 Bundle-Version: 5.0.0
 Import-Package:\
-	com.liferay.portal.kernel.portlet;version="[10.2.0,10.3)",\
+	com.liferay.portal.kernel.portlet;version="[10.2.0,11.1)",\
 	\
 	*
 Web-ContextPath: /asset-publisher-web

--- a/modules/apps/document-library/document-library-service/build.gradle
+++ b/modules/apps/document-library/document-library-service/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	compileOnly project(":apps:portal-configuration:portal-configuration-upgrade-api")
 	compileOnly project(":apps:portal-instances:portal-instances-api")
 	compileOnly project(":apps:portal-search:portal-search-api")
+	compileOnly project(":apps:portal-search:portal-search-engine-adapter-api")
 	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFolderModelDocumentContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFolderModelDocumentContributor.java
@@ -14,15 +14,32 @@
 
 package com.liferay.document.library.internal.search.spi.model.index.contributor;
 
+import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
+import com.liferay.portal.search.engine.adapter.document.GetDocumentRequest;
+import com.liferay.portal.search.engine.adapter.document.GetDocumentResponse;
+import com.liferay.portal.search.index.IndexNameBuilder;
+import com.liferay.portal.search.indexer.IndexerWriter;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 import com.liferay.trash.TrashHelper;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -64,12 +81,164 @@ public class DLFolderModelDocumentContributor
 		if (_log.isDebugEnabled()) {
 			_log.debug("Document " + dlFolder + " indexed successfully");
 		}
+
+		if (_changingPermissions(document, dlFolder)) {
+			_updateChildrenPermissions(document, dlFolder);
+		}
 	}
+
+	@Reference(unbind = "-")
+	protected void setIndexNameBuilder(IndexNameBuilder indexNameBuilder) {
+		_indexNameBuilder = indexNameBuilder;
+	}
+
+	@Reference(
+		target = "(indexer.class.name=com.liferay.document.library.kernel.model.DLFileEntry)"
+	)
+	protected IndexerWriter<DLFileEntry> dLFileEntryIndexerWriter;
+
+	@Reference
+	protected DLFileEntryLocalService dlFileEntryLocalService;
+
+	@Reference(
+		target = "(indexer.class.name=com.liferay.document.library.kernel.model.DLFolder)"
+	)
+	protected IndexerWriter<DLFolder> dLFolderIndexerWriter;
+
+	@Reference
+	protected DLFolderLocalService dlFolderLocalService;
 
 	@Reference
 	protected TrashHelper trashHelper;
 
+	private boolean _changingPermissions(Document document, DLFolder dlFolder) {
+		String indexName = _indexNameBuilder.getIndexName(
+			dlFolder.getCompanyId());
+
+		Field uidField = document.getField(Field.UID);
+
+		GetDocumentRequest getDocumentRequest = new GetDocumentRequest(
+			indexName, uidField.getValue());
+
+		String permissionFieldNames =
+			Field.ROLE_ID + StringPool.COMMA + Field.GROUP_ROLE_ID;
+
+		getDocumentRequest.setFetchSource(true);
+		getDocumentRequest.setFetchSourceInclude(permissionFieldNames);
+		getDocumentRequest.setPreferLocalCluster(false);
+
+		GetDocumentResponse getDocumentResponse = _searchEngineAdapter.execute(
+			getDocumentRequest);
+
+		if (!getDocumentResponse.isExists()) {
+			return true;
+		}
+
+		com.liferay.portal.search.document.Document indexedDocument =
+			getDocumentResponse.getDocument();
+
+		List<String> indexedRoleIds = indexedDocument.getStrings(Field.ROLE_ID);
+		List<String> indexedGroupRoleIds = indexedDocument.getStrings(
+			Field.GROUP_ROLE_ID);
+
+		List<Long> roleIds = new ArrayList<>();
+		List<String> groupRoleIds = new ArrayList<>();
+
+		try {
+			List<Role> roles =
+				_resourcePermissionLocalService.getDynamicInheritanceRoles(
+					dlFolder.getCompanyId(),
+					"com.liferay.document.library.kernel.model.DLFolder",
+					ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(dlFolder.getFolderId()), "VIEW");
+
+			for (Role role : roles) {
+				if ((role.getType() == RoleConstants.TYPE_ORGANIZATION) ||
+					(role.getType() == RoleConstants.TYPE_SITE)) {
+
+					groupRoleIds.add(
+						dlFolder.getGroupId() + StringPool.DASH +
+							role.getRoleId());
+				}
+				else {
+					roleIds.add(role.getRoleId());
+				}
+			}
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to retrieve roles for DLFolder " +
+					dlFolder.getFolderId(),
+				exception);
+		}
+
+		if ((roleIds.size() != indexedRoleIds.size()) ||
+			(groupRoleIds.size() != indexedGroupRoleIds.size())) {
+
+			return true;
+		}
+
+		for (String indexedGroupRole : indexedGroupRoleIds) {
+			if (groupRoleIds.contains(indexedGroupRole)) {
+				continue;
+			}
+
+			return true;
+		}
+
+		for (String indexedRoleId : indexedRoleIds) {
+			if (roleIds.contains(GetterUtil.getLong(indexedRoleId))) {
+				continue;
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private void _updateChildrenPermissions(
+		Document document, DLFolder parentFolder) {
+
+		List<DLFileEntry> dlFileEntries =
+			dlFileEntryLocalService.getFileEntries(
+				parentFolder.getGroupId(), parentFolder.getFolderId());
+
+		for (DLFileEntry dlFileEntry : dlFileEntries) {
+			dLFileEntryIndexerWriter.updatePermissionFields(dlFileEntry);
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Document " + dlFileEntry +
+						" permissions indexed successfully");
+			}
+		}
+
+		List<DLFolder> dlFolders = dlFolderLocalService.getFolders(
+			parentFolder.getGroupId(), parentFolder.getFolderId());
+
+		for (DLFolder dlFolder : dlFolders) {
+			dLFolderIndexerWriter.updatePermissionFields(dlFolder);
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Document " + dlFolder +
+						" permissions indexed successfully");
+			}
+
+			_updateChildrenPermissions(document, dlFolder);
+		}
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		DLFolderModelDocumentContributor.class);
+
+	private IndexNameBuilder _indexNameBuilder;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private SearchEngineAdapter _searchEngineAdapter;
 
 }

--- a/modules/apps/frontend-editor/frontend-editor-lang/bnd.bnd
+++ b/modules/apps/frontend-editor/frontend-editor-lang/bnd.bnd
@@ -2,6 +2,6 @@ Bundle-Name: Liferay Frontend Editor Lang
 Bundle-SymbolicName: com.liferay.frontend.editor.lang
 Bundle-Version: 6.0.0
 Import-Package:\
-	com.liferay.portal.kernel.util;version="[7.38.0,11.0.0)",\
+	com.liferay.portal.kernel.util;version="[7.38.0,11.1.0)",\
 	\
 	*

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/bnd.bnd
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/bnd.bnd
@@ -2,7 +2,7 @@ Bundle-Name: Liferay Layout Type Controller Asset Display
 Bundle-SymbolicName: com.liferay.layout.type.controller.asset.display
 Bundle-Version: 4.0.0
 Import-Package:\
-	com.liferay.portal.kernel.portlet;version="[10.2.0,10.3)",\
+	com.liferay.portal.kernel.portlet;version="[10.2.0,11.1)",\
 	\
 	*
 Web-ContextPath: /layout-type-controller-asset-display

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/bnd.bnd
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/bnd.bnd
@@ -2,7 +2,7 @@ Bundle-Name: Liferay Layout Type Controller Display Page
 Bundle-SymbolicName: com.liferay.layout.type.controller.display.page
 Bundle-Version: 3.0.0
 Import-Package:\
-	com.liferay.portal.kernel.portlet;version="[10.2.0,10.3)",\
+	com.liferay.portal.kernel.portlet;version="[10.2.0,11.1)",\
 	\
 	*
 Web-ContextPath: /layout-type-controller-display-page

--- a/modules/apps/portal-language/portal-language-extender/bnd.bnd
+++ b/modules/apps/portal-language/portal-language-extender/bnd.bnd
@@ -2,6 +2,6 @@ Bundle-Name: Liferay Portal Language Extender
 Bundle-SymbolicName: com.liferay.portal.language.extender
 Bundle-Version: 6.0.0
 Import-Package:\
-	com.liferay.portal.kernel.util;version="[7.38.0,11.0.0)",\
+	com.liferay.portal.kernel.util;version="[7.38.0,11.1.0)",\
 	\
 	*

--- a/modules/apps/portal-language/portal-language-servlet-filter/bnd.bnd
+++ b/modules/apps/portal-language/portal-language-servlet-filter/bnd.bnd
@@ -2,6 +2,6 @@ Bundle-Name: Liferay Portal Language Servlet Filter
 Bundle-SymbolicName: com.liferay.portal.language.servlet.filter
 Bundle-Version: 6.0.0
 Import-Package:\
-	com.liferay.portal.kernel.util;version="[7.38.0,11.0.0)",\
+	com.liferay.portal.kernel.util;version="[7.38.0,11.1.0)",\
 	\
 	*

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/document/DefaultElasticsearchDocumentFactory.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/document/DefaultElasticsearchDocumentFactory.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.search.elasticsearch7.internal.document;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -127,10 +128,6 @@ public class DefaultElasticsearchDocumentFactory
 		if (!field.isLocalized()) {
 			String[] values = field.getValues();
 
-			if (ArrayUtil.isEmpty(values)) {
-				return;
-			}
-
 			List<String> valuesList = new ArrayList<>(values.length);
 
 			for (String value : values) {
@@ -139,10 +136,6 @@ public class DefaultElasticsearchDocumentFactory
 				}
 
 				valuesList.add(value.trim());
-			}
-
-			if (valuesList.isEmpty()) {
-				return;
 			}
 
 			values = valuesList.toArray(new String[0]);
@@ -218,8 +211,13 @@ public class DefaultElasticsearchDocumentFactory
 			addDates(xContentBuilder, field);
 		}
 		else {
-			for (String value : values) {
-				xContentBuilder.value(translateValue(field, value));
+			if (values.length < 1) {
+				xContentBuilder.value(translateValue(field, StringPool.BLANK));
+			}
+			else {
+				for (String value : values) {
+					xContentBuilder.value(translateValue(field, value));
+				}
 			}
 		}
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/document/DefaultElasticsearchDocumentFactoryTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/document/DefaultElasticsearchDocumentFactoryTest.java
@@ -197,7 +197,7 @@ public class DefaultElasticsearchDocumentFactoryTest {
 
 	@Test
 	public void testNull() throws Exception {
-		assertDocumentSameAsLegacy(null, "{}");
+		assertDocumentSameAsLegacy(null, "{\"field\":\"\"}");
 	}
 
 	@Test

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchPermissionCheckerImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchPermissionCheckerImpl.java
@@ -285,9 +285,10 @@ public class SearchPermissionCheckerImpl implements SearchPermissionChecker {
 				document, className, classPK);
 		}
 
-		List<Role> roles = resourcePermissionLocalService.getRoles(
-			companyId, className, ResourceConstants.SCOPE_INDIVIDUAL,
-			String.valueOf(classPK), viewActionId);
+		List<Role> roles =
+			resourcePermissionLocalService.getDynamicInheritanceRoles(
+				companyId, className, ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(classPK), viewActionId);
 
 		if (roles.isEmpty()) {
 			return;

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/document/DocumentImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/document/DocumentImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.search.internal.document;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.search.document.Document;
@@ -175,11 +176,10 @@ public class DocumentImpl implements Document {
 
 	public void setFieldValues(String name, Collection<Object> values) {
 		if ((values == null) || values.isEmpty()) {
-			removeField(name);
+			values = Arrays.asList(StringPool.BLANK);
 		}
-		else {
-			putField(name, values);
-		}
+
+		putField(name, values);
 	}
 
 	@Override

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/BaseModelDocumentFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/BaseModelDocumentFactoryImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.search.internal.indexer;
 
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ResourcedModel;
 import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
@@ -53,6 +54,11 @@ public class BaseModelDocumentFactoryImpl implements BaseModelDocumentFactory {
 			Field.ROOT_ENTRY_CLASS_PK,
 			getRootEntryClassPK(classPKResourcePrimKeyTuple)
 		);
+
+		if (baseModel instanceof GroupedModel) {
+			documentBuilder.setLong(
+				Field.GROUP_ID, ((GroupedModel)baseModel).getGroupId());
+		}
 
 		uidFactory.setUID(baseModel, documentBuilder);
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchPermissionDocumentContributorImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchPermissionDocumentContributorImpl.java
@@ -138,9 +138,11 @@ public class SearchPermissionDocumentContributorImpl
 		String permissionName = _getPermissionName(document, className);
 
 		try {
-			List<Role> roles = _resourcePermissionLocalService.getRoles(
-				companyId, permissionName, ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(classPK), viewActionId);
+			List<Role> roles =
+				_resourcePermissionLocalService.getDynamicInheritanceRoles(
+					companyId, permissionName,
+					ResourceConstants.SCOPE_INDIVIDUAL, String.valueOf(classPK),
+					viewActionId);
 
 			if (roles.isEmpty()) {
 				return;

--- a/modules/apps/portal/portal-monitoring/bnd.bnd
+++ b/modules/apps/portal/portal-monitoring/bnd.bnd
@@ -2,6 +2,6 @@ Bundle-Name: Liferay Portal Monitoring
 Bundle-SymbolicName: com.liferay.portal.monitoring
 Bundle-Version: 9.0.0
 Import-Package:\
-	com.liferay.portal.kernel.portlet;version="[10.2.0,10.3)",\
+	com.liferay.portal.kernel.portlet;version="[10.2.0,11.1)",\
 	\
 	*

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -14,11 +14,14 @@
 
 package com.liferay.portal.service.impl;
 
+import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLFolderLocalServiceUtil;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
 import com.liferay.portal.kernel.dao.orm.QueryPos;
 import com.liferay.portal.kernel.dao.orm.SQLQuery;
@@ -33,6 +36,7 @@ import com.liferay.portal.kernel.internal.service.permission.ModelPermissionsImp
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.AuditedModel;
+import com.liferay.portal.kernel.model.BaseChildModel;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.Resource;
@@ -776,6 +780,43 @@ public class ResourcePermissionLocalServiceImpl
 		}
 
 		return availableActionIds;
+	}
+
+	@Override
+	public List<Role> getDynamicInheritanceRoles(
+			long companyId, String name, int scope, String primKey,
+			String actionId)
+		throws PortalException {
+
+		List<Role> roles = getRoles(companyId, name, scope, primKey, actionId);
+
+		BaseChildModel baseChildModel = _getChildModel(name, primKey);
+
+		if (baseChildModel == null) {
+			return roles;
+		}
+
+		String parentClassPK = baseChildModel.getParentClassPK();
+
+		if (Validator.isNull(parentClassPK) || parentClassPK.equals("0")) {
+			return roles;
+		}
+
+		List<Role> parentAccessRoles = getRoles(
+			companyId, baseChildModel.getParentClassName(),
+			ResourceConstants.SCOPE_INDIVIDUAL, parentClassPK, "ACCESS");
+
+		parentAccessRoles.retainAll(roles);
+
+		List<Role> parentViewRoles = _getTreePathRoles(
+			baseChildModel, companyId, roles);
+
+		Set<Role> rolesSet = new HashSet<>();
+
+		rolesSet.addAll(parentAccessRoles);
+		rolesSet.addAll(parentViewRoles);
+
+		return new ArrayList<>(rolesSet);
 	}
 
 	@Override
@@ -1955,6 +1996,39 @@ public class ResourcePermissionLocalServiceImpl
 		}
 	}
 
+	private BaseChildModel _getChildModel(String name, String primKey) {
+		try {
+			if (name.equals(
+					"com.liferay.document.library.kernel.model.DLFileEntry")) {
+
+				return DLFileEntryLocalServiceUtil.getDLFileEntry(
+					GetterUtil.getLong(primKey));
+			}
+
+			if (name.equals(
+					"com.liferay.document.library.kernel.model.DLFolder")) {
+
+				return DLFolderLocalServiceUtil.getDLFolder(
+					GetterUtil.getLong(primKey));
+			}
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				StringBundler sb = new StringBundler(5);
+
+				sb.append("Unable to retrieve parent of ");
+				sb.append(name);
+				sb.append(" with primKey ");
+				sb.append(primKey);
+				sb.append(".");
+
+				_log.debug(sb.toString(), portalException);
+			}
+		}
+
+		return null;
+	}
+
 	private Map<Long, ResourcePermission> _getResourcePermissionsMap(
 		List<ResourcePermission> resourcePermissions) {
 
@@ -1966,6 +2040,28 @@ public class ResourcePermissionLocalServiceImpl
 		}
 
 		return resourcePermissionsMap;
+	}
+
+	private List<Role> _getTreePathRoles(
+			BaseChildModel baseChildModel, long companyId, List<Role> roles)
+		throws PortalException {
+
+		String[] parentFolderIds = StringUtil.split(
+			baseChildModel.getTreePath(), StringPool.SLASH);
+
+		List<Role> folderRoles;
+
+		for (int i = parentFolderIds.length - 1; !roles.isEmpty() && (i > 0);
+			 i--) {
+
+			folderRoles = getRoles(
+				companyId, baseChildModel.getParentClassName(),
+				ResourceConstants.SCOPE_INDIVIDUAL, parentFolderIds[i], "VIEW");
+
+			roles.retainAll(folderRoles);
+		}
+
+		return roles;
 	}
 
 	private void _initPortletDefaultPermissions(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryImpl.java
@@ -272,6 +272,16 @@ public class DLFileEntryImpl extends DLFileEntryBaseImpl {
 	}
 
 	@Override
+	public String getParentClassName() {
+		return "com.liferay.document.library.kernel.model.DLFolder";
+	}
+
+	@Override
+	public String getParentClassPK() {
+		return String.valueOf(getFolderId());
+	}
+
+	@Override
 	public long getReadCount() {
 		return ViewCountManagerUtil.getViewCount(
 			getCompanyId(),

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryModelImpl.java
@@ -341,6 +341,16 @@ public class DLFileEntryModelImpl
 	}
 
 	@Override
+	public String getParentClassName() {
+		return "com.liferay.document.library.kernel.model.DLFolder";
+	}
+
+	@Override
+	public String getParentClassPK() {
+		return String.valueOf(getFolderId());
+	}
+
+	@Override
 	public long getPrimaryKey() {
 		return _fileEntryId;
 	}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFolderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFolderImpl.java
@@ -86,6 +86,16 @@ public class DLFolderImpl extends DLFolderBaseImpl {
 	}
 
 	@Override
+	public String getParentClassName() {
+		return "com.liferay.document.library.kernel.model.DLFolder";
+	}
+
+	@Override
+	public String getParentClassPK() {
+		return String.valueOf(getParentFolderId());
+	}
+
+	@Override
 	public DLFolder getParentFolder() throws PortalException {
 		if (getParentFolderId() == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 			return null;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFolderModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFolderModelImpl.java
@@ -321,6 +321,16 @@ public class DLFolderModelImpl
 	}
 
 	@Override
+	public String getParentClassName() {
+		return "com.liferay.document.library.kernel.model.DLFolder";
+	}
+
+	@Override
+	public String getParentClassPK() {
+		return String.valueOf(getParentFolderId());
+	}
+
+	@Override
 	public long getPrimaryKey() {
 		return _folderId;
 	}

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileEntryModel.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileEntryModel.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.AttachedModel;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.BaseChildModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedGroupedModel;
@@ -41,8 +42,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface DLFileEntryModel
-	extends AttachedModel, BaseModel<DLFileEntry>, CTModel<DLFileEntry>,
-			MVCCModel, ShardedModel, StagedGroupedModel, TrashedModel {
+	extends AttachedModel, BaseModel<DLFileEntry>, BaseChildModel,
+			CTModel<DLFileEntry>, MVCCModel, ShardedModel, StagedGroupedModel,
+			TrashedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileEntryWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileEntryWrapper.java
@@ -617,6 +617,16 @@ public class DLFileEntryWrapper
 		return model.getName();
 	}
 
+	@Override
+	public String getParentClassName() {
+		return model.getParentClassName();
+	}
+
+	@Override
+	public String getParentClassPK() {
+		return model.getParentClassPK();
+	}
+
 	/**
 	 * Returns the primary key of this document library file entry.
 	 *

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/DLFolderModel.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/DLFolderModel.java
@@ -17,6 +17,7 @@ package com.liferay.document.library.kernel.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.BaseChildModel;
 import com.liferay.portal.kernel.model.ContainerModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
@@ -42,8 +43,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface DLFolderModel
-	extends BaseModel<DLFolder>, ContainerModel, CTModel<DLFolder>, MVCCModel,
-			ShardedModel, StagedGroupedModel, TrashedModel, WorkflowedModel {
+	extends BaseModel<DLFolder>, BaseChildModel, ContainerModel,
+			CTModel<DLFolder>, MVCCModel, ShardedModel, StagedGroupedModel,
+			TrashedModel, WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/DLFolderWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/DLFolderWrapper.java
@@ -409,6 +409,16 @@ public class DLFolderWrapper
 		return model.getName();
 	}
 
+	@Override
+	public String getParentClassName() {
+		return model.getParentClassName();
+	}
+
+	@Override
+	public String getParentClassPK() {
+		return model.getParentClassPK();
+	}
+
 	/**
 	 * Returns the parent container model ID of this document library folder.
 	 *

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 4.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/model/BaseChildModel.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/BaseChildModel.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.model;
+
+/**
+ * @author Joshua Cords
+ */
+public interface BaseChildModel {
+
+	public String getParentClassName();
+
+	public String getParentClassPK();
+
+	public String getTreePath();
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 5.5.0
+version 5.6.0

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalService.java
@@ -580,6 +580,12 @@ public interface ResourcePermissionLocalService
 			String actionId)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<Role> getDynamicInheritanceRoles(
+		long companyId, String name, int scope, String primKey,
+		String actionId)
+		throws PortalException;
+
 	/**
 	 * Returns all the resource permissions where scope = any &#63;.
 	 *

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceUtil.java
@@ -677,6 +677,16 @@ public class ResourcePermissionLocalServiceUtil {
 		return getService().getRoles(companyId, name, scope, primKey, actionId);
 	}
 
+	public static java.util.List<com.liferay.portal.kernel.model.Role>
+		getDynamicInheritanceRoles(
+			long companyId, String name, int scope, String primKey,
+			String actionId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().getDynamicInheritanceRoles(
+			companyId, name, scope, primKey, actionId);
+	}
+
 	/**
 	 * Returns all the resource permissions where scope = any &#63;.
 	 *

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceWrapper.java
@@ -712,6 +712,16 @@ public class ResourcePermissionLocalServiceWrapper
 			companyId, name, scope, primKey, actionId);
 	}
 
+	@Override
+	public java.util.List<com.liferay.portal.kernel.model.Role> getDynamicInheritanceRoles(
+		long companyId, String name, int scope, String primKey,
+		String actionId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _resourcePermissionLocalService.getDynamicInheritanceRoles(
+			companyId, name, scope, primKey, actionId);
+	}
+
 	/**
 	 * Returns all the resource permissions where scope = any &#63;.
 	 *

--- a/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.8.0
+version 4.9.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-119230 

**Author**: @joshuacords

I need feedback on the direction of this fix. This prototype is working for DLFileEntries and DLFolders, but the final fix will be Bookmarks and their folders, JournalArticles and their folders, and MessageBoards and MessageCategories. I haven't figured out tests yet, you can look at the LPS for reproduction steps. I wanted to make sure I was on the right path before investing any more in this direction. Part of this fix is a permissions issue which I am talking to a core engineer about, the other part is indexing which I need feedback on. I'll list the particular commits which need review.

**Issue:** When a foldered object is indexed into a search engine, we index all permissions of that object. However, this is problematic because it ignores the Dynamic Inheritance Permissions of parent objects and folders. If a object's parent's permissions restricts the roles able to view the object, the search query used will not filter out those objects and they will be returned. In most cases this is okay, because we have post filtering which removes the objects returned for which the user doesn't have permissions. This step also decrements the counts of the facets. BUT, in the case where we select a facet, the other selectable options in that same facet are calculated by the search engine, and because the objects are never returned it is impossible to do post filtering to decrement counts. This results in facet counts revealing the number and type of content the current user doesn't have permission to see.

**Solution:** We need to index the objects with their Dynamic Inheritance Permissions (and keep them up to date) so that we can trust the facet counts. I'm working with a core engineer to get the getDynamicInheritanceRoles method needed. 

Commits to review:
**Addresses indexing dynamic inheritance:**
https://github.com/liferay/liferay-portal/commit/69b2c1e7c5ec5aed8621ff96d29ec6dddf9378a9 LPS-119230 portal-search: use dynamicInheritanceRoles when indexing
https://github.com/liferay/liferay-portal/commit/88cf7708aced953209a761793c7949f2c1ca6139 LPS-119230 portal-search: add groupId to document for use by SearchPe
https://github.com/liferay/liferay-portal/commit/4add93d2262e246396bee48a02df40d5ccd96b6a LPS-119230 document-library-service: cascade reindex child DLFolders (When indexing a DLFolder, checks to see if permissions were modified in comparison with what is indexed. If so, will recursively reindex the permissions of all child folders and their objects. Note, it didn't seem worth it to check each DLFolder for permissions changes during the recursion, but perhaps more checks could be worthwhile as many clients have large numbers of documents.)

**Addresses Partial Reindexing bug:**
https://github.com/liferay/liferay-portal/commit/b0d8e71ff7df58bf806702a46bdb91a17e192afd LPS-119230 portal-search-elasticsearch7-impl: Update expectations of … (Partial reindexing used in the above commit has a bug. When the document in ES has a field with a value, and the new value is empty, our addField Logic doesn't add the field to the request. This results in the original value persisting in the search engine.)
https://github.com/liferay/liferay-portal/commit/a8029d8302458dbe93131db570574f0d19590139 LPS-119230 portal-search-elasticsearch7-impl: allow for empty values (The changes to the addField Logic to index "" instead of having no field, insuring that the old value is overwritten. Note: there is ES API to r[emove fields during a partial reindex](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html) however I looked into how to implement this and it seems far too complicated.)
https://github.com/liferay/liferay-portal/commit/a919b9d83c3b3896878f73d699752b75ae5b3283 LPS-119230 portal-search: allow for empty values in portal.search.Fields 


