### PR TITLE
[TS] LPS-130227 portal-search-web: don't rely on httpServletRequest URL

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/task/SearchHttpUtil.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/task/SearchHttpUtil.java
@@ -50,7 +50,10 @@ public class SearchHttpUtil {
 				JavaConstants.JAVAX_SERVLET_FORWARD_QUERY_STRING);
 		}
 		else {
-			requestURL = String.valueOf(httpServletRequest.getRequestURL());
+			requestURL = _portal.getAbsoluteURL(
+				httpServletRequest,
+				_http.getPath(
+					String.valueOf(httpServletRequest.getRequestURL())));
 
 			queryString = httpServletRequest.getQueryString();
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-130227

When accessed via HTTPS, the pagination URL for the "Search Result" widget will not be generated correctly.

Author: @joshuacords with help from Minhchau.

Note: if possible, functional tests should be added to cover this change.