### PR TITLE
LPS-135538 Check permissions for multiple resourcePermissionNames

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchPermissionCheckerImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchPermissionCheckerImpl.java
@@ -502,10 +502,34 @@ public class SearchPermissionCheckerImpl implements SearchPermissionChecker {
 		searchContext.setAttribute(
 			"searchPermissionContext", searchPermissionContext);
 
-		return _getPermissionFilter(
-			companyId, searchGroupIds, userId, permissionChecker,
-			_getPermissionName(searchContext, className),
-			searchPermissionContext);
+		String[] permissionNamesArray = _getPermissionNamesArray(
+			searchContext, className);
+
+		if (permissionNamesArray.length == 1) {
+			return _getPermissionFilter(
+				companyId, searchGroupIds, userId, permissionChecker,
+				permissionNamesArray[0], searchPermissionContext);
+		}
+
+		BooleanFilter booleanFilter = new BooleanFilter();
+
+		for (String permissionName : permissionNamesArray) {
+			BooleanFilter permissionNameBooleanFilter = _getPermissionFilter(
+				companyId, searchGroupIds, userId, permissionChecker,
+				permissionName, searchPermissionContext);
+
+			if (permissionNameBooleanFilter != null) {
+				booleanFilter.add(
+					permissionNameBooleanFilter, BooleanClauseOccur.SHOULD);
+			}
+			else {
+				booleanFilter.add(
+					new TermFilter("resourcePermissionName", permissionName),
+					BooleanClauseOccur.SHOULD);
+			}
+		}
+
+		return booleanFilter;
 	}
 
 	private BooleanFilter _getPermissionFilter(
@@ -603,11 +627,23 @@ public class SearchPermissionCheckerImpl implements SearchPermissionChecker {
 		return booleanFilter;
 	}
 
-	private String _getPermissionName(
+	private String[] _getPermissionNamesArray(
 		SearchContext searchContext, String defaultValue) {
 
-		return GetterUtil.getString(
-			searchContext.getAttribute("resourcePermissionName"), defaultValue);
+		String[] resourcePermissionNamesArray = GetterUtil.getStringValues(
+			searchContext.getAttribute("resourcePermissionNames"));
+
+		if (ArrayUtil.isEmpty(resourcePermissionNamesArray)) {
+			String resourcePermissionName = GetterUtil.getString(
+				searchContext.getAttribute("resourcePermissionName"),
+				defaultValue);
+
+			resourcePermissionNamesArray = new String[] {
+				resourcePermissionName
+			};
+		}
+
+		return resourcePermissionNamesArray;
 	}
 
 	private static final String _NULL_SEARCH_PERMISSION_CONTEXT =

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/SearchPermissionCheckerImplTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/SearchPermissionCheckerImplTest.java
@@ -15,19 +15,26 @@
 package com.liferay.portal.search.internal;
 
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchPermissionChecker;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.UserBag;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.configuration.SearchPermissionCheckerConfiguration;
+import com.liferay.portal.search.spi.model.permission.SearchPermissionFilterContributor;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -35,6 +42,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -69,6 +77,112 @@ public class SearchPermissionCheckerImplTest {
 		Assert.assertNull(
 			_searchPermissionChecker.getPermissionBooleanFilter(
 				0, null, 0, null, null, null));
+	}
+
+	@Test
+	public void testPermissionFilterMultipleResourcePermissionName()
+		throws Exception {
+
+		long userId = RandomTestUtil.randomLong();
+
+		whenIndexerIsPermissionAware(true);
+		whenPermissionCheckerGetUser(_user);
+		whenPermissionCheckerGetUserBag(_userBag);
+		whenUserGetUserId(userId);
+
+		ReflectionTestUtil.getAndSetFieldValue(
+			_searchPermissionChecker, "_searchPermissionFilterContributors",
+			Arrays.asList(_searchPermissionFilterContributor));
+
+		SearchContext searchContext = new SearchContext();
+		String resourceName1 =
+			"com.liferay.asset.kernel.model.AssetCategory-" +
+				"com.liferay.dynamic.data.mapping.model.DDMTemplate";
+		String resourceName2 =
+			"com.liferay.dynamic.data.mapping.model.DDMTemplate-" +
+				"com.liferay.journal.model.JournalArticle";
+
+		searchContext.setAttribute(
+			"resourcePermissionNames",
+			new String[] {resourceName1, resourceName2});
+
+		BooleanFilter booleanFilter = null;
+
+		BooleanFilter permissionBooleanFilter =
+			_searchPermissionChecker.getPermissionBooleanFilter(
+				0, null, userId, null, booleanFilter, searchContext);
+
+		Assert.assertNotNull(permissionBooleanFilter);
+
+		List<BooleanClause<Filter>> shouldBooleanClauses =
+			permissionBooleanFilter.getShouldBooleanClauses();
+
+		Assert.assertEquals(
+			shouldBooleanClauses.toString(), 2, shouldBooleanClauses.size());
+
+		Mockito.verify(
+			_searchPermissionFilterContributor
+		).contribute(
+			Matchers.any(BooleanFilter.class), Matchers.eq((long)0),
+			Matchers.eq(null), Matchers.eq(userId),
+			Matchers.eq(_permissionChecker), Matchers.eq(resourceName1)
+		);
+
+		Mockito.verify(
+			_searchPermissionFilterContributor
+		).contribute(
+			Matchers.any(BooleanFilter.class), Matchers.eq((long)0),
+			Matchers.eq(null), Matchers.eq(userId),
+			Matchers.eq(_permissionChecker), Matchers.eq(resourceName2)
+		);
+
+		Mockito.verifyNoMoreInteractions(_searchPermissionFilterContributor);
+	}
+
+	@Test
+	public void testPermissionFilterSingleResourcePermissionName()
+		throws Exception {
+
+		long userId = RandomTestUtil.randomLong();
+
+		whenIndexerIsPermissionAware(true);
+		whenPermissionCheckerGetUser(_user);
+		whenPermissionCheckerGetUserBag(_userBag);
+		whenUserGetUserId(userId);
+
+		ReflectionTestUtil.getAndSetFieldValue(
+			_searchPermissionChecker, "_searchPermissionFilterContributors",
+			Arrays.asList(_searchPermissionFilterContributor));
+
+		SearchContext searchContext = new SearchContext();
+		String resourceName =
+			"com.liferay.asset.kernel.model.AssetCategory-" +
+				"com.liferay.dynamic.data.mapping.model.DDMTemplate";
+
+		searchContext.setAttribute("resourcePermissionName", resourceName);
+
+		BooleanFilter booleanFilter = null;
+
+		BooleanFilter permissionBooleanFilter =
+			_searchPermissionChecker.getPermissionBooleanFilter(
+				0, null, userId, null, booleanFilter, searchContext);
+
+		Assert.assertNotNull(permissionBooleanFilter);
+
+		List<BooleanClause<Filter>> shouldBooleanClauses =
+			permissionBooleanFilter.getShouldBooleanClauses();
+
+		Assert.assertEquals(
+			shouldBooleanClauses.toString(), 1, shouldBooleanClauses.size());
+
+		Mockito.verify(
+			_searchPermissionFilterContributor
+		).contribute(
+			permissionBooleanFilter, 0, null, userId, _permissionChecker,
+			resourceName
+		);
+
+		Mockito.verifyNoMoreInteractions(_searchPermissionFilterContributor);
 	}
 
 	@Test
@@ -160,6 +274,10 @@ public class SearchPermissionCheckerImplTest {
 	@Mock
 	private SearchPermissionCheckerConfiguration
 		_searchPermissionCheckerConfiguration;
+
+	@Mock
+	private SearchPermissionFilterContributor
+		_searchPermissionFilterContributor;
 
 	@Mock
 	private User _user;


### PR DESCRIPTION
Hi Team,
To implement https://issues.liferay.com/browse/LPS-124478 we need DDMTemplate search methods that accept multiple resourceClassNameIds. So, we need to be able of check permissions for multiple resourcePermissionNames. We have developed this capability, please, could you review this PR?
Thanks a lot!
Regards

Related PR: https://github.com/liferay-data-engine/liferay-portal/pull/572