### PR TITLE
LPS-151389 Do not log the generic Liferay search query in ElasticsearchIndexSearcher as it's flooding the log with no real value

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchIndexSearcher.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchIndexSearcher.java
@@ -181,8 +181,7 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 
 				_log.info(
 					StringBundler.concat(
-						"Searching ", query, " took ", stopWatch.getTime(),
-						" ms"));
+						"Searching took ", stopWatch.getTime(), " ms"));
 			}
 		}
 	}
@@ -231,8 +230,7 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 
 				_log.info(
 					StringBundler.concat(
-						"Searching ", query.toString(), " took ",
-						stopWatch.getTime(), " ms"));
+						"Searching took ", stopWatch.getTime(), " ms"));
 			}
 		}
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-151389