### PR TITLE
LPS-150425

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/upgrade/PortalSearchUpgrade.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/upgrade/PortalSearchUpgrade.java
@@ -33,19 +33,21 @@ public class PortalSearchUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.1", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.0.2", new DummyUpgradeStep());
 
-		registry.register(
-			"0.0.1", "1.0.0",
-			_configurationUpgradeStepFactory.createUpgradeStep(
-				"com.liferay.portal.search.internal.index." +
-					"IndexStatusManagerInternalConfiguration",
-				IndexStatusManagerInternalConfiguration.class.getName()));
+		registry.register("0.0.1", "1.0.0", new DummyUpgradeStep());
 
 		registry.register(
 			"1.0.0", "1.0.1",
 			new ReindexConfigurationUpgradeProcess(
 				_configurationAdmin, _prefsProps));
+
+		registry.register(
+			"1.0.1", "1.0.2",
+			_configurationUpgradeStepFactory.createUpgradeStep(
+				"com.liferay.portal.search.internal.index." +
+					"IndexStatusManagerInternalConfiguration",
+				IndexStatusManagerInternalConfiguration.class.getName()));
 	}
 
 	@Reference


### PR DESCRIPTION
I would like to backport the 1.0.0-1.0.1 upgrade process, which this ticket, added to 7.3.x. However, this is not possible currently because it is preceded by a 0.0.1-1.0.0 upgrade process which is unbackportable (that upgrade process was added in Task Ticket [LPS-122572](https://issues.liferay.com/browse/LPS-122572), and its [pull request](https://github.com/brianchandotcom/liferay-portal/pull/95362) contains a "[DO NOT BACKPORT]" message in its title).

I discussed this with @SamZiemer and we agreed that the best solution is to move the 0.0.1-1.0.0 upgrade process to be after the 1.0.0-1.0.1 upgrade process. This way, users on the latest fix pack of 7.3 can upgrade to the latest update of 7.4 and have the unbackportable upgrade process be run when they do.

I realize that unfortunately, this is still not ideal, because if a user on the latest 7.3 fix pack upgrades to an earlier 7.4 update, they will not have the unbackportable upgrade process be run until they upgrade to a later 7.4 update. But we couldn't see any better solution.

https://issues.liferay.com/browse/LPS-150425