### PR TITLE
LPS-90570 Search Insights widget displays JSON in 'pretty' format

### DIFF
--- a/modules/apps/portal-search/portal-search-web/npmscripts.config.js
+++ b/modules/apps/portal-search/portal-search-web/npmscripts.config.js
@@ -15,7 +15,16 @@
 module.exports = {
 	build: {
 		bundler: {
-			ignore: ['**/*'],
+			ignore: [
+				'**/config.js',
+				'**/custom_filter.js',
+				'**/facet_util.js',
+				'**/modified_facet_configuration.js',
+				'**/modified_facet.js',
+				'**/search_bar.js',
+				'**/sort_configuration.js',
+				'**/sort_util.js',
+			],
 		},
 	},
 };

--- a/modules/apps/portal-search/portal-search-web/package.json
+++ b/modules/apps/portal-search/portal-search-web/package.json
@@ -1,4 +1,7 @@
 {
+	"dependencies": {
+		"codemirror": "^5.59.0"
+	},
 	"jest": {
 		"setupFilesAfterEnv": [
 			"<rootDir>/test/setup.js"

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/insights/display/context/SearchInsightsDisplayContext.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/insights/display/context/SearchInsightsDisplayContext.java
@@ -31,14 +31,26 @@ public class SearchInsightsDisplayContext implements Serializable {
 	}
 
 	public String getRequestString() {
-		return prettyPrintJSONString(_requestString);
+		return _getPrettyPrintedJSONString(_requestString);
 	}
 
 	public String getResponseString() {
-		return prettyPrintJSONString(_responseString);
+		return _getPrettyPrintedJSONString(_responseString);
 	}
 
-	public String prettyPrintJSONString(String jsonString) {
+	public void setHelpMessage(String helpMessage) {
+		_helpMessage = helpMessage;
+	}
+
+	public void setRequestString(String queryString) {
+		_requestString = queryString;
+	}
+
+	public void setResponseString(String responseString) {
+		_responseString = responseString;
+	}
+
+	private String _getPrettyPrintedJSONString(String jsonString) {
 		try {
 			JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 				jsonString);
@@ -52,18 +64,6 @@ public class SearchInsightsDisplayContext implements Serializable {
 
 			return jsonString;
 		}
-	}
-
-	public void setHelpMessage(String helpMessage) {
-		_helpMessage = helpMessage;
-	}
-
-	public void setRequestString(String queryString) {
-		_requestString = queryString;
-	}
-
-	public void setResponseString(String responseString) {
-		_responseString = responseString;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/insights/display/context/SearchInsightsDisplayContext.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/insights/display/context/SearchInsightsDisplayContext.java
@@ -14,6 +14,11 @@
 
 package com.liferay.portal.search.web.internal.search.insights.display.context;
 
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
 import java.io.Serializable;
 
 /**
@@ -26,11 +31,27 @@ public class SearchInsightsDisplayContext implements Serializable {
 	}
 
 	public String getRequestString() {
-		return _requestString;
+		return prettyPrintJSONString(_requestString);
 	}
 
 	public String getResponseString() {
-		return _responseString;
+		return prettyPrintJSONString(_responseString);
+	}
+
+	public String prettyPrintJSONString(String jsonString) {
+		try {
+			JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+				jsonString);
+
+			return jsonObject.toString(4);
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+
+			return jsonString;
+		}
 	}
 
 	public void setHelpMessage(String helpMessage) {
@@ -44,6 +65,9 @@ public class SearchInsightsDisplayContext implements Serializable {
 	public void setResponseString(String responseString) {
 		_responseString = responseString;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SearchInsightsDisplayContext.class);
 
 	private String _helpMessage;
 	private String _requestString;

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/_search_insights.scss
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/_search_insights.scss
@@ -1,23 +1,27 @@
 .portlet-search-insights {
-	textarea {
-		background: #f5f5f8;
-		border-color: #cdced9;
-		font-family: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
-			'Courier New', monospace;
-		height: 300px;
+	.codemirror-editor-wrapper {
+		border: 1px solid #e7e7ed;
+		border-radius: 4px;
 		margin-top: 16px;
-		padding: 16px;
-		resize: none;
-		width: 100%;
 
-		&:focus-visible {
-			outline: none;
+		textarea {
+			border: none;
+			border-radius: 4px;
+			font-family: SFMono-Regular, Menlo, Monaco, Consolas,
+				'Liberation Mono', 'Courier New', monospace;
+			height: 300px;
+			padding: 16px;
+			resize: none;
+			width: 100%;
+
+			&:focus-visible {
+				outline: none;
+			}
 		}
-	}
 
-	.CodeMirror {
-		border: 1px solid #cdced9;
-		height: 300px;
-		margin-top: 16px;
+		.CodeMirror {
+			border-radius: 4px;
+			height: 300px;
+		}
 	}
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/_search_insights.scss
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/_search_insights.scss
@@ -1,0 +1,17 @@
+.portlet-search-insights {
+	textarea {
+		background: #f5f5f8;
+		border-color: #cdced9;
+		font-family: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+			'Courier New', monospace;
+		height: 300px;
+		margin-top: 16px;
+		padding: 16px;
+		resize: none;
+		width: 100%;
+
+		&:focus-visible {
+			outline: none;
+		}
+	}
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/_search_insights.scss
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/_search_insights.scss
@@ -14,4 +14,10 @@
 			outline: none;
 		}
 	}
+
+	.CodeMirror {
+		border: 1px solid #cdced9;
+		height: 300px;
+		margin-top: 16px;
+	}
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,6 +1,7 @@
 @import 'search-results/search_results';
 @import 'search_bar';
 @import 'search_facet';
+@import 'search_insights';
 @import 'search_options';
 @import 'search_portlet';
 @import 'suggestions';

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/CodeMirrorTextArea.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/CodeMirrorTextArea.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import 'codemirror/addon/edit/closebrackets';
+
+import 'codemirror/addon/edit/closetag';
+
+import 'codemirror/addon/edit/matchbrackets';
+
+import 'codemirror/addon/fold/brace-fold';
+
+import 'codemirror/addon/fold/comment-fold';
+
+import 'codemirror/addon/fold/foldcode';
+
+import 'codemirror/addon/fold/foldgutter.css';
+
+import 'codemirror/addon/fold/foldgutter';
+
+import 'codemirror/addon/fold/indent-fold';
+
+import 'codemirror/lib/codemirror.css';
+
+import 'codemirror/mode/javascript/javascript';
+import CodeMirror from 'codemirror';
+
+export default function CodeMirrorTextArea({id}) {
+	CodeMirror.fromTextArea(document.getElementById(id), {
+		foldGutter: true,
+		gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
+		indentWithTabs: true,
+		inputStyle: 'contenteditable',
+		lineNumbers: true,
+		matchBrackets: true,
+		mode: {globalVars: true, name: 'application/json'},
+		readOnly: true,
+		tabSize: 2,
+	});
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/insights/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/insights/view.jsp
@@ -20,9 +20,11 @@
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
+<%@ page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
+page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.portal.search.web.internal.search.insights.display.context.SearchInsightsDisplayContext" %>
@@ -71,6 +73,15 @@ SearchInsightsDisplayContext searchInsightsDisplayContext = (SearchInsightsDispl
 					/>
 
 					<textarea readonly id="<portlet:namespace />insightsRequest"><%= HtmlUtil.escape(searchInsightsDisplayContext.getRequestString()) %></textarea>
+
+					<liferay-frontend:component
+						context='<%=
+							HashMapBuilder.<String, Object>put(
+								"id", liferayPortletResponse.getNamespace() + "insightsRequest"
+							).build()
+						%>'
+						module="js/CodeMirrorTextArea"
+					/>
 				</liferay-ui:panel>
 
 				<liferay-ui:panel
@@ -89,6 +100,15 @@ SearchInsightsDisplayContext searchInsightsDisplayContext = (SearchInsightsDispl
 					/>
 
 					<textarea readonly id="<portlet:namespace />insightsResponse"><%= HtmlUtil.escape(searchInsightsDisplayContext.getResponseString()) %></textarea>
+
+					<liferay-frontend:component
+						context='<%=
+							HashMapBuilder.<String, Object>put(
+								"id", liferayPortletResponse.getNamespace() + "insightsResponse"
+							).build()
+						%>'
+						module="js/CodeMirrorTextArea"
+					/>
 				</liferay-ui:panel>
 			</liferay-ui:panel-container>
 		</div>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/insights/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/insights/view.jsp
@@ -72,7 +72,9 @@ SearchInsightsDisplayContext searchInsightsDisplayContext = (SearchInsightsDispl
 						small="<%= true %>"
 					/>
 
-					<textarea readonly id="<portlet:namespace />insightsRequest"><%= HtmlUtil.escape(searchInsightsDisplayContext.getRequestString()) %></textarea>
+					<div class="codemirror-editor-wrapper">
+						<textarea readonly id="<portlet:namespace />insightsRequest"><%= HtmlUtil.escape(searchInsightsDisplayContext.getRequestString()) %></textarea>
+					</div>
 
 					<liferay-frontend:component
 						context='<%=
@@ -99,7 +101,9 @@ SearchInsightsDisplayContext searchInsightsDisplayContext = (SearchInsightsDispl
 						small="<%= true %>"
 					/>
 
-					<textarea readonly id="<portlet:namespace />insightsResponse"><%= HtmlUtil.escape(searchInsightsDisplayContext.getResponseString()) %></textarea>
+					<div class="codemirror-editor-wrapper">
+						<textarea readonly id="<portlet:namespace />insightsResponse"><%= HtmlUtil.escape(searchInsightsDisplayContext.getResponseString()) %></textarea>
+					</div>
 
 					<liferay-frontend:component
 						context='<%=

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/insights/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/insights/view.jsp
@@ -18,7 +18,9 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
@@ -60,9 +62,15 @@ SearchInsightsDisplayContext searchInsightsDisplayContext = (SearchInsightsDispl
 					persistState="<%= true %>"
 					title="request-string"
 				>
-					<code>
-						<%= HtmlUtil.escape(searchInsightsDisplayContext.getRequestString()) %>
-					</code>
+					<clay:button
+						displayType="secondary"
+						icon="copy"
+						label="copy-to-clipboard"
+						onClick='<%= liferayPortletResponse.getNamespace() + "copyToClipboard('insightsRequest');" %>'
+						small="<%= true %>"
+					/>
+
+					<textarea readonly id="<portlet:namespace />insightsRequest"><%= HtmlUtil.escape(searchInsightsDisplayContext.getRequestString()) %></textarea>
 				</liferay-ui:panel>
 
 				<liferay-ui:panel
@@ -72,11 +80,39 @@ SearchInsightsDisplayContext searchInsightsDisplayContext = (SearchInsightsDispl
 					persistState="<%= true %>"
 					title="response-string"
 				>
-					<code>
-						<%= HtmlUtil.escape(searchInsightsDisplayContext.getResponseString()) %>
-					</code>
+					<clay:button
+						displayType="secondary"
+						icon="copy"
+						label="copy-to-clipboard"
+						onClick='<%= liferayPortletResponse.getNamespace() + "copyToClipboard('insightsResponse');" %>'
+						small="<%= true %>"
+					/>
+
+					<textarea readonly id="<portlet:namespace />insightsResponse"><%= HtmlUtil.escape(searchInsightsDisplayContext.getResponseString()) %></textarea>
 				</liferay-ui:panel>
 			</liferay-ui:panel-container>
 		</div>
 	</c:otherwise>
 </c:choose>
+
+<aui:script>
+	function <portlet:namespace />copyToClipboard(id) {
+		const text = document.getElementById('<portlet:namespace />' + id).value;
+
+		navigator.clipboard.writeText(text).then(
+			() => {
+				Liferay.Util.openToast({
+					message: '<liferay-ui:message key="copied-to-clipboard" />',
+					type: 'success',
+				});
+			},
+			() => {
+				Liferay.Util.openToast({
+					message:
+						'<liferay-ui:message key="an-unexpected-error-occurred" />',
+					type: 'danger',
+				});
+			}
+		);
+	}
+</aui:script>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/insights/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/insights/view.jsp
@@ -33,6 +33,9 @@ page import="com.liferay.portal.search.web.internal.search.insights.display.cont
 
 <%
 SearchInsightsDisplayContext searchInsightsDisplayContext = (SearchInsightsDisplayContext)java.util.Objects.requireNonNull(request.getAttribute(WebKeys.PORTLET_DISPLAY_CONTEXT));
+
+String insightsRequestId = liferayPortletResponse.getNamespace() + "insightsRequest";
+String insightsResponseId = liferayPortletResponse.getNamespace() + "insightsResponse";
 %>
 
 <style>
@@ -68,18 +71,18 @@ SearchInsightsDisplayContext searchInsightsDisplayContext = (SearchInsightsDispl
 						displayType="secondary"
 						icon="copy"
 						label="copy-to-clipboard"
-						onClick='<%= liferayPortletResponse.getNamespace() + "copyToClipboard('insightsRequest');" %>'
+						onClick='<%= liferayPortletResponse.getNamespace() + "copyToClipboard('" + insightsRequestId + "');" %>'
 						small="<%= true %>"
 					/>
 
 					<div class="codemirror-editor-wrapper">
-						<textarea readonly id="<portlet:namespace />insightsRequest"><%= HtmlUtil.escape(searchInsightsDisplayContext.getRequestString()) %></textarea>
+						<textarea readonly id="<%= insightsRequestId %>"><%= HtmlUtil.escape(searchInsightsDisplayContext.getRequestString()) %></textarea>
 					</div>
 
 					<liferay-frontend:component
 						context='<%=
 							HashMapBuilder.<String, Object>put(
-								"id", liferayPortletResponse.getNamespace() + "insightsRequest"
+								"id", insightsRequestId
 							).build()
 						%>'
 						module="js/CodeMirrorTextArea"
@@ -97,18 +100,18 @@ SearchInsightsDisplayContext searchInsightsDisplayContext = (SearchInsightsDispl
 						displayType="secondary"
 						icon="copy"
 						label="copy-to-clipboard"
-						onClick='<%= liferayPortletResponse.getNamespace() + "copyToClipboard('insightsResponse');" %>'
+						onClick='<%= liferayPortletResponse.getNamespace() + "copyToClipboard('" + insightsResponseId + "');" %>'
 						small="<%= true %>"
 					/>
 
 					<div class="codemirror-editor-wrapper">
-						<textarea readonly id="<portlet:namespace />insightsResponse"><%= HtmlUtil.escape(searchInsightsDisplayContext.getResponseString()) %></textarea>
+						<textarea readonly id="<%= insightsResponseId %>"><%= HtmlUtil.escape(searchInsightsDisplayContext.getResponseString()) %></textarea>
 					</div>
 
 					<liferay-frontend:component
 						context='<%=
 							HashMapBuilder.<String, Object>put(
-								"id", liferayPortletResponse.getNamespace() + "insightsResponse"
+								"id", insightsResponseId
 							).build()
 						%>'
 						module="js/CodeMirrorTextArea"
@@ -121,7 +124,7 @@ SearchInsightsDisplayContext searchInsightsDisplayContext = (SearchInsightsDispl
 
 <aui:script>
 	function <portlet:namespace />copyToClipboard(id) {
-		const text = document.getElementById('<portlet:namespace />' + id).value;
+		const text = document.getElementById(id).value;
 
 		navigator.clipboard.writeText(text).then(
 			() => {

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/search/SearchResults.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/search/SearchResults.path
@@ -217,12 +217,12 @@
 <!--SEARCH_INSIGHTS_PORTLET-->
 <tr>
 	<td>SEARCH_INSIGHTS_PORTLET_RESPONSE_QUERY</td>
-	<td>//div[contains(@id,'insightsResponsePanel')]//code</td>
+	<td>//div[contains(@id,'insightsResponsePanelContent')]//div[contains(@class,'CodeMirror cm-s-default')]//span[contains(@class,'cm-string')][normalize-space()='${key_text}']</td>
 	<td></td>
 </tr>
 <tr>
-	<td>SEARCH_INSIGHTS_PORTLET_STRING_QUERY</td>
-	<td>//div[contains(@id,'insightsRequestPanel')]//code</td>
+	<td>SEARCH_INSIGHTS_PORTLET_REQUEST_QUERY</td>
+	<td>//div[contains(@id,'insightsRequestPanelContent')]//div[contains(@class,'CodeMirror cm-s-default')]//span[contains(@class,'cm-string')][normalize-space()='${key_text}']</td>
 	<td></td>
 </tr>
 <!--CUSTOM_FACET-->

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/elasticsearch/Elasticsearch7.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/elasticsearch/Elasticsearch7.testcase
@@ -195,17 +195,13 @@ definition {
 
 		SearchPortlets.searchEmbedded(searchTerm = "apple");
 
-		AssertTextEquals.assertPartialText(
-			locator1 = "SearchResults#SEARCH_INSIGHTS_PORTLET_STRING_QUERY",
-			value1 = "&quot;explain&quot;:true");
+		AssertElementPresent(
+			key_text = "&quot;explain&quot;",
+			locator1 = "SearchResults#SEARCH_INSIGHTS_PORTLET_REQUEST_QUERY");
 
-		AssertTextEquals.assertPartialText(
-			locator1 = "SearchResults#SEARCH_INSIGHTS_PORTLET_RESPONSE_QUERY",
-			value1 = "buckets");
-
-		AssertTextEquals.assertPartialText(
-			locator1 = "SearchResults#SEARCH_INSIGHTS_PORTLET_RESPONSE_QUERY",
-			value1 = "_explanation");
+		AssertElementPresent(
+			key_text = "&quot;_explanation&quot;",
+			locator1 = "SearchResults#SEARCH_INSIGHTS_PORTLET_RESPONSE_QUERY");
 
 		Portlet.gotoPortletOptions(
 			portletName = "Search Insights",
@@ -223,13 +219,13 @@ definition {
 
 		SearchPortlets.searchEmbedded(searchTerm = "apple");
 
-		AssertTextEquals.assertPartialText(
-			locator1 = "SearchResults#SEARCH_INSIGHTS_PORTLET_STRING_QUERY",
-			value1 = "&quot;explain&quot;:false");
+		AssertElementPresent(
+			key_text = "&quot;explain&quot;",
+			locator1 = "SearchResults#SEARCH_INSIGHTS_PORTLET_REQUEST_QUERY");
 
-		AssertTextNotEquals.assertNotPartialText(
-			locator1 = "SearchResults#SEARCH_INSIGHTS_PORTLET_RESPONSE_QUERY",
-			value1 = "_explanation");
+		AssertElementNotPresent(
+			key_text = "&quot;_explanation&quot;",
+			locator1 = "SearchResults#SEARCH_INSIGHTS_PORTLET_RESPONSE_QUERY");
 	}
 
 	@priority = "5"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
@@ -120,9 +120,9 @@ definition {
 
 		SearchPortlets.searchEmbedded(searchTerm = "test");
 
-		AssertTextNotEquals.assertNotPartialText(
-			locator1 = "SearchResults#SEARCH_INSIGHTS_PORTLET_RESPONSE_QUERY",
-			value1 = "hits");
+		AssertElementNotPresent(
+			key_text = "hits",
+			locator1 = "SearchResults#SEARCH_INSIGHTS_PORTLET_RESPONSE_QUERY");
 	}
 
 	test ApplyBlueprintToContentPageViaBlueprintsOptions {


### PR DESCRIPTION
_Copied from https://github.com/liferay-search/liferay-portal/pull/345_

https://issues.liferay.com/browse/LPS-90570 - Search Insights widget displays JSON in 'pretty' format when Elasticsearch is the search engine

Notes:
- The search insights display context uses a function to pretty print the JSON string.
- Added `Copy to Clipboard` button
- Added use of CodeMirror. So CodeMirror actually takes about a second to load, and the page will show the original textarea in the same place before the CodeMirror renders. I ended up separating this out into the second commit in case we prefer using textarea instead, let me know what you think!

`textarea` 
<img width="651" alt="Screen Shot 2022-03-16 at 4 33 44 PM" src="https://user-images.githubusercontent.com/14063502/158709272-41d86fd0-a483-4154-a6e6-90c7bd871190.png">

`CodeMirror`
<img width="657" alt="Screen Shot 2022-03-16 at 4 33 27 PM" src="https://user-images.githubusercontent.com/14063502/158709458-2da6eeb3-5614-445f-86fd-1027a1cbc414.png">