### PR TITLE
LPS-144391 search-experiences-web: Return full element JSON when clicking on  'View Element JSON'

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/index.js
@@ -24,7 +24,7 @@ import {DEFAULT_SXP_ELEMENT_ICON} from '../../utils/data';
 import {INPUT_TYPES} from '../../utils/inputTypes';
 import {
 	cleanUIConfiguration,
-	getConfigurationEntry,
+	getSXPElementJSON,
 	isDefined,
 } from '../../utils/utils';
 import {PreviewModalWithCopyDownload} from '../PreviewModal';
@@ -355,10 +355,10 @@ function SXPElement({
 								fileName="sxpElement.json"
 								size="lg"
 								text={JSON.stringify(
-									getConfigurationEntry({
+									getSXPElementJSON(
 										sxpElement,
-										uiConfigurationValues,
-									}),
+										uiConfigurationValues
+									),
 									null,
 									'\t'
 								)}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
@@ -550,8 +550,8 @@ export function getDefaultValue(item) {
  * The elementDefinition's configuration is updated to have its variables replaced with
  * values from uiConfigurationValues.
  *
- * @param {object} _.sxpElement SXP Element with title, description, elementDefinition
- * @param {object} _.uiConfigurationValues Values that will replace the keys in uiConfiguration
+ * @param {object} sxpElement SXP Element with title, description, elementDefinition
+ * @param {object} uiConfigurationValues Values that will replace the keys in uiConfiguration
  * @return {object}
  */
 export function getSXPElementJSON(sxpElement, uiConfigurationValues) {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
@@ -566,6 +566,34 @@ export function parseCustomSXPElement(sxpElement, uiConfigurationValues) {
 }
 
 /**
+ * Function that provides the element JSON, with title, description, and elementDefinition.
+ * The elementDefinition's configuration is updated to have its variables replaced with
+ * values from uiConfigurationValues.
+ *
+ * @param {object} _.sxpElement SXP Element with title, description, elementDefinition
+ * @param {object} _.uiConfigurationValues Values that will replace the keys in uiConfiguration
+ * @return {object}
+ */
+export function getSXPElementJSON(sxpElement, uiConfigurationValues) {
+	const {description_i18n, elementDefinition, title_i18n} = sxpElement;
+
+	const {category, icon} = elementDefinition;
+
+	return {
+		description_i18n,
+		elementDefinition: {
+			category,
+			configuration: getConfigurationEntry({
+				sxpElement,
+				uiConfigurationValues,
+			}),
+			icon,
+		},
+		title_i18n,
+	};
+}
+
+/**
  * Function for getting all the default values from an SXPElement. For non-custom
  * json elements, returns the configuration values after looping over all fieldSets.
  * For custom json elements, returns a stringified sxpElement for the editor.

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
@@ -253,97 +253,6 @@ export function cleanUIConfiguration(uiConfiguration = {}) {
 }
 
 /**
- * Function for retrieving a valid default value from one element
- * configuration entry. Returns the proper empty value for invalid values.
- *
- * Examples:
- * getDefaultValue({
- *  	defaultValue: 10,
- *  	label: 'Title Boost',
- *  	name: 'boost',
- *  	type: 'slider',
- *  })
- * => 10
- *
- * getDefaultValue({
- * 		label: 'Enabled',
- * 		name: 'enabled',
- * 		type: 'select',
- * 		typeOptions: {
- * 			options: [
- * 				{
- * 					label: 'True',
- * 					value: true,
- * 				},
- * 				{
- * 					label: 'False',
- * 					value: false,
- * 				},
- * 			],
- * 		},
- * 	})
- * => true
- *
- * @param {object} item Configuration with label, name, type, defaultValue
- * @return {(string|Array|number)}
- */
-export function getDefaultValue(item) {
-	const itemValue = item.defaultValue;
-
-	switch (item.type) {
-		case INPUT_TYPES.DATE:
-			return typeof itemValue === 'number'
-				? itemValue
-				: moment(itemValue, ['MM-DD-YYYY', 'YYYY-MM-DD']).isValid()
-				? moment(itemValue, ['MM-DD-YYYY', 'YYYY-MM-DD']).unix()
-				: '';
-		case INPUT_TYPES.FIELD_MAPPING:
-			return typeof itemValue === 'object' && itemValue.field
-				? itemValue
-				: {
-						field: '',
-						locale: '',
-				  };
-		case INPUT_TYPES.FIELD_MAPPING_LIST:
-			return Array.isArray(itemValue)
-				? itemValue.filter(({field}) => !!field) // Remove empty fields
-				: [];
-		case INPUT_TYPES.ITEM_SELECTOR:
-			return Array.isArray(itemValue)
-				? itemValue.filter((item) => item.label && item.value)
-				: [];
-		case INPUT_TYPES.JSON:
-			return typeof itemValue === 'object'
-				? JSON.stringify(itemValue, null, '\t')
-				: '{}';
-		case INPUT_TYPES.MULTISELECT:
-			return Array.isArray(itemValue)
-				? itemValue.filter((item) => item.label && item.value)
-				: [];
-		case INPUT_TYPES.NUMBER:
-			return typeof itemValue === 'number'
-				? itemValue
-				: typeof toNumber(itemValue) === 'number'
-				? toNumber(itemValue)
-				: '';
-		case INPUT_TYPES.SELECT:
-			return typeof itemValue === 'string'
-				? itemValue
-				: typeof item.typeOptions?.options?.[0]?.value === 'string'
-				? item.typeOptions.options[0].value
-				: '';
-		case INPUT_TYPES.SLIDER:
-			return typeof itemValue === 'number'
-				? itemValue
-				: typeof toNumber(itemValue) === 'number'
-				? toNumber(itemValue)
-				: '';
-		default:
-			return typeof itemValue === 'string' ? itemValue : '';
-	}
-}
-
-/**
  * Function for replacing the ${variable_name} with actual value.
  *
  * @param {object} _.sxpElement SXP Element with elementDefinition
@@ -546,22 +455,93 @@ export function getConfigurationEntry({sxpElement, uiConfigurationValues}) {
 }
 
 /**
- * Function for parsing custom json element text into sxpElement
+ * Function for retrieving a valid default value from one element
+ * configuration entry. Returns the proper empty value for invalid values.
  *
- * @param {object} sxpElement Original sxpElement (default)
- * @param {object} uiConfigurationValues Contains custom JSON for sxpElement
- * @return {object}
+ * Examples:
+ * getDefaultValue({
+ *  	defaultValue: 10,
+ *  	label: 'Title Boost',
+ *  	name: 'boost',
+ *  	type: 'slider',
+ *  })
+ * => 10
+ *
+ * getDefaultValue({
+ * 		label: 'Enabled',
+ * 		name: 'enabled',
+ * 		type: 'select',
+ * 		typeOptions: {
+ * 			options: [
+ * 				{
+ * 					label: 'True',
+ * 					value: true,
+ * 				},
+ * 				{
+ * 					label: 'False',
+ * 					value: false,
+ * 				},
+ * 			],
+ * 		},
+ * 	})
+ * => true
+ *
+ * @param {object} item Configuration with label, name, type, defaultValue
+ * @return {(string|Array|number)}
  */
-export function parseCustomSXPElement(sxpElement, uiConfigurationValues) {
-	try {
-		if (isDefined(uiConfigurationValues.sxpElement)) {
-			return JSON.parse(uiConfigurationValues.sxpElement);
-		}
+export function getDefaultValue(item) {
+	const itemValue = item.defaultValue;
 
-		return sxpElement;
-	}
-	catch {
-		return sxpElement;
+	switch (item.type) {
+		case INPUT_TYPES.DATE:
+			return typeof itemValue === 'number'
+				? itemValue
+				: moment(itemValue, ['MM-DD-YYYY', 'YYYY-MM-DD']).isValid()
+				? moment(itemValue, ['MM-DD-YYYY', 'YYYY-MM-DD']).unix()
+				: '';
+		case INPUT_TYPES.FIELD_MAPPING:
+			return typeof itemValue === 'object' && itemValue.field
+				? itemValue
+				: {
+						field: '',
+						locale: '',
+				  };
+		case INPUT_TYPES.FIELD_MAPPING_LIST:
+			return Array.isArray(itemValue)
+				? itemValue.filter(({field}) => !!field) // Remove empty fields
+				: [];
+		case INPUT_TYPES.ITEM_SELECTOR:
+			return Array.isArray(itemValue)
+				? itemValue.filter((item) => item.label && item.value)
+				: [];
+		case INPUT_TYPES.JSON:
+			return typeof itemValue === 'object'
+				? JSON.stringify(itemValue, null, '\t')
+				: '{}';
+		case INPUT_TYPES.MULTISELECT:
+			return Array.isArray(itemValue)
+				? itemValue.filter((item) => item.label && item.value)
+				: [];
+		case INPUT_TYPES.NUMBER:
+			return typeof itemValue === 'number'
+				? itemValue
+				: typeof toNumber(itemValue) === 'number'
+				? toNumber(itemValue)
+				: '';
+		case INPUT_TYPES.SELECT:
+			return typeof itemValue === 'string'
+				? itemValue
+				: typeof item.typeOptions?.options?.[0]?.value === 'string'
+				? item.typeOptions.options[0].value
+				: '';
+		case INPUT_TYPES.SLIDER:
+			return typeof itemValue === 'number'
+				? itemValue
+				: typeof toNumber(itemValue) === 'number'
+				? toNumber(itemValue)
+				: '';
+		default:
+			return typeof itemValue === 'string' ? itemValue : '';
 	}
 }
 
@@ -638,6 +618,26 @@ export function getUIConfigurationValues(sxpElement = {}) {
  */
 export function isCustomJSONSXPElement(uiConfigurationValues) {
 	return isDefined(uiConfigurationValues.sxpElement);
+}
+
+/**
+ * Function for parsing custom json element text into sxpElement
+ *
+ * @param {object} sxpElement Original sxpElement (default)
+ * @param {object} uiConfigurationValues Contains custom JSON for sxpElement
+ * @return {object}
+ */
+export function parseCustomSXPElement(sxpElement, uiConfigurationValues) {
+	try {
+		if (isDefined(uiConfigurationValues.sxpElement)) {
+			return JSON.parse(uiConfigurationValues.sxpElement);
+		}
+
+		return sxpElement;
+	}
+	catch {
+		return sxpElement;
+	}
 }
 
 /**


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-144391 - "View Element JSON" should return the full JSON of the Element (with replaced variables)

Notes:
- Created the util `getSXPElementJSON` inside `util.js` so as not to clutter the SXPElement component
- Ended up alphabetizing some of the util functions related to elements and configurations

Thanks for taking a look!