### PR TITLE
[TS] LPS-134832 SearchPhaseExecutionException when using special char in keyword for AP filter

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/legacy/query/StringQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/legacy/query/StringQueryTranslatorImpl.java
@@ -33,6 +33,10 @@ public class StringQueryTranslatorImpl implements StringQueryTranslator {
 		QueryStringQueryBuilder queryStringQueryBuilder =
 			QueryBuilders.queryStringQuery(stringQuery.getQuery());
 
+		if (stringQuery.getEscape() != null) {
+			queryStringQueryBuilder.escape(stringQuery.getEscape());
+		}
+
 		if (!stringQuery.isDefaultBoost()) {
 			queryStringQueryBuilder.boost(stringQuery.getBoost());
 		}

--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetSearcher.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetSearcher.java
@@ -128,6 +128,8 @@ public class AssetSearcher extends BaseSearcher {
 
 			StringQuery stringQuery = new StringQuery(keyword);
 
+			stringQuery.setEscape(true);
+
 			keywordsQuery.add(stringQuery, BooleanClauseOccur.MUST);
 		}
 
@@ -202,6 +204,8 @@ public class AssetSearcher extends BaseSearcher {
 			}
 
 			StringQuery stringQuery = new StringQuery(keyword);
+
+			stringQuery.setEscape(true);
 
 			keywordsQuery.add(stringQuery, BooleanClauseOccur.SHOULD);
 		}
@@ -332,6 +336,8 @@ public class AssetSearcher extends BaseSearcher {
 
 			StringQuery stringQuery = new StringQuery(keyword);
 
+			stringQuery.setEscape(true);
+
 			keywordsQuery.add(stringQuery, BooleanClauseOccur.MUST);
 		}
 
@@ -406,6 +412,8 @@ public class AssetSearcher extends BaseSearcher {
 			}
 
 			StringQuery stringQuery = new StringQuery(keyword);
+
+			stringQuery.setEscape(true);
 
 			keywordsQuery.add(stringQuery, BooleanClauseOccur.SHOULD);
 		}

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 12.0.1
+Bundle-Version: 12.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.test.*,\

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/StringQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/StringQuery.java
@@ -42,8 +42,16 @@ public class StringQuery extends BaseQueryImpl implements Query {
 		return queryVisitor.visitQuery(this);
 	}
 
+	public Boolean getEscape() {
+		return _escape;
+	}
+
 	public String getQuery() {
 		return _query;
+	}
+
+	public void setEscape(boolean escape) {
+		_escape = escape;
 	}
 
 	@Override
@@ -63,6 +71,7 @@ public class StringQuery extends BaseQueryImpl implements Query {
 		return sb.toString();
 	}
 
+	private Boolean _escape;
 	private final String _query;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-134832

/cc @HuongNguyen-gs @huynguyen-codeengine 

Based on research from the TSE, there doesn't seem to be a situation where we would want to call `queryStringQueryBuilder.escape` with a false value, so in my head, it would make more sense to simplify always call the method with true and not update the API. However, in case there is such a situation, I've forwarded the pull as-is to let the search team evaluate which solution makes sense.