### PR TITLE
LPS-147218 Integration test for using a custom parameter within Paste Any Elasticsearch Query element

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
@@ -133,7 +133,8 @@ public class SXPBlueprintSearchResultTest {
 
 		_sxpBlueprint = _sxpBlueprintLocalService.addSXPBlueprint(
 			_user.getUserId(),
-			SXPBlueprintSearchResultTestUtil.JSON_QUERY_CONFIGURATION,
+			SXPBlueprintSearchResultTestUtil.
+				JSON_QUERY_CONFIGURATION_JSON_OBJECT.toString(),
 			Collections.singletonMap(LocaleUtil.US, ""), null, "",
 			Collections.singletonMap(
 				LocaleUtil.US, RandomTestUtil.randomString()),
@@ -453,19 +454,13 @@ public class SXPBlueprintSearchResultTest {
 		throws Exception {
 
 		_sxpBlueprint.setConfigurationJSON(
-			JSONUtil.put(
-				"generalConfiguration",
-				JSONUtil.put(
-					"searchableAssetTypes",
-					JSONUtil.put("com.liferay.journal.model.JournalArticle"))
-			).put(
-				"parameterConfiguration",
-				JSONUtil.put(
-					"parameters",
-					JSONUtil.put("myparam", JSONUtil.put("type", "String")))
-			).put(
-				"queryConfiguration", JSONUtil.put("applyIndexerClauses", true)
-			).toString());
+			SXPBlueprintSearchResultTestUtil.
+				JSON_QUERY_CONFIGURATION_JSON_OBJECT.put(
+					"parameterConfiguration",
+					JSONUtil.put(
+						"parameters",
+						JSONUtil.put("myparam", JSONUtil.put("type", "String")))
+				).toString());
 
 		_updateSXPBlueprint();
 
@@ -482,10 +477,7 @@ public class SXPBlueprintSearchResultTest {
 					JSONUtil.put(
 						"match",
 						JSONUtil.put(
-							"title_en_US",
-							JSONUtil.put(
-								"query", "${myparam}"
-							)))
+							"title_en_US", JSONUtil.put("query", "${myparam}")))
 				).build()
 			},
 			new String[] {"Paste Any Elasticsearch Query"});
@@ -657,7 +649,8 @@ public class SXPBlueprintSearchResultTest {
 
 		_assertSearchIgnoreRelevance("[cola coca, cola pepsi, cola sprite]");
 
-		_updateElementInstancesJSON(null, new String[] {"Limit Search to My Contents"});
+		_updateElementInstancesJSON(
+			null, new String[] {"Limit Search to My Contents"});
 
 		_assertSearchIgnoreRelevance("[cola coca, cola pepsi, cola sprite]");
 
@@ -665,7 +658,8 @@ public class SXPBlueprintSearchResultTest {
 
 		_serviceContext.setUserId(user.getUserId());
 
-		_updateElementInstancesJSON(null, new String[] {"Limit Search to My Sites"});
+		_updateElementInstancesJSON(
+			null, new String[] {"Limit Search to My Sites"});
 
 		_assertSearchIgnoreRelevance("[cola coca]");
 

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTestUtil.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTestUtil.java
@@ -79,9 +79,8 @@ public class SXPBlueprintSearchResultTestUtil {
 			).findFirst(
 			).get();
 
-			ElementDefinition elementDefinition =
-				ElementDefinitionUtil.toElementDefinition(
-					sxpElement.getElementDefinitionJSON());
+			ElementDefinition elementDefinition = ElementDefinitionUtil.unpack(
+				ElementDefinition.toDTO(sxpElement.getElementDefinitionJSON()));
 
 			String configurationJSON = String.valueOf(
 				elementDefinition.getConfiguration());

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTestUtil.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTestUtil.java
@@ -48,14 +48,15 @@ public class SXPBlueprintSearchResultTestUtil {
 		"content_${context.language_id}^1"
 	};
 
-	public static final String JSON_QUERY_CONFIGURATION = JSONUtil.put(
-		"generalConfiguration",
+	public static final JSONObject JSON_QUERY_CONFIGURATION_JSON_OBJECT =
 		JSONUtil.put(
-			"searchableAssetTypes",
-			JSONUtil.put("com.liferay.journal.model.JournalArticle"))
-	).put(
-		"queryConfiguration", JSONUtil.put("applyIndexerClauses", true)
-	).toString();
+			"generalConfiguration",
+			JSONUtil.put(
+				"searchableAssetTypes",
+				JSONUtil.put("com.liferay.journal.model.JournalArticle"))
+		).put(
+			"queryConfiguration", JSONUtil.put("applyIndexerClauses", true)
+		);
 
 	public static String getElementInstancesJSON(
 			Object[] configurationValuesArray, String[] sxpElementNames,


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-147218

Refactored SXPBlueprintSearchResultTest.java to standardize consumers usage.

Examples:
https://github.com/liferay/liferay-portal/blob/d92fe65fc49967c308cc122b6a4de5e8bf79ac62/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/clause/contributors/test/IndexerClauseContributorsTest.java#L357-L375

https://github.com/liferay/liferay-portal/blob/d92fe65fc49967c308cc122b6a4de5e8bf79ac62/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/clause/contributors/test/IndexerClauseContributorsTest.java#L348-L349

https://github.com/liferay/liferay-portal/blob/d92fe65fc49967c308cc122b6a4de5e8bf79ac62/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/clause/contributors/test/IndexerClauseContributorsTest.java#L173-L178

Changes were made in pair programing with @arboliveira 