### PR TITLE
[TS] LPS-145648 portal-kernel: don't index empty keyword fields

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/search/DocumentImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/DocumentImpl.java
@@ -400,9 +400,14 @@ public class DocumentImpl implements Document {
 			return;
 		}
 
-		createField(name, values);
+		String[] filteredValues = Arrays.stream(values).filter(value -> Validator.isNotNull(value)).toArray(String[]::new);
+		if( ArrayUtil.isEmpty(filteredValues)){
+			return;
+		}
 
-		_createSortableTextField(name, true, values);
+		createField(name, filteredValues);
+
+		_createSortableTextField(name, true, filteredValues);
 	}
 
 	@Override


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-145648

Author: @jgarcialr

This is a corner case not covered on LPS-130126, it's caused by repeatable fields. 
String[] values is not null but have empty strings so we end up indexing empty keywords.
Causes empty facet problems.﻿
