### PR TITLE
[TS] LPS-121251 Thumbnails and icons do not show in search results

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/asset/model/LayoutAssetRendererFactory.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/asset/model/LayoutAssetRendererFactory.java
@@ -100,6 +100,11 @@ public class LayoutAssetRendererFactory
 	}
 
 	@Override
+	public String getIconCssClass() {
+		return "page";
+	}
+
+	@Override
 	public String getType() {
 		return TYPE;
 	}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultSummaryDisplayBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultSummaryDisplayBuilder.java
@@ -610,6 +610,9 @@ public class SearchResultSummaryDisplayBuilder {
 			}
 		}
 		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception, exception);
+			}
 		}
 
 		SearchResultImage searchResultImage = new SearchResultImage() {

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultSummaryDisplayBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultSummaryDisplayBuilder.java
@@ -53,6 +53,7 @@ import com.liferay.portal.search.web.internal.result.display.context.SearchResul
 import com.liferay.portal.search.web.internal.result.display.context.SearchResultSummaryDisplayContext;
 import com.liferay.portal.search.web.internal.util.SearchStringUtil;
 import com.liferay.portal.search.web.internal.util.SearchUtil;
+import com.liferay.portal.search.web.search.result.SearchResultImage;
 import com.liferay.portal.search.web.search.result.SearchResultImageContributor;
 
 import java.text.DateFormat;
@@ -610,6 +611,39 @@ public class SearchResultSummaryDisplayBuilder {
 		}
 		catch (Exception exception) {
 		}
+
+		SearchResultImage searchResultImage = new SearchResultImage() {
+
+			@Override
+			public String getClassName() {
+				return assetRenderer.getClassName();
+			}
+
+			@Override
+			public long getClassPK() {
+				return assetRenderer.getClassPK();
+			}
+
+			@Override
+			public void setIcon(String iconName) {
+				searchResultSummaryDisplayContext.setIconId(iconName);
+				searchResultSummaryDisplayContext.setIconVisible(true);
+				searchResultSummaryDisplayContext.setPathThemeImages(
+					_themeDisplay.getPathThemeImages());
+			}
+
+			@Override
+			public void setThumbnail(String thumbnailURLString) {
+				searchResultSummaryDisplayContext.setThumbnailURLString(
+					thumbnailURLString);
+				searchResultSummaryDisplayContext.setThumbnailVisible(true);
+			}
+
+		};
+
+		_searchResultImageContributorsStream.forEach(
+			searchResultImageContributor ->
+				searchResultImageContributor.contribute(searchResultImage));
 	}
 
 	protected void buildLocaleReminder(

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultSummaryDisplayBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultSummaryDisplayBuilder.java
@@ -362,6 +362,8 @@ public class SearchResultSummaryDisplayBuilder {
 			summary.getTitle());
 		searchResultSummaryDisplayContext.setPortletURL(
 			_portletURLFactory.getPortletURL());
+		searchResultSummaryDisplayContext.setTitle(
+			assetRenderer.getTitle(summary.getLocale()));
 
 		if (_abridged) {
 			return searchResultSummaryDisplayContext;

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/search-results/_display_list.scss
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/search-results/_display_list.scss
@@ -20,6 +20,15 @@
 		}
 	}
 
+	.search-asset-type-sticker {
+		margin-top: 0.1rem;
+	}
+
+	.search-result-thumbnail-img {
+		margin-top: 0.5rem;
+		width: 2rem;
+	}
+
 	.table-details {
 		td,
 		th {

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/template/dependencies/portlet_display_template_card.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/template/dependencies/portlet_display_template_card.ftl
@@ -10,7 +10,7 @@
 					<div class="card card-type-asset file-card">
 						<div class="aspect-ratio card-item-first">
 							<#if entry.isThumbnailVisible()>
-								<img alt="${entry.getTitle()}" class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-vertical-fluid" src="${entry.getThumbnailURLString()}" />
+								<img alt="${htmlUtil.escape(entry.getTitle())}" class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-vertical-fluid" src="${entry.getThumbnailURLString()}" />
 							<#else>
 								<div class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-vertical-fluid card-type-asset-icon">
 									<@clay.icon symbol="${(entry.isIconVisible())?then(entry.getIconId(),'web-content')}" />

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/template/dependencies/portlet_display_template_list.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/template/dependencies/portlet_display_template_list.ftl
@@ -15,9 +15,7 @@
 
 							<#if entry.isThumbnailVisible()>
 								<img alt="${languageUtil.get(locale, "thumbnail")}" class="rounded search-result-thumbnail-img" src="${entry.getThumbnailURLString()}" />
-							</#if>
-
-							<#if entry.isIconVisible()>
+							<#elseif entry.isIconVisible()>
 								<span class="search-asset-type-sticker sticker sticker-rounded sticker-secondary sticker-static">
 									<@clay.icon symbol="${entry.getIconId()}" />
 								</span>


### PR DESCRIPTION
Hi team,

According to [PTR-2230](https://issues.liferay.com/browse/PTR-2230)'s conclusions, I have been working on Tibor's proposal to fix [LPS-121251](https://issues.liferay.com/browse/LPS-121251) checking that all views are functional with any type of asset and trying to keep the appearance of thumbnails and icons as consistent as in other similar views, hence the decision of not showing the icon if there is a thumbnail set for a specific search result in list view. Hope it makes sense for you as well.

I have also reduced the size of the thumbnail to 0.5rem to keep the alignment among search results.

Finally, I found beneficial for developers to override the default icons and thumbnails so I kept the existing extension point based on SearchResultImageContributors.

Could you please review it?

Please, let me know if further clarifications are needed.

Thanks in advance