### PR TITLE
[TS] LPS-124605 Not all available locales are returned by BaseIndexer

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/search/BaseIndexer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/BaseIndexer.java
@@ -703,7 +703,7 @@ public abstract class BaseIndexer<T> implements Indexer<T> {
 				addSelectedLocalizedFieldNames(
 					selectedFieldNames,
 					LocaleUtil.toLanguageIds(
-						LanguageUtil.getSupportedLocales()));
+						LanguageUtil.getAvailableLocales()));
 			}
 			else {
 				addSelectedLocalizedFieldNames(


### PR DESCRIPTION
[LPS-124605](https://issues.liferay.com/browse/LPS-124605)
Dear Team,

Please review my change.

The issue is that we return only fields belonging to supported (i.e. non-beta) locales instead of available (i.e. enabled) locales.

Thank you,
Istvan