### PR TITLE
LPS-133224 Allow filtering object entries by object field values

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/graphql/test/ObjectDefinitionGraphQLTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/graphql/test/ObjectDefinitionGraphQLTest.java
@@ -162,6 +162,84 @@ public class ObjectDefinitionGraphQLTest {
 	}
 
 	@Test
+	public void testGetListObjectEntryFilterByObjectFieldUsingContains()
+		throws Exception {
+
+		String key = TextFormatter.formatPlural(
+			StringUtil.lowerCaseFirstLetter(_objectDefinitionName));
+
+		JSONObject jsonObject = _invoke(
+			new GraphQLField(
+				"query",
+				new GraphQLField(
+					key,
+					HashMapBuilder.<String, Object>put(
+						"filter",
+						"\"contains(" + _objectFieldName +
+							",'peter@liferay.com')\""
+					).build(),
+					new GraphQLField(
+						"items", new GraphQLField(_objectFieldName)))));
+
+		Assert.assertEquals(
+			"peter@liferay.com",
+			JSONUtil.getValueAsString(
+				jsonObject, "JSONObject/data", "JSONObject/" + key,
+				"Object/items", "Object/0", "Object/" + _objectFieldName));
+	}
+
+	@Test
+	public void testGetListObjectEntryFilterByObjectFieldUsingEquals()
+		throws Exception {
+
+		String key = TextFormatter.formatPlural(
+			StringUtil.lowerCaseFirstLetter(_objectDefinitionName));
+
+		JSONObject jsonObject = _invoke(
+			new GraphQLField(
+				"query",
+				new GraphQLField(
+					key,
+					HashMapBuilder.<String, Object>put(
+						"filter",
+						"\"" + _objectFieldName + " eq 'peter@liferay.com'\""
+					).build(),
+					new GraphQLField(
+						"items", new GraphQLField(_objectFieldName)))));
+
+		Assert.assertEquals(
+			"peter@liferay.com",
+			JSONUtil.getValueAsString(
+				jsonObject, "JSONObject/data", "JSONObject/" + key,
+				"Object/items", "Object/0", "Object/" + _objectFieldName));
+	}
+
+	@Test
+	public void testGetListObjectEntryFilterByObjectFieldUsingNotEquals()
+		throws Exception {
+
+		String key = TextFormatter.formatPlural(
+			StringUtil.lowerCaseFirstLetter(_objectDefinitionName));
+
+		JSONObject jsonObject = _invoke(
+			new GraphQLField(
+				"query",
+				new GraphQLField(
+					key,
+					HashMapBuilder.<String, Object>put(
+						"filter",
+						"\"" + _objectFieldName + " ne 'peter@liferay.com'\""
+					).build(),
+					new GraphQLField("totalCount"))));
+
+		Assert.assertEquals(
+			0,
+			JSONUtil.getValueAsInt(
+				jsonObject, "JSONObject/data", "JSONObject/" + key,
+				"Object/totalCount"));
+	}
+
+	@Test
 	public void testGetObjectEntry() throws Exception {
 		String key = StringUtil.lowerCaseFirstLetter(_objectDefinitionName);
 
@@ -242,6 +320,8 @@ public class ObjectDefinitionGraphQLTest {
 		ObjectField objectField = ObjectFieldLocalServiceUtil.createObjectField(
 			0);
 
+		objectField.setIndexed(true);
+		objectField.setIndexedAsKeyword(true);
 		objectField.setName(name);
 		objectField.setType(type);
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/filter/NestedFieldArrayTranslatorUtil.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/filter/NestedFieldArrayTranslatorUtil.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.filter;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.function.Function;
+
+import org.apache.lucene.search.join.ScoreMode;
+
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.NestedQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+
+/**
+ * @author Javier de Arcos
+ */
+public class NestedFieldArrayTranslatorUtil {
+
+	public static boolean isNestedFieldArrayQuery(String filterField) {
+		return filterField.startsWith("nestedFieldArray");
+	}
+
+	public static QueryBuilder translate(
+		String filterField,
+		Function<String, QueryBuilder> queryBuilderFunction) {
+
+		String[] parts = StringUtil.split(filterField, StringPool.POUND);
+
+		String nestedFieldName = parts[0];
+
+		String fieldName = parts[1];
+
+		BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
+
+		return new NestedQueryBuilder(
+			"nestedFieldArray",
+			boolQueryBuilder.must(
+				QueryBuilders.termQuery("nestedFieldArray.fieldName", fieldName)
+			).must(
+				queryBuilderFunction.apply(nestedFieldName)
+			),
+			ScoreMode.None);
+	}
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/filter/NestedFieldArrayTranslatorUtil.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/filter/NestedFieldArrayTranslatorUtil.java
@@ -32,7 +32,13 @@ import org.elasticsearch.index.query.QueryBuilders;
 public class NestedFieldArrayTranslatorUtil {
 
 	public static boolean isNestedFieldArrayQuery(String filterField) {
-		return filterField.startsWith("nestedFieldArray");
+		if (filterField.startsWith("nestedFieldArray") &&
+			filterField.contains(StringPool.POUND)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	public static QueryBuilder translate(

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/filter/RangeTermFilterTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/filter/RangeTermFilterTranslatorImpl.java
@@ -31,8 +31,22 @@ public class RangeTermFilterTranslatorImpl
 
 	@Override
 	public QueryBuilder translate(RangeTermFilter rangeTermFilter) {
-		RangeQueryBuilder rangeQueryBuilder = QueryBuilders.rangeQuery(
-			rangeTermFilter.getField());
+		String field = rangeTermFilter.getField();
+
+		if (NestedFieldArrayTranslatorUtil.isNestedFieldArrayQuery(field)) {
+			return NestedFieldArrayTranslatorUtil.translate(
+				field,
+				nestedFieldName -> _createRangeQueryBuilder(
+					nestedFieldName, rangeTermFilter));
+		}
+
+		return _createRangeQueryBuilder(field, rangeTermFilter);
+	}
+
+	private RangeQueryBuilder _createRangeQueryBuilder(
+		String field, RangeTermFilter rangeTermFilter) {
+
+		RangeQueryBuilder rangeQueryBuilder = QueryBuilders.rangeQuery(field);
 
 		rangeQueryBuilder.from(rangeTermFilter.getLowerBound());
 		rangeQueryBuilder.includeLower(rangeTermFilter.isIncludesLower());

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/filter/TermFilterTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/filter/TermFilterTranslatorImpl.java
@@ -29,8 +29,16 @@ public class TermFilterTranslatorImpl implements TermFilterTranslator {
 
 	@Override
 	public QueryBuilder translate(TermFilter termFilter) {
-		return QueryBuilders.termQuery(
-			termFilter.getField(), termFilter.getValue());
+		String field = termFilter.getField();
+
+		if (NestedFieldArrayTranslatorUtil.isNestedFieldArrayQuery(field)) {
+			return NestedFieldArrayTranslatorUtil.translate(
+				field,
+				nestedFieldName -> QueryBuilders.termQuery(
+					nestedFieldName, termFilter.getValue()));
+		}
+
+		return QueryBuilders.termQuery(field, termFilter.getValue());
 	}
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/filter/TermsFilterTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/filter/TermsFilterTranslatorImpl.java
@@ -29,8 +29,16 @@ public class TermsFilterTranslatorImpl implements TermsFilterTranslator {
 
 	@Override
 	public QueryBuilder translate(TermsFilter termsFilter) {
-		return QueryBuilders.termsQuery(
-			termsFilter.getField(), termsFilter.getValues());
+		String field = termsFilter.getField();
+
+		if (NestedFieldArrayTranslatorUtil.isNestedFieldArrayQuery(field)) {
+			return NestedFieldArrayTranslatorUtil.translate(
+				field,
+				nestedFieldName -> QueryBuilders.termsQuery(
+					nestedFieldName, termsFilter.getValues()));
+		}
+
+		return QueryBuilders.termsQuery(field, termsFilter.getValues());
 	}
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/legacy/query/WildcardQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/legacy/query/WildcardQueryTranslatorImpl.java
@@ -16,6 +16,7 @@ package com.liferay.portal.search.elasticsearch7.internal.legacy.query;
 
 import com.liferay.portal.kernel.search.QueryTerm;
 import com.liferay.portal.kernel.search.WildcardQuery;
+import com.liferay.portal.search.elasticsearch7.internal.filter.NestedFieldArrayTranslatorUtil;
 
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -33,8 +34,24 @@ public class WildcardQueryTranslatorImpl implements WildcardQueryTranslator {
 	public QueryBuilder translate(WildcardQuery wildcardQuery) {
 		QueryTerm queryTerm = wildcardQuery.getQueryTerm();
 
+		String field = queryTerm.getField();
+
+		if (NestedFieldArrayTranslatorUtil.isNestedFieldArrayQuery(field)) {
+			return NestedFieldArrayTranslatorUtil.translate(
+				field,
+				nestedFieldName -> _createWildcardQueryBuilder(
+					nestedFieldName, queryTerm.getValue(), wildcardQuery));
+		}
+
+		return _createWildcardQueryBuilder(
+			field, queryTerm.getValue(), wildcardQuery);
+	}
+
+	private WildcardQueryBuilder _createWildcardQueryBuilder(
+		String name, String value, WildcardQuery wildcardQuery) {
+
 		WildcardQueryBuilder wildcardQueryBuilder = QueryBuilders.wildcardQuery(
-			queryTerm.getField(), queryTerm.getValue());
+			name, value);
 
 		if (!wildcardQuery.isDefaultBoost()) {
 			wildcardQueryBuilder.boost(wildcardQuery.getBoost());


### PR DESCRIPTION
Hello team,

I was working on a bug related to filter object fields in the Object Entry APIs [LPS-133224](https://issues.liferay.com/browse/LPS-133224).

Following the same approach that @BryanEngler to allow sorting by ObjectEntry fields, I've modified the FilterTranslatorImpls to take into account the nestedFieldArray case. As this is an important portal future, it makes sense to me to be considered in the core of the portal and this way, the implementation of the rest of the modules is very clean.

I've considered the filter types that I think are more important, but please tell me if you think I need to add some more.

Please, can you take a look at this PR and tell me if you find some trouble with it?

Thank you very much