### PR TITLE
[TS] LPS-134716 Set the network bind host to the correct elasticsearch network.bind_host setting

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchInstanceSettingsBuilder.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchInstanceSettingsBuilder.java
@@ -188,7 +188,7 @@ public class ElasticsearchInstanceSettingsBuilder {
 			_elasticsearchConfigurationWrapper.networkPublishHost();
 
 		if (Validator.isNotNull(networkBindHost)) {
-			put("network.bind.host", networkBindHost);
+			put("network.bind_host", networkBindHost);
 		}
 
 		if (!Validator.isBlank(_networkHost)) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-134716

In the ElasticsearchInstanceSettingsBuilder class we are setting the network.bind.host configuration parameter of Elasticsearch, but it doesn't exist, it seems it is a typo, the correct parameter is network.bind_host, with a "_" between bind and host, see: https://www.elastic.co/guide/en/elasticsearch/reference/7.9/modules-network.html#advanced-network-settings