### PR TITLE
LPS-143720 configuration autocomplete

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/configuration_tab/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/configuration_tab/index.js
@@ -14,8 +14,21 @@ import ClayLayout from '@clayui/layout';
 import getCN from 'classnames';
 import React from 'react';
 
+import advancedConfigurationSchema from '../../../schemas/advanced-configuration.schema.json';
+import aggregationConfigurationSchema from '../../../schemas/aggregation-configuration.schema.json';
+import highlightConfigurationSchema from '../../../schemas/highlight-configuration.schema.json';
+import parameterConfigurationSchema from '../../../schemas/parameter-configuration.schema.json';
+import sortConfigurationSchema from '../../../schemas/sort-configuration.schema.json';
 import CodeMirrorEditor from '../../shared/CodeMirrorEditor';
 import LearnMessage from '../../shared/LearnMessage';
+
+const CONFIGURATION_SCHEMAS = {
+	advancedConfig: advancedConfigurationSchema,
+	aggregationConfig: aggregationConfigurationSchema,
+	highlightConfig: highlightConfigurationSchema,
+	parameterConfig: parameterConfigurationSchema,
+	sortConfig: sortConfigurationSchema,
+};
 
 function ConfigurationTab({
 	advancedConfig,
@@ -36,6 +49,7 @@ function ConfigurationTab({
 			onBlur={() => setFieldTouched(configName)}
 		>
 			<CodeMirrorEditor
+				autocompleteSchema={CONFIGURATION_SCHEMAS[configName]}
 				onChange={(value) => setFieldValue(configName, value)}
 				value={configValue}
 			/>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
@@ -565,20 +565,19 @@ const CodeMirrorEditor = React.forwardRef(
 				// Enable autocomplete if `autocompleteSchema` is defined.
 
 				if (autocompleteSchema && jsonAutocompleteEnabled) {
-					CodeMirror.registerHelper('hint', 'json', (cm) =>
-						getCodeMirrorHints(
-							cm,
-							autocompleteSchema,
-							availableLanguages
-						)
-					);
-
 					codeMirror.on('keyup', (cm, event) => {
+						const hint = () =>
+							getCodeMirrorHints(
+								cm,
+								autocompleteSchema,
+								availableLanguages
+							);
+
 						if (
 							!cm.state.completionActive &&
 							!AUTOCOMPLETE_EXCLUDED_KEYS.has(event.key)
 						) {
-							codeMirror.showHint();
+							codeMirror.showHint({hint});
 						}
 					});
 				}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
@@ -79,7 +79,7 @@ function getCodeMirrorHints(cm, autocompleteSchema, availableLanguages) {
 	const start = token.start - 1;
 	const end = token.end;
 
-	if (token.type !== 'string property') {
+	if (token.type !== 'string property' && token.type !== 'string') {
 		return;
 	}
 
@@ -118,6 +118,23 @@ function getCodeMirrorHints(cm, autocompleteSchema, availableLanguages) {
 			...linePropertyBracketList,
 		];
 	}
+
+	// Get the property on current line to check for an enum list later.
+
+	const currentProperty = cm
+		.getLineTokens(cursor.line)
+		.filter((token) => {
+			if (token.end > cursor.ch) {
+				return false;
+			}
+
+			return (
+				token.string.length > 1 &&
+				token.string.startsWith('"') &&
+				token.string.endsWith('"')
+			);
+		})
+		.map((token) => removeQuotes(token.string));
 
 	// Filter the `propertyBracketList` to get only the parent properties.
 
@@ -179,9 +196,41 @@ function getCodeMirrorHints(cm, autocompleteSchema, availableLanguages) {
 		availableLanguages
 	);
 
-	// Filter matched strings.
-
 	const search = token.string.match(/[@]?\w+/);
+
+	// Return a filtered enum list if the property on the current line
+	// matches a property inside schemaProperties with an enum.
+
+	if (token.type === 'string') {
+		const property = list.find((item) => item.name === currentProperty[0]);
+
+		if (property?.enum && currentProperty.length === 1) {
+			let enumList = property.enum;
+
+			if (search !== null) {
+				enumList = property.enum.filter(
+					(item) =>
+						item.toLowerCase().indexOf(search[0].toLowerCase()) > -1
+				);
+			}
+
+			return {
+				from: CodeMirror.Pos(cursor.line, start + 2),
+				list: enumList.map((item) => {
+					return {
+						displayText: `${item}`,
+						text: `${item}"`,
+					};
+				}),
+
+				to: CodeMirror.Pos(cursor.line, end),
+			};
+		}
+
+		return;
+	}
+
+	// Filter matched strings.
 
 	if (search !== null) {
 		list = list.filter((item) => {
@@ -367,6 +416,7 @@ function getSchemaProperties(
 			// Get `type` value, forward $ref reference if defined.
 
 			let type = schema.properties[name].type || '';
+			let enumList = schema.properties[name].enum;
 
 			if (
 				schema.properties[name].$ref &&
@@ -383,6 +433,11 @@ function getSchemaProperties(
 				);
 
 				type = refSchema.type || '';
+				enumList = refSchema.enum;
+			}
+
+			if (type === 'string' && enumList) {
+				return {enum: enumList, name, type};
 			}
 
 			return {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
@@ -389,6 +389,21 @@ function getSchemaProperties(
 				schema.$ref.substring(2)
 			);
 
+			// Pass in the additionalProperties if it exists, in case a property is
+			// not defined in the $ref schema.
+
+			if (schema.additionalProperties) {
+				return getSchemaProperties(
+					{
+						...refSchema,
+						additionalProperties: schema.additionalProperties,
+					},
+					propertyPathList,
+					availableLanguages,
+					fullSchema
+				);
+			}
+
 			return getSchemaProperties(
 				refSchema,
 				propertyPathList,
@@ -476,6 +491,22 @@ function getSchemaProperties(
 				fullSchema
 			);
 		}
+	}
+
+	// If property is not available in schema's properties, persist with
+	// schema's additionalProperties instead.
+
+	if (schema.additionalProperties) {
+		if (!fullSchema) {
+			fullSchema = schema;
+		}
+
+		return getSchemaProperties(
+			schema.additionalProperties,
+			propertyPathList.slice(1),
+			availableLanguages,
+			fullSchema
+		);
 	}
 
 	return [];

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
@@ -233,9 +233,10 @@ function getCodeMirrorHints(cm, autocompleteSchema, availableLanguages) {
 	// Filter matched strings.
 
 	if (search !== null) {
-		list = list.filter((item) => {
-			return item.name.indexOf(search) > -1;
-		});
+		list = list.filter(
+			(item) =>
+				item.name.toLowerCase().indexOf(search[0].toLowerCase()) > -1
+		);
 	}
 
 	return {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/advanced-configuration.schema.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/advanced-configuration.schema.json
@@ -1,0 +1,27 @@
+{
+	"$id": "advanced-configuration.schema.json",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"properties": {
+		"source": {
+			"properties": {
+				"excludes": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"fetchSource": {
+					"type": "boolean"
+				},
+				"includes": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				}
+			},
+			"type": "object"
+		}
+	},
+	"type": "object"
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/aggregation-configuration.schema.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/aggregation-configuration.schema.json
@@ -1,0 +1,10 @@
+{
+	"$id": "aggregation-configuration.schema.json",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"properties": {
+		"aggs": {
+			"type": "object"
+		}
+	},
+	"type": "object"
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/highlight-configuration.schema.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/highlight-configuration.schema.json
@@ -1,0 +1,53 @@
+{
+	"$id": "highlight-configuration.schema.json",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"HighlightField": {
+			"properties": {
+				"fragment_offset": {
+					"type": "integer"
+				},
+				"fragment_size": {
+					"type": "integer"
+				},
+				"number_of_fragments": {
+					"type": "integer"
+				}
+			},
+			"type": "object"
+		}
+	},
+	"properties": {
+		"fields": {
+			"additionalProperties": {
+				"$ref": "#/definitions/HighlightField"
+			},
+			"type": "object"
+		},
+		"fragment_size": {
+			"type": "integer"
+		},
+		"number_of_fragments": {
+			"type": "integer"
+		},
+		"post_tags": {
+			"items": {
+				"type": "string"
+			},
+			"type": "array"
+		},
+		"pre_tags": {
+			"items": {
+				"type": "string"
+			},
+			"type": "array"
+		},
+		"require_field_match": {
+			"type": "boolean"
+		},
+		"type": {
+			"type": "string"
+		}
+	},
+	"type": "object"
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/parameter-configuration.schema.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/parameter-configuration.schema.json
@@ -1,0 +1,48 @@
+{
+	"$id": "parameter-configuration.schema.json",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"Parameter": {
+			"properties": {
+				"defaultValue": {
+					"type": "object"
+				},
+				"format": {
+					"type": "string"
+				},
+				"max": {
+					"type": "object"
+				},
+				"min": {
+					"type": "object"
+				},
+				"type": {
+					"enum": [
+						"Boolean",
+						"Date",
+						"Double",
+						"Float",
+						"Integer",
+						"IntegerArray",
+						"Long",
+						"LongArray",
+						"String",
+						"StringArray",
+						"TimeRange"
+					],
+					"type": "string"
+				}
+			},
+			"type": "object"
+		}
+	},
+	"properties": {
+		"parameters": {
+			"additionalProperties": {
+				"$ref": "#/definitions/Parameter"
+			},
+			"type": "object"
+		}
+	},
+	"type": "object"
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/sort-configuration.schema.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/sort-configuration.schema.json
@@ -1,0 +1,10 @@
+{
+	"$id": "sort-configuration.schema.json",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"properties": {
+		"sorts": {
+			"type": "object"
+		}
+	},
+	"type": "object"
+}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-143720 - When editing my Blueprint's Configurations JSON, I am aided by schema-driven auto-completion

Autocomplete for the blueprint configurations!

Some notes:
- Added updates to CodeMirrorEditor, to accommodate for multiple editors on one page and to check a schema's `additionalProperties` as well. Also included some support for enums.
- Each configuration is tied to its own `schema.json` @peerkar would you mind checking these files and let me know if they are correct? I was mainly referencing https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml

Some screenshots:
<img width="871" alt="Screen Shot 2022-04-27 at 5 37 14 PM" src="https://user-images.githubusercontent.com/14063502/165653743-5a676037-1b70-433b-ad62-4c636920e50b.png">

<img width="903" alt="Screen Shot 2022-04-27 at 5 46 58 PM" src="https://user-images.githubusercontent.com/14063502/165654290-519fbd78-a665-404e-96b4-99ed1d7785ba.png">

<img width="911" alt="Screen Shot 2022-04-27 at 5 37 36 PM" src="https://user-images.githubusercontent.com/14063502/165653403-fe229c16-b717-4bff-a000-8379e91f0d57.png">
