### PR TITLE
[TS] LPS-138944 Result is not fully highlighted 

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
@@ -249,11 +249,20 @@ public class DLFileEntryModelDocumentContributor
 
 		StringBundler sb = new StringBundler(dlFileEntryMetadatas.size());
 
+		boolean firstField = true;
+
 		for (DLFileEntryMetadata dlFileEntryMetadata : dlFileEntryMetadatas) {
 			try {
 				DDMFormValues ddmFormValues =
 					_storageEngineManager.getDDMFormValues(
 						dlFileEntryMetadata.getDDMStorageId());
+
+				if (!firstField) {
+					sb.append(StringPool.SPACE);
+				}
+				else {
+					firstField = false;
+				}
 
 				if (ddmFormValues != null) {
 					sb.append(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -359,6 +359,8 @@ public class DDMIndexerImpl implements DDMIndexer {
 
 		Fields fields = toFields(ddmStructure, ddmFormValues);
 
+		boolean firstField = true;
+
 		for (Field field : fields) {
 			try {
 				String indexType = ddmStructure.getFieldProperty(
@@ -370,20 +372,24 @@ public class DDMIndexerImpl implements DDMIndexer {
 
 				Serializable value = field.getValue(locale);
 
+				if (!firstField) {
+					sb.append(StringPool.SPACE);
+				}
+				else {
+					firstField = false;
+				}
+
 				if (value instanceof Boolean || value instanceof Number) {
 					sb.append(value);
-					sb.append(StringPool.SPACE);
 				}
 				else if (value instanceof Date) {
 					sb.append(dateFormat.format(value));
-					sb.append(StringPool.SPACE);
 				}
 				else if (value instanceof Date[]) {
 					Date[] dates = (Date[])value;
 
 					for (Date date : dates) {
 						sb.append(dateFormat.format(date));
-						sb.append(StringPool.SPACE);
 					}
 				}
 				else if (value instanceof Object[]) {
@@ -391,7 +397,6 @@ public class DDMIndexerImpl implements DDMIndexer {
 
 					for (Object object : values) {
 						sb.append(object);
-						sb.append(StringPool.SPACE);
 					}
 				}
 				else {
@@ -409,8 +414,6 @@ public class DDMIndexerImpl implements DDMIndexer {
 							jsonArray);
 
 						sb.append(stringArray);
-
-						sb.append(StringPool.SPACE);
 					}
 					else {
 						if (type.equals(DDMFormFieldTypeConstants.RICH_TEXT)) {
@@ -418,7 +421,6 @@ public class DDMIndexerImpl implements DDMIndexer {
 						}
 
 						sb.append(valueString);
-						sb.append(StringPool.SPACE);
 					}
 				}
 			}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleIndexerSummaryTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleIndexerSummaryTest.java
@@ -19,6 +19,7 @@ import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.test.util.search.JournalArticleBlueprint;
 import com.liferay.journal.test.util.search.JournalArticleContent;
+import com.liferay.journal.test.util.search.JournalArticleDescription;
 import com.liferay.journal.test.util.search.JournalArticleSearchFixture;
 import com.liferay.journal.test.util.search.JournalArticleTitle;
 import com.liferay.petra.string.StringBundler;
@@ -96,8 +97,10 @@ public class JournalArticleIndexerSummaryTest {
 		String content = "test content";
 		String title = "test title";
 
+		String content2 = "test content "; //see DDMIndexerImpl adds a space line 421
+
 		_summaryFixture.assertSummary(
-			title, content, getDocument(title, content));
+			title, content2, getDocument(title, content));
 	}
 
 	@Test

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleIndexerSummaryTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleIndexerSummaryTest.java
@@ -19,7 +19,6 @@ import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.test.util.search.JournalArticleBlueprint;
 import com.liferay.journal.test.util.search.JournalArticleContent;
-import com.liferay.journal.test.util.search.JournalArticleDescription;
 import com.liferay.journal.test.util.search.JournalArticleSearchFixture;
 import com.liferay.journal.test.util.search.JournalArticleTitle;
 import com.liferay.petra.string.StringBundler;
@@ -97,10 +96,8 @@ public class JournalArticleIndexerSummaryTest {
 		String content = "test content";
 		String title = "test title";
 
-		String content2 = "test content "; //see DDMIndexerImpl adds a space line 421
-
 		_summaryFixture.assertSummary(
-			title, content2, getDocument(title, content));
+			title, content, getDocument(title, content));
 	}
 
 	@Test
@@ -121,45 +118,6 @@ public class JournalArticleIndexerSummaryTest {
 
 		_summaryFixture.assertSummary(
 			highlightedTitle, highlightedContent, document);
-	}
-
-	@Test
-	public void testStaleTitleFreshContent() throws Exception {
-		String content = "test content";
-		String title = "test title";
-
-		Document document = getDocument(title, content);
-
-		String staleContent = "stale content";
-		String staleTitle = "stale title";
-
-		setFields(staleTitle, staleContent, document);
-
-		_summaryFixture.assertSummary(staleTitle, content, document);
-	}
-
-	@Test
-	public void testStaleTitleFreshContentHighlighted() throws Exception {
-		String content = "test content";
-		String title = "test title";
-
-		Document document = getDocument(title, content);
-
-		String staleHighlightedContent = StringBundler.concat(
-			HighlightUtil.HIGHLIGHT_TAG_OPEN, "test",
-			HighlightUtil.HIGHLIGHT_TAG_CLOSE, " stale content");
-		String staleHighlightedTitle = StringBundler.concat(
-			HighlightUtil.HIGHLIGHT_TAG_OPEN, "test",
-			HighlightUtil.HIGHLIGHT_TAG_CLOSE, " stale title");
-
-		setSnippets(staleHighlightedTitle, staleHighlightedContent, document);
-
-		String highlightedContent = StringBundler.concat(
-			HighlightUtil.HIGHLIGHT_TAG_OPEN, "test",
-			HighlightUtil.HIGHLIGHT_TAG_CLOSE, " content");
-
-		_summaryFixture.assertSummary(
-			staleHighlightedTitle, highlightedContent, document);
 	}
 
 	@Rule

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleMultiLanguageSearchJapaneseSummaryTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleMultiLanguageSearchJapaneseSummaryTest.java
@@ -116,7 +116,8 @@ public class JournalArticleMultiLanguageSearchJapaneseSummaryTest {
 
 		setSnippets(highlightedTitle, highlightedContent, document, locale);
 
-		_summaryFixture.assertSummary(highlightedTitle, _KEYWORD, document);
+		_summaryFixture.assertSummary(
+			highlightedTitle, highlightedContent, document);
 	}
 
 	@Test

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleMultiLanguageSearchSummaryTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleMultiLanguageSearchSummaryTest.java
@@ -153,9 +153,7 @@ public class JournalArticleMultiLanguageSearchSummaryTest {
 		_summaryFixture.assertSummary(
 			brTitle,
 			StringBundler.concat(
-				"Sobre ", HighlightUtil.HIGHLIGHT_TAG_OPEN,
-				HighlightUtil.HIGHLIGHT_TAG_OPEN, "times",
-				HighlightUtil.HIGHLIGHT_TAG_CLOSE,
+				"Sobre ", HighlightUtil.HIGHLIGHT_TAG_OPEN, "times",
 				HighlightUtil.HIGHLIGHT_TAG_CLOSE, " de futebol"),
 			LocaleUtil.BRAZIL, document2);
 
@@ -189,9 +187,7 @@ public class JournalArticleMultiLanguageSearchSummaryTest {
 		_summaryFixture.assertSummary(
 			title,
 			StringBundler.concat(
-				"On clocks and ", HighlightUtil.HIGHLIGHT_TAG_OPEN,
-				HighlightUtil.HIGHLIGHT_TAG_OPEN, "time",
-				HighlightUtil.HIGHLIGHT_TAG_CLOSE,
+				"On clocks and ", HighlightUtil.HIGHLIGHT_TAG_OPEN, "time",
 				HighlightUtil.HIGHLIGHT_TAG_CLOSE),
 			LocaleUtil.BRAZIL, document1);
 
@@ -200,9 +196,7 @@ public class JournalArticleMultiLanguageSearchSummaryTest {
 		_summaryFixture.assertSummary(
 			brTitle,
 			StringBundler.concat(
-				"Sobre ", HighlightUtil.HIGHLIGHT_TAG_OPEN,
-				HighlightUtil.HIGHLIGHT_TAG_OPEN, "times",
-				HighlightUtil.HIGHLIGHT_TAG_CLOSE,
+				"Sobre ", HighlightUtil.HIGHLIGHT_TAG_OPEN, "times",
 				HighlightUtil.HIGHLIGHT_TAG_CLOSE, " de futebol"),
 			LocaleUtil.BRAZIL, document2);
 
@@ -245,7 +239,7 @@ public class JournalArticleMultiLanguageSearchSummaryTest {
 	}
 
 	@Test
-	public void testUsDescriptionUntranslatedHighlightedTwiceTranslatedPlain()
+	public void testUsDescriptionUntranslatedHighlightedOnceTranslatedPlain()
 		throws Exception {
 
 		String content = "Clocks are great for telling time";
@@ -272,9 +266,7 @@ public class JournalArticleMultiLanguageSearchSummaryTest {
 		_summaryFixture.assertSummary(
 			title,
 			StringBundler.concat(
-				"On clocks and ", HighlightUtil.HIGHLIGHT_TAG_OPEN,
-				HighlightUtil.HIGHLIGHT_TAG_OPEN, "time",
-				HighlightUtil.HIGHLIGHT_TAG_CLOSE,
+				"On clocks and ", HighlightUtil.HIGHLIGHT_TAG_OPEN, "time",
 				HighlightUtil.HIGHLIGHT_TAG_CLOSE),
 			LocaleUtil.US, document1);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-138944

Removed behavior of checking for updated content after returning from search. Trying to support this behavior guarantees there will be cases where we won't match the search engine's highlighting. Additionally, JournalArticles seem to be the only assets trying to do this. If an index is stale because of some type of outage, it needs to be reindexed.

I've also tested against the tickets that originated the highlighting change and did not experience any regression bugs:
- https://issues.liferay.com/browse/LPS-72222
- https://issues.liferay.com/browse/LPS-72670
- https://issues.liferay.com/browse/LPS-74642

Author: @joshuacords