### PR TITLE
LPS-146033 Handle requests unable to resolve or slow to resolve

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/_preview_sidebar.scss
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/_preview_sidebar.scss
@@ -34,6 +34,10 @@
 		padding: 16px 0;
 		text-align: center;
 		width: 340px;
+
+		.cancel {
+			margin-top: 16px;
+		}
 	}
 
 	.sidebar-search {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -686,21 +686,23 @@ function EditSXPBlueprintForm({
 				signal: controllerRef.current.signal,
 			}
 		)
-			.then((response) => {
-				if (!response.ok) {
-					if (response.status === 400) {
-						return response.json().then((json) => {
-							return getResultsError({msg: json.title});
-						});
-					}
-				}
+			.then((response) =>
+				response.json().then((data) => ({
+					ok: response.ok,
+					responseContent: data,
+					status: response.status,
+				}))
+			)
+			.then(({ok, responseContent, status}) => {
+				const errorResponse = getResultsError(
+					status === 400 ? {msg: responseContent.title} : {}
+				);
 
-				return response.json();
-			})
-			.then((responseContent) => {
 				setPreviewInfo({
 					loading: false,
-					results: parseResponseContent(responseContent),
+					results: parseResponseContent(
+						ok ? responseContent : errorResponse
+					),
 				});
 			})
 			.catch((error) => {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -98,23 +98,38 @@ function EditSXPBlueprintForm({
 	const [tab, setTab] = useState('query-builder');
 
 	const [indexFields, setIndexFields] = useState(null);
-	const [keywordQueryContributors, setKeywordQueryContributors] = useState(
-		null
-	);
-	const [
-		modelPrefilterContributors,
-		setModelPrefilterContributors,
-	] = useState(null);
-	const [
-		queryPrefilterContributors,
-		setQueryPrefilterContributors,
-	] = useState(null);
 
 	const {
 		data: searchableTypes,
 		refetch: refetchSearchableTypes,
 	} = useFetchData({
 		resource: `/o/search-experiences-rest/v1.0/searchable-asset-names/${locale}`,
+	});
+
+	const {
+		data: keywordQueryContributors,
+		refetch: refetchKeywordQueryContributors,
+	} = useFetchData({
+		getData: (response) => filterAndSortClassNames(response?.items),
+		resource: '/o/search-experiences-rest/v1.0/keyword-query-contributors',
+	});
+
+	const {
+		data: modelPrefilterContributors,
+		refetch: refetchModelPrefilterContributors,
+	} = useFetchData({
+		getData: (response) => filterAndSortClassNames(response?.items),
+		resource:
+			'/o/search-experiences-rest/v1.0/model-prefilter-contributors',
+	});
+
+	const {
+		data: queryPrefilterContributors,
+		refetch: refetchQueryPrefilterContributors,
+	} = useFetchData({
+		getData: (response) => filterAndSortClassNames(response?.items),
+		resource:
+			'/o/search-experiences-rest/v1.0/query-prefilter-contributors',
 	});
 
 	/**
@@ -389,30 +404,6 @@ function EditSXPBlueprintForm({
 		fetchData(`/o/search-experiences-rest/v1.0/field-mapping-infos`)
 			.then((responseContent) => setIndexFields(responseContent.items))
 			.catch(() => setIndexFields([]));
-
-		[
-			{
-				setProperty: setKeywordQueryContributors,
-				url:
-					'/o/search-experiences-rest/v1.0/keyword-query-contributors',
-			},
-			{
-				setProperty: setModelPrefilterContributors,
-				url:
-					'/o/search-experiences-rest/v1.0/model-prefilter-contributors',
-			},
-			{
-				setProperty: setQueryPrefilterContributors,
-				url:
-					'/o/search-experiences-rest/v1.0/query-prefilter-contributors',
-			},
-		].forEach(({setProperty, url}) =>
-			fetchData(url)
-				.then((responseContent) =>
-					setProperty(filterAndSortClassNames(responseContent.items))
-				)
-				.catch(() => setProperty([]))
-		);
 
 		setStorageAddSXPElementSidebar('open');
 	}, []); //eslint-disable-line
@@ -808,6 +799,11 @@ function EditSXPBlueprintForm({
 							onFrameworkConfigChange={
 								_handleFrameworkConfigChange
 							}
+							refetchContributors={() => {
+								refetchKeywordQueryContributors();
+								refetchModelPrefilterContributors();
+								refetchQueryPrefilterContributors();
+							}}
 							visible={
 								openSidebar === SIDEBARS.CLAUSE_CONTRIBUTORS
 							}
@@ -885,12 +881,7 @@ function EditSXPBlueprintForm({
 		}
 	};
 
-	if (
-		!indexFields ||
-		!keywordQueryContributors ||
-		!modelPrefilterContributors ||
-		!queryPrefilterContributors
-	) {
+	if (!indexFields) {
 		return null;
 	}
 

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -39,6 +39,7 @@ import {
 	openSuccessToast,
 	setInitialSuccessToast,
 } from '../utils/toasts';
+import useFetchData from '../utils/useFetchData';
 import useShouldConfirmBeforeNavigate from '../utils/useShouldConfirmBeforeNavigate';
 import {
 	cleanUIConfiguration,
@@ -108,7 +109,13 @@ function EditSXPBlueprintForm({
 		queryPrefilterContributors,
 		setQueryPrefilterContributors,
 	] = useState(null);
-	const [searchableTypes, setSearchableTypes] = useState(null);
+
+	const {
+		data: searchableTypes,
+		refetch: refetchSearchableTypes,
+	} = useFetchData({
+		resource: `/o/search-experiences-rest/v1.0/searchable-asset-names/${locale}`,
+	});
 
 	/**
 	 * This method must go before the useFormik hook.
@@ -379,14 +386,6 @@ function EditSXPBlueprintForm({
 	useShouldConfirmBeforeNavigate(formik.dirty && !formik.isSubmitting);
 
 	useEffect(() => {
-		fetchData(
-			`/o/search-experiences-rest/v1.0/searchable-asset-names/${locale}`
-		)
-			.then((responseContent) =>
-				setSearchableTypes(responseContent.items)
-			)
-			.catch(() => setSearchableTypes([]));
-
 		fetchData(`/o/search-experiences-rest/v1.0/field-mapping-infos`)
 			.then((responseContent) => setIndexFields(responseContent.items))
 			.catch(() => setIndexFields([]));
@@ -873,7 +872,8 @@ function EditSXPBlueprintForm({
 									_handleFrameworkConfigChange
 								}
 								openSidebar={openSidebar}
-								searchableTypes={searchableTypes}
+								refetchSearchableTypes={refetchSearchableTypes}
+								searchableTypes={searchableTypes?.items}
 								setFieldTouched={formik.setFieldTouched}
 								setFieldValue={formik.setFieldValue}
 								setOpenSidebar={setOpenSidebar}
@@ -889,8 +889,7 @@ function EditSXPBlueprintForm({
 		!indexFields ||
 		!keywordQueryContributors ||
 		!modelPrefilterContributors ||
-		!queryPrefilterContributors ||
-		!searchableTypes
+		!queryPrefilterContributors
 	) {
 		return null;
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/clause_contributors_sidebar/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/clause_contributors_sidebar/index.js
@@ -9,6 +9,8 @@
  * distribution rights of the Software.
  */
 
+import ClayAlert from '@clayui/alert';
+import ClayButton from '@clayui/button';
 import {ClayCheckbox, ClayToggle} from '@clayui/form';
 import ClayList from '@clayui/list';
 import React, {useEffect, useState} from 'react';
@@ -48,6 +50,7 @@ export default function ({
 	initialClauseContributorsList = [],
 	onClose,
 	onFrameworkConfigChange,
+	refetchContributors,
 	visible,
 }) {
 	const [category, setCategory] = useState(ALL);
@@ -255,13 +258,35 @@ export default function ({
 				/>
 
 				<ClayList>
-					{contributors.map((contributor) => (
-						<React.Fragment key={contributor.label}>
-							<ClayList.Header>
-								{contributor.label}
-							</ClayList.Header>
+					{initialClauseContributorsList.some(
+						({value}) => value.length === 0
+					) && (
+						<ClayAlert
+							actions={
+								<ClayButton.Group>
+									<ClayButton
+										alert
+										onClick={refetchContributors}
+									>
+										{Liferay.Language.get('refresh')}
+									</ClayButton>
+								</ClayButton.Group>
+							}
+							displayType="danger"
+							title={Liferay.Language.get('error')}
+							variant="inline"
+						>
+							{Liferay.Language.get(
+								'an-error-has-occurred-and-we-were-unable-to-load-the-results'
+							)}
+						</ClayAlert>
+					)}
 
-							{contributor.value.map((className) => (
+					{contributors.map(({label, value}) => (
+						<React.Fragment key={label}>
+							<ClayList.Header>{label}</ClayList.Header>
+
+							{value.map((className) => (
 								<ClayList.Item
 									active={selected.includes(className)}
 									flex

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/preview_sidebar/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/preview_sidebar/index.js
@@ -41,6 +41,7 @@ function PreviewSidebar({
 	hits = [],
 	loading,
 	onClose,
+	onFetchCancel,
 	onFetchResults,
 	onFocusSXPElement,
 	responseString = '',
@@ -51,6 +52,7 @@ function PreviewSidebar({
 	const [activeDelta, setActiveDelta] = useState(10);
 	const [activePage, setActivePage] = useState(1);
 	const [attributes, setAttributes] = useState([]);
+	const [showCancel, setShowCancel] = useState(false);
 	const [value, setValue] = useState('');
 
 	const _handleAttributesSubmit = (attributes) => {
@@ -58,7 +60,9 @@ function PreviewSidebar({
 	};
 
 	const _handleFetch = () => {
+		setShowCancel(false);
 		onFetchResults(value, activeDelta, activePage, attributes);
+		setTimeout(() => setShowCancel(true), 10000);
 	};
 
 	useDidUpdateEffect(() => {
@@ -294,7 +298,26 @@ function PreviewSidebar({
 					</div>
 				)
 			) : (
-				<ClayLoadingIndicator />
+				<>
+					<ClayLoadingIndicator />
+
+					{showCancel && (
+						<div className="search-message">
+							{Liferay.Language.get(
+								'it-looks-like-this-is-taking-longer-than-expected'
+							)}
+
+							<ClayButton
+								className="cancel"
+								displayType="secondary"
+								onClick={onFetchCancel}
+								small
+							>
+								{Liferay.Language.get('cancel')}
+							</ClayButton>
+						</div>
+					)}
+				</>
 			)}
 		</div>
 	);
@@ -305,6 +328,7 @@ PreviewSidebar.propTypes = {
 	hits: PropTypes.arrayOf(PropTypes.object),
 	loading: PropTypes.bool,
 	onClose: PropTypes.func,
+	onFetchCancel: PropTypes.func,
 	onFetchResults: PropTypes.func,
 	onFocusSXPElement: PropTypes.func,
 	responseString: PropTypes.string,

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/QuerySettings.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/QuerySettings.js
@@ -27,6 +27,7 @@ function QuerySettings({
 	onChangeClauseContributorsVisibility,
 	onChangeIndexerClausesVisibility,
 	onFrameworkConfigChange,
+	refetchSearchableTypes,
 	searchableTypes,
 }) {
 	const [selectAllTypes, setSelectAllTypes] = useState(
@@ -113,6 +114,9 @@ function QuerySettings({
 									<SelectTypes
 										onFrameworkConfigChange={
 											onFrameworkConfigChange
+										}
+										refetchSearchableTypes={
+											refetchSearchableTypes
 										}
 										searchableTypes={searchableTypes}
 										selectedTypes={

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/SelectTypes.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/SelectTypes.js
@@ -10,6 +10,7 @@
  */
 
 import ClayButton from '@clayui/button';
+import ClayEmptyState from '@clayui/empty-state';
 import {ClayCheckbox} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayManagementToolbar from '@clayui/management-toolbar';
@@ -22,6 +23,7 @@ import {sub} from '../../utils/language';
 
 function SelectTypes({
 	onFrameworkConfigChange,
+	refetchSearchableTypes,
 	searchableTypes = [],
 	selectedTypes = [],
 }) {
@@ -123,115 +125,147 @@ function SelectTypes({
 						{Liferay.Language.get('select-types')}
 					</ClayModal.Header>
 
-					<ClayManagementToolbar
-						className={
-							modalSelectedTypes.length > 0 &&
-							'management-bar-primary'
-						}
-					>
-						<div className="navbar-form navbar-form-autofit navbar-overlay">
-							<ClayManagementToolbar.ItemList>
-								<ClayManagementToolbar.Item>
-									<ClayCheckbox
-										checked={modalSelectedTypes.length > 0}
-										indeterminate={
-											modalSelectedTypes.length > 0 &&
-											modalSelectedTypes.length !==
-												searchableTypes.length
-										}
-										onChange={() =>
-											setModalSelectedTypes(
-												modalSelectedTypes.length === 0
-													? searchableTypesClassNames
-													: []
-											)
-										}
-									/>
-								</ClayManagementToolbar.Item>
+					{searchableTypes.length > 0 ? (
+						<>
+							<ClayManagementToolbar
+								className={
+									modalSelectedTypes.length > 0 &&
+									'management-bar-primary'
+								}
+							>
+								<div className="navbar-form navbar-form-autofit navbar-overlay">
+									<ClayManagementToolbar.ItemList>
+										<ClayManagementToolbar.Item>
+											<ClayCheckbox
+												checked={
+													modalSelectedTypes.length >
+													0
+												}
+												indeterminate={
+													modalSelectedTypes.length >
+														0 &&
+													modalSelectedTypes.length !==
+														searchableTypes.length
+												}
+												onChange={() =>
+													setModalSelectedTypes(
+														modalSelectedTypes.length ===
+															0
+															? searchableTypesClassNames
+															: []
+													)
+												}
+											/>
+										</ClayManagementToolbar.Item>
 
-								<ClayManagementToolbar.Item>
-									{modalSelectedTypes.length > 0 ? (
-										<>
-											<span className="component-text">
-												{sub(
-													Liferay.Language.get(
-														'x-of-x-selected'
-													),
-													[
-														modalSelectedTypes.length,
-														searchableTypes.length,
-													],
-													false
-												)}
-											</span>
+										<ClayManagementToolbar.Item>
+											{modalSelectedTypes.length > 0 ? (
+												<>
+													<span className="component-text">
+														{sub(
+															Liferay.Language.get(
+																'x-of-x-selected'
+															),
+															[
+																modalSelectedTypes.length,
+																searchableTypes.length,
+															],
+															false
+														)}
+													</span>
 
-											{modalSelectedTypes.length <
-												searchableTypes.length && (
-												<ClayButton
-													displayType="link"
-													onClick={() => {
-														setModalSelectedTypes(
-															searchableTypesClassNames
-														);
-													}}
-													small
-												>
+													{modalSelectedTypes.length <
+														searchableTypes.length && (
+														<ClayButton
+															displayType="link"
+															onClick={() => {
+																setModalSelectedTypes(
+																	searchableTypesClassNames
+																);
+															}}
+															small
+														>
+															{Liferay.Language.get(
+																'select-all'
+															)}
+														</ClayButton>
+													)}
+												</>
+											) : (
+												<span className="component-text">
 													{Liferay.Language.get(
 														'select-all'
 													)}
-												</ClayButton>
+												</span>
 											)}
-										</>
-									) : (
-										<span className="component-text">
-											{Liferay.Language.get('select-all')}
-										</span>
-									)}
-								</ClayManagementToolbar.Item>
-							</ClayManagementToolbar.ItemList>
-						</div>
-					</ClayManagementToolbar>
+										</ClayManagementToolbar.Item>
+									</ClayManagementToolbar.ItemList>
+								</div>
+							</ClayManagementToolbar>
 
-					<ClayModal.Body scrollable>
-						<ClayTable>
-							<ClayTable.Body>
-								{searchableTypesSorted.map(
-									({className, displayName}) => {
-										const isSelected = modalSelectedTypes.includes(
-											className
-										);
-
-										return (
-											<ClayTable.Row
-												active={isSelected}
-												className="cursor-pointer"
-												key={className}
-												onClick={_handleRowCheck(
+							<ClayModal.Body scrollable>
+								<ClayTable>
+									<ClayTable.Body>
+										{searchableTypesSorted.map(
+											({className, displayName}) => {
+												const isSelected = modalSelectedTypes.includes(
 													className
-												)}
-											>
-												<ClayTable.Cell>
-													<ClayCheckbox
-														checked={isSelected}
-														onChange={_handleRowCheck(
+												);
+
+												return (
+													<ClayTable.Row
+														active={isSelected}
+														className="cursor-pointer"
+														key={className}
+														onClick={_handleRowCheck(
 															className
 														)}
-													/>
-												</ClayTable.Cell>
+													>
+														<ClayTable.Cell>
+															<ClayCheckbox
+																checked={
+																	isSelected
+																}
+																onChange={_handleRowCheck(
+																	className
+																)}
+															/>
+														</ClayTable.Cell>
 
-												<ClayTable.Cell
-													expanded
-													headingTitle
-												>
-													{displayName}
-												</ClayTable.Cell>
-											</ClayTable.Row>
-										);
-									}
+														<ClayTable.Cell
+															expanded
+															headingTitle
+														>
+															{displayName}
+														</ClayTable.Cell>
+													</ClayTable.Row>
+												);
+											}
+										)}
+									</ClayTable.Body>
+								</ClayTable>
+							</ClayModal.Body>
+						</>
+					) : (
+						<ClayModal.Body>
+							<ClayEmptyState
+								description={Liferay.Language.get(
+									'an-error-has-occurred-and-we-were-unable-to-load-the-results'
 								)}
-							</ClayTable.Body>
-						</ClayTable>
-					</ClayModal.Body>
+								imgSrc="/o/admin-theme/images/states/empty_state.gif"
+								title={Liferay.Language.get(
+									'no-items-were-found'
+								)}
+							>
+								<ClayButton
+									displayType="secondary"
+									onClick={refetchSearchableTypes}
+								>
+									{Liferay.Language.get('refresh')}
+								</ClayButton>
+							</ClayEmptyState>
+						</ClayModal.Body>
+					)}
 
 					<ClayModal.Footer
 						last={

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/index.js
@@ -38,6 +38,7 @@ function QueryBuilderTab({
 	onChange,
 	onDeleteSXPElement,
 	onFrameworkConfigChange,
+	refetchSearchableTypes,
 	searchableTypes = [],
 	setFieldTouched,
 	setFieldValue,
@@ -179,6 +180,9 @@ function QueryBuilderTab({
 									onFrameworkConfigChange={
 										onFrameworkConfigChange
 									}
+									refetchSearchableTypes={
+										refetchSearchableTypes
+									}
 									searchableTypes={searchableTypes}
 								/>
 							)}
@@ -205,6 +209,7 @@ QueryBuilderTab.propTypes = {
 	onDeleteSXPElement: PropTypes.func,
 	onFrameworkConfigChange: PropTypes.func,
 	openSidebar: PropTypes.string,
+	refetchSearchableTypes: PropTypes.func,
 	searchableTypes: PropTypes.arrayOf(PropTypes.object),
 	setFieldTouched: PropTypes.func,
 	setFieldValue: PropTypes.func,

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/useFetchData.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/useFetchData.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import {useEffect, useState} from 'react';
+
+import {fetchData} from './fetch';
+
+/**
+ * Hook for fetching data from a resource and providing the function to refetch.
+ * @param {!string|!Request} resource The URL to the resource, or a Resource
+ * object.
+ * @param {Object=} init An optional object containing custom configuration.
+ * @param {function=} getData An optional function to get the desired data from
+ * response.
+ * @param {Object=} defaultValue An optional value for the data to be
+ * initially and if fetchData errors.
+ * @return {Object}
+ */
+function useFetchData({
+	resource,
+	init,
+	getData = (responseContent) => responseContent,
+	defaultValue = [],
+}) {
+	const [data, setData] = useState(defaultValue);
+
+	const _handleFetch = () => {
+		fetchData(resource, init)
+			.then((responseContent) => setData(getData(responseContent)))
+			.catch(() => setData(defaultValue));
+	};
+
+	useEffect(() => {
+		_handleFetch();
+	}, []); //eslint-disable-line
+
+	return {data, refetch: _handleFetch};
+}
+
+export default useFetchData;

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
@@ -20,7 +20,7 @@ import {INPUT_TYPES} from './inputTypes';
  * @param {Array} items Array of objects with classNames
  * @return {Array} Array of classNames
  */
-export function filterAndSortClassNames(items) {
+export function filterAndSortClassNames(items = []) {
 	return items
 		.map(({className}) => className)
 		.filter((item) => item)


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-146033 Handle requests unable or very slow to resolve (preview search, searchable types, and query contributors)

Some notes:
- Added a hook `useFetchData` that would offer the chance to refetch.
- There was a small bug if you do a search on the preview sidebar when not logged in (403 error). It wouldn't say there was an error, so I just added that in the last commit.
- To test the slow loading on preview sidebar, I went to the Network tab and made a custom throttling of 1 kbit/s 🐢 
- To test the clause contributors/searchable types messages, I used Storybook and just remained logged out of portal. 

Some screenshots of the new features:
<img width="657" alt="clause contributors" src="https://user-images.githubusercontent.com/14063502/159990359-c9dceda1-fc79-4c0d-85ad-78b33a753675.png">

<img width="918" alt="searchable types" src="https://user-images.githubusercontent.com/14063502/159990376-563d16c1-13bc-4db3-91ec-a114e5080338.png">

Cancel button will occur after 10 seconds of loading.
<img width="613" alt="preview sidebar" src="https://user-images.githubusercontent.com/14063502/159990384-0dc51daf-c6e3-4cb6-9019-f02ae8a037be.png">

