### PR TITLE
[TS] LPS-124310 Enable nested queries in Custom Filter portlet

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/portlet/action/QueryTypeEntriesHolder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/portlet/action/QueryTypeEntriesHolder.java
@@ -31,6 +31,7 @@ public class QueryTypeEntriesHolder {
 		add("match_phrase", "Match Phrase");
 		add("match_phrase_prefix", "Match Phrase Prefix");
 		add("multi_match", "Multi Match");
+		add("nested", "Nested");
 		add("prefix", "Prefix");
 		add("query_string", "Query String");
 		add("range", "Range");

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/filter/ComplexQueryBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/filter/ComplexQueryBuilderImpl.java
@@ -22,6 +22,7 @@ import com.liferay.portal.search.internal.filter.range.RangeTermQueryValue;
 import com.liferay.portal.search.internal.filter.range.RangeTermQueryValueParser;
 import com.liferay.portal.search.internal.util.SearchStringUtil;
 import com.liferay.portal.search.query.BooleanQuery;
+import com.liferay.portal.search.query.NestedQuery;
 import com.liferay.portal.search.query.Queries;
 import com.liferay.portal.search.query.Query;
 import com.liferay.portal.search.query.SimpleStringQuery;
@@ -213,6 +214,10 @@ public class ComplexQueryBuilderImpl implements ComplexQueryBuilder {
 				return _queries.prefix(field, value);
 			}
 
+			if (Objects.equals(type, "nested")) {
+				return _queries.nested(field, _queries.booleanQuery());
+			}
+
 			if (Objects.equals(type, "query_string")) {
 				if (Validator.isBlank(value)) {
 					return null;
@@ -303,6 +308,12 @@ public class ComplexQueryBuilderImpl implements ComplexQueryBuilder {
 
 				if (complexQueryPart != null) {
 					Query query = hydrate(complexQueryPart);
+
+					if (query instanceof NestedQuery) {
+						NestedQuery nestedQuery = (NestedQuery)query;
+
+						query = nestedQuery.getQuery();
+					}
 
 					if (query instanceof BooleanQuery) {
 						return (BooleanQuery)query;

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/filter/ComplexQueryBuilderImplTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/filter/ComplexQueryBuilderImplTest.java
@@ -22,6 +22,7 @@ import com.liferay.portal.search.query.BooleanQuery;
 import com.liferay.portal.search.query.DateRangeTermQuery;
 import com.liferay.portal.search.query.FuzzyQuery;
 import com.liferay.portal.search.query.MatchQuery;
+import com.liferay.portal.search.query.NestedQuery;
 import com.liferay.portal.search.query.Queries;
 import com.liferay.portal.search.query.Query;
 import com.liferay.portal.search.query.RangeTermQuery;
@@ -88,6 +89,16 @@ public class ComplexQueryBuilderImplTest {
 		Query query = _getQuery(complexQueryBuilderImpl, "match", "match-me");
 
 		Assert.assertTrue(query instanceof MatchQuery);
+	}
+
+	@Test
+	public void testFilterNestedQuery() {
+		ComplexQueryBuilderImpl complexQueryBuilderImpl =
+			new ComplexQueryBuilderImpl(_queries, _scripts);
+
+		Query query = _getQuery(complexQueryBuilderImpl, "nested", "path");
+
+		Assert.assertTrue(query instanceof NestedQuery);
 	}
 
 	@Test


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-124310

In LPS-103224 we implemented nested fields for DDM. This breaks the custom filter widget which can only support a single top level field to aggregate on.

I have added support to nested queries in QueryTypeEntriesHolder and ComplexQueryBuilderImpl classes.

That allows adding a parent "nested" custom filter portlet with several child filter portlets.

For example if in previous Liferay versions you was filtering:
    - **Filter Query Type:** Match
    - **Filter Field:** ddm__keyword__40635__Field14510226_en_US (_name of the ddm structure field in elasticsearch_)
    - **Filter Value:** value_to_filter

...now you will be able to do the same using the nested fields:

1. **First custom filter portlet:** nested parent query
    - **Filter Query Type:** Nested (_new query type added in this LPS_)
    - **Filter Field:** ddmFieldArray  => _it will be used as the path of the nested query_
    - **Query Name:** nested_query
    - **Parent Query Name:** _(empty)_
2. **Second custom filter portlet:** first match child filter
    - **Filter Query Type:** Match
    - **Filter Field:** ddmFieldArray.ddmFieldName
    - **Filter Value:** ddm__keyword__40635__Field14510226_en_US   (_name of the ddm structure field in elasticsearch_)
    - **Query Name:** _(empty)_
    - **Parent Query Name:** nested_query
3. **Third custom filter portlet:** second match child filter
    - **Filter Query Type:** Match
    - **Filter Field:** ddmFieldArray.ddmFieldValueKeyword_en_US
    - **Filter Value:** value_to_filter
    - **Query Name:** _(empty)_
    - **Parent Query Name:** nested_query

This functionality should be also documented in the official Custom Filter portlet documentation