### PR TITLE
LPS-127030 Elasticsearch7 unit test NoClassDefFoundError and ExceptionInInitializerError failures

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/configuration/DDMFormWebConfigurationTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/configuration/DDMFormWebConfigurationTest.java
@@ -16,14 +16,22 @@ package com.liferay.dynamic.data.mapping.form.web.internal.configuration;
 
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.util.PropsImpl;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
  * @author Pedro Queiroz
  */
 public class DDMFormWebConfigurationTest {
+
+	@Before
+	public void setUp() {
+		PropsUtil.setProps(new PropsImpl());
+	}
 
 	@Test
 	public void testCreateDefaultDDMFormWebConfiguration() {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/configuration/persistence/listener/DDMFormWebConfigurationModelListenerTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/configuration/persistence/listener/DDMFormWebConfigurationModelListenerTest.java
@@ -16,7 +16,9 @@ package com.liferay.dynamic.data.mapping.form.web.internal.configuration.persist
 
 import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException;
 import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.util.PropsImpl;
 
 import java.util.Dictionary;
 import java.util.Locale;
@@ -41,6 +43,7 @@ public class DDMFormWebConfigurationModelListenerTest extends PowerMockito {
 	@Before
 	public void setUp() {
 		_setUpDDMFormWebConfigurationModelListener();
+		_setUpProps();
 		_setUpResourceBundleUtil();
 	}
 
@@ -58,6 +61,10 @@ public class DDMFormWebConfigurationModelListenerTest extends PowerMockito {
 	private void _setUpDDMFormWebConfigurationModelListener() {
 		_ddmFormWebConfigurationModelListener =
 			new DDMFormWebConfigurationModelListener();
+	}
+
+	private void _setUpProps() {
+		PropsUtil.setProps(new PropsImpl());
 	}
 
 	private void _setUpResourceBundleUtil() {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/upload/DDMFormUploadValidatorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/upload/DDMFormUploadValidatorTest.java
@@ -22,7 +22,9 @@ import com.liferay.dynamic.data.mapping.form.web.internal.configuration.activato
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.util.FileImpl;
+import com.liferay.portal.util.PropsImpl;
 
 import java.io.File;
 
@@ -41,6 +43,7 @@ public class DDMFormUploadValidatorTest {
 
 	@Before
 	public void setUp() throws Exception {
+		setUpProps();
 		setUpDDMFormWebConfigurationActivator();
 		setUpFileUtil();
 	}
@@ -107,6 +110,10 @@ public class DDMFormUploadValidatorTest {
 		FileUtil fileUtil = new FileUtil();
 
 		fileUtil.setFile(FileImpl.getInstance());
+	}
+
+	protected void setUpProps() {
+		PropsUtil.setProps(new PropsImpl());
 	}
 
 	private static final long _FILE_LENGTH_MB = 1024 * 1024;

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compileInclude group: "javax.annotation", name: "javax.annotation-api", version: "1.3"
 
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
@@ -29,6 +30,7 @@ dependencies {
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/test/java/com/liferay/oauth2/provider/rest/internal/spi/bearer/token/provider/DefaultBearerTokenProviderTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/test/java/com/liferay/oauth2/provider/rest/internal/spi/bearer/token/provider/DefaultBearerTokenProviderTest.java
@@ -17,6 +17,8 @@ package com.liferay.oauth2.provider.rest.internal.spi.bearer.token.provider;
 import com.liferay.oauth2.provider.rest.spi.bearer.token.provider.BearerTokenProvider;
 import com.liferay.portal.kernel.security.SecureRandomUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.util.PropsImpl;
 
 import java.util.Map;
 
@@ -38,6 +40,8 @@ public class DefaultBearerTokenProviderTest extends PowerMockito {
 
 	@Before
 	public void setUp() throws Exception {
+		PropsUtil.setProps(new PropsImpl());
+
 		Map<String, Object> properties = HashMapBuilder.<String, Object>put(
 			"access.token.expires.in", _ACCESS_TOKEN_EXPIRES_IN
 		).put(

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-spi")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-string")
 

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/internal/liferay/ScopeLocatorImplTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/internal/liferay/ScopeLocatorImplTest.java
@@ -26,6 +26,8 @@ import com.liferay.oauth2.provider.scope.spi.scope.mapper.ScopeMapper;
 import com.liferay.oauth2.provider.scope.spi.scope.matcher.ScopeMatcherFactory;
 import com.liferay.osgi.service.tracker.collections.ServiceReferenceServiceTuple;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.util.PropsImpl;
 
 import java.lang.reflect.Field;
 
@@ -40,6 +42,7 @@ import java.util.stream.Stream;
 import org.hamcrest.CoreMatchers;
 
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -57,6 +60,11 @@ import org.powermock.modules.junit4.PowerMockRunner;
  */
 @RunWith(PowerMockRunner.class)
 public class ScopeLocatorImplTest extends PowerMockito {
+
+	@BeforeClass
+	public static void setUpClass() {
+		PropsUtil.setProps(new PropsImpl());
+	}
 
 	@Test
 	public void testPrefixHandlerFactoryByNameAndCompany() throws Exception {

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchConnectionHttpTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchConnectionHttpTest.java
@@ -16,7 +16,9 @@ package com.liferay.portal.search.elasticsearch7.internal.connection;
 
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.util.PropsImpl;
 
 import java.io.InputStream;
 
@@ -47,6 +49,8 @@ public class ElasticsearchConnectionHttpTest {
 
 	@BeforeClass
 	public static void setUpClass() {
+		PropsUtil.setProps(new PropsImpl());
+
 		String clusterName = RandomTestUtil.randomString();
 
 		ElasticsearchConnectionFixture elasticsearchConnectionFixture =

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/DocumentFixture.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/DocumentFixture.java
@@ -29,6 +29,8 @@ import com.liferay.portal.kernel.util.PropsUtil;
 
 import java.text.SimpleDateFormat;
 
+import java.util.Properties;
+
 import org.mockito.Mockito;
 
 /**
@@ -116,6 +118,8 @@ public class DocumentFixture {
 				PropsKeys.INDEX_SEARCH_SCORING_ENABLED, "true"
 			).put(
 				PropsKeys.INDEX_SORTABLE_TEXT_FIELDS_TRUNCATED_LENGTH, "255"
+			).put(
+				"configuration.override.", new Properties()
 			).build());
 	}
 

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/batch/BatchIndexingHelperImplBulkSizesTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/batch/BatchIndexingHelperImplBulkSizesTest.java
@@ -16,17 +16,25 @@ package com.liferay.portal.search.internal.batch;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.util.PropsImpl;
 
 import java.util.Arrays;
 import java.util.Collections;
 
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
  * @author André de Oliveira
  */
 public class BatchIndexingHelperImplBulkSizesTest {
+
+	@BeforeClass
+	public static void setUpClass() {
+		PropsUtil.setProps(new PropsImpl());
+	}
 
 	@Test
 	public void testConfiguration() {

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/buffer/IndexerRequestBufferHandlerTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/buffer/IndexerRequestBufferHandlerTest.java
@@ -16,7 +16,9 @@ package com.liferay.portal.search.internal.buffer;
 
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.search.configuration.IndexerRegistryConfiguration;
+import com.liferay.portal.util.PropsImpl;
 
 import java.lang.reflect.Method;
 
@@ -24,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.mockito.Mockito;
@@ -33,6 +36,11 @@ import org.mockito.Mockito;
  * @author André de Oliveira
  */
 public class IndexerRequestBufferHandlerTest {
+
+	@BeforeClass
+	public static void setUpClass() {
+		PropsUtil.setProps(new PropsImpl());
+	}
 
 	public IndexerRequestBufferHandlerTest() throws Exception {
 		_method = Indexer.class.getDeclaredMethod(

--- a/modules/apps/portal-template/portal-template-freemarker/build.gradle
+++ b/modules/apps/portal-template/portal-template-freemarker/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-concurrent")
 	compileOnly project(":core:petra:petra-executor")

--- a/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/FreeMarkerTemplateTest.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/FreeMarkerTemplateTest.java
@@ -23,8 +23,10 @@ import com.liferay.portal.kernel.template.TemplateResource;
 import com.liferay.portal.kernel.template.TemplateResourceCache;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.template.TemplateContextHelper;
 import com.liferay.portal.template.freemarker.configuration.FreeMarkerEngineConfiguration;
+import com.liferay.portal.util.PropsImpl;
 
 import freemarker.cache.TemplateCache;
 
@@ -62,6 +64,8 @@ public class FreeMarkerTemplateTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
+		PropsUtil.setProps(new PropsImpl());
+
 		_templateResourceCache = new FreeMarkerTemplateResourceCache() {
 
 			@Override

--- a/modules/apps/portal-template/portal-template-velocity/build.gradle
+++ b/modules/apps/portal-template/portal-template-velocity/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/portal-template/portal-template-velocity/src/test/java/com/liferay/portal/template/velocity/internal/VelocityTemplateTest.java
+++ b/modules/apps/portal-template/portal-template-velocity/src/test/java/com/liferay/portal/template/velocity/internal/VelocityTemplateTest.java
@@ -24,11 +24,13 @@ import com.liferay.portal.kernel.template.TemplateResourceCache;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.template.ClassLoaderResourceParser;
 import com.liferay.portal.template.TemplateContextHelper;
 import com.liferay.portal.template.velocity.configuration.VelocityEngineConfiguration;
 import com.liferay.portal.util.FileImpl;
+import com.liferay.portal.util.PropsImpl;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -74,6 +76,8 @@ public class VelocityTemplateTest {
 		};
 
 		_velocityTemplateResourceLoader = new VelocityTemplateResourceLoader();
+
+		PropsUtil.setProps(new PropsImpl());
 
 		ReflectionTestUtil.setFieldValue(
 			_velocityTemplateResourceLoader, "_velocityTemplateResourceCache",

--- a/modules/apps/portal/portal-cluster-multiple/build.gradle
+++ b/modules/apps/portal/portal-cluster-multiple/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":apps:static:portal:portal-profile-api")
 	compileOnly project(":core:petra:petra-concurrent")
 	compileOnly project(":core:petra:petra-executor")

--- a/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/ClusterExecutorImplTest.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/ClusterExecutorImplTest.java
@@ -39,6 +39,7 @@ import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 
 import org.junit.Assert;
@@ -381,6 +382,8 @@ public class ClusterExecutorImplTest extends BaseClusterTestCase {
 				).put(
 					PropsKeys.CLUSTER_LINK_CHANNEL_PROPERTIES_CONTROL,
 					"test-channel-properties-control"
+				).put(
+					"configuration.override.", new Properties()
 				).build()));
 
 		clusterExecutorImpl.setClusterChannelFactory(

--- a/modules/dxp/apps/saml/saml-impl/build.gradle
+++ b/modules/dxp/apps/saml/saml-impl/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
@@ -9,6 +10,7 @@ dependencies {
 	compileOnly project(":apps:portal-security:portal-security-export-import-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":core:petra:petra-string")
 	compileOnly project(":dxp:apps:saml:saml-api")

--- a/modules/dxp/apps/saml/saml-impl/src/test/java/com/liferay/saml/runtime/internal/upgrade/UpgradeSamlIdpSsoSessionMaxAgePropertyTest.java
+++ b/modules/dxp/apps/saml/saml-impl/src/test/java/com/liferay/saml/runtime/internal/upgrade/UpgradeSamlIdpSsoSessionMaxAgePropertyTest.java
@@ -18,6 +18,8 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.util.PropsImpl;
 import com.liferay.saml.runtime.configuration.SamlProviderConfiguration;
 import com.liferay.saml.runtime.internal.constants.LegacySamlPropsKeys;
 import com.liferay.saml.runtime.internal.upgrade.v1_0_0.UpgradeSamlIdpSsoSessionMaxAgeProperty;
@@ -26,6 +28,7 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -43,6 +46,11 @@ import org.powermock.modules.junit4.PowerMockRunner;
  */
 @RunWith(PowerMockRunner.class)
 public class UpgradeSamlIdpSsoSessionMaxAgePropertyTest extends PowerMockito {
+
+	@BeforeClass
+	public static void setUpClass() {
+		PropsUtil.setProps(new PropsImpl());
+	}
 
 	@Test
 	public void testSamlProviderPropertyMapping() throws Exception {


### PR DESCRIPTION
Fixes regressions to Unit Tests caused by https://issues.liferay.com/browse/LPS-126920 

Author: @joshuacords 

cc: @brookedalton 