### PR TITLE
LPS-150634 Pasting "Element JSON" into the element editor doesn't work | master

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
@@ -360,6 +360,7 @@ function EditSXPElementForm({
 					{isCustomJSONSXPElement(uiConfigurationValues) ? (
 						<JSONSXPElement
 							collapseAll={false}
+							readOnly={true}
 							sxpElement={previewSXPElementJSON}
 							uiConfigurationValues={uiConfigurationValues}
 						/>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
@@ -30,6 +30,7 @@ import React, {
 import useShouldConfirmBeforeNavigate from '../hooks/useShouldConfirmBeforeNavigate';
 import CodeMirrorEditor from '../shared/CodeMirrorEditor';
 import ErrorBoundary from '../shared/ErrorBoundary';
+import JSONSXPElement from '../shared/JSONSXPElement';
 import LearnMessage from '../shared/LearnMessage';
 import PreviewModal from '../shared/PreviewModal';
 import SearchInput from '../shared/SearchInput';
@@ -40,7 +41,7 @@ import SXPElement from '../shared/sxp_element/index';
 import {CONFIG_PREFIX, DEFAULT_ERROR} from '../utils/constants';
 import {sub} from '../utils/language';
 import {openErrorToast, setInitialSuccessToast} from '../utils/toasts';
-import {getUIConfigurationValues} from '../utils/utils';
+import {getUIConfigurationValues, isCustomJSONSXPElement} from '../utils/utils';
 import SidebarPanel from './SidebarPanel';
 
 /**
@@ -76,7 +77,7 @@ const validateConfigKeys = (
 		...JSON.stringify(configurationJSONObject).matchAll(regex),
 	].map((item) => item[1]);
 
-	const uiConfigKeys = uiConfigurationJSONObject.fieldSets
+	const uiConfigKeys = uiConfigurationJSONObject?.fieldSets
 		? uiConfigurationJSONObject.fieldSets.reduce((acc, curr) => {
 
 				// Find names within each fields array
@@ -332,9 +333,14 @@ function EditSXPElementForm({
 
 	function _renderPreviewBody() {
 		let previewSXPElementJSON = {};
+		let uiConfigurationValues = {};
 
 		try {
 			previewSXPElementJSON = JSON.parse(elementJSONEditorValue);
+
+			uiConfigurationValues = getUIConfigurationValues(
+				previewSXPElementJSON
+			);
 		}
 		catch (error) {
 			return (
@@ -351,13 +357,19 @@ function EditSXPElementForm({
 		return (
 			<div className="portlet-sxp-blueprint-admin">
 				<ErrorBoundary>
-					<SXPElement
-						collapseAll={false}
-						sxpElement={previewSXPElementJSON}
-						uiConfigurationValues={getUIConfigurationValues(
-							previewSXPElementJSON
-						)}
-					/>
+					{isCustomJSONSXPElement(uiConfigurationValues) ? (
+						<JSONSXPElement
+							collapseAll={false}
+							sxpElement={previewSXPElementJSON}
+							uiConfigurationValues={uiConfigurationValues}
+						/>
+					) : (
+						<SXPElement
+							collapseAll={false}
+							sxpElement={previewSXPElementJSON}
+							uiConfigurationValues={uiConfigurationValues}
+						/>
+					)}
 				</ErrorBoundary>
 			</div>
 		);

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/JSONSXPElement.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/JSONSXPElement.js
@@ -33,8 +33,8 @@ function JSONSXPElement({
 	isSubmitting,
 	onDeleteSXPElement,
 	prefixedId,
-	setFieldTouched,
-	setFieldValue,
+	setFieldTouched = () => {},
+	setFieldValue = () => {},
 	touched = {},
 	uiConfigurationValues = {},
 }) {
@@ -86,32 +86,34 @@ function JSONSXPElement({
 						)}
 					</ClayList.ItemField>
 
-					<ClayDropDown
-						active={active}
-						alignmentPosition={3}
-						onActiveChange={setActive}
-						trigger={
-							<ClayList.ItemField>
-								<ClayButton
-									aria-label={Liferay.Language.get(
-										'dropdown'
-									)}
-									className="component-action"
-									displayType="unstyled"
+					{onDeleteSXPElement && (
+						<ClayDropDown
+							active={active}
+							alignmentPosition={3}
+							onActiveChange={setActive}
+							trigger={
+								<ClayList.ItemField>
+									<ClayButton
+										aria-label={Liferay.Language.get(
+											'dropdown'
+										)}
+										className="component-action"
+										displayType="unstyled"
+									>
+										<ClayIcon symbol="ellipsis-v" />
+									</ClayButton>
+								</ClayList.ItemField>
+							}
+						>
+							<ClayDropDown.ItemList>
+								<ClayDropDown.Item
+									onClick={() => onDeleteSXPElement(id)}
 								>
-									<ClayIcon symbol="ellipsis-v" />
-								</ClayButton>
-							</ClayList.ItemField>
-						}
-					>
-						<ClayDropDown.ItemList>
-							<ClayDropDown.Item
-								onClick={() => onDeleteSXPElement(id)}
-							>
-								{Liferay.Language.get('remove')}
-							</ClayDropDown.Item>
-						</ClayDropDown.ItemList>
-					</ClayDropDown>
+									{Liferay.Language.get('remove')}
+								</ClayDropDown.Item>
+							</ClayDropDown.ItemList>
+						</ClayDropDown>
+					)}
 
 					<ClayList.ItemField>
 						<ClayButton

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/JSONSXPElement.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/JSONSXPElement.js
@@ -33,6 +33,7 @@ function JSONSXPElement({
 	isSubmitting,
 	onDeleteSXPElement,
 	prefixedId,
+	readOnly,
 	setFieldTouched = () => {},
 	setFieldValue = () => {},
 	touched = {},
@@ -147,6 +148,7 @@ function JSONSXPElement({
 					<JSONInput
 						disabled={isSubmitting}
 						name={_inputName(index)}
+						readOnly={readOnly}
 						setFieldTouched={setFieldTouched}
 						setFieldValue={setFieldValue}
 						value={
@@ -178,6 +180,7 @@ JSONSXPElement.propTypes = {
 	isSubmitting: PropTypes.bool,
 	onDeleteSXPElement: PropTypes.func,
 	prefixedId: PropTypes.string,
+	readOnly: PropTypes.bool,
 	setFieldTouched: PropTypes.func,
 	setFieldValue: PropTypes.func,
 	sxpElement: PropTypes.object,

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/JSONInput.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/JSONInput.js
@@ -19,6 +19,7 @@ function JSONInput({
 	value,
 	label = Liferay.Language.get('json[stands-for]'),
 	nullable,
+	readOnly = false,
 	required = true,
 	name,
 	setFieldValue,
@@ -50,7 +51,11 @@ function JSONInput({
 				)}
 			</label>
 
-			<CodeMirrorEditor onChange={setEditValue} value={editValue} />
+			<CodeMirrorEditor
+				onChange={setEditValue}
+				readOnly={readOnly}
+				value={editValue}
+			/>
 		</div>
 	);
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/language.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/language.js
@@ -108,8 +108,11 @@ export function getLocalizedLearnMessageObject(
 }
 
 /**
- * Used for getting the element title and description. Titles and descriptions
- * handle both string `'title'` and a localized object `{'en_US': 'Title'}`.
+ * Used for getting the blueprint or element title and description. Titles
+ * and descriptions handle both string `'title'` and a localized object
+ * `{'en_US': 'Title'}`. This also accommodates for when elements
+ * have titles and descriptions that use the BCP 47 language code,
+ * such as `{'en-US': 'Title'}`.
  * @param {string|Object} value
  * @param {string} locale
  */
@@ -119,6 +122,9 @@ export function getLocalizedText(value, locale) {
 	}
 	else if (value[locale]) {
 		return value[locale];
+	}
+	else if (value[locale.replace('_', '-')]) {
+		return value[locale.replace('_', '-')];
 	}
 	else if (typeof value === 'string' || value instanceof String) {
 		return value;

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
@@ -13,6 +13,7 @@ import moment from 'moment';
 
 import {CONFIG_PREFIX, DEFAULT_ERROR} from './constants';
 import {INPUT_TYPES} from './inputTypes';
+import {renameKeys} from './language';
 
 /**
  * Function to get valid classNames and return them sorted.
@@ -551,13 +552,13 @@ export function getDefaultValue(item) {
  * values from uiConfigurationValues.
  *
  * @param {object} sxpElement SXP Element with title, description, elementDefinition
- * @param {object} uiConfigurationValues Values that will replace the keys in uiConfiguration
+ * @param {object=} uiConfigurationValues Values that will replace the keys in uiConfiguration
  * @return {object}
  */
 export function getSXPElementJSON(sxpElement, uiConfigurationValues) {
 	const {description_i18n, elementDefinition, title_i18n} = sxpElement;
 
-	const {category, icon} = elementDefinition;
+	const {category, configuration, icon} = elementDefinition;
 
 	return {
 		description_i18n: renameKeys(description_i18n, (str) =>
@@ -565,10 +566,12 @@ export function getSXPElementJSON(sxpElement, uiConfigurationValues) {
 		),
 		elementDefinition: {
 			category,
-			configuration: getConfigurationEntry({
-				sxpElement,
-				uiConfigurationValues,
-			}),
+			configuration: uiConfigurationValues
+				? getConfigurationEntry({
+						sxpElement,
+						uiConfigurationValues,
+				  })
+				: configuration,
 			icon,
 		},
 		title_i18n: renameKeys(title_i18n, (str) => str.replace('-', '_')),
@@ -608,7 +611,9 @@ export function getUIConfigurationValues(sxpElement = {}) {
 		);
 	}
 
-	return {sxpElement: JSON.stringify(sxpElement, null, '\t')};
+	return {
+		sxpElement: JSON.stringify(getSXPElementJSON(sxpElement), null, '\t'),
+	};
 }
 
 /**

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
@@ -560,7 +560,9 @@ export function getSXPElementJSON(sxpElement, uiConfigurationValues) {
 	const {category, icon} = elementDefinition;
 
 	return {
-		description_i18n,
+		description_i18n: renameKeys(description_i18n, (str) =>
+			str.replace('-', '_')
+		),
 		elementDefinition: {
 			category,
 			configuration: getConfigurationEntry({
@@ -569,7 +571,7 @@ export function getSXPElementJSON(sxpElement, uiConfigurationValues) {
 			}),
 			icon,
 		},
-		title_i18n,
+		title_i18n: renameKeys(title_i18n, (str) => str.replace('-', '_')),
 	};
 }
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
@@ -2791,7 +2791,7 @@ definition {
 
 		Button.clickSave();
 
-		Alert.viewErrorMessage(errorMessage = "TypeError: Cannot read property 'fieldSets' of undefined");
+		Alert.viewErrorMessage(errorMessage = "The title cannot be blank.");
 
 		var elementSourceJson = '''
 {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-150634 - Pasting "Element JSON" into the element editor doesn't work
https://issues.liferay.com/browse/LRQA-74217 - Test fix due to change in the custom element JSON validation error message

From @oliv-yu 

Lots of smaller changes that seem to make quite a difference for element JSONs:
- Fixed the title_i18n and description_i18n format within the element JSON
- `getLocalizedText` util should handle a locale in BCP47 by just switching out the `_` to `-`
- Added Custom Element JSON support to the element editor
- If you add this Custom Element onto the query builder, it actually would include too much info like actions/date created/schema version/type, so that was updated
- For the preview inside element editor, it seemed strange that the CodeMirror would still be editable, so passed in a `readOnly` property

Let me know what you think! Thanks!!

@thektan