### PR TITLE
[TS] LPS-140070 Listed elements should be in div tag instead of heading tag in search result widget

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search_result_form.jspf
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search_result_form.jspf
@@ -27,7 +27,7 @@
 		<liferay-ui:search-container-column-text
 			colspan="<%= 2 %>"
 		>
-			<h5>
+			<div>
 				<a href="<%= searchResultSummaryDisplayContext.getViewURL() %>">
 					<strong><%= searchResultSummaryDisplayContext.getHighlightedTitle() %></strong>
 				</a>
@@ -37,9 +37,9 @@
 						<liferay-ui:message arguments="<%= HtmlUtil.escape(searchResultSummaryDisplayContext.getTitle()) %>" key="download-x" />
 					</aui:a>
 				</c:if>
-			</h5>
+			</div>
 
-			<h6 class="text-default">
+			<span class="text-default">
 				<%= searchResultSummaryDisplayContext.getModelResource() %>
 
 				<c:if test="<%= searchResultSummaryDisplayContext.isLocaleReminderVisible() %>">
@@ -48,16 +48,16 @@
 						message="<%= searchResultSummaryDisplayContext.getLocaleReminder() %>"
 					/>
 				</c:if>
-			</h6>
+			</span>
 
 			<c:if test="<%= searchResultSummaryDisplayContext.isContentVisible() %>">
-				<h6 class="text-default">
+				<span class="text-default">
 					<%= searchResultSummaryDisplayContext.getContent() %>
-				</h6>
+				</span>
 			</c:if>
 
 			<c:if test="<%= searchResultSummaryDisplayContext.isAssetCategoriesOrTagsVisible() %>">
-				<h6 class="text-default">
+				<div class="text-default">
 					<liferay-asset:asset-tags-summary
 						className="<%= searchResultSummaryDisplayContext.getClassName() %>"
 						classPK="<%= searchResultSummaryDisplayContext.getClassPK() %>"
@@ -71,11 +71,11 @@
 						paramName="<%= searchResultSummaryDisplayContext.getFieldAssetCategoryIds() %>"
 						portletURL="<%= searchResultSummaryDisplayContext.getPortletURL() %>"
 					/>
-				</h6>
+				</div>
 			</c:if>
 
 			<c:if test="<%= searchResultSummaryDisplayContext.isDocumentFormVisible() %>">
-				<h6 class="expand-details text-default"><a href="javascript:;"><liferay-ui:message key="details" />...</a></h6>
+				<div class="expand-details text-default"><a href="javascript:;"><liferay-ui:message key="details" />...</a></div>
 
 				<div class="hide table-details table-responsive">
 					<table class="table">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/template/dependencies/portlet_display_template_list.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/template/dependencies/portlet_display_template_list.ftl
@@ -97,7 +97,7 @@
 									</#if>
 
 									<#if entry.isAssetCategoriesOrTagsVisible()>
-										<h6 class="search-document-tags text-default">
+										<div class="h6 search-document-tags text-default">
 											<@liferay_asset["asset-tags-summary"]
 												className=entry.getClassName()
 												classPK=entry.getClassPK()
@@ -111,17 +111,17 @@
 												paramName=entry.getFieldAssetCategoryIds()
 												portletURL=entry.getPortletURL()
 											/>
-										</h6>
+										</div>
 									</#if>
 
 									<#if entry.isDocumentFormVisible()>
-										<h6 class="expand-details text-default">
+										<div class="expand-details h6 text-default">
 											<span class="list-group-text" style="">
 												<a href="javascript:;">
 													<@liferay.language key="details" />...
 												</a>
 											</span>
-										</h6>
+										</div>
 
 										<div class="hide search-results-list table-details table-responsive">
 											<table class="table">


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-140070

Hi @thektan @lipusz,
PR related to https://github.com/liferay/liferay-portal-ee/pull/25588

I changed heading tags to div. It was necessary to add "h6" as a class to the div, so the style remained unchanged.

tag and details **before** (font-size is 0.8125rem)
![before tag](https://user-images.githubusercontent.com/69793575/135863592-6379e869-bb66-4a58-aa93-c3843ae36548.JPG)
**after**
![after tag](https://user-images.githubusercontent.com/69793575/135863723-ccb1f794-00ca-4430-b9a9-4129fc6aa01c.JPG)

Besides these changes, I can see one more file using heading tags in a search container, but could not find where they are on the Portal: https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search_result_form.jspf#L42-L78
I could check them, too, and make a change if needed. Please let me know.

cc.  @georgel-pop-lr 

Thanks!
