### PR TITLE
[TS] LPS-138027 Missing languages (et_EE, fa_IR, gl_ES, in_ID, lt_LT) in the liferay-type-mappings.json Elasticsearch mapping configuration file

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -203,6 +203,19 @@
 				}
 			},
 			{
+				"template_et": {
+					"mapping": {
+						"analyzer": "estonian",
+						"store": true,
+						"term_vector": "with_positions_offsets",
+						"type": "text"
+					},
+					"match": "\\w+_et\\b|\\w+_et_[A-Z]{2}\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
 				"template_eu": {
 					"mapping": {
 						"analyzer": "basque",
@@ -211,6 +224,19 @@
 						"type": "text"
 					},
 					"match": "\\w+_eu\\b|\\w+_eu_[A-Z]{2}\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_fa": {
+					"mapping": {
+						"analyzer": "persian",
+						"store": true,
+						"term_vector": "with_positions_offsets",
+						"type": "text"
+					},
+					"match": "\\w+_fa\\b|\\w+_fa_[A-Z]{2}\\b",
 					"match_mapping_type": "string",
 					"match_pattern": "regex"
 				}
@@ -237,6 +263,19 @@
 						"type": "text"
 					},
 					"match": "\\w+_fr\\b|\\w+_fr_[A-Z]{2}\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_gl": {
+					"mapping": {
+						"analyzer": "galician",
+						"store": true,
+						"term_vector": "with_positions_offsets",
+						"type": "text"
+					},
+					"match": "\\w+_gl\\b|\\w+_gl_[A-Z]{2}\\b",
 					"match_mapping_type": "string",
 					"match_pattern": "regex"
 				}
@@ -281,14 +320,14 @@
 				}
 			},
 			{
-				"template_id": {
+				"template_in": {
 					"mapping": {
 						"analyzer": "indonesian",
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
 					},
-					"match": "\\w+_id\\b|\\w+_id_[A-Z]{2}\\b",
+					"match": "\\w+_in\\b|\\w+_in_[A-Z]{2}\\b",
 					"match_mapping_type": "string",
 					"match_pattern": "regex"
 				}
@@ -328,6 +367,19 @@
 						"type": "text"
 					},
 					"match": "\\w+_ko\\b|\\w+_ko_[A-Z]{2}\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_lt": {
+					"mapping": {
+						"analyzer": "lithuanian",
+						"store": true,
+						"term_vector": "with_positions_offsets",
+						"type": "text"
+					},
+					"match": "\\w+_lt\\b|\\w+_lt_[A-Z]{2}\\b",
 					"match_mapping_type": "string",
 					"match_pattern": "regex"
 				}


### PR DESCRIPTION
See full explanation in the https://issues.liferay.com/browse/LPS-138027 description
