### PR TITLE
LPS-145820 Adapt layout search creation and removes no needed methods

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/layout/prototype/AddLayoutPrototypePortalInstanceLifecycleListener.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/layout/prototype/AddLayoutPrototypePortalInstanceLifecycleListener.java
@@ -36,8 +36,6 @@ public class AddLayoutPrototypePortalInstanceLifecycleListener
 
 	@Override
 	public void portalInstanceRegistered(Company company) throws Exception {
-		searchLayoutFactory.createSearchLayoutPrototype(company);
-
 		Group guestGroup = groupLocalService.getGroup(
 			company.getCompanyId(), GroupConstants.GUEST);
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/layout/prototype/SearchLayoutFactory.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/layout/prototype/SearchLayoutFactory.java
@@ -14,7 +14,6 @@
 
 package com.liferay.portal.search.web.internal.layout.prototype;
 
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 
 /**
@@ -23,7 +22,5 @@ import com.liferay.portal.kernel.model.Group;
 public interface SearchLayoutFactory {
 
 	public void createSearchLayout(Group group);
-
-	public void createSearchLayoutPrototype(Company company);
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/layout/prototype/SearchLayoutFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/layout/prototype/SearchLayoutFactoryImpl.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
@@ -66,24 +65,6 @@ public class SearchLayoutFactoryImpl implements SearchLayoutFactory {
 
 		optional.ifPresent(
 			layoutPrototype -> createSearchLayout(group, layoutPrototype));
-	}
-
-	@Override
-	public void createSearchLayoutPrototype(Company company) {
-		long companyId = company.getCompanyId();
-
-		try {
-			createSearchLayoutPrototype(
-				companyId, userLocalService.getDefaultUserId(companyId),
-				_getSearchTitleLocalizationMap(),
-				_getSearchDescriptionLocalizationMap());
-		}
-		catch (RuntimeException runtimeException) {
-			throw runtimeException;
-		}
-		catch (Exception exception) {
-			throw new SystemException(exception);
-		}
 	}
 
 	protected void createSearchLayout(

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/layout/prototype/SearchLayoutFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/layout/prototype/SearchLayoutFactoryImpl.java
@@ -14,31 +14,25 @@
 
 package com.liferay.portal.search.web.internal.layout.prototype;
 
-import com.liferay.layout.page.template.util.LayoutPrototypeHelperUtil;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
-import com.liferay.portal.kernel.model.LayoutPrototype;
+import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
-import com.liferay.portal.kernel.service.LayoutPrototypeLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.language.LanguageResources;
 import com.liferay.portal.search.web.layout.prototype.SearchLayoutPrototypeCustomizer;
 
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Stream;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -60,89 +54,7 @@ public class SearchLayoutFactoryImpl implements SearchLayoutFactory {
 			return;
 		}
 
-		Optional<LayoutPrototype> optional = _findSearchLayoutPrototype(
-			group.getCompanyId());
-
-		optional.ifPresent(
-			layoutPrototype -> createSearchLayout(group, layoutPrototype));
-	}
-
-	protected void createSearchLayout(
-		Group group, LayoutPrototype layoutPrototype) {
-
-		try {
-			Layout baseLayout = layoutPrototype.getLayout();
-
-			createSearchLayout(group, layoutPrototype, baseLayout);
-		}
-		catch (RuntimeException runtimeException) {
-			throw runtimeException;
-		}
-		catch (Exception exception) {
-			throw new SystemException(exception);
-		}
-	}
-
-	protected void createSearchLayout(
-			Group group, LayoutPrototype layoutPrototype, Layout baseLayout)
-		throws Exception {
-
-		ServiceContext serviceContext = new ServiceContext();
-
-		serviceContext.setAttribute(
-			"layoutPrototypeLinkEnabled", Boolean.FALSE);
-
-		serviceContext.setAttribute(
-			"layoutPrototypeUuid", layoutPrototype.getUuid());
-
-		serviceContext.setUserId(group.getCreatorUserId());
-
-		layoutLocalService.addLayout(
-			group.getCreatorUserId(), group.getGroupId(), false,
-			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID,
-			layoutPrototype.getNameMap(), baseLayout.getTitleMap(),
-			layoutPrototype.getDescriptionMap(), baseLayout.getKeywordsMap(),
-			baseLayout.getRobotsMap(), LayoutConstants.TYPE_PORTLET,
-			baseLayout.getTypeSettings(), baseLayout.isPrivateLayout(),
-			_getFriendlyURLMap(), serviceContext);
-
-		UnicodeProperties unicodeProperties = group.getTypeSettingsProperties();
-
-		unicodeProperties.put("searchLayoutCreated", "true");
-
-		group.setTypeSettingsProperties(unicodeProperties);
-
-		groupLocalService.updateGroup(group);
-
-		if (_log.isInfoEnabled()) {
-			_log.info("Search Page created");
-		}
-	}
-
-	protected void createSearchLayoutPrototype(
-			long companyId, long defaultUserId, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap)
-		throws Exception {
-
-		String layoutTemplateId = getLayoutTemplateId();
-
-		List<LayoutPrototype> layoutPrototypes =
-			layoutPrototypeLocalService.search(
-				companyId, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
-
-		Layout layout = LayoutPrototypeHelperUtil.addLayoutPrototype(
-			layoutPrototypeLocalService, companyId, defaultUserId, nameMap,
-			descriptionMap, layoutTemplateId, layoutPrototypes);
-
-		if (layout == null) {
-			return;
-		}
-
-		customize(layout);
-
-		if (_log.isInfoEnabled()) {
-			_log.info("Search Page Template created");
-		}
+		_createSearchLayout(group);
 	}
 
 	protected void customize(Layout layout) throws Exception {
@@ -168,9 +80,6 @@ public class SearchLayoutFactoryImpl implements SearchLayoutFactory {
 	@Reference
 	protected LayoutLocalService layoutLocalService;
 
-	@Reference
-	protected LayoutPrototypeLocalService layoutPrototypeLocalService;
-
 	@Reference(
 		cardinality = ReferenceCardinality.OPTIONAL,
 		policy = ReferencePolicy.DYNAMIC,
@@ -179,26 +88,47 @@ public class SearchLayoutFactoryImpl implements SearchLayoutFactory {
 	protected volatile SearchLayoutPrototypeCustomizer
 		searchLayoutPrototypeCustomizer;
 
-	@Reference
-	protected UserLocalService userLocalService;
+	private void _createSearchLayout(Group group) {
+		try {
+			Layout layout = layoutLocalService.addLayout(
+				group.getCreatorUserId(), group.getGroupId(), false,
+				LayoutConstants.DEFAULT_PARENT_LAYOUT_ID,
+				_getSearchTitleLocalizationMap(), null,
+				_getSearchDescriptionLocalizationMap(), null, null,
+				LayoutConstants.TYPE_PORTLET, StringPool.BLANK, true,
+				_getFriendlyURLMap(), new ServiceContext());
 
-	private Optional<LayoutPrototype> _findSearchLayoutPrototype(
-		long companyId) {
+			LayoutTypePortlet layoutTypePortlet =
+				(LayoutTypePortlet)layout.getLayoutType();
 
-		Map<Locale, String> searchTitleLocalizationMap =
-			_getSearchTitleLocalizationMap();
+			layoutTypePortlet.setLayoutTemplateId(
+				0, getLayoutTemplateId(), false);
 
-		List<LayoutPrototype> layoutPrototypes =
-			layoutPrototypeLocalService.getLayoutPrototypes(
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+			layoutLocalService.updateLayout(
+				layout.getGroupId(), layout.isPrivateLayout(),
+				layout.getLayoutId(), layout.getTypeSettings());
 
-		Stream<LayoutPrototype> stream1 = layoutPrototypes.stream();
+			customize(layout);
 
-		Stream<LayoutPrototype> stream2 = stream1.filter(
-			layoutPrototype -> _isSearchLayoutPrototype(
-				layoutPrototype, companyId, searchTitleLocalizationMap));
+			UnicodeProperties unicodeProperties =
+				group.getTypeSettingsProperties();
 
-		return stream2.findAny();
+			unicodeProperties.put("searchLayoutCreated", "true");
+
+			group.setTypeSettingsProperties(unicodeProperties);
+
+			groupLocalService.updateGroup(group);
+
+			if (_log.isInfoEnabled()) {
+				_log.info("Search Page created");
+			}
+		}
+		catch (RuntimeException runtimeException) {
+			throw runtimeException;
+		}
+		catch (Exception exception) {
+			throw new SystemException(exception);
+		}
 	}
 
 	private Map<Locale, String> _getFriendlyURLMap() {
@@ -223,19 +153,6 @@ public class SearchLayoutFactoryImpl implements SearchLayoutFactory {
 			group.getGroupId(), false, "/search");
 
 		if (layout != null) {
-			return true;
-		}
-
-		return false;
-	}
-
-	private boolean _isSearchLayoutPrototype(
-		LayoutPrototype layoutPrototype, long companyId,
-		Map<Locale, String> searchTitleLocalizationMap) {
-
-		if ((layoutPrototype.getCompanyId() == companyId) &&
-			searchTitleLocalizationMap.equals(layoutPrototype.getNameMap())) {
-
 			return true;
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-145820

Motivation
=======
Liferay provides some page templates out of the box with the goal of showcasing the page template functionality. The original goal was for this page templates to also provide a good starting point to cover real world use cases. However, because they haven't been adapted with the years to these real world needs they currently add very little value.

Considering this it's been decided that it is better to remove the out of the box page templates so that they are not created in new installations. Existing installations will not be affected by this change, since the page templates will already have been created and thus will not be impacted.

[Link to the issue](https://issues.liferay.com/browse/LPS-110243) 

Proposed Solution
========
It removes the creation of layout page template from **AddLayoutPrototypePortalInstanceLifecycleListener** class, also update the way we are creating the Search layout since we were using the page template to create it.