### PR TITLE
LPS-147134 Set up in-product links 

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/build.gradle
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:journal:journal-api")
+	compileOnly project(":apps:learn:learn-api")
 	compileOnly project(":apps:petra:petra-portlet-url-builder")
 	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":apps:portal-search:portal-search-web-api")

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/init.jsp
@@ -29,6 +29,7 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.JSPNavigationItemList" %><%@
+page import="com.liferay.learn.LearnMessageUtil" %><%@
 page import="com.liferay.petra.portlet.url.builder.PortletURLBuilder" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/edit_sxp_blueprint.jsp
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/edit_sxp_blueprint.jsp
@@ -44,6 +44,8 @@ renderResponse.setTitle(LanguageUtil.get(request, "edit-blueprint"));
 			).put(
 				"defaultLocale", LocaleUtil.toLanguageId(LocaleUtil.getDefault())
 			).put(
+				"learnMessages", LearnMessageUtil.getJSONObject("search-experiences-web")
+			).put(
 				"locale", themeDisplay.getLanguageId()
 			).put(
 				"namespace", liferayPortletResponse.getNamespace()

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/edit_sxp_element.jsp
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/edit_sxp_element.jsp
@@ -44,6 +44,10 @@ renderResponse.setTitle(LanguageUtil.get(request, "view-element"));
 			HashMapBuilder.<String, Object>put(
 				"defaultLocale", LocaleUtil.toLanguageId(LocaleUtil.getDefault())
 			).put(
+				"learnMessages", LearnMessageUtil.getJSONObject("search-experiences-web")
+			).put(
+				"locale", themeDisplay.getLanguageId()
+			).put(
 				"namespace", liferayPortletResponse.getNamespace()
 			).put(
 				"redirectURL", redirect

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/index.js
@@ -21,6 +21,7 @@ import EditSXPBlueprintForm from './EditSXPBlueprintForm';
 export default function ({
 	contextPath,
 	defaultLocale,
+	learnMessages,
 	locale,
 	namespace,
 	redirectURL,
@@ -49,6 +50,7 @@ export default function ({
 				availableLanguages: Liferay.Language.available,
 				contextPath,
 				defaultLocale,
+				learnMessages,
 				locale,
 				namespace,
 				redirectURL,

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/index.js
@@ -73,6 +73,8 @@ const transformToSXPElementExportFormat = (
 
 export default function ({
 	defaultLocale,
+	learnMessages,
+	locale,
 	namespace,
 	redirectURL,
 	sxpElementId,
@@ -111,6 +113,8 @@ export default function ({
 			value={{
 				availableLanguages: Liferay.Language.available,
 				defaultLocale,
+				learnMessages,
+				locale,
 				namespace,
 				redirectURL,
 			}}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/LearnMessage.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/LearnMessage.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import ClayLink from '@clayui/link';
+import React, {useContext} from 'react';
+
+import ThemeContext from './ThemeContext';
+
+/**
+ * LearnMessage is used to render links to resources, like Liferay Learn
+ * articles. The json object `learnMessages` contains the messages and urls
+ * and is taken from portal/learn-resources.
+ *
+ * Example of `learnMessages`:
+ * {
+ *	"general": {
+ *		"en_US": {
+ *			"message": "Tell me more",
+ *			"url": "https://learn.liferay.com/"
+ *		}
+ *	}
+ * }
+ *
+ * @param {string} resourceKey Identifies which resource to render
+ */
+export default function LearnMessage({resourceKey}) {
+	const {defaultLocale, learnMessages, locale} = useContext(ThemeContext);
+
+	const keyLink = learnMessages?.[resourceKey] || {en_US: {}};
+
+	const link =
+		keyLink[locale] ||
+		keyLink[defaultLocale] ||
+		keyLink[Object.keys(keyLink)[0]];
+
+	return (
+		<ClayLink className="learn-message" href={link.url}>
+			{!!link.url && link.message}
+		</ClayLink>
+	);
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/ThemeContext.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/ThemeContext.js
@@ -15,6 +15,7 @@ export default React.createContext({
 	availableLanguages: {},
 	contextPath: '/o/search-experiences-web',
 	defaultLocale: 'en_US',
+	learnMessages: {},
 	locale: 'en_US',
 	namespace: '',
 	redirectURL: '',


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-147134 - Set up process for referencing learn links inside a React app

This won't alter the UI at all, but it will set up the documentation links on Liferay learn resource so that we can start adding in-product links once the designs are finished! Subtask of https://issues.liferay.com/browse/LPS-147066

Resent after https://github.com/liferay-search/liferay-portal/pull/287