### PR TITLE
[TS] LPS-124433 Sort widget no longer works with DDM fields

### DIFF
--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
@@ -718,16 +718,15 @@ public class AssetHelperImpl implements AssetHelper {
 
 		int sortType = _getDDMFormFieldTypeSortType(ddmFormField);
 
-		Sort sort = SortFactoryUtil.getSort(
-			AssetEntry.class, sortType,
-			_getDDMFormFieldTypeOrderByCol(
-				ddmFormField, sortField,
-				_getDDMFormFieldLocalizable(sortField), sortType, locale),
-			false, orderByType);
+		String orderByCol = _getDDMFormFieldTypeOrderByCol(
+			ddmFormField, sortField,
+			_getDDMFormFieldLocalizable(sortField), sortType, locale);
 
-		FieldSort fieldSort = _sorts.field(sort.getFieldName());
+		FieldSort fieldSort = _sorts.field(orderByCol);
 
-		if (sort.isReverse()) {
+		if (Validator.isNotNull(orderByType) &&
+			!StringUtil.equalsIgnoreCase(orderByType, "asc")) {
+
 			fieldSort.setSortOrder(SortOrder.DESC);
 		}
 

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
@@ -693,6 +693,10 @@ public class AssetHelperImpl implements AssetHelper {
 			String orderByType, String sortField, Locale locale)
 		throws Exception {
 
+		if (sortField.startsWith(DDMIndexer.DDM_FIELD_PREFIX)) {
+			return _getSearchSortDDMField(orderByType, sortField, locale);
+		}
+
 		Sort sort = SortFactoryUtil.getSort(
 			AssetEntry.class, _getSortType(sortField),
 			_getOrderByCol(sortField, locale), true, orderByType);
@@ -703,22 +707,25 @@ public class AssetHelperImpl implements AssetHelper {
 			fieldSort.setSortOrder(SortOrder.DESC);
 		}
 
-		if (!sortField.startsWith(DDMIndexer.DDM_FIELD_PREFIX)) {
-			return fieldSort;
-		}
+		return fieldSort;
+	}
+
+	private com.liferay.portal.search.sort.Sort _getSearchSortDDMField(
+			String orderByType, String sortField, Locale locale)
+		throws Exception {
 
 		DDMFormField ddmFormField = _getDDMFormField(sortField);
 
 		int sortType = _getDDMFormFieldTypeSortType(ddmFormField);
 
-		sort = SortFactoryUtil.getSort(
+		Sort sort = SortFactoryUtil.getSort(
 			AssetEntry.class, sortType,
 			_getDDMFormFieldTypeOrderByCol(
 				ddmFormField, sortField,
 				_getDDMFormFieldLocalizable(sortField), sortType, locale),
 			false, orderByType);
 
-		fieldSort = _sorts.field(sort.getFieldName());
+		FieldSort fieldSort = _sorts.field(sort.getFieldName());
 
 		if (sort.isReverse()) {
 			fieldSort.setSortOrder(SortOrder.DESC);

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
@@ -674,7 +674,13 @@ public class AssetHelperImpl implements AssetHelper {
 
 		DDMFormField ddmFormField = _getDDMFormField(sortField);
 
-		if (!GetterUtil.getBoolean(ddmFormField.getProperty("localizable"))) {
+		if (GetterUtil.getBoolean(ddmFormField.getProperty("localizable"))) {
+			if (locale == null) {
+				throw new IllegalArgumentException(
+					"Locale cannot be null if the ddmFormField is localizable");
+			}
+		}
+		else {
 			locale = null;
 		}
 

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
@@ -585,14 +585,6 @@ public class AssetHelperImpl implements AssetHelper {
 		return ddmStructure.getDDMFormField(fieldName);
 	}
 
-	private boolean _getDDMFormFieldLocalizable(String sortField)
-		throws Exception {
-
-		DDMFormField ddmFormField = _getDDMFormField(sortField);
-
-		return GetterUtil.getBoolean(ddmFormField.getProperty("localizable"));
-	}
-
 	private String _getDDMFormFieldTypeOrderByCol(
 		String ddmFormField, String ddmFormFieldType, Locale locale) {
 
@@ -682,7 +674,7 @@ public class AssetHelperImpl implements AssetHelper {
 
 		DDMFormField ddmFormField = _getDDMFormField(sortField);
 
-		if (!_getDDMFormFieldLocalizable(sortField)) {
+		if (!GetterUtil.getBoolean(ddmFormField.getProperty("localizable"))) {
 			locale = null;
 		}
 

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataRecordResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataRecordResourceImpl.java
@@ -32,8 +32,6 @@ import com.liferay.dynamic.data.lists.model.DDLRecordSetVersion;
 import com.liferay.dynamic.data.lists.service.DDLRecordLocalService;
 import com.liferay.dynamic.data.lists.service.DDLRecordSetLocalService;
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldTypeServicesTracker;
-import com.liferay.dynamic.data.mapping.model.DDMFormField;
-import com.liferay.dynamic.data.mapping.model.DDMFormFieldType;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMStructureVersion;
 import com.liferay.dynamic.data.mapping.service.DDMStorageLinkLocalService;
@@ -62,7 +60,6 @@ import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.odata.entity.EntityField;
@@ -71,7 +68,6 @@ import com.liferay.portal.odata.entity.StringEntityField;
 import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.query.Queries;
 import com.liferay.portal.search.sort.FieldSort;
-import com.liferay.portal.search.sort.NestedSort;
 import com.liferay.portal.search.sort.SortOrder;
 import com.liferay.portal.search.sort.Sorts;
 import com.liferay.portal.vulcan.pagination.Page;
@@ -231,7 +227,7 @@ public class DataRecordResourceImpl
 					_searchRequestBuilderFactory.builder(
 						searchContext
 					).sorts(
-						_getFieldSorts(ddlRecordSet.getDDMStructure(), sorts)
+						_getSearchSorts(ddlRecordSet.getDDMStructure(), sorts)
 					);
 				}
 
@@ -443,10 +439,8 @@ public class DataRecordResourceImpl
 
 				fieldBooleanFilter.add(
 					_ddmIndexer.createFieldValueQueryFilter(
-						_getIndexFieldName(
-							ddmStructure.getStructureId(), fieldName,
-							contextAcceptLanguage.getPreferredLocale()),
-						value, contextAcceptLanguage.getPreferredLocale()),
+						ddmStructure, fieldName, value,
+						contextAcceptLanguage.getPreferredLocale()),
 					BooleanClauseOccur.SHOULD);
 			}
 
@@ -484,76 +478,31 @@ public class DataRecordResourceImpl
 		return ddlRecordSet.getRecordSetId();
 	}
 
-	private FieldSort[] _getFieldSorts(DDMStructure ddmStructure, Sort[] sorts)
+	private com.liferay.portal.search.sort.Sort[] _getSearchSorts(
+			DDMStructure ddmStructure, Sort[] sorts)
 		throws PortalException {
 
-		List<FieldSort> fieldSorts = new ArrayList<>();
+		List<com.liferay.portal.search.sort.Sort> searchSorts =
+			new ArrayList<>();
 
 		for (Sort sort : sorts) {
 			String fieldName = sort.getFieldName();
 
-			FieldSort fieldSort = _sorts.field(
-				_getSortableFieldName(ddmStructure, fieldName));
+			SortOrder sortOrder = SortOrder.ASC;
 
 			if (sort.isReverse()) {
-				fieldSort.setSortOrder(SortOrder.DESC);
+				sortOrder = SortOrder.DESC;
 			}
 
-			NestedSort nestedSort = _sorts.nested(DDMIndexer.DDM_FIELD_ARRAY);
+			com.liferay.portal.search.sort.Sort searchSort =
+				_ddmIndexer.createDDMStructureFieldSort(
+					ddmStructure, fieldName,
+					contextAcceptLanguage.getPreferredLocale(), sortOrder);
 
-			nestedSort.setFilterQuery(
-				_queries.term(
-					StringBundler.concat(
-						DDMIndexer.DDM_FIELD_ARRAY, StringPool.PERIOD,
-						DDMIndexer.DDM_FIELD_NAME),
-					_getIndexFieldName(
-						ddmStructure.getStructureId(), fieldName,
-						contextAcceptLanguage.getPreferredLocale())));
-
-			fieldSort.setNestedSort(nestedSort);
-
-			fieldSorts.add(fieldSort);
+			searchSorts.add(searchSort);
 		}
 
-		return fieldSorts.toArray(new FieldSort[0]);
-	}
-
-	private String _getIndexFieldName(
-		long ddmStructureId, String fieldName, Locale locale) {
-
-		return _ddmIndexer.encodeName(ddmStructureId, fieldName, locale);
-	}
-
-	private String _getSortableFieldName(
-			DDMStructure ddmStructure, String fieldName)
-		throws PortalException {
-
-		StringBundler sb = new StringBundler(5);
-
-		sb.append(DDMIndexer.DDM_FIELD_ARRAY);
-		sb.append(StringPool.PERIOD);
-		sb.append(
-			_ddmIndexer.getValueFieldName(
-				ddmStructure.getFieldProperty(fieldName, "indexType"),
-				contextAcceptLanguage.getPreferredLocale()));
-		sb.append(StringPool.UNDERLINE);
-
-		DDMFormField ddmFormField = ddmStructure.getDDMFormField(fieldName);
-
-		String ddmFormFieldType = ddmFormField.getType();
-
-		if (StringUtil.equals(ddmFormFieldType, DDMFormFieldType.DECIMAL) ||
-			StringUtil.equals(ddmFormFieldType, DDMFormFieldType.INTEGER) ||
-			StringUtil.equals(ddmFormFieldType, DDMFormFieldType.NUMBER) ||
-			StringUtil.equals(ddmFormFieldType, DDMFormFieldType.NUMERIC)) {
-
-			sb.append("Number");
-		}
-		else {
-			sb.append("String");
-		}
-
-		return Field.getSortableFieldName(sb.toString());
+		return searchSorts.toArray(new FieldSort[0]);
 	}
 
 	private DataRecord _toDataRecord(DDLRecord ddlRecord) throws Exception {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:journal:journal-article-dynamic-data-mapping-form-field-type-api")
 	compileOnly project(":apps:layout:layout-dynamic-data-mapping-form-field-type-api")
+	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:osgi-service-tracker-collections")

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMIndexer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMIndexer.java
@@ -53,8 +53,18 @@ public interface DDMIndexer {
 		DDMFormValues ddmFormValues);
 
 	public Sort createDDMStructureFieldSort(
-		String ddmStructureFieldName,Locale locale, SortOrder sortOrder)
-	throws PortalException;
+			DDMStructure ddmStructure, String fieldName, Locale locale,
+			SortOrder sortOrder)
+		throws PortalException;
+
+	public Sort createDDMStructureFieldSort(
+			String ddmStructureFieldName, Locale locale, SortOrder sortOrder)
+		throws PortalException;
+
+	public QueryFilter createFieldValueQueryFilter(
+			DDMStructure ddmStructure, String fieldName, Serializable value,
+			Locale locale)
+		throws Exception;
 
 	public QueryFilter createFieldValueQueryFilter(
 			String ddmStructureFieldName, Serializable ddmStructureFieldValue,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMIndexer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMIndexer.java
@@ -17,8 +17,11 @@ package com.liferay.dynamic.data.mapping.util;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.filter.QueryFilter;
+import com.liferay.portal.search.sort.Sort;
+import com.liferay.portal.search.sort.SortOrder;
 
 import java.io.Serializable;
 
@@ -48,6 +51,10 @@ public interface DDMIndexer {
 	public void addAttributes(
 		Document document, DDMStructure ddmStructure,
 		DDMFormValues ddmFormValues);
+
+	public Sort createDDMStructureFieldSort(
+		String ddmStructureFieldName,Locale locale, SortOrder sortOrder)
+	throws PortalException;
 
 	public QueryFilter createFieldValueQueryFilter(
 			String ddmStructureFieldName, Serializable ddmStructureFieldValue,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/search/sort/SortUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/search/sort/SortUtil.java
@@ -16,11 +16,11 @@ package com.liferay.headless.delivery.internal.search.sort;
 
 import com.liferay.dynamic.data.mapping.util.DDMIndexer;
 import com.liferay.headless.delivery.internal.dynamic.data.mapping.DDMStructureField;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.search.query.Queries;
 import com.liferay.portal.search.searcher.SearchRequestBuilder;
-import com.liferay.portal.search.sort.FieldSort;
-import com.liferay.portal.search.sort.NestedSort;
 import com.liferay.portal.search.sort.SortOrder;
 import com.liferay.portal.search.sort.Sorts;
 
@@ -33,10 +33,12 @@ import java.util.List;
 public class SortUtil {
 
 	public static void processSorts(
-		DDMIndexer ddmIndexer, SearchRequestBuilder searchRequestBuilder,
-		Sort[] oldSorts, Queries queries, Sorts sorts) {
+			DDMIndexer ddmIndexer, SearchRequestBuilder searchRequestBuilder,
+			Sort[] oldSorts, Queries queries, Sorts sorts)
+		throws PortalException {
 
-		List<FieldSort> fieldSorts = new ArrayList<>();
+		List<com.liferay.portal.search.sort.Sort> searchSorts =
+			new ArrayList<>();
 
 		for (Sort oldSort : oldSorts) {
 			String sortFieldName = oldSort.getFieldName();
@@ -46,7 +48,7 @@ public class SortUtil {
 			if (!sortFieldName.startsWith(DDMIndexer.DDM_FIELD_PREFIX) ||
 				ddmIndexer.isLegacyDDMIndexFieldsEnabled()) {
 
-				fieldSorts.add(sorts.field(sortFieldName, sortOrder));
+				searchSorts.add(sorts.field(sortFieldName, sortOrder));
 
 				continue;
 			}
@@ -54,23 +56,15 @@ public class SortUtil {
 			DDMStructureField ddmStructureField = DDMStructureField.from(
 				sortFieldName);
 
-			FieldSort fieldSort = sorts.field(
-				ddmStructureField.getDDMStructureNestedTypeSortableFieldName(),
-				sortOrder);
-
-			NestedSort nestedSort = sorts.nested(DDMIndexer.DDM_FIELD_ARRAY);
-
-			nestedSort.setFilterQuery(
-				queries.term(
-					DDMStructureField.getNestedFieldName(),
-					ddmStructureField.getDDMStructureFieldName()));
-
-			fieldSort.setNestedSort(nestedSort);
-
-			fieldSorts.add(fieldSort);
+			searchSorts.add(
+				ddmIndexer.createDDMStructureFieldSort(
+					ddmStructureField.getDDMStructureFieldName(),
+					LocaleUtil.fromLanguageId(ddmStructureField.getLocale()),
+					sortOrder));
 		}
 
-		searchRequestBuilder.sorts(fieldSorts.toArray(new FieldSort[0]));
+		searchRequestBuilder.sorts(
+			searchSorts.toArray(new com.liferay.portal.search.sort.Sort[0]));
 	}
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-124433

In order to solve this issue, I have created two new `createDDMStructureFieldSort` methods in the DDMIndexer class that creates the correct Sort configuration for the Nested and the Legacy cases.

The new `createDDMStructureFieldSort` methods are applied into the four places where we are sorting a search query with DDM fields:

1. AssetHelperImpl (used by the asset publisher and other asset-related functionality)
2. Data Engine (DataRecordResourceImpl.java)
3. Headless API (SortUtil.java)
4. Sort widget => new usage

For 1st, 2nd, and 3rd cases, I am replacing the existing direct search API usage with a call to the new createDDMStructureFieldSort method
In the fourth case, I am adding a new usage of this createDDMStructureFieldSort in order to solve the issue reported in this LPS.

Let me know if you have any question.

Thank you,
Jorge