### PR TITLE
LPS-133190 Search Blueprints Filtering by Title should default to ascending order

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/java/com/liferay/portal/search/tuning/blueprints/admin/web/internal/display/context/ViewEntriesDisplayContext.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-blueprints-admin-web/src/main/java/com/liferay/portal/search/tuning/blueprints/admin/web/internal/display/context/ViewEntriesDisplayContext.java
@@ -32,6 +32,8 @@ import com.liferay.portal.search.tuning.blueprints.admin.web.internal.constants.
 import com.liferay.portal.search.tuning.blueprints.admin.web.internal.constants.BlueprintsAdminWebKeys;
 import com.liferay.portal.search.tuning.blueprints.constants.BlueprintsPortletKeys;
 
+import java.util.Objects;
+
 import javax.portlet.PortletException;
 import javax.portlet.PortletURL;
 
@@ -103,8 +105,18 @@ public abstract class ViewEntriesDisplayContext<R> {
 	}
 
 	protected String getOrderByType() {
-		return ParamUtil.getString(
-			liferayPortletRequest, "orderByType", "desc");
+		String orderByType = ParamUtil.getString(
+			liferayPortletRequest, "orderByType");
+
+		if (Validator.isNotNull(orderByType)) {
+			return orderByType;
+		}
+
+		if (Objects.equals(getOrderByCol(), Field.TITLE)) {
+			return "asc";
+		}
+
+		return "desc";
 	}
 
 	protected SearchContainer<R> getSearchContainer()


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-133190

title sort defaults to asc, Created and Modified stay defaulted to desc. 

Note: we are not currently using portalPreferences to save the ordering like other portlets do, see [JournalDisplayContext](https://github.com/liferay/liferay-portal/blob/48875791fb773902d8b6ded7f4c26328345030b0/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java#L806-L836). Also, Web Content defaults to have Modified Date be "desc" and all others "asc", but given our other 2 sort columns are dates, I think it makes sense to keep them both "desc" by default.

**Author**: @joshuacords 