### PR TITLE
LPS-146797 search-experiences-web: Change conditions for 'Select All'

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/_searchable_types_modal.scss
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/_searchable_types_modal.scss
@@ -1,13 +1,13 @@
 .sxp-blueprint-searchable-types-modal {
-	.inline-scroller {
-		max-height: unset;
-	}
-
 	.component-text {
 		margin-left: 12px;
 
-		&.link-primary {
+		& + .btn-link {
 			font-weight: 600;
 		}
+	}
+
+	.inline-scroller {
+		max-height: unset;
 	}
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/SelectTypes.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/SelectTypes.js
@@ -12,7 +12,6 @@
 import ClayButton from '@clayui/button';
 import {ClayCheckbox} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
-import ClayLink from '@clayui/link';
 import ClayManagementToolbar from '@clayui/management-toolbar';
 import ClayModal, {useModal} from '@clayui/modal';
 import ClayTable from '@clayui/table';
@@ -166,19 +165,22 @@ function SelectTypes({
 												)}
 											</span>
 
-											<ClayLink
-												className="component-text"
-												displayType="primary"
-												onClick={() => {
-													setModalSelectedTypes(
-														searchableTypesClassNames
-													);
-												}}
-											>
-												{Liferay.Language.get(
-													'select-all'
-												)}
-											</ClayLink>
+											{modalSelectedTypes.length <
+												searchableTypes.length && (
+												<ClayButton
+													displayType="link"
+													onClick={() => {
+														setModalSelectedTypes(
+															searchableTypesClassNames
+														);
+													}}
+													small
+												>
+													{Liferay.Language.get(
+														'select-all'
+													)}
+												</ClayButton>
+											)}
 										</>
 									) : (
 										<span className="component-text">


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-146797 - The "Select All" button should not appear within the Select Asset Types modal when all checkboxes are already checked

Small changes! Let me know if the styling/functionality is ok.
- Make 'Select All' only appear when not all are selected
- Turn 'Select All' link to button