### PR TITLE
LPS-121100 portal-search: Escape non-highlighted content and title

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/summary/SummaryBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/summary/SummaryBuilderImpl.java
@@ -77,21 +77,23 @@ public class SummaryBuilderImpl implements SummaryBuilder {
 			return _buildContentHighlighted();
 		}
 
-		return _buildContentPlain();
+		return _buildContentPlain(_content);
 	}
 
 	private String _buildContentHighlighted() {
 		return _escapeAndHighlight(_content);
 	}
 
-	private String _buildContentPlain() {
-		if ((_maxContentLength <= 0) ||
-			(_content.length() <= _maxContentLength)) {
-
-			return _content;
+	private String _buildContentPlain(String text) {
+		if (_escape) {
+			text = _html.escape(text);
 		}
 
-		return StringUtil.shorten(_content, _maxContentLength);
+		if ((_maxContentLength <= 0) || (text.length() <= _maxContentLength)) {
+			return text;
+		}
+
+		return StringUtil.shorten(text, _maxContentLength);
 	}
 
 	private String _buildTitle() {
@@ -101,6 +103,10 @@ public class SummaryBuilderImpl implements SummaryBuilder {
 
 		if (_highlight) {
 			return _buildTitleHighlighted();
+		}
+
+		if (_escape) {
+			return _html.escape(_title);
 		}
 
 		return _title;

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/summary/SummaryBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/summary/SummaryBuilderImpl.java
@@ -74,14 +74,10 @@ public class SummaryBuilderImpl implements SummaryBuilder {
 		}
 
 		if (_highlight) {
-			return _buildContentHighlighted();
+			return _escapeAndHighlight(_content);
 		}
 
 		return _buildContentPlain(_content);
-	}
-
-	private String _buildContentHighlighted() {
-		return _escapeAndHighlight(_content);
 	}
 
 	private String _buildContentPlain(String text) {
@@ -102,7 +98,7 @@ public class SummaryBuilderImpl implements SummaryBuilder {
 		}
 
 		if (_highlight) {
-			return _buildTitleHighlighted();
+			return _escapeAndHighlight(_title);
 		}
 
 		if (_escape) {
@@ -110,10 +106,6 @@ public class SummaryBuilderImpl implements SummaryBuilder {
 		}
 
 		return _title;
-	}
-
-	private String _buildTitleHighlighted() {
-		return _escapeAndHighlight(_title);
 	}
 
 	private String _escapeAndHighlight(String text) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-121100

This adds escaping to non-highlighted `content` and `title`.

I added additional `_html.escape` calls (instead of a single step of escaping) since `_escapeAndHighlight` does string replacing before and after escaping.