### PR TITLE
[Test] LPS-129828 SynonymSearchTest integration test fails when run with a remote Elasticsearch server

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web-test/build.gradle
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web-test/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	testIntegrationCompile group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	testIntegrationCompile group: "org.osgi", name: "org.osgi.service.cm", version: "1.5.0"
 	testIntegrationCompile project(":apps:journal:journal-api")
 	testIntegrationCompile project(":apps:journal:journal-test-util")
 	testIntegrationCompile project(":apps:layout:layout-test-util")


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-129828

We need to account that the Elasticsearch config may have already been altered by the test env (e.g. in `ci:test:search-remote`) so we have to keep the current properties to prevent "resetting" the config unintentionally. Plus some minor cosmetics.

@ Brian: this should be clean cherry-pick, so I'd appreciate if you could backport this to 7.3.x. For 72x, I'll send a PR as it requires slight changes due to the differences between 7.3 and 7.2. Thanks!