### PR TITLE
[TS] LPS-130126 portal-kernel: don't index empty keyword fields

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/search/DocumentImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/DocumentImpl.java
@@ -347,6 +347,10 @@ public class DocumentImpl implements Document {
 
 	@Override
 	public void addKeyword(String name, String value, boolean lowerCase) {
+		if (Validator.isNull(value)) {
+			return;
+		}
+
 		createKeywordField(name, value, lowerCase);
 
 		createSortableKeywordField(name, value);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-130126

Author: @joshuacords 

All other field types are null checked, why isn't keyword? Causes empty facet problems.