### PR TITLE
LPS-132257 Follow the same pattern for inclusion and exclusion of tests

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/build.gradle
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/build.gradle
@@ -196,8 +196,10 @@ test {
 }
 
 test {
-	if (project.hasProperty('excludeTests')) {
-		exclude project.property('excludeTests')
+	filter {
+		if (project.hasProperty('excludeTests')) {
+			excludeTestsMatching project.property('excludeTests')
+		}
 	}
 }
 

--- a/modules/apps/portal-search/portal-search-admin-web/build.gradle
+++ b/modules/apps/portal-search/portal-search-admin-web/build.gradle
@@ -26,7 +26,9 @@ dependencies {
 }
 
 test {
-	if (project.hasProperty('excludeTests')) {
-		exclude project.property('excludeTests')
+	filter {
+		if (project.hasProperty('excludeTests')) {
+			excludeTestsMatching project.property('excludeTests')
+		}
 	}
 }

--- a/modules/apps/portal-search/portal-search-test/build.gradle
+++ b/modules/apps/portal-search/portal-search-test/build.gradle
@@ -29,13 +29,17 @@ dependencies {
 }
 
 test {
-	if (project.hasProperty('excludeTests')) {
-		exclude project.property('excludeTests')
+	filter {
+		if (project.hasProperty('excludeTests')) {
+			excludeTestsMatching project.property('excludeTests')
+		}
 	}
 }
 
 testIntegration {
-	if (project.hasProperty('excludeTests')) {
-		exclude project.property('excludeTests')
+	filter {
+		if (project.hasProperty('excludeTests')) {
+			excludeTestsMatching project.property('excludeTests')
+		}
 	}
 }

--- a/modules/apps/portal-search/portal-search-web/build.gradle
+++ b/modules/apps/portal-search/portal-search-web/build.gradle
@@ -42,7 +42,9 @@ dependencies {
 }
 
 test {
-	if (project.hasProperty('excludeTests')) {
-		exclude project.property('excludeTests')
+	filter {
+		if (project.hasProperty('excludeTests')) {
+			excludeTestsMatching project.property('excludeTests')
+		}
 	}
 }

--- a/modules/apps/portal-search/portal-search/build.gradle
+++ b/modules/apps/portal-search/portal-search/build.gradle
@@ -34,7 +34,9 @@ dependencies {
 }
 
 test {
-	if (project.hasProperty('excludeTests')) {
-		exclude project.property('excludeTests')
+	filter {
+		if (project.hasProperty('excludeTests')) {
+			excludeTestsMatching project.property('excludeTests')
+		}
 	}
 }


### PR DESCRIPTION
Follow-up addressing concerns from https://github.com/brianchandotcom/liferay-portal/pull/101848#issuecomment-841960201. Command line does look better now 😃 

`gw test --tests *.searcher.*Test -PexcludeTests=*.FacetedSearcherImplTest`

Thank you @petershin for the `excludeTestsMatching` tip... that was brilliant!!! 💯 

https://issues.liferay.com/browse/LPS-132257