### PR TITLE
LPS-128402 portal-search-test: fix flaky FacetedSearcherTest

### DIFF
--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FacetedSearcherTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FacetedSearcherTest.java
@@ -103,6 +103,10 @@ public class FacetedSearcherTest extends BaseFacetedSearcherTestCase {
 			SearchContext searchContext)
 		throws Exception {
 
+		String[] userClassName = {User.class.getName()};
+
+		searchContext.setEntryClassNames(userClassName);
+
 		Hits hits = search(searchContext);
 
 		assertTags(keywords, hits, expected, searchContext);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-128402

Prevents other class types, such as the Hello World content page, from being found by the random prefix.

Author: @joshuacords 
