### PR TITLE
LPS-130001 Change the default value of ProxyModeThreadLocal#forceSync to TRUE

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/action/AssignAccountGroupAccountEntriesMVCActionCommand.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/action/AssignAccountGroupAccountEntriesMVCActionCommand.java
@@ -17,8 +17,6 @@ package com.liferay.account.admin.web.internal.portlet.action;
 import com.liferay.account.constants.AccountPortletKeys;
 import com.liferay.account.model.AccountEntry;
 import com.liferay.account.service.AccountGroupRelLocalService;
-import com.liferay.petra.lang.SafeClosable;
-import com.liferay.portal.kernel.messaging.proxy.ProxyModeThreadLocal;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -53,12 +51,8 @@ public class AssignAccountGroupAccountEntriesMVCActionCommand
 		long[] accountEntryIds = ParamUtil.getLongValues(
 			actionRequest, "accountEntryIds");
 
-		try (SafeClosable safeClosable =
-				ProxyModeThreadLocal.setWithSafeClosable(true)) {
-
-			_accountGroupRelLocalService.addAccountGroupRels(
-				accountGroupId, AccountEntry.class.getName(), accountEntryIds);
-		}
+		_accountGroupRelLocalService.addAccountGroupRels(
+			accountGroupId, AccountEntry.class.getName(), accountEntryIds);
 	}
 
 	@Reference

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/action/AssignAccountOrganizationsMVCActionCommand.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/action/AssignAccountOrganizationsMVCActionCommand.java
@@ -16,8 +16,6 @@ package com.liferay.account.admin.web.internal.portlet.action;
 
 import com.liferay.account.constants.AccountPortletKeys;
 import com.liferay.account.service.AccountEntryOrganizationRelLocalService;
-import com.liferay.petra.lang.SafeClosable;
-import com.liferay.portal.kernel.messaging.proxy.ProxyModeThreadLocal;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -52,13 +50,9 @@ public class AssignAccountOrganizationsMVCActionCommand
 		long[] accountOrganizationIds = ParamUtil.getLongValues(
 			actionRequest, "accountOrganizationIds");
 
-		try (SafeClosable safeClosable =
-				ProxyModeThreadLocal.setWithSafeClosable(true)) {
-
-			_accountEntryOrganizationRelLocalService.
-				addAccountEntryOrganizationRels(
-					accountEntryId, accountOrganizationIds);
-		}
+		_accountEntryOrganizationRelLocalService.
+			addAccountEntryOrganizationRels(
+				accountEntryId, accountOrganizationIds);
 	}
 
 	@Reference

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/action/EditAccountUserAccountEntriesMVCActionCommand.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/action/EditAccountUserAccountEntriesMVCActionCommand.java
@@ -16,8 +16,6 @@ package com.liferay.account.admin.web.internal.portlet.action;
 
 import com.liferay.account.constants.AccountPortletKeys;
 import com.liferay.account.service.AccountEntryUserRelLocalService;
-import com.liferay.petra.lang.SafeClosable;
-import com.liferay.portal.kernel.messaging.proxy.ProxyModeThreadLocal;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -53,12 +51,8 @@ public class EditAccountUserAccountEntriesMVCActionCommand
 			actionRequest, "deleteAccountEntryIds");
 		long accountUserId = ParamUtil.getLong(actionRequest, "accountUserId");
 
-		try (SafeClosable safeClosable =
-				ProxyModeThreadLocal.setWithSafeClosable(true)) {
-
-			_accountEntryUserRelLocalService.updateAccountEntryUserRels(
-				addAccountEntryIds, deleteAccountEntryIds, accountUserId);
-		}
+		_accountEntryUserRelLocalService.updateAccountEntryUserRels(
+			addAccountEntryIds, deleteAccountEntryIds, accountUserId);
 	}
 
 	@Reference

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/action/RemoveAccountGroupAccountEntriesMVCActionCommand.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/action/RemoveAccountGroupAccountEntriesMVCActionCommand.java
@@ -18,8 +18,6 @@ import com.liferay.account.constants.AccountPortletKeys;
 import com.liferay.account.exception.NoSuchGroupAccountEntryRelException;
 import com.liferay.account.model.AccountEntry;
 import com.liferay.account.service.AccountGroupRelLocalService;
-import com.liferay.petra.lang.SafeClosable;
-import com.liferay.portal.kernel.messaging.proxy.ProxyModeThreadLocal;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.servlet.SessionErrors;
@@ -51,9 +49,7 @@ public class RemoveAccountGroupAccountEntriesMVCActionCommand
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
 
-		try (SafeClosable safeClosable =
-				ProxyModeThreadLocal.setWithSafeClosable(true)) {
-
+		try {
 			long accountGroupId = ParamUtil.getLong(
 				actionRequest, "accountGroupId");
 			long[] accountEntryIds = ParamUtil.getLongValues(

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/action/RemoveAccountOrganizationsMVCActionCommand.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/action/RemoveAccountOrganizationsMVCActionCommand.java
@@ -17,8 +17,6 @@ package com.liferay.account.admin.web.internal.portlet.action;
 import com.liferay.account.constants.AccountPortletKeys;
 import com.liferay.account.exception.NoSuchEntryOrganizationRelException;
 import com.liferay.account.service.AccountEntryOrganizationRelLocalService;
-import com.liferay.petra.lang.SafeClosable;
-import com.liferay.portal.kernel.messaging.proxy.ProxyModeThreadLocal;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.servlet.SessionErrors;
@@ -50,9 +48,7 @@ public class RemoveAccountOrganizationsMVCActionCommand
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
 
-		try (SafeClosable safeClosable =
-				ProxyModeThreadLocal.setWithSafeClosable(true)) {
-
+		try {
 			long accountEntryId = ParamUtil.getLong(
 				actionRequest, "accountEntryId");
 			long[] accountOrganizationIds = ParamUtil.getLongValues(

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/action/UpdateAccountEntryStatusMVCActionCommand.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/action/UpdateAccountEntryStatusMVCActionCommand.java
@@ -16,8 +16,6 @@ package com.liferay.account.admin.web.internal.portlet.action;
 
 import com.liferay.account.constants.AccountPortletKeys;
 import com.liferay.account.service.AccountEntryLocalService;
-import com.liferay.petra.lang.SafeClosable;
-import com.liferay.portal.kernel.messaging.proxy.ProxyModeThreadLocal;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.util.Constants;
@@ -54,20 +52,10 @@ public class UpdateAccountEntryStatusMVCActionCommand
 			actionRequest, "accountEntryIds");
 
 		if (cmd.equals(Constants.DEACTIVATE)) {
-			try (SafeClosable safeClosable =
-					ProxyModeThreadLocal.setWithSafeClosable(true)) {
-
-				_accountEntryLocalService.deactivateAccountEntries(
-					accountEntryIds);
-			}
+			_accountEntryLocalService.deactivateAccountEntries(accountEntryIds);
 		}
 		else if (cmd.equals(Constants.RESTORE)) {
-			try (SafeClosable safeClosable =
-					ProxyModeThreadLocal.setWithSafeClosable(true)) {
-
-				_accountEntryLocalService.activateAccountEntries(
-					accountEntryIds);
-			}
+			_accountEntryLocalService.activateAccountEntries(accountEntryIds);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/search/IndexableAdvice.java
+++ b/portal-impl/src/com/liferay/portal/search/IndexableAdvice.java
@@ -14,16 +14,13 @@
 
 package com.liferay.portal.search;
 
-import com.liferay.petra.lang.SafeClosable;
 import com.liferay.portal.kernel.aop.AopMethodInvocation;
 import com.liferay.portal.kernel.aop.ChainableMethodAdvice;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.messaging.proxy.ProxyModeThreadLocal;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.search.IndexWriterHelperUtil;
 import com.liferay.portal.kernel.search.Indexable;
-import com.liferay.portal.kernel.search.IndexableThreadLocal;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
@@ -126,16 +123,11 @@ public class IndexableAdvice extends ChainableMethodAdvice {
 			}
 		}
 
-		try (SafeClosable safeClosable =
-				ProxyModeThreadLocal.setWithSafeClosable(
-					IndexableThreadLocal.isForceSync())) {
-
-			if (indexableContext._indexableType == IndexableType.DELETE) {
-				indexer.delete(result);
-			}
-			else {
-				indexer.reindex(result);
-			}
+		if (indexableContext._indexableType == IndexableType.DELETE) {
+			indexer.delete(result);
+		}
+		else {
+			indexer.reindex(result);
 		}
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/messaging/proxy/ProxyModeThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/messaging/proxy/ProxyModeThreadLocal.java
@@ -41,6 +41,6 @@ public class ProxyModeThreadLocal {
 
 	private static final CentralizedThreadLocal<Boolean> _forceSync =
 		new CentralizedThreadLocal<>(
-			ProxyModeThreadLocal.class + "_forceSync", () -> Boolean.FALSE);
+			ProxyModeThreadLocal.class + "_forceSync", () -> Boolean.TRUE);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/search/IndexableThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/IndexableThreadLocal.java
@@ -19,7 +19,9 @@ import com.liferay.petra.lang.SafeClosable;
 
 /**
  * @author Shuyang Zhou
+ * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
  */
+@Deprecated
 public class IndexableThreadLocal {
 
 	public static boolean isForceSync() {


### PR DESCRIPTION
This is an update for [LPS-130001](https://issues.liferay.com/browse/LPS-130001).<br/><br/>This relates to an on-going issue across portal where the UI does not show up-to-date indexer results after an action that triggers a reindex on a number of documents. This occurs because reindexing is asynchronous by default, with the option to force synchronous reindexing using ProxyModeThreadLocal used often to work around this issue (see the changes in accounts-admin-web for examples). After discussing this issue with Shuyang, we would like to make reindexing synchronous by default, with the option to force asynchronous indexing still present by the same means. This should make it easy to resolve instances where performance is a concern.<br/><br/>/cc @pei-jung @alee8888 @ChrisKian @dejuknow @patriciajeanperez @shuyangzhou