### PR TITLE
LPS-126486 FIX: Move of sync-service to archived makes all integration tests fail with "liferay/document_library_sync_event_processor is not available" on Search CI

### DIFF
--- a/portal-test/src/com/liferay/portal/test/rule/DestinationAwaitClassTestRule.java
+++ b/portal-test/src/com/liferay/portal/test/rule/DestinationAwaitClassTestRule.java
@@ -35,9 +35,7 @@ public class DestinationAwaitClassTestRule
 	extends ClassTestRule<Set<CountDownLatch>> {
 
 	public static final DestinationAwaitClassTestRule INSTANCE =
-		new DestinationAwaitClassTestRule(
-			DestinationNames.DOCUMENT_LIBRARY_SYNC_EVENT_PROCESSOR,
-			DestinationNames.HOT_DEPLOY);
+		new DestinationAwaitClassTestRule(DestinationNames.HOT_DEPLOY);
 
 	public DestinationAwaitClassTestRule(String... destinationNames) {
 		_destinationNames = destinationNames;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-126486