### PR TITLE
[TS] LPS-131302 Add showExtraInfo parameter for searched documents

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetDisplayTag.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetDisplayTag.java
@@ -22,6 +22,7 @@ import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.asset.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.util.IncludeTag;
@@ -266,6 +267,9 @@ public class AssetDisplayTag extends IncludeTag {
 		}
 
 		httpServletRequest.setAttribute(WebKeys.ASSET_ENTRY_VIEW_URL, _viewURL);
+
+		_showExtraInfo = ParamUtil.getBoolean(
+			httpServletRequest, "showExtraInfo");
 
 		addParam("showComments", String.valueOf(_showComments));
 		addParam("showExtraInfo", String.valueOf(_showExtraInfo));

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/util/SearchUtil.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/util/SearchUtil.java
@@ -179,9 +179,15 @@ public class SearchUtil {
 					viewContentURL.toString(), "p_l_back_url", currentURL);
 			}
 
+			String assetType = assetRendererFactory.getType();
+
 			viewContentURL.setParameter(
 				"assetEntryId", String.valueOf(assetEntry.getEntryId()));
-			viewContentURL.setParameter("type", assetRendererFactory.getType());
+			viewContentURL.setParameter("type", assetType);
+
+			if (assetType.equals("document")) {
+				viewContentURL.setParameter("showExtraInfo", "true");
+			}
 
 			if (!viewInContext) {
 				return HttpUtil.setParameter(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-131302

The issue here is that the info button does not appear for searched documents that have a preview. This was occurring because all documents with a preview were being viewed by view_file_entry_simple_view.jsp because showExtraInfo is always equal to false.

I resolved this issue by adding a showExtraInfo parameter to the generated URL. I also needed to update showExtraInfo in AssetDisplayTag because it was overriding the one I added to the URL.