### PR TITLE
[TS] LPS-123216 Fix NPE in FacetBucketUtil

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/facet/FacetBucketUtil.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/facet/FacetBucketUtil.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.search.facet.RangeFacet;
 import com.liferay.portal.kernel.search.facet.util.RangeParserUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 /**
  * @author Bryan Engler
@@ -37,7 +38,9 @@ public class FacetBucketUtil {
 
 			String value = field.getValue();
 
-			if ((lower.compareTo(value) <= 0) && (value.compareTo(upper) < 0)) {
+			if (Validator.isNotNull(lower) && (lower.compareTo(value) <= 0) &&
+				Validator.isNotNull(upper) && (value.compareTo(upper) < 0)) {
+
 				return true;
 			}
 

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/facet/FacetBucketUtilTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/facet/FacetBucketUtilTest.java
@@ -56,6 +56,8 @@ public class FacetBucketUtilTest {
 
 		Assert.assertTrue(
 			FacetBucketUtil.isFieldInBucket(field, "[001 TO 999]", facet));
+		Assert.assertFalse(
+			FacetBucketUtil.isFieldInBucket(field, "undefined", facet));
 	}
 
 	@Test


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-123216

Background: https://issues.liferay.com/browse/LPS-123216?focusedCommentId=2310468&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2310468

Caused by: https://issues.liferay.com/browse/LPS-123216?focusedCommentId=2311620&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2311620

From André:
> Well, regardless of the User document, it does look like FacetBucketUtil has a bug. It should be more robust against undefined and other possible terms missing a bucket, instead of dying with a NullPointerException. Search should replicate this scenario with an integration test, fix it by returning false (field is not in bucket) and let U&SM figure out what they want to do with the User document.

So I'm not dealing with the `roleIds` part, though we should probably report this to the U&SM team as the current logic can result in a lots of documents fetched back from the search engine unnecessarily.