### PR TITLE
[TS] LPS-145648 portal-kernel: don't index empty keyword fields

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/search/DocumentImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/DocumentImpl.java
@@ -48,6 +48,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * @author Brian Wing Shun Chan
@@ -400,9 +401,19 @@ public class DocumentImpl implements Document {
 			return;
 		}
 
-		createField(name, values);
+		Stream<String> valuesStream = Arrays.stream(values);
 
-		_createSortableTextField(name, true, values);
+		valuesStream.filter(value -> Validator.isNotNull(value));
+
+		String[] filteredValues = valuesStream.toArray(String[]::new);
+
+		if (ArrayUtil.isEmpty(filteredValues)) {
+			return;
+		}
+
+		createField(name, filteredValues);
+
+		_createSortableTextField(name, true, filteredValues);
 	}
 
 	@Override


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-145648

Author: @jgarcialr

This is a corner case not covered on LPS-130126, it's caused by repeatable fields.
String[] values is not null but have empty strings so we end up indexing empty keywords.
Causes empty facet problems.﻿﻿﻿
