### PR TITLE
[TS] LPS-135245_master

### DIFF
--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 7.8.4
+Bundle-Version: 7.9.0
 Export-Package:\
 	com.liferay.portal.asm,\
 	com.liferay.portal.bean,\

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -2467,6 +2467,9 @@ public class PropsValues {
 		GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.PREFERENCE_VALIDATE_ON_STARTUP));
 
+	public static final boolean PROXYTHREAD_MODE = GetterUtil.getBoolean(
+		PropsUtil.get(PropsKeys.PROXYTHREAD_MODE));
+
 	public static final int RATINGS_DEFAULT_NUMBER_OF_STARS =
 		GetterUtil.getInteger(
 			PropsUtil.get(PropsKeys.RATINGS_DEFAULT_NUMBER_OF_STARS));

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 5.3.0
+version 5.4.0

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -8862,6 +8862,19 @@
     portal.fabric.shutdown.timeout=60000
 
 ##
+## Proxy Thread
+##
+
+    #
+    # Set this property to false to execute the thread managed by
+    # ProxyModeThreadLocal in asynchronized mode. By default, the execution is
+    # synchronous.
+    #
+    # Env: LIFERAY_PROXYTHREAD_PERIOD_MODE_PERIOD_SYNC
+    #
+    proxythread.mode.sync=true
+
+##
 ## Quartz
 ##
 

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 12.0.1
+Bundle-Version: 12.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.test.*,\

--- a/portal-kernel/src/com/liferay/portal/kernel/messaging/proxy/ProxyModeThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/messaging/proxy/ProxyModeThreadLocal.java
@@ -17,6 +17,9 @@ package com.liferay.portal.kernel.messaging.proxy;
 import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.petra.lang.SafeClosable;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
 
 /**
  * @author Shuyang Zhou
@@ -51,6 +54,8 @@ public class ProxyModeThreadLocal {
 
 	private static final CentralizedThreadLocal<Boolean> _forceSync =
 		new CentralizedThreadLocal<>(
-			ProxyModeThreadLocal.class + "_forceSync", () -> Boolean.TRUE);
+			ProxyModeThreadLocal.class + "_forceSync",
+			() -> GetterUtil.getBoolean(
+				PropsUtil.get(PropsKeys.PROXYTHREAD_MODE)));
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2756,6 +2756,8 @@ public interface PropsKeys {
 	public static final String PREFERENCE_VALIDATE_ON_STARTUP =
 		"preference.validate.on.startup";
 
+	public static final String PROXYTHREAD_MODE = "proxythread.mode.sync";
+
 	public static final String RATINGS_DEFAULT_NUMBER_OF_STARS =
 		"ratings.default.number.of.stars";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 12.0.0
+version 12.1.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-135245

Make sync-asynchronous mode in index write operations configurable.

After analyzing the changes made in the index operations from an asynchronous to the synchronous mode in PTR-2496, it was decided to make this behavior configurable by a portal property.

The changes in the index write operations were made in:

- LPS-127843 (Flip IndexableAdvice to do sync indexing by default, and add a manual switch to allow override. ) already released in 7.3 FP1
- LPS-130001 (Change the default value of ProxyModeThreadLocal#forceSync to TRUE) committed to 7.3.x but not released yet in an FP1

En master, by default, we selected the synchronous mode but, as Tibor Lipusz told in the PTR, this selection could be changed during the PR review.

To add the new portal.property, I added a new section too (Proxy Thread). After a research of the existing sections, I didn't find any appropriated for the new property. I Thought in the "Search" section but the changes made in this LPS effect to other components, not only to Search. You can check that by executing the following:

```
git grep -lw ProxyModeThreadLocal.isForceSync
modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexWriterHelperImpl.java
modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/IndexerRequest.java
modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/index/UpdateDocumentIndexWriterImpl.java
modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/reindexer/ReindexerImpl.java
portal-impl/src/com/liferay/portal/messaging/proxy/MultiDestinationMessagingProxyInvocationHandler.java
portal-kernel/src/com/liferay/portal/kernel/messaging/proxy/MessagingProxyInvocationHandler.java
portal-kernel/src/com/liferay/portal/kernel/messaging/proxy/ProxyModeThreadLocalCloseable.java
```

As you can see, MultiDestinationMessagingProxyInvocationHandler and MessagingProxyInvocationHandler are also implicated. If you think that a new section is no necesary, please let me know.