### PR TITLE
LPS-151895 search-experiences-web: Include language ids for i18n

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/sxp-query-element.schema.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/sxp-query-element.schema.json
@@ -203,10 +203,34 @@
 				"ar_SA": {
 					"type": "string"
 				},
+				"bg_BG": {
+					"type": "string"
+				},
+				"ca_AD": {
+					"type": "string"
+				},
 				"ca_ES": {
 					"type": "string"
 				},
+				"ca_ES_VALENCIA": {
+					"type": "string"
+				},
+				"cs_CZ": {
+					"type": "string"
+				},
+				"da_DK": {
+					"type": "string"
+				},
 				"de_DE": {
+					"type": "string"
+				},
+				"el_GR": {
+					"type": "string"
+				},
+				"en_AU": {
+					"type": "string"
+				},
+				"en_GB": {
 					"type": "string"
 				},
 				"en_US": {
@@ -215,28 +239,121 @@
 				"es_ES": {
 					"type": "string"
 				},
+				"et_EE": {
+					"type": "string"
+				},
+				"eu_ES": {
+					"type": "string"
+				},
+				"fa_IR": {
+					"type": "string"
+				},
 				"fi_FI": {
+					"type": "string"
+				},
+				"fr_CA": {
 					"type": "string"
 				},
 				"fr_FR": {
 					"type": "string"
 				},
+				"gl_ES": {
+					"type": "string"
+				},
+				"hi_IN": {
+					"type": "string"
+				},
+				"hr_HR": {
+					"type": "string"
+				},
 				"hu_HU": {
+					"type": "string"
+				},
+				"in_ID": {
+					"type": "string"
+				},
+				"it_IT": {
+					"type": "string"
+				},
+				"iw_IL": {
 					"type": "string"
 				},
 				"ja_JP": {
 					"type": "string"
 				},
+				"kk_KZ": {
+					"type": "string"
+				},
+				"ko_KR": {
+					"type": "string"
+				},
+				"lo_LA": {
+					"type": "string"
+				},
+				"lt_LT": {
+					"type": "string"
+				},
+				"ms_MY": {
+					"type": "string"
+				},
+				"nb_NO": {
+					"type": "string"
+				},
+				"nl_BE": {
+					"type": "string"
+				},
 				"nl_NL": {
+					"type": "string"
+				},
+				"pl_PL": {
 					"type": "string"
 				},
 				"pt_BR": {
 					"type": "string"
 				},
+				"pt_PT": {
+					"type": "string"
+				},
+				"ro_RO": {
+					"type": "string"
+				},
+				"ru_RU": {
+					"type": "string"
+				},
+				"sk_SK": {
+					"type": "string"
+				},
+				"sl_SI": {
+					"type": "string"
+				},
+				"sr_RS": {
+					"type": "string"
+				},
+				"sr_RS_latin": {
+					"type": "string"
+				},
 				"sv_SE": {
 					"type": "string"
 				},
+				"ta_IN": {
+					"type": "string"
+				},
+				"th_TH": {
+					"type": "string"
+				},
+				"tr_TR": {
+					"type": "string"
+				},
+				"uk_UA": {
+					"type": "string"
+				},
+				"vi_VN": {
+					"type": "string"
+				},
 				"zh_CN": {
+					"type": "string"
+				},
+				"zh_TW": {
 					"type": "string"
 				}
 			}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/sxp-query-element.schema.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/sxp-query-element.schema.json
@@ -198,6 +198,49 @@
 			},
 			"type": "object"
 		},
+		"LanguageId": {
+			"properties": {
+				"ar_SA": {
+					"type": "string"
+				},
+				"ca_ES": {
+					"type": "string"
+				},
+				"de_DE": {
+					"type": "string"
+				},
+				"en_US": {
+					"type": "string"
+				},
+				"es_ES": {
+					"type": "string"
+				},
+				"fi_FI": {
+					"type": "string"
+				},
+				"fr_FR": {
+					"type": "string"
+				},
+				"hu_HU": {
+					"type": "string"
+				},
+				"ja_JP": {
+					"type": "string"
+				},
+				"nl_NL": {
+					"type": "string"
+				},
+				"pt_BR": {
+					"type": "string"
+				},
+				"sv_SE": {
+					"type": "string"
+				},
+				"zh_CN": {
+					"type": "string"
+				}
+			}
+		},
 		"Option": {
 			"properties": {
 				"label": {
@@ -329,6 +372,7 @@
 	},
 	"properties": {
 		"description_i18n": {
+			"$ref": "#/definitions/LanguageId",
 			"additionalProperties": {
 				"type": "string"
 			},
@@ -338,6 +382,7 @@
 			"$ref": "#/definitions/ElementDefinition"
 		},
 		"title_i18n": {
+			"$ref": "#/definitions/LanguageId",
 			"additionalProperties": {
 				"type": "string"
 			},


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-151895 - Add i18n language codes "sxp-query-element.schema.json" (title, description)

Subtask of https://issues.liferay.com/browse/LPS-148749

Pretty straightforward, just adding language ids into the `sxp-query-element.schema.json` for title_i18n and description_i18n :)