### PR TITLE
[TS] LPS-147271 IllegalArgumentException is thrown in the classic search portlet by robot requests if "Let the User Choose" scope is selected

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/display/context/SearchDisplayContext.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/display/context/SearchDisplayContext.java
@@ -357,6 +357,10 @@ public class SearchDisplayContext {
 	public String getSearchScopeParameterString() {
 		SearchScope searchScope = getSearchScope();
 
+		if (searchScope == null) {
+			searchScope = SearchScopePreference.THIS_SITE.getSearchScope();
+		}
+
 		return searchScope.getParameterString();
 	}
 
@@ -529,15 +533,7 @@ public class SearchDisplayContext {
 		SearchScopePreference searchScopePreference =
 			getSearchScopePreference();
 
-		SearchScope searchScope = searchScopePreference.getSearchScope();
-
-		if (searchScope == null) {
-			throw new IllegalArgumentException(
-				"Scope parameter is empty and no default is set in " +
-					"preferences");
-		}
-
-		return searchScope;
+		return searchScopePreference.getSearchScope();
 	}
 
 	protected SearchScopePreference getSearchScopePreference() {


### PR DESCRIPTION
See https://issues.liferay.com/browse/LPS-147271 description