### PR TITLE
[TS] LPS-124886 Cannot exclude Asset Types from search results

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/AssetEntriesSearchFacet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/AssetEntriesSearchFacet.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.SearchEngineHelper;
 import com.liferay.portal.kernel.search.facet.config.FacetConfiguration;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -217,14 +218,22 @@ public class AssetEntriesSearchFacet extends BaseJSPSearchFacet {
 			AssetRendererFactoryRegistryUtil.getAssetRendererFactories(
 				companyId);
 
+		String[] engineHelperAllowedEntryClassNames =
+			searchEngineHelper.getEntryClassNames();
+
 		for (AssetRendererFactory<?> assetRendererFactory :
 				assetRendererFactories) {
 
-			if (!assetRendererFactory.isSearchable()) {
+			String className = assetRendererFactory.getClassName();
+
+			if (!assetRendererFactory.isSearchable() ||
+				!ArrayUtil.contains(
+					engineHelperAllowedEntryClassNames, className, false)) {
+
 				continue;
 			}
 
-			assetTypes.add(assetRendererFactory.getClassName());
+			assetTypes.add(className);
 		}
 
 		return ArrayUtil.toStringArray(assetTypes);
@@ -237,6 +246,9 @@ public class AssetEntriesSearchFacet extends BaseJSPSearchFacet {
 
 	@Reference
 	protected AssetEntriesFacetFactory assetEntriesFacetFactory;
+
+	@Reference
+	protected SearchEngineHelper searchEngineHelper;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		AssetEntriesSearchFacet.class);

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/asset/SearchableAssetClassNamesProviderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/asset/SearchableAssetClassNamesProviderImpl.java
@@ -16,6 +16,7 @@ package com.liferay.portal.search.internal.asset;
 
 import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.portal.kernel.search.SearchEngineHelper;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.search.asset.SearchableAssetClassNamesProvider;
 
@@ -23,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Bryan Engler
@@ -39,17 +41,28 @@ public class SearchableAssetClassNamesProviderImpl
 			AssetRendererFactoryRegistryUtil.getAssetRendererFactories(
 				companyId);
 
+		String[] engineHelperAllowedEntryClassNames =
+			searchEngineHelper.getEntryClassNames();
+
 		for (AssetRendererFactory<?> assetRendererFactory :
 				assetRendererFactories) {
 
-			if (!assetRendererFactory.isSearchable()) {
+			String className = assetRendererFactory.getClassName();
+
+			if (!assetRendererFactory.isSearchable() ||
+				!ArrayUtil.contains(
+					engineHelperAllowedEntryClassNames, className, false)) {
+
 				continue;
 			}
 
-			classNames.add(assetRendererFactory.getClassName());
+			classNames.add(className);
 		}
 
 		return ArrayUtil.toStringArray(classNames);
 	}
+
+	@Reference
+	protected SearchEngineHelper searchEngineHelper;
 
 }


### PR DESCRIPTION
[LPS-124886](https://issues.liferay.com/browse/LPS-124886)
Dear Search Team,

Please review my changes.

**Issue:** In short, Engine Helper configuration - designed for excluding entry class names from search - doesn't take effect. The root of the problem is that we stopped using the Engine Helper configuration, but that change doesn't look intentional.

For **Classic Search** it looks like it stopped working with LPS-121803, when _FacetedSearcherImpl_ stopped using _SearchEngineHelperUtil.getEntryClassNames()_. See [related commit](https://github.com/liferay/liferay-portal-ee/commit/2adbba4945a1034e85df6825cfc4a693dadc35d0).

For **Composite Search** it is wrong because of the following call in _TypeFacetPortletSharedSearchContributor_:
```
searchRequestBuilder.entryClassNames(
 typeFacetPortletPreferences.getCurrentAssetTypesArray(
 themeDisplay.getCompanyId()));
```
But originally it started probably in _TypeFacetPortlet_ with LPS-72998, setting wrong entryClassNames directly on _SearchContext_. See [related commit](https://github.com/liferay/liferay-portal-ee/commit/5687878cb296f81a67527f78e4bd26e2ee9180e6).

**Solution:** Take into account the Engine Helper configuration everywhere we compose the list of searchable entry class names. I've tested the fix for Classic Search, Composite Search and Type Facet widget configuration. 

Please let me know if you have any questions or concerns.

Thank you,
István