### PR TITLE
LPS-143720 Schema-driven auto-completion in blueprint configurations

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/configuration_tab/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/configuration_tab/index.js
@@ -14,8 +14,21 @@ import ClayLayout from '@clayui/layout';
 import getCN from 'classnames';
 import React from 'react';
 
+import advancedConfigurationSchema from '../../../schemas/advanced-configuration.schema.json';
+import aggregationConfigurationSchema from '../../../schemas/aggregation-configuration.schema.json';
+import highlightConfigurationSchema from '../../../schemas/highlight-configuration.schema.json';
+import parameterConfigurationSchema from '../../../schemas/parameter-configuration.schema.json';
+import sortConfigurationSchema from '../../../schemas/sort-configuration.schema.json';
 import CodeMirrorEditor from '../../shared/CodeMirrorEditor';
 import LearnMessage from '../../shared/LearnMessage';
+
+const CONFIGURATION_SCHEMAS = {
+	advancedConfig: advancedConfigurationSchema,
+	aggregationConfig: aggregationConfigurationSchema,
+	highlightConfig: highlightConfigurationSchema,
+	parameterConfig: parameterConfigurationSchema,
+	sortConfig: sortConfigurationSchema,
+};
 
 function ConfigurationTab({
 	advancedConfig,
@@ -36,6 +49,7 @@ function ConfigurationTab({
 			onBlur={() => setFieldTouched(configName)}
 		>
 			<CodeMirrorEditor
+				autocompleteSchema={CONFIGURATION_SCHEMAS[configName]}
 				onChange={(value) => setFieldValue(configName, value)}
 				value={configValue}
 			/>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
@@ -565,20 +565,19 @@ const CodeMirrorEditor = React.forwardRef(
 				// Enable autocomplete if `autocompleteSchema` is defined.
 
 				if (autocompleteSchema && jsonAutocompleteEnabled) {
-					CodeMirror.registerHelper('hint', 'json', (cm) =>
-						getCodeMirrorHints(
-							cm,
-							autocompleteSchema,
-							availableLanguages
-						)
-					);
-
 					codeMirror.on('keyup', (cm, event) => {
+						const hint = () =>
+							getCodeMirrorHints(
+								cm,
+								autocompleteSchema,
+								availableLanguages
+							);
+
 						if (
 							!cm.state.completionActive &&
 							!AUTOCOMPLETE_EXCLUDED_KEYS.has(event.key)
 						) {
-							codeMirror.showHint();
+							codeMirror.showHint({hint});
 						}
 					});
 				}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
@@ -478,6 +478,22 @@ function getSchemaProperties(
 		}
 	}
 
+	// If property is not available in schema's properties, persist with
+	// schema's additionalProperties instead.
+
+	if (schema.additionalProperties) {
+		if (!fullSchema) {
+			fullSchema = schema;
+		}
+
+		return getSchemaProperties(
+			schema.additionalProperties,
+			propertyPathList.slice(1),
+			availableLanguages,
+			fullSchema
+		);
+	}
+
 	return [];
 }
 

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
@@ -376,6 +376,32 @@ function getSchemaProperties(
 		fullSchema = schema;
 	}
 
+	// If an `allOf` or `anyOf` property is available, separate the schema
+	// and getSchemaProperties from each one.
+
+	if (schema.allOf || schema.anyOf) {
+		const {allOf, anyOf, ...restOfSchema} = schema;
+
+		const ofProperties = (allOf || anyOf).map((item) =>
+			getSchemaProperties(
+				item,
+				propertyPathList,
+				availableLanguages,
+				fullSchema
+			)
+		);
+
+		return [
+			...getSchemaProperties(
+				restOfSchema,
+				propertyPathList,
+				availableLanguages,
+				fullSchema
+			),
+			...removeDuplicateProperties(ofProperties.flat()),
+		];
+	}
+
 	// If the schema links to a reference ($ref), forward to the referenced
 	// schema.
 
@@ -508,6 +534,29 @@ function isObjectProperty(token) {
 		token.string.startsWith('"') &&
 		token.string.endsWith('"')
 	);
+}
+
+/**
+ * Removes any duplicate properties in an array with the same type and name.
+ * This could happen in some cases like when flattening properties from `anyOf`
+ * in a schema.
+ * @param {Array} items An array of properties
+ * @returns {Array}
+ */
+function removeDuplicateProperties(items) {
+	const uniqueProperties = [];
+
+	items.forEach((item) => {
+		if (
+			uniqueProperties.findIndex(
+				({name, type}) => name === item.name && type === item.type
+			) === -1
+		) {
+			uniqueProperties.push(item);
+		}
+	});
+
+	return uniqueProperties;
 }
 
 /**

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
@@ -367,6 +367,13 @@ function getSchemaProperties(
 		return [];
 	}
 
+	// Set fullSchema for recursive calls that might need to reference it.
+	// This will only be called on the first `getSchemaProperties` call.
+
+	if (!fullSchema) {
+		fullSchema = schema;
+	}
+
 	// If the schema links to a reference ($ref), forward to the referenced
 	// schema.
 
@@ -453,14 +460,6 @@ function getSchemaProperties(
 	const property = propertyPathList[0];
 
 	if (schema.properties && schema.properties[property.name]) {
-
-		// Set fullSchema for recursive calls that might need to reference it.
-		// This will only be called on the first `getSchemaProperties` call.
-
-		if (!fullSchema) {
-			fullSchema = schema;
-		}
-
 		if (property.type === 'array') {
 			return getSchemaProperties(
 				schema.properties[property.name].items,
@@ -483,10 +482,6 @@ function getSchemaProperties(
 	// schema's additionalProperties instead.
 
 	if (schema.additionalProperties) {
-		if (!fullSchema) {
-			fullSchema = schema;
-		}
-
 		return getSchemaProperties(
 			schema.additionalProperties,
 			propertyPathList.slice(1),

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
@@ -247,7 +247,9 @@ function getCodeMirrorHints(cm, autocompleteSchema, availableLanguages) {
 				// The `#` character is used to pass the `type` to the `render`
 				// method.
 
-				displayText: `${item.name}#${item.type}`,
+				displayText: `${item.name}#${
+					Array.isArray(item.type) ? item.type.join('|') : item.type
+				}`,
 				render: (element, cm, data) => {
 					const [propertyName, propertyType] = data.displayText.split(
 						'#'

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
@@ -79,7 +79,7 @@ function getCodeMirrorHints(cm, autocompleteSchema, availableLanguages) {
 	const start = token.start - 1;
 	const end = token.end;
 
-	if (token.type !== 'string property') {
+	if (token.type !== 'string property' && token.type !== 'string') {
 		return;
 	}
 
@@ -118,6 +118,23 @@ function getCodeMirrorHints(cm, autocompleteSchema, availableLanguages) {
 			...linePropertyBracketList,
 		];
 	}
+
+	// Get the property on current line to check for an enum list later.
+
+	const currentProperty = cm
+		.getLineTokens(cursor.line)
+		.filter((token) => {
+			if (token.end > cursor.ch) {
+				return false;
+			}
+
+			return (
+				token.string.length > 1 &&
+				token.string.startsWith('"') &&
+				token.string.endsWith('"')
+			);
+		})
+		.map((token) => removeQuotes(token.string));
 
 	// Filter the `propertyBracketList` to get only the parent properties.
 
@@ -179,9 +196,41 @@ function getCodeMirrorHints(cm, autocompleteSchema, availableLanguages) {
 		availableLanguages
 	);
 
-	// Filter matched strings.
-
 	const search = token.string.match(/[@]?\w+/);
+
+	// Return a filtered enum list if the property on the current line
+	// matches a property inside schemaProperties with an enum.
+
+	if (token.type === 'string') {
+		const property = list.find((item) => item.name === currentProperty[0]);
+
+		if (property?.enum && currentProperty.length === 1) {
+			let enumList = property.enum;
+
+			if (search !== null) {
+				enumList = property.enum.filter(
+					(item) =>
+						item.toLowerCase().indexOf(search[0].toLowerCase()) > -1
+				);
+			}
+
+			return {
+				from: CodeMirror.Pos(cursor.line, start + 2),
+				list: enumList.map((item) => {
+					return {
+						displayText: `${item}`,
+						text: `${item}"`,
+					};
+				}),
+
+				to: CodeMirror.Pos(cursor.line, end),
+			};
+		}
+
+		return;
+	}
+
+	// Filter matched strings.
 
 	if (search !== null) {
 		list = list.filter((item) => {
@@ -367,6 +416,7 @@ function getSchemaProperties(
 			// Get `type` value, forward $ref reference if defined.
 
 			let type = schema.properties[name].type || '';
+			let enumList = schema.properties[name].enum;
 
 			if (
 				schema.properties[name].$ref &&
@@ -383,6 +433,11 @@ function getSchemaProperties(
 				);
 
 				type = refSchema.type || '';
+				enumList = refSchema.enum;
+			}
+
+			if (type === 'string' && enumList) {
+				return {enum: enumList, name, type};
 			}
 
 			return {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
@@ -233,9 +233,10 @@ function getCodeMirrorHints(cm, autocompleteSchema, availableLanguages) {
 	// Filter matched strings.
 
 	if (search !== null) {
-		list = list.filter((item) => {
-			return item.name.indexOf(search) > -1;
-		});
+		list = list.filter(
+			(item) =>
+				item.name.toLowerCase().indexOf(search[0].toLowerCase()) > -1
+		);
 	}
 
 	return {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/advanced-configuration.schema.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/advanced-configuration.schema.json
@@ -1,0 +1,27 @@
+{
+	"$id": "advanced-configuration.schema.json",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"properties": {
+		"source": {
+			"properties": {
+				"excludes": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"fetchSource": {
+					"type": "boolean"
+				},
+				"includes": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				}
+			},
+			"type": "object"
+		}
+	},
+	"type": "object"
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/aggregation-configuration.schema.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/aggregation-configuration.schema.json
@@ -1,8 +1,1099 @@
 {
 	"$id": "aggregation-configuration.schema.json",
 	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"Aggregation": {
+			"properties": {
+				"aggs": {
+					"additionalProperties": {
+						"$ref": "#/definitions/Aggregations"
+					},
+					"type": "object"
+				},
+				"background_filter": {
+					"$ref": "#/definitions/Query"
+				},
+				"buckets_path": {
+					"type": [
+						"string",
+						"object"
+					]
+				},
+				"distance_type": {
+					"enum": [
+						"arc",
+						"plane"
+					],
+					"type": "string"
+				},
+				"enabled": {
+					"type": "boolean"
+				},
+				"exclude": {
+					"type": [
+						"array",
+						"string"
+					]
+				},
+				"execution_hint": {
+					"type": "string"
+				},
+				"extended_bounds": {
+					"$ref": "#/definitions/Bound"
+				},
+				"field": {
+					"type": "string"
+				},
+				"format": {
+					"type": "string"
+				},
+				"gap_policy": {
+					"enum": [
+						"instant_zeros",
+						"skip"
+					],
+					"type": "string"
+				},
+				"hard_bounds": {
+					"$ref": "#/definitions/Bound"
+				},
+				"hdr": {
+					"properties": {
+						"number_of_significant_value_digits": {
+							"minimum": 1,
+							"type": "number"
+						}
+					},
+					"type": "object"
+				},
+				"include": {
+					"type": [
+						"array",
+						"string"
+					]
+				},
+				"keyed": {
+					"type": "boolean"
+				},
+				"min_doc_count": {
+					"minimum": 1,
+					"type": "number"
+				},
+				"missing": {
+					"type": [
+						"number",
+						"string"
+					]
+				},
+				"offset": {
+					"type": [
+						"number",
+						"string"
+					]
+				},
+				"order": {
+					"type": "object"
+				},
+				"percents": {
+					"items": {
+						"type": "number"
+					},
+					"type": "array"
+				},
+				"ranges": {
+					"items": {
+						"$ref": "#/definitions/Range"
+					},
+					"type": "array"
+				},
+				"script": {
+					"$ref": "#/definitions/Script"
+				},
+				"shard_min_doc_count": {
+					"minimum": 1,
+					"type": "number"
+				},
+				"shard_size": {
+					"minimum": 1,
+					"type": "number"
+				},
+				"sigma": {
+					"type": "number"
+				},
+				"size": {
+					"minimum": 1,
+					"type": "number"
+				},
+				"sort": {
+					"$ref": "#/definitions/Sort"
+				},
+				"tdigest": {
+					"properties": {
+						"compression": {
+							"minimum": 0,
+							"type": "number"
+						}
+					},
+					"type": "object"
+				},
+				"unit": {
+					"enum": [
+						"cm",
+						"ft",
+						"in",
+						"km",
+						"m",
+						"mi",
+						"mm",
+						"yd"
+					],
+					"type": "string"
+				},
+				"window": {
+					"minimum": 0,
+					"type": "number"
+				}
+			},
+			"type": "object"
+		},
+		"Aggregations": {
+			"properties": {
+				"aggs": {
+					"additionalProperties": {
+						"$ref": "#/definitions/Aggregations"
+					},
+					"type": "object"
+				},
+				"avg": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"field"
+					],
+					"type": "object"
+				},
+				"avg_bucket": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"buckets_path"
+					],
+					"type": "object"
+				},
+				"bucket_script": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"buckets_path",
+						"script"
+					],
+					"type": "object"
+				},
+				"bucket_selector": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"buckets_path",
+						"script"
+					],
+					"type": "object"
+				},
+				"bucket_sort": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"type": "object"
+				},
+				"cardinality": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"properties": {
+						"precision_threshold": {
+							"maximum": 40000,
+							"minimum": 0,
+							"type": "number"
+						}
+					},
+					"required": [
+						"field"
+					],
+					"type": "object"
+				},
+				"cumulative_sum": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"buckets_path"
+					],
+					"type": "object"
+				},
+				"date_histogram": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"properties": {
+						"date_histogram_interval": {
+							"enum": [
+								"minute",
+								"1m",
+								"hour",
+								"1h",
+								"day",
+								"1d",
+								"week",
+								"1w",
+								"month",
+								"1M",
+								"quarter",
+								"1q",
+								"year",
+								"1y"
+							],
+							"type": "string"
+						}
+					},
+					"required": [
+						"field"
+					],
+					"type": "object"
+				},
+				"date_range": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"field"
+					],
+					"type": "object"
+				},
+				"derivative": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"buckets_path"
+					],
+					"type": "object"
+				},
+				"diversified_sampler": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"properties": {
+						"max_docs_per_value": {
+							"type": "number"
+						}
+					},
+					"required": [
+						"field"
+					],
+					"type": "object"
+				},
+				"extended_stats": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"type": "object"
+				},
+				"extended_stats_bucket": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"buckets_path"
+					],
+					"type": "object"
+				},
+				"filter": {
+					"$ref": "#/definitions/Query"
+				},
+				"filters": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"properties": {
+						"filters": {
+							"type": [
+								"array",
+								"object"
+							]
+						},
+						"other_bucket": {
+							"type": "boolean"
+						},
+						"other_bucket_key": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"filters"
+					],
+					"type": "object"
+				},
+				"geo_bounds": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"properties": {
+						"wrap_longitude": {
+							"type": "boolean"
+						}
+					},
+					"required": [
+						"field"
+					],
+					"type": "object"
+				},
+				"geo_centroid": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"field"
+					],
+					"type": "object"
+				},
+				"geo_distance": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"properties": {
+						"origin": {
+							"pattern": "^[0-9]+(\\.[0-9]+)?\\,[0-9]+(\\.[0-9]+)?$",
+							"type": "string"
+						}
+					},
+					"required": [
+						"field",
+						"origin"
+					],
+					"type": "object"
+				},
+				"geohash_grid": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"properties": {
+						"precision": {
+							"maximum": 12,
+							"minimum": 1,
+							"type": "number"
+						}
+					},
+					"required": [
+						"field"
+					],
+					"type": "object"
+				},
+				"global": {
+					"type": "object"
+				},
+				"histogram": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"properties": {
+						"interval": {
+							"type": "number"
+						}
+					},
+					"required": [
+						"field"
+					],
+					"type": "object"
+				},
+				"max": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"field"
+					],
+					"type": "object"
+				},
+				"max_bucket": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"buckets_path"
+					],
+					"type": "object"
+				},
+				"min": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"field"
+					],
+					"type": "object"
+				},
+				"min_bucket": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"buckets_path"
+					],
+					"type": "object"
+				},
+				"missing": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"field"
+					],
+					"type": "object"
+				},
+				"moving_function": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"buckets_path",
+						"script",
+						"window"
+					],
+					"type": "object"
+				},
+				"nested": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"properties": {
+						"path": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"path"
+					],
+					"type": "object"
+				},
+				"percentile_ranks": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"properties": {
+						"values": {
+							"items": {
+								"type": "number"
+							},
+							"type": "array"
+						}
+					},
+					"required": [
+						"field",
+						"values"
+					],
+					"type": "object"
+				},
+				"percentiles": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"field"
+					],
+					"type": "object"
+				},
+				"percentiles_bucket": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"buckets_path"
+					],
+					"type": "object"
+				},
+				"range": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"field",
+						"ranges"
+					],
+					"type": "object"
+				},
+				"reverse_nested": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"properties": {
+						"path": {
+							"type": "string"
+						}
+					},
+					"type": "object"
+				},
+				"sampler": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"type": "object"
+				},
+				"scripted_metric": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"properties": {
+						"combine_script": {
+							"$ref": "#/definitions/Script"
+						},
+						"init_script": {
+							"$ref": "#/definitions/Script"
+						},
+						"map_script": {
+							"$ref": "#/definitions/Script"
+						},
+						"params": {
+							"type": "object"
+						},
+						"reduce_script": {
+							"$ref": "#/definitions/Script"
+						}
+					},
+					"required": [
+						"combine_script",
+						"map_script",
+						"reduce_script"
+					],
+					"type": "object"
+				},
+				"serial_differencing": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"properties": {
+						"lag": {
+							"minimum": 1,
+							"type": "number"
+						}
+					},
+					"required": [
+						"buckets_path"
+					],
+					"type": "object"
+				},
+				"significant_terms": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						},
+						{
+							"$ref": "#/definitions/SignificanceHeuristics"
+						}
+					],
+					"required": [
+						"field"
+					],
+					"type": "object"
+				},
+				"significant_text": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						},
+						{
+							"$ref": "#/definitions/SignificanceHeuristics"
+						}
+					],
+					"properties": {
+						"filter_duplicate_text": {
+							"type": "boolean"
+						}
+					},
+					"required": [
+						"field"
+					],
+					"type": "object"
+				},
+				"stats": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"field"
+					],
+					"type": "object"
+				},
+				"stats_bucket": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"buckets_path"
+					],
+					"type": "object"
+				},
+				"sum": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"field"
+					],
+					"type": "object"
+				},
+				"sum_bucket": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"buckets_path"
+					],
+					"type": "object"
+				},
+				"terms": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"properties": {
+						"collect_mode": {
+							"enum": [
+								"breadth_first",
+								"depth_first"
+							],
+							"type": "string"
+						},
+						"show_term_doc_count_error": {
+							"type": "boolean"
+						}
+					},
+					"required": [
+						"field"
+					],
+					"type": "object"
+				},
+				"top_hits": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"properties": {
+						"_source": {
+							"$ref": "#/definitions/Source"
+						},
+						"docvalue_fields": {
+							"items": {
+								"type": "string"
+							},
+							"type": "array"
+						},
+						"explain": {
+							"type": "boolean"
+						},
+						"from": {
+							"minimum": 0,
+							"type": "number"
+						},
+						"highlight": {
+							"$ref": "#/definitions/Highlight"
+						},
+						"script_fields": {
+							"items": {
+								"$ref": "#/definitions/Script"
+							},
+							"type": "array"
+						},
+						"track_scores": {
+							"type": "boolean"
+						},
+						"version": {
+							"type": "boolean"
+						}
+					},
+					"type": "object"
+				},
+				"value_count": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"required": [
+						"field"
+					],
+					"type": "object"
+				},
+				"weighted_avg": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Aggregation"
+						}
+					],
+					"properties": {
+						"value": {
+							"properties": {
+								"field": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"field"
+							],
+							"type": "object"
+						},
+						"weight": {
+							"properties": {
+								"field": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"field"
+							],
+							"type": "object"
+						}
+					},
+					"type": "object"
+				}
+			}
+		},
+		"Bound": {
+			"properties": {
+				"max": {
+					"type": [
+						"number",
+						"string"
+					]
+				},
+				"min": {
+					"type": [
+						"number",
+						"string"
+					]
+				}
+			},
+			"type": "object"
+		},
+		"Highlight": {
+			"properties": {
+				"fragment_offset": {
+					"minimum": 0,
+					"type": "number"
+				},
+				"fragment_size": {
+					"minimum": 0,
+					"type": "number"
+				},
+				"number_of_fragments": {
+					"minimum": 0,
+					"type": "number"
+				},
+				"post_tags": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array",
+					"uniqueItems": true
+				},
+				"pre_tags": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array",
+					"uniqueItems": true
+				},
+				"require_field_match": {
+					"type": "boolean"
+				},
+				"type": {
+					"enum": [
+						"fvh",
+						"plain",
+						"unified"
+					],
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"NestedSort": {
+			"properties": {
+				"filter": {
+					"type": "object"
+				},
+				"nested": {
+					"$ref": "#/definitions/NestedSort"
+				},
+				"path": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"path"
+			],
+			"type": "object"
+		},
+		"Query": {
+			"type": "object"
+		},
+		"Range": {
+			"properties": {
+				"from": {
+					"type": [
+						"number",
+						"string"
+					]
+				},
+				"key": {
+					"type": "string"
+				},
+				"to": {
+					"type": [
+						"number",
+						"string"
+					]
+				}
+			},
+			"type": "object"
+		},
+		"Script": {
+			"anyOf": [
+				{
+					"properties": {
+						"id": {
+							"type": "string"
+						},
+						"params": {
+							"type": "object"
+						}
+					},
+					"required": [
+						"id"
+					],
+					"type": "object"
+				},
+				{
+					"properties": {
+						"_options": {
+							"type": "object"
+						},
+						"lang": {
+							"enum": [
+								"expression",
+								"java",
+								"mustache",
+								"painless"
+							],
+							"type": "string"
+						},
+						"params": {
+							"type": "object"
+						},
+						"source": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"source"
+					],
+					"type": "object"
+				}
+			],
+			"type": "object"
+		},
+		"SignificanceHeuristics": {
+			"properties": {
+				"chi_square": {
+					"properties": {
+						"background_is_superset": {
+							"type": "boolean"
+						},
+						"include_negatives": {
+							"type": "boolean"
+						}
+					},
+					"type": "object"
+				},
+				"gnd": {
+					"properties": {
+						"background_is_superset": {
+							"type": "boolean"
+						}
+					},
+					"type": "object"
+				},
+				"jlh": {
+					"type": "object"
+				},
+				"mutual_information": {
+					"properties": {
+						"background_is_superset": {
+							"type": "boolean"
+						},
+						"include_negatives": {
+							"type": "boolean"
+						}
+					},
+					"type": "object"
+				},
+				"percentage": {
+					"type": "object"
+				},
+				"script_heuristic": {
+					"properties": {
+						"script": {
+							"$ref": "#/definitions/Script"
+						}
+					},
+					"required": [
+						"script"
+					],
+					"type": "object"
+				}
+			},
+			"type": "object"
+		},
+		"Sort": {
+			"properties": {
+				"missing": {
+					"type": "string"
+				},
+				"mode": {
+					"enum": [
+						"avg",
+						"max",
+						"median",
+						"min",
+						"sum"
+					],
+					"type": "string"
+				},
+				"nested": {
+					"$ref": "#/definitions/NestedSort"
+				},
+				"order": {
+					"$ref": "#/definitions/SortOrder"
+				}
+			},
+			"type": [
+				"string",
+				"object"
+			]
+		},
+		"SortOrder": {
+			"enum": [
+				"asc",
+				"desc"
+			],
+			"type": "string"
+		},
+		"Source": {
+			"properties": {
+				"excludes": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"includes": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				}
+			},
+			"type": [
+				"boolean",
+				"object"
+			]
+		}
+	},
 	"properties": {
 		"aggs": {
+			"additionalProperties": {
+				"$ref": "#/definitions/Aggregations"
+			},
 			"type": "object"
 		}
 	},

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/aggregation-configuration.schema.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/aggregation-configuration.schema.json
@@ -1,0 +1,10 @@
+{
+	"$id": "aggregation-configuration.schema.json",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"properties": {
+		"aggs": {
+			"type": "object"
+		}
+	},
+	"type": "object"
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/highlight-configuration.schema.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/highlight-configuration.schema.json
@@ -1,0 +1,53 @@
+{
+	"$id": "highlight-configuration.schema.json",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"HighlightField": {
+			"properties": {
+				"fragment_offset": {
+					"type": "integer"
+				},
+				"fragment_size": {
+					"type": "integer"
+				},
+				"number_of_fragments": {
+					"type": "integer"
+				}
+			},
+			"type": "object"
+		}
+	},
+	"properties": {
+		"fields": {
+			"additionalProperties": {
+				"$ref": "#/definitions/HighlightField"
+			},
+			"type": "object"
+		},
+		"fragment_size": {
+			"type": "integer"
+		},
+		"number_of_fragments": {
+			"type": "integer"
+		},
+		"post_tags": {
+			"items": {
+				"type": "string"
+			},
+			"type": "array"
+		},
+		"pre_tags": {
+			"items": {
+				"type": "string"
+			},
+			"type": "array"
+		},
+		"require_field_match": {
+			"type": "boolean"
+		},
+		"type": {
+			"type": "string"
+		}
+	},
+	"type": "object"
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/parameter-configuration.schema.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/parameter-configuration.schema.json
@@ -1,0 +1,48 @@
+{
+	"$id": "parameter-configuration.schema.json",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"Parameter": {
+			"properties": {
+				"defaultValue": {
+					"type": "object"
+				},
+				"format": {
+					"type": "string"
+				},
+				"max": {
+					"type": "object"
+				},
+				"min": {
+					"type": "object"
+				},
+				"type": {
+					"enum": [
+						"Boolean",
+						"Date",
+						"Double",
+						"Float",
+						"Integer",
+						"IntegerArray",
+						"Long",
+						"LongArray",
+						"String",
+						"StringArray",
+						"TimeRange"
+					],
+					"type": "string"
+				}
+			},
+			"type": "object"
+		}
+	},
+	"properties": {
+		"parameters": {
+			"additionalProperties": {
+				"$ref": "#/definitions/Parameter"
+			},
+			"type": "object"
+		}
+	},
+	"type": "object"
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/sort-configuration.schema.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/sort-configuration.schema.json
@@ -1,0 +1,10 @@
+{
+	"$id": "sort-configuration.schema.json",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"properties": {
+		"sorts": {
+			"type": "object"
+		}
+	},
+	"type": "object"
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/sort-configuration.schema.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/sort-configuration.schema.json
@@ -1,9 +1,196 @@
 {
 	"$id": "sort-configuration.schema.json",
 	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"Geopoint": {
+			"items": {
+				"maxItems": 2,
+				"minItems": 2,
+				"type": [
+					"string",
+					"number"
+				]
+			},
+			"type": "array"
+		},
+		"NestedSort": {
+			"properties": {
+				"filter": {
+					"type": "object"
+				},
+				"nested": {
+					"$ref": "#/definitions/NestedSort"
+				},
+				"path": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"path"
+			],
+			"type": "object"
+		},
+		"Script": {
+			"anyOf": [
+				{
+					"properties": {
+						"id": {
+							"type": "string"
+						},
+						"params": {
+							"type": "object"
+						}
+					},
+					"required": [
+						"id"
+					],
+					"type": "object"
+				},
+				{
+					"properties": {
+						"_options": {
+							"type": "object"
+						},
+						"lang": {
+							"enum": [
+								"expression",
+								"java",
+								"mustache",
+								"painless"
+							],
+							"type": "string"
+						},
+						"params": {
+							"type": "object"
+						},
+						"source": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"source"
+					],
+					"type": "object"
+				}
+			],
+			"type": "object"
+		},
+		"Sort": {
+			"properties": {
+				"missing": {
+					"type": "string"
+				},
+				"mode": {
+					"enum": [
+						"avg",
+						"max",
+						"median",
+						"min",
+						"sum"
+					],
+					"type": "string"
+				},
+				"nested": {
+					"$ref": "#/definitions/NestedSort"
+				},
+				"order": {
+					"$ref": "#/definitions/SortOrder"
+				}
+			},
+			"type": [
+				"string",
+				"object"
+			]
+		},
+		"SortOrder": {
+			"enum": [
+				"asc",
+				"desc"
+			],
+			"type": "string"
+		},
+		"Sorts": {
+			"properties": {
+				"_geo_distance": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Sort"
+						}
+					],
+					"properties": {
+						"distance_type": {
+							"enum": [
+								"arc",
+								"plane"
+							],
+							"type": "string"
+						},
+						"field": {
+							"type": "string"
+						},
+						"locations": {
+							"items": {
+								"$ref": "#/definitions/Geopoint"
+							},
+							"type": "array"
+						},
+						"unit": {
+							"enum": [
+								"cm",
+								"ft",
+								"in",
+								"km",
+								"m",
+								"mi",
+								"mm",
+								"yd"
+							],
+							"type": "string"
+						}
+					},
+					"required": [
+						"field",
+						"locations"
+					],
+					"type": "object"
+				},
+				"_score": {
+					"$ref": "#/definitions/Sort"
+				},
+				"_script": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/Sort"
+						}
+					],
+					"properties": {
+						"script": {
+							"$ref": "#/definitions/Script"
+						},
+						"type": {
+							"enum": [
+								"number",
+								"string"
+							],
+							"type": "string"
+						}
+					},
+					"required": [
+						"script",
+						"type"
+					],
+					"type": "object"
+				}
+			},
+			"type": "object"
+		}
+	},
 	"properties": {
 		"sorts": {
-			"type": "object"
+			"items": {
+				"$ref": "#/definitions/Sorts"
+			},
+			"type": "array"
 		}
 	},
 	"type": "object"

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/sxp-query-element.schema.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/sxp-query-element.schema.json
@@ -330,9 +330,6 @@
 	"properties": {
 		"description_i18n": {
 			"$ref": "LanguageId",
-			"additionalProperties": {
-				"type": "string"
-			},
 			"type": "object"
 		},
 		"elementDefinition": {
@@ -340,9 +337,6 @@
 		},
 		"title_i18n": {
 			"$ref": "LanguageId",
-			"additionalProperties": {
-				"type": "string"
-			},
 			"type": "object"
 		}
 	},


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-143720 - When editing my Blueprint's Configurations JSON, I am aided by schema-driven auto-completion

Autocomplete for the blueprint configurations! (Resent after https://github.com/liferay-search/liferay-portal/pull/425)

Some updates to CodeMirrorEditor: 
- accommodate for multiple editors on a single page
- check a schema's additionalProperties
- added support for `enum`s
- make autocomplete case-insensitive
- display multiple types of schema property (it will look like: `string|object`)
- prevent an error if a `$ref` is at the top level
- added support for `allOf` or `anyOf` situations, which occur in aggregation and sort mainly

Each configuration is tied to its own schema.json, these mainly reference https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml and https://github.com/liferay/liferay-portal/tree/master/modules/dxp/apps/search-experiences/search-experiences-service/src/main/resources/com/liferay/search/experiences/internal/validator/dependencies

@peerkar Would you mind checking over the updates to the sort and aggregation schemas? I tried to follow the original schemas while still keeping in mind validation from rest-openapi.yaml, but let me know if they need updating!

Some screenshots:
<img width="907" alt="Screen Shot 2022-05-02 at 5 39 17 PM" src="https://user-images.githubusercontent.com/14063502/166370977-4a30cbe2-73fc-444f-ab7c-490f6c99c99b.png">
<img width="916" alt="Screen Shot 2022-05-02 at 5 33 49 PM" src="https://user-images.githubusercontent.com/14063502/166360949-0175cf0c-12e5-49a1-b7f9-9fb1d90b3c77.png">
<img width="922" alt="Screen Shot 2022-05-02 at 5 34 55 PM" src="https://user-images.githubusercontent.com/14063502/166361480-8944974c-7e4d-4856-bf36-cac9ea04a72e.png">
<img width="931" alt="Screen Shot 2022-05-02 at 5 35 21 PM" src="https://user-images.githubusercontent.com/14063502/166361690-e5e994fd-1ce3-4221-b83c-59ea5ec458cb.png">
<img width="941" alt="Screen Shot 2022-05-02 at 5 35 52 PM" src="https://user-images.githubusercontent.com/14063502/166362189-a462a10d-5948-46e4-a715-e08fbef1438b.png">