### PR TITLE
LPS-131812 Search configuration: No more Lucene

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -5807,7 +5807,7 @@
     #control.panel.default.entry.class=com.liferay.portal.kernel.portlet.DefaultControlPanelEntry
 
 ##
-## Lucene Search
+## Search
 ##
 
     #


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-131812

As discussed here: https://liferay.slack.com/archives/C04D8F2LM/p1620309559100400?thread_ts=1620309041.098800&cid=C04D8F2LM
With "Lucene" in the headline it looks like this section is outdated for 5 years now, but apparently it isn't (you might want to validate if it indeed isn't outdated, now that quite some search-related configuration is in OSGi)