### PR TITLE
Lps xxxxxx test role ids permission in prefilter

### DIFF
--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/searcher/test/RoleIdEntryClassNameRelationshipTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/searcher/test/RoleIdEntryClassNameRelationshipTest.java
@@ -68,43 +68,76 @@ import org.junit.runner.RunWith;
 /**
  * @author Wade Cao
  * 
- * From test results, once moving roleId array to top/bottom
+ * From test results, once moving roleId array and other permissions to top
  * in the boolean prefilter from associated within entryClassName,
- * We get one more result of document(the modelIndexerClassNames 
- * has 3 different class model indexers for the testing) which is 
- * not expected document returned. The resource permission looks 
- * like not be impacted by moving the roleId array location.
+ * everything but perhaps CPDefinition would remain the same. The resource
+ * permission looks like not be impacted by moving the roleId array location.
  * and all scores are identical except an extra document sneaked in. 
  * 
- * After moving the rolId to top or bottom. The json for pre-filter
+ * After moving the roleId and other permissions to top. The json for pre-filter
  * looks like the following:
+ * "filter": [
  * {
- *	"bool":{
- *	 "must":[
- *		 ......
- *		 {
- *          "term":{
- *              "entryClassName":{
- *                  "value":"com.liferay.knowledge.base.model.KBArticle"
- *               }
- *          }
- *       },                                 
- *       {
- *          "bool":{
- *              "should":[
- *                  {
- *                     "terms":{
- *                         "roleId":[
- *                              "20110"
- *                          ]
- *                      }
- *                  }
- *               ]
- *           }
- *       }
- *     ]
- *   }
- * }
+ * 	"bool": {
+ * 		"must": [
+ * 		{
+ * 			"term": {
+ * 				"companyId": {
+ * 					"value": "20100"
+ * 				}
+ * 			}
+ * 		},
+ * 		{
+ * 			"bool": {
+ * 				"must": [
+ * 				{
+ * 					"bool": {
+ * 						"should": [
+ * 						{
+ * 							"term": {
+ * 								"userId": {
+ * 									"value": "20105"
+ * 								}
+ * 							}
+ * 						},
+ * 						{
+ * 							"terms": {
+ * 								"roleId": [
+ * 									"20109"
+ * 								]
+ * 							}
+ * 						},
+ * 						{
+ * 							"terms": {
+ * 								"roleIds": [
+ * 									"20109"
+ * 								]
+ * 							}
+ * 						},
+ * 						{
+ * 							"terms": {
+ * 								"sharedToUserId": [
+ * 									"20105"
+ * 								]
+ * 							}
+ * 						}]
+ * 					}
+ * 				}]
+ * 			}
+ * 		},
+ * 		{
+ * 			"bool": {
+ * 				"should": [
+ * 					{
+ * 						"bool": {
+ * 							"must": [
+ * 							{
+ * 								"term": {
+ * 									"entryClassName": {
+ * 										"value": "com.liferay.wiki.model.WikiPage"
+ * 									}
+ * 								}
+ * 							}, ...
  * 
  */
 @DataGuard(scope = DataGuard.Scope.METHOD)
@@ -237,7 +270,8 @@ public class RoleIdEntryClassNameRelationshipTest {
 
 		//****The result is NOT matched with one more document****//
 		//****which is also not one of no-indexable/no-viewable ****//
-		Assert.assertNotEquals(documents1.length, documents2.length);
+		//Assert.assertNotEquals(documents1.length, documents2.length);
+		Assert.assertEquals(documents1.length, documents2.length);
 
 		//The score values are matched with the previous query on 
 		//corresponding document except the extra one
@@ -299,7 +333,7 @@ public class RoleIdEntryClassNameRelationshipTest {
 
 		//****The result is NOT matched with one more document****//
 		//****which is also not one of no-indexable/no-viewable ****//
-		Assert.assertNotEquals(documents1.length, documents2.length);
+		Assert.assertEquals(documents1.length, documents2.length);
 
 		//The score values are matched with the previous query on 
 		//corresponding document except the extra one

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchPermissionCheckerImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchPermissionCheckerImpl.java
@@ -177,6 +177,66 @@ public class SearchPermissionCheckerImpl implements SearchPermissionChecker {
 		}
 	}
 
+	public final Collection<SearchPermissionFilterContributor>
+		_searchPermissionFilterContributors = new CopyOnWriteArrayList<>();
+
+	public static class SearchPermissionContext implements Serializable {
+
+		public boolean containsGroupId(long groupId) {
+			for (UsersGroupIdRoles usersGroupIdRoles : _usersGroupIdsRoles) {
+				if (groupId == usersGroupIdRoles._groupId) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		public final TermsFilter _rolesTermsFilter = new TermsFilter(
+			Field.ROLE_ID);
+
+		private SearchPermissionContext(
+			Set<Role> roles, List<UsersGroupIdRoles> usersGroupIdsRoles) {
+
+			_usersGroupIdsRoles = usersGroupIdsRoles;
+
+			List<Long> roleIds = new ArrayList<>(roles.size());
+			List<Long> regularRoleIds = new ArrayList<>();
+
+			for (Role role : roles) {
+				roleIds.add(role.getRoleId());
+
+				if (role.getType() == RoleConstants.TYPE_REGULAR) {
+					regularRoleIds.add(role.getRoleId());
+				}
+
+				_rolesTermsFilter.addValue(String.valueOf(role.getRoleId()));
+			}
+
+			_roleIds = ArrayUtil.toLongArray(roleIds);
+			_regularRoleIds = ArrayUtil.toLongArray(regularRoleIds);
+
+			for (UsersGroupIdRoles usersGroupIdRoles : _usersGroupIdsRoles) {
+				long groupId = usersGroupIdRoles._groupId;
+				List<Role> groupRoles = usersGroupIdRoles._groupRoles;
+
+				for (Role groupRole : groupRoles) {
+					_groupRolesTermsFilter.addValue(
+						groupId + StringPool.DASH + groupRole.getRoleId());
+				}
+			}
+		}
+
+		private static final long serialVersionUID = 1L;
+
+		public final TermsFilter _groupRolesTermsFilter = new TermsFilter(
+			Field.GROUP_ROLE_ID);
+		private final long[] _regularRoleIds;
+		private final long[] _roleIds;
+		private final List<UsersGroupIdRoles> _usersGroupIdsRoles;
+
+	}
+
 	@Activate
 	@Modified
 	protected void activate(Map<String, Object> properties) {
@@ -501,7 +561,7 @@ public class SearchPermissionCheckerImpl implements SearchPermissionChecker {
 
 		searchContext.setAttribute(
 			"searchPermissionContext", searchPermissionContext);
-		
+
 		return _getPermissionFilter(
 			companyId, searchGroupIds, userId, permissionChecker,
 			_getPermissionName(searchContext, className),
@@ -520,11 +580,11 @@ public class SearchPermissionCheckerImpl implements SearchPermissionChecker {
 
 		BooleanFilter booleanFilter = new BooleanFilter();
 
-		if (userId > 0) {
-			booleanFilter.add(
-				new TermFilter(Field.USER_ID, String.valueOf(userId)),
-				BooleanClauseOccur.SHOULD);
-		}
+		//		if (userId > 0) {
+		//			booleanFilter.add(
+		//				new TermFilter(Field.USER_ID, String.valueOf(userId)),
+		//				BooleanClauseOccur.SHOULD);
+		//		}
 
 		TermsFilter groupRolesTermsFilter =
 			searchPermissionContext._groupRolesTermsFilter;
@@ -584,22 +644,28 @@ public class SearchPermissionCheckerImpl implements SearchPermissionChecker {
 			}
 		}
 
-		_add(booleanFilter, groupRolesTermsFilter);
-		_add(booleanFilter, groupsTermsFilter);
-		
-		if (searchContext.getAttribute("testMoveupRolesTermsFilter") == null)  {
+		if (searchContext.getAttribute("testMoveupRolesTermsFilter") == null) {
+			if (userId > 0) {
+				booleanFilter.add(
+					new TermFilter(Field.USER_ID, String.valueOf(userId)),
+					BooleanClauseOccur.SHOULD);
+			}
+			_add(booleanFilter, groupRolesTermsFilter);
 			_add(booleanFilter, rolesTermsFilter);
+
+			for (SearchPermissionFilterContributor
+					searchPermissionFilterContributor :
+						_searchPermissionFilterContributors) {
+
+				searchPermissionFilterContributor.contribute(
+					booleanFilter, companyId, groupIds, userId,
+					permissionChecker, className);
+			}
 		}
+
+		_add(booleanFilter, groupsTermsFilter);
+		//_add(booleanFilter, groupRolesTermsFilter);
 		//_add(booleanFilter, rolesTermsFilter);
-
-		for (SearchPermissionFilterContributor
-				searchPermissionFilterContributor :
-					_searchPermissionFilterContributors) {
-
-			searchPermissionFilterContributor.contribute(
-				booleanFilter, companyId, groupIds, userId, permissionChecker,
-				className);
-		}
 
 		if (!booleanFilter.hasClauses()) {
 			return null;
@@ -623,64 +689,6 @@ public class SearchPermissionCheckerImpl implements SearchPermissionChecker {
 
 	private final Collection<SearchPermissionFieldContributor>
 		_searchPermissionFieldContributors = new CopyOnWriteArrayList<>();
-	private final Collection<SearchPermissionFilterContributor>
-		_searchPermissionFilterContributors = new CopyOnWriteArrayList<>();
-
-	public static class SearchPermissionContext implements Serializable {
-
-		public boolean containsGroupId(long groupId) {
-			for (UsersGroupIdRoles usersGroupIdRoles : _usersGroupIdsRoles) {
-				if (groupId == usersGroupIdRoles._groupId) {
-					return true;
-				}
-			}
-
-			return false;
-		}
-
-		private SearchPermissionContext(
-			Set<Role> roles, List<UsersGroupIdRoles> usersGroupIdsRoles) {
-
-			_usersGroupIdsRoles = usersGroupIdsRoles;
-
-			List<Long> roleIds = new ArrayList<>(roles.size());
-			List<Long> regularRoleIds = new ArrayList<>();
-
-			for (Role role : roles) {
-				roleIds.add(role.getRoleId());
-
-				if (role.getType() == RoleConstants.TYPE_REGULAR) {
-					regularRoleIds.add(role.getRoleId());
-				}
-
-				_rolesTermsFilter.addValue(String.valueOf(role.getRoleId()));
-			}
-
-			_roleIds = ArrayUtil.toLongArray(roleIds);
-			_regularRoleIds = ArrayUtil.toLongArray(regularRoleIds);
-
-			for (UsersGroupIdRoles usersGroupIdRoles : _usersGroupIdsRoles) {
-				long groupId = usersGroupIdRoles._groupId;
-				List<Role> groupRoles = usersGroupIdRoles._groupRoles;
-
-				for (Role groupRole : groupRoles) {
-					_groupRolesTermsFilter.addValue(
-						groupId + StringPool.DASH + groupRole.getRoleId());
-				}
-			}
-		}
-
-		private static final long serialVersionUID = 1L;
-
-		private final TermsFilter _groupRolesTermsFilter = new TermsFilter(
-			Field.GROUP_ROLE_ID);
-		private final long[] _regularRoleIds;
-		private final long[] _roleIds;
-		public final TermsFilter _rolesTermsFilter = new TermsFilter(
-			Field.ROLE_ID);
-		private final List<UsersGroupIdRoles> _usersGroupIdsRoles;
-
-	}
 
 	private static class UsersGroupIdRoles implements Serializable {
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/PreFilterContributorHelperImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/PreFilterContributorHelperImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.search.internal.indexer;
 
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Indexer;
@@ -23,6 +24,7 @@ import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchPermissionChecker;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.search.filter.TermFilter;
 import com.liferay.portal.kernel.search.filter.TermsFilter;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.search.internal.SearchPermissionCheckerImpl.SearchPermissionContext;
@@ -66,11 +68,12 @@ public class PreFilterContributorHelperImpl
 					entryClassName, indexer, searchContext),
 				BooleanClauseOccur.SHOULD);
 		}
-		
-		if (searchContext.getAttribute("testMoveupRolesTermsFilter") != null)  {
-			_addRolesTermsFilter(preFilterBooleanFilter, searchContext);
+
+		if (searchContext.getAttribute("testMoveupRolesTermsFilter") != null) {
+			//need to add permissions clause at higher level alongside companyId
+			_addRolesTermsFilter(booleanFilter, searchContext);
 		}
-	
+
 		if (preFilterBooleanFilter.hasClauses()) {
 			booleanFilter.add(preFilterBooleanFilter, BooleanClauseOccur.MUST);
 		}
@@ -174,6 +177,90 @@ public class PreFilterContributorHelperImpl
 				booleanFilter, searchContext));
 	}
 
+	private void _addRolesTermsFilter(
+		BooleanFilter booleanFilter, SearchContext searchContext) {
+
+		long userId = searchContext.getUserId();
+
+		if (userId == 0) {
+			return;
+		}
+
+		SearchPermissionContext searchPermissionContext = null;
+
+		try {
+			searchPermissionContext =
+				(SearchPermissionContext)searchContext.getAttribute(
+					"searchPermissionContext");
+		}
+		catch (Exception exception) {
+			return;
+		}
+
+		TermsFilter groupRolesTermsFilter =
+			searchPermissionContext._groupRolesTermsFilter;
+
+		TermsFilter rolesTermsFilter =
+			searchPermissionContext._rolesTermsFilter;
+
+		if (!rolesTermsFilter.isEmpty()) {
+			BooleanFilter permissionClauseFilter = new BooleanFilter();
+
+			if (userId > 0) {
+				//From SearchPermissionCheckerImpl._getPermissionFilter
+				permissionClauseFilter.add(
+					new TermFilter(Field.USER_ID, String.valueOf(userId)),
+					BooleanClauseOccur.SHOULD);
+
+				//From SharingEntrySearchPermissionFilterContributor
+				TermsFilter termsFilter = new TermsFilter("sharedToUserId");
+
+				termsFilter.addValue(String.valueOf(userId));
+
+				_add(permissionClauseFilter, termsFilter);
+			}
+
+			_add(permissionClauseFilter, groupRolesTermsFilter);
+			_add(permissionClauseFilter, rolesTermsFilter);
+
+			_contributeUserSearchPermissionFilters(booleanFilter);
+
+			booleanFilter.add(permissionClauseFilter, BooleanClauseOccur.MUST);
+		}
+	}
+
+	private void _add(BooleanFilter booleanFilter, TermsFilter termsFilter) {
+		if (!termsFilter.isEmpty()) {
+			booleanFilter.add(termsFilter, BooleanClauseOccur.SHOULD);
+		}
+	}
+
+	private void _contributeUserSearchPermissionFilters(
+		BooleanFilter booleanFilter) {
+
+		for (BooleanClause<Filter> clause :
+				booleanFilter.getShouldBooleanClauses()) {
+
+			if (clause.getClause() instanceof TermsFilter) {
+				TermsFilter termsFilter = (TermsFilter)clause.getClause();
+
+				String field = termsFilter.getField();
+
+				if (field.equals(Field.ROLE_ID)) {
+					TermsFilter roleIdsTermsFilter = new TermsFilter(
+						Field.ROLE_IDS);
+
+					roleIdsTermsFilter.addValues(termsFilter.getValues());
+
+					booleanFilter.add(roleIdsTermsFilter);
+
+					break;
+				}
+			}
+		}
+	}
+
+	// From UserSearchPermissionFilterContributor
 	private Filter _createPreFilterForEntryClassName(
 		String entryClassName, Indexer<?> indexer,
 		SearchContext searchContext) {
@@ -184,42 +271,13 @@ public class PreFilterContributorHelperImpl
 			Field.ENTRY_CLASS_NAME, entryClassName, BooleanClauseOccur.MUST);
 
 		_addPermissionFilter(booleanFilter, entryClassName, searchContext);
-		
+
 		_addIndexerProvidedPreFilters(booleanFilter, indexer, searchContext);
 
 		_addModelProvidedPreFilters(
 			booleanFilter, _getModelSearchSettings(indexer), searchContext);
 
 		return booleanFilter;
-	}
-
-	private void _addRolesTermsFilter(
-		BooleanFilter booleanFilter, SearchContext searchContext) {
-		if (searchContext.getUserId() == 0) {
-			return;
-		}
-		
-		SearchPermissionContext searchPermissionContext = null;
-		
-		try {
-			searchPermissionContext = 
-				(SearchPermissionContext)searchContext.getAttribute(
-					"searchPermissionContext");
-		} catch (Exception exception) {
-			return;
-		}
-				
-		TermsFilter rolesTermsFilter =
-			searchPermissionContext._rolesTermsFilter;
-		
-		if (!rolesTermsFilter.isEmpty()) {
-			BooleanFilter roleBooleanFilter = new BooleanFilter();
-			
-			roleBooleanFilter.add(rolesTermsFilter, BooleanClauseOccur.SHOULD);
-			
-			booleanFilter.add(roleBooleanFilter);
-		}
-		
 	}
 
 	private ModelSearchSettings _getModelSearchSettings(Indexer<?> indexer) {


### PR DESCRIPTION
Hi @wcao20170619,

This was a very good test. I built on it and was able to get the results to be the same. An important aspect is to keep all the permission type logic in the same clause. userId, roleIds, groupRoleIds, etc need to stick together. I also needed to put the permission clause at the top level. 

While all the tests now pass with equivalent results, I did find one model contributor which I suspect will not work by moving permissions to the top level. Our good special friend CPDefinition (from Commerce). All other contributors have the same permission clause EXCEPT CPDefinition, which means searches for that Asset type return no results using the top level permission. I supposed there are ways to fix this, for example nest with the permission logic