### PR TITLE
LPS-152791 search-experiences-web: Fix autocomplete for fields in sxp…

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/sxp-query-element.schema.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/sxp-query-element.schema.json
@@ -135,11 +135,16 @@
 		},
 		"Field": {
 			"properties": {
-				"fieldMappings": {
+				"defaultValue": {
 					"items": {
 						"$ref": "#/definitions/FieldMapping"
 					},
-					"type": "array"
+					"type": [
+						"array",
+						"number",
+						"object",
+						"string"
+					]
 				},
 				"helpText": {
 					"type": "string"
@@ -150,10 +155,20 @@
 				"name": {
 					"type": "string"
 				},
-				"step": {
-					"type": "object"
-				},
 				"type": {
+					"enum": [
+						"date",
+						"fieldMapping",
+						"fieldMappingList",
+						"json",
+						"keywords",
+						"multiselect",
+						"number",
+						"searchableType",
+						"select",
+						"slider",
+						"text"
+					],
 					"type": "string"
 				},
 				"typeOptions": {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-152791 - Incorrect and missing JSON autocomplete properties

Notes:
- removed `fieldMappings` and `step` 
- added more types to `defaultValue`
- included items of `fieldMappings` into `defaultValue`
- added enums to `type`