### PR TITLE
LPS-151040 search-experiences-test: Unflaky testBoostContentswithMore…

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
@@ -593,7 +593,7 @@ public class SXPBlueprintSearchResultTest {
 				HashMapBuilder.<String, Object>put(
 					"boost", 100
 				).put(
-					"factor", 1.2
+					"factor", 10
 				).put(
 					"modifier", "sqrt"
 				).build()


### PR DESCRIPTION
…Versions

https://issues.liferay.com/browse/LPS-151040

my theory is that this element is fine and without any bug, this flaky is caused by some cases where the boost is not sufficient to make the article with more versions be returned as the first. My change only adds an expressive boost to avoid that.