### PR TITLE
[TS] LPS-152937 Elasticsearch sort doesn't work with accented words

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -23,6 +23,90 @@
 				}
 			},
 			{
+				"template_string_sortable_en": {
+					"mapping": {
+						"country": "US",
+						"language": "en",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "*_en_US_sortable",
+					"match_mapping_type": "string"
+				}
+			},
+			{
+				"template_string_sortable_fr": {
+					"mapping": {
+						"country": "FR",
+						"language": "fr",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "*_fr_FR_sortable",
+					"match_mapping_type": "string"
+				}
+			},
+			{
+				"template_string_sortable_de": {
+					"mapping": {
+						"country": "DE",
+						"language": "de",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "*_de_DE_sortable",
+					"match_mapping_type": "string"
+				}
+			},
+			{
+				"template_string_sortable_pl": {
+					"mapping": {
+						"country": "PL",
+						"language": "pl",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "*_pl_PL_sortable",
+					"match_mapping_type": "string"
+				}
+			},
+			{
+				"template_string_sortable_pt": {
+					"mapping": {
+						"country": "BR",
+						"language": "pt",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "*_pt_BR_sortable",
+					"match_mapping_type": "string"
+				}
+			},
+			{
+				"template_string_sortable_ja": {
+					"mapping": {
+						"country": "JP",
+						"language": "ja",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "*_ja_JP_sortable",
+					"match_mapping_type": "string"
+				}
+			},
+			{
+				"template_string_sortable_es": {
+					"mapping": {
+						"country": "ES",
+						"language": "es",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "*_es_ES_sortable",
+					"match_mapping_type": "string"
+				}
+			},
+			{
 				"template_string_sortable": {
 					"mapping": {
 						"store": true,

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -83,6 +83,19 @@
 				}
 			},
 			{
+				"template_string_sortable_de_AT": {
+					"mapping": {
+						"country": "AT",
+						"language": "de",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_de_AT_sortable\\b|\\w+_de_AT_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
 				"template_string_sortable_de": {
 					"mapping": {
 						"language": "de",
@@ -174,6 +187,19 @@
 						"type": "icu_collation_keyword"
 					},
 					"match": "\\w+_fi_[A-Z]{2}_sortable\\b|\\w+_fi_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_fr_CA": {
+					"mapping": {
+						"country": "CA",
+						"language": "fr",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_fr_CA_sortable\\b|\\w+_fr_CA_\\w+_sortable\\b",
 					"match_mapping_type": "string",
 					"match_pattern": "regex"
 				}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -23,27 +23,61 @@
 				}
 			},
 			{
-				"template_string_sortable_en": {
+				"template_string_sortable_ar": {
 					"mapping": {
-						"country": "US",
-						"language": "en",
+						"language": "ar",
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "\\w+_en_[A-Z]{2}_sortable\\b|\\w+_en_[A-Z]{2}_\\w+_sortable\\b",
+					"match": "\\w+_ar_[A-Z]{2}_sortable\\b|\\w+_ar_[A-Z]{2}_\\w+_sortable\\b",
 					"match_mapping_type": "string",
 					"match_pattern": "regex"
 				}
 			},
 			{
-				"template_string_sortable_fr": {
+				"template_string_sortable_bg": {
 					"mapping": {
-						"country": "FR",
-						"language": "fr",
+						"language": "bg",
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "\\w+_fr_[A-Z]{2}_sortable\\b|\\w+_fr_[A-Z]{2}_\\w+_sortable\\b",
+					"match": "\\w+_bg_[A-Z]{2}_sortable\\b|\\w+_bg_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_ca": {
+					"mapping": {
+						"language": "ca",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_ca_[A-Z]{2}_sortable\\b|\\w+_ca_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_cs": {
+					"mapping": {
+						"language": "cs",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_cs_[A-Z]{2}_sortable\\b|\\w+_cs_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_da": {
+					"mapping": {
+						"language": "da",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_da_[A-Z]{2}_sortable\\b|\\w+_da_[A-Z]{2}_\\w+_sortable\\b",
 					"match_mapping_type": "string",
 					"match_pattern": "regex"
 				}
@@ -51,7 +85,6 @@
 			{
 				"template_string_sortable_de": {
 					"mapping": {
-						"country": "DE",
 						"language": "de",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -62,9 +95,296 @@
 				}
 			},
 			{
+				"template_string_sortable_el": {
+					"mapping": {
+						"language": "el",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_el_[A-Z]{2}_sortable\\b|\\w+_el_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_en": {
+					"mapping": {
+						"language": "en",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_en_[A-Z]{2}_sortable\\b|\\w+_en_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_es": {
+					"mapping": {
+						"language": "es",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_es_[A-Z]{2}_sortable\\b|\\w+_es_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_et": {
+					"mapping": {
+						"language": "et",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_et_[A-Z]{2}_sortable\\b|\\w+_et_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_eu": {
+					"mapping": {
+						"language": "eu",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_eu_[A-Z]{2}_sortable\\b|\\w+_eu_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_fa": {
+					"mapping": {
+						"language": "fa",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_fa_[A-Z]{2}_sortable\\b|\\w+_fa_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_fi": {
+					"mapping": {
+						"language": "fi",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_fi_[A-Z]{2}_sortable\\b|\\w+_fi_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_fr": {
+					"mapping": {
+						"language": "fr",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_fr_[A-Z]{2}_sortable\\b|\\w+_fr_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_gl": {
+					"mapping": {
+						"language": "gl",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_gl_[A-Z]{2}_sortable\\b|\\w+_gl_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_hi": {
+					"mapping": {
+						"language": "hi",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_hi_[A-Z]{2}_sortable\\b|\\w+_hi_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_hr": {
+					"mapping": {
+						"language": "hr",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_hr_[A-Z]{2}_sortable\\b|\\w+_hr_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_hu": {
+					"mapping": {
+						"language": "hu",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_hu_[A-Z]{2}_sortable\\b|\\w+_hu_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_hy": {
+					"mapping": {
+						"language": "hy",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_hy_[A-Z]{2}_sortable\\b|\\w+_hy_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_in": {
+					"mapping": {
+						"language": "in",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_in_[A-Z]{2}_sortable\\b|\\w+_in_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_it": {
+					"mapping": {
+						"language": "it",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_it_[A-Z]{2}_sortable\\b|\\w+_it_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_ja": {
+					"mapping": {
+						"language": "ja",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_ja_[A-Z]{2}_sortable\\b|\\w+_ja_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_kk": {
+					"mapping": {
+						"language": "kk",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_kk_[A-Z]{2}_sortable\\b|\\w+_kk_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_ko": {
+					"mapping": {
+						"language": "ko",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_ko_[A-Z]{2}_sortable\\b|\\w+_ko_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_lo": {
+					"mapping": {
+						"language": "lo",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_lo_[A-Z]{2}_sortable\\b|\\w+_lo_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_lt": {
+					"mapping": {
+						"language": "lt",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_lt_[A-Z]{2}_sortable\\b|\\w+_lt_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_ms": {
+					"mapping": {
+						"language": "ms",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_ms_[A-Z]{2}_sortable\\b|\\w+_ms_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_nb": {
+					"mapping": {
+						"language": "nb",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_nb_[A-Z]{2}_sortable\\b|\\w+_nb_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_nl": {
+					"mapping": {
+						"language": "nl",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_nl_[A-Z]{2}_sortable\\b|\\w+_nl_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_no": {
+					"mapping": {
+						"language": "no",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_no_[A-Z]{2}_sortable\\b|\\w+_no_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
 				"template_string_sortable_pl": {
 					"mapping": {
-						"country": "PL",
 						"language": "pl",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -77,7 +397,6 @@
 			{
 				"template_string_sortable_pt": {
 					"mapping": {
-						"country": "BR",
 						"language": "pt",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -88,27 +407,145 @@
 				}
 			},
 			{
-				"template_string_sortable_ja": {
+				"template_string_sortable_ro": {
 					"mapping": {
-						"country": "JP",
-						"language": "ja",
+						"language": "ro",
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "\\w+_ja_[A-Z]{2}_sortable\\b|\\w+_ja_[A-Z]{2}_\\w+_sortable\\b",
+					"match": "\\w+_ro_[A-Z]{2}_sortable\\b|\\w+_ro_[A-Z]{2}_\\w+_sortable\\b",
 					"match_mapping_type": "string",
 					"match_pattern": "regex"
 				}
 			},
 			{
-				"template_string_sortable_es": {
+				"template_string_sortable_ru": {
 					"mapping": {
-						"country": "ES",
-						"language": "es",
+						"language": "ru",
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "\\w+_es_[A-Z]{2}_sortable\\b|\\w+_es_[A-Z]{2}_\\w+_sortable\\b",
+					"match": "\\w+_ru_[A-Z]{2}_sortable\\b|\\w+_ru_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_sk": {
+					"mapping": {
+						"language": "sk",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_sk_[A-Z]{2}_sortable\\b|\\w+_sk_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_sl": {
+					"mapping": {
+						"language": "sl",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_sl_[A-Z]{2}_sortable\\b|\\w+_sl_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_sr": {
+					"mapping": {
+						"language": "sr",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_sr_[A-Z]{2}_sortable\\b|\\w+_sr_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_sv": {
+					"mapping": {
+						"language": "sv",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_sv_[A-Z]{2}_sortable\\b|\\w+_sv_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_ta": {
+					"mapping": {
+						"language": "ta",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_ta_[A-Z]{2}_sortable\\b|\\w+_ta_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_th": {
+					"mapping": {
+						"language": "th",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_th_[A-Z]{2}_sortable\\b|\\w+_th_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_tr": {
+					"mapping": {
+						"language": "tr",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_tr_[A-Z]{2}_sortable\\b|\\w+_tr_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_uk": {
+					"mapping": {
+						"language": "uk",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_uk_[A-Z]{2}_sortable\\b|\\w+_uk_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_vi": {
+					"mapping": {
+						"language": "vi",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_vi_[A-Z]{2}_sortable\\b|\\w+_vi_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_zh": {
+					"mapping": {
+						"language": "zh",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_zh_[A-Z]{2}_sortable\\b|\\w+_zh_[A-Z]{2}_\\w+_sortable\\b",
 					"match_mapping_type": "string",
 					"match_pattern": "regex"
 				}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -30,8 +30,9 @@
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "*_en_US_sortable",
-					"match_mapping_type": "string"
+					"match": "\\w+_en_[A-Z]{2}_sortable\\b|\\w+_en_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
 				}
 			},
 			{
@@ -42,8 +43,9 @@
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "*_fr_FR_sortable",
-					"match_mapping_type": "string"
+					"match": "\\w+_fr_[A-Z]{2}_sortable\\b|\\w+_fr_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
 				}
 			},
 			{
@@ -54,8 +56,9 @@
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "*_de_DE_sortable",
-					"match_mapping_type": "string"
+					"match": "\\w+_de_[A-Z]{2}_sortable\\b|\\w+_de_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
 				}
 			},
 			{
@@ -66,8 +69,9 @@
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "*_pl_PL_sortable",
-					"match_mapping_type": "string"
+					"match": "\\w+_pl_[A-Z]{2}_sortable\\b|\\w+_pl_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
 				}
 			},
 			{
@@ -78,8 +82,9 @@
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "*_pt_BR_sortable",
-					"match_mapping_type": "string"
+					"match": "\\w+_pt_[A-Z]{2}_sortable\\b|\\w+_pt_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
 				}
 			},
 			{
@@ -90,8 +95,9 @@
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "*_ja_JP_sortable",
-					"match_mapping_type": "string"
+					"match": "\\w+_ja_[A-Z]{2}_sortable\\b|\\w+_ja_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
 				}
 			},
 			{
@@ -102,8 +108,9 @@
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "*_es_ES_sortable",
-					"match_mapping_type": "string"
+					"match": "\\w+_es_[A-Z]{2}_sortable\\b|\\w+_es_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
 				}
 			},
 			{

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -25,6 +25,12 @@
 			{
 				"template_string_sortable_ar": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "ar",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -37,6 +43,12 @@
 			{
 				"template_string_sortable_bg": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "bg",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -49,6 +61,12 @@
 			{
 				"template_string_sortable_ca": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "ca",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -61,6 +79,12 @@
 			{
 				"template_string_sortable_cs": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "cs",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -73,6 +97,12 @@
 			{
 				"template_string_sortable_da": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "da",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -86,6 +116,12 @@
 				"template_string_sortable_de_AT": {
 					"mapping": {
 						"country": "AT",
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "de",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -98,6 +134,12 @@
 			{
 				"template_string_sortable_de": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "de",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -110,6 +152,12 @@
 			{
 				"template_string_sortable_el": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "el",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -122,6 +170,12 @@
 			{
 				"template_string_sortable_en": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "en",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -134,6 +188,12 @@
 			{
 				"template_string_sortable_es": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "es",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -146,6 +206,12 @@
 			{
 				"template_string_sortable_et": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "et",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -158,6 +224,12 @@
 			{
 				"template_string_sortable_eu": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "eu",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -170,6 +242,12 @@
 			{
 				"template_string_sortable_fa": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "fa",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -182,6 +260,12 @@
 			{
 				"template_string_sortable_fi": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "fi",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -195,6 +279,12 @@
 				"template_string_sortable_fr_CA": {
 					"mapping": {
 						"country": "CA",
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "fr",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -207,6 +297,12 @@
 			{
 				"template_string_sortable_fr": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "fr",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -219,6 +315,12 @@
 			{
 				"template_string_sortable_gl": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "gl",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -231,6 +333,12 @@
 			{
 				"template_string_sortable_hi": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "hi",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -243,6 +351,12 @@
 			{
 				"template_string_sortable_hr": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "hr",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -255,6 +369,12 @@
 			{
 				"template_string_sortable_hu": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "hu",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -267,6 +387,12 @@
 			{
 				"template_string_sortable_hy": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "hy",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -279,6 +405,12 @@
 			{
 				"template_string_sortable_in": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "in",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -291,6 +423,12 @@
 			{
 				"template_string_sortable_it": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "it",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -303,6 +441,12 @@
 			{
 				"template_string_sortable_ja": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "ja",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -315,6 +459,12 @@
 			{
 				"template_string_sortable_kk": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "kk",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -327,6 +477,12 @@
 			{
 				"template_string_sortable_ko": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "ko",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -339,6 +495,12 @@
 			{
 				"template_string_sortable_lo": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "lo",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -351,6 +513,12 @@
 			{
 				"template_string_sortable_lt": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "lt",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -363,6 +531,12 @@
 			{
 				"template_string_sortable_ms": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "ms",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -375,6 +549,12 @@
 			{
 				"template_string_sortable_nb": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "nb",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -387,6 +567,12 @@
 			{
 				"template_string_sortable_nl": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "nl",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -399,6 +585,12 @@
 			{
 				"template_string_sortable_no": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "no",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -411,6 +603,12 @@
 			{
 				"template_string_sortable_pl": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "pl",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -423,6 +621,12 @@
 			{
 				"template_string_sortable_pt": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "pt",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -435,6 +639,12 @@
 			{
 				"template_string_sortable_ro": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "ro",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -447,6 +657,12 @@
 			{
 				"template_string_sortable_ru": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "ru",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -459,6 +675,12 @@
 			{
 				"template_string_sortable_sk": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "sk",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -471,6 +693,12 @@
 			{
 				"template_string_sortable_sl": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "sl",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -483,6 +711,12 @@
 			{
 				"template_string_sortable_sr": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "sr",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -495,6 +729,12 @@
 			{
 				"template_string_sortable_sv": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "sv",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -507,6 +747,12 @@
 			{
 				"template_string_sortable_ta": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "ta",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -519,6 +765,12 @@
 			{
 				"template_string_sortable_th": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "th",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -531,6 +783,12 @@
 			{
 				"template_string_sortable_tr": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "tr",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -543,6 +801,12 @@
 			{
 				"template_string_sortable_uk": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "uk",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -555,6 +819,12 @@
 			{
 				"template_string_sortable_vi": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "vi",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -567,6 +837,12 @@
 			{
 				"template_string_sortable_zh": {
 					"mapping": {
+						"fields": {
+							"raw": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"language": "zh",
 						"store": true,
 						"type": "icu_collation_keyword"

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/sort/ElasticsearchMultiLanguageSortTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/sort/ElasticsearchMultiLanguageSortTest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.sort;
+
+import com.liferay.portal.search.elasticsearch7.internal.LiferayElasticsearchIndexingFixtureFactory;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+import com.liferay.portal.search.test.util.sort.BaseMultiLanguageSortTestCase;
+
+/**
+ * @author Vagner B.C
+ */
+public class ElasticsearchMultiLanguageSortTest
+	extends BaseMultiLanguageSortTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() throws Exception {
+		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
+	}
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/sort/ElasticsearchMultiLanguageSortTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/sort/ElasticsearchMultiLanguageSortTest.java
@@ -17,12 +17,21 @@ package com.liferay.portal.search.elasticsearch7.internal.sort;
 import com.liferay.portal.search.elasticsearch7.internal.LiferayElasticsearchIndexingFixtureFactory;
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
 import com.liferay.portal.search.test.util.sort.BaseMultiLanguageSortTestCase;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
 
 /**
  * @author Vagner B.C
  */
 public class ElasticsearchMultiLanguageSortTest
 	extends BaseMultiLanguageSortTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
 
 	@Override
 	protected IndexingFixture createIndexingFixture() throws Exception {

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
@@ -24,6 +24,836 @@
 					}
 				},
 				{
+					"template_string_sortable_ar": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "ar",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_ar_[A-Z]{2}_sortable\\b|\\w+_ar_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_bg": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "bg",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_bg_[A-Z]{2}_sortable\\b|\\w+_bg_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_ca": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "ca",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_ca_[A-Z]{2}_sortable\\b|\\w+_ca_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_cs": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "cs",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_cs_[A-Z]{2}_sortable\\b|\\w+_cs_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_da": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "da",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_da_[A-Z]{2}_sortable\\b|\\w+_da_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_de_AT": {
+						"mapping": {
+							"country": "AT",
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "de",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_de_AT_sortable\\b|\\w+_de_AT_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_de": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "de",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_de_[A-Z]{2}_sortable\\b|\\w+_de_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_el": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "el",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_el_[A-Z]{2}_sortable\\b|\\w+_el_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_en": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "en",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_en_[A-Z]{2}_sortable\\b|\\w+_en_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_es": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "es",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_es_[A-Z]{2}_sortable\\b|\\w+_es_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_et": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "et",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_et_[A-Z]{2}_sortable\\b|\\w+_et_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_eu": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "eu",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_eu_[A-Z]{2}_sortable\\b|\\w+_eu_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_fa": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "fa",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_fa_[A-Z]{2}_sortable\\b|\\w+_fa_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_fi": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "fi",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_fi_[A-Z]{2}_sortable\\b|\\w+_fi_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_fr_CA": {
+						"mapping": {
+							"country": "CA",
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "fr",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_fr_CA_sortable\\b|\\w+_fr_CA_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_fr": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "fr",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_fr_[A-Z]{2}_sortable\\b|\\w+_fr_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_gl": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "gl",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_gl_[A-Z]{2}_sortable\\b|\\w+_gl_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_hi": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "hi",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_hi_[A-Z]{2}_sortable\\b|\\w+_hi_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_hr": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "hr",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_hr_[A-Z]{2}_sortable\\b|\\w+_hr_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_hu": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "hu",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_hu_[A-Z]{2}_sortable\\b|\\w+_hu_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_hy": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "hy",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_hy_[A-Z]{2}_sortable\\b|\\w+_hy_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_in": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "in",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_in_[A-Z]{2}_sortable\\b|\\w+_in_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_it": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "it",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_it_[A-Z]{2}_sortable\\b|\\w+_it_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_ja": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "ja",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_ja_[A-Z]{2}_sortable\\b|\\w+_ja_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_kk": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "kk",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_kk_[A-Z]{2}_sortable\\b|\\w+_kk_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_ko": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "ko",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_ko_[A-Z]{2}_sortable\\b|\\w+_ko_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_lo": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "lo",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_lo_[A-Z]{2}_sortable\\b|\\w+_lo_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_lt": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "lt",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_lt_[A-Z]{2}_sortable\\b|\\w+_lt_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_ms": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "ms",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_ms_[A-Z]{2}_sortable\\b|\\w+_ms_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_nb": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "nb",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_nb_[A-Z]{2}_sortable\\b|\\w+_nb_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_nl": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "nl",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_nl_[A-Z]{2}_sortable\\b|\\w+_nl_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_no": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "no",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_no_[A-Z]{2}_sortable\\b|\\w+_no_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_pl": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "pl",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_pl_[A-Z]{2}_sortable\\b|\\w+_pl_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_pt": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "pt",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_pt_[A-Z]{2}_sortable\\b|\\w+_pt_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_ro": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "ro",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_ro_[A-Z]{2}_sortable\\b|\\w+_ro_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_ru": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "ru",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_ru_[A-Z]{2}_sortable\\b|\\w+_ru_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_sk": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "sk",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_sk_[A-Z]{2}_sortable\\b|\\w+_sk_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_sl": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "sl",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_sl_[A-Z]{2}_sortable\\b|\\w+_sl_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_sr": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "sr",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_sr_[A-Z]{2}_sortable\\b|\\w+_sr_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_sv": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "sv",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_sv_[A-Z]{2}_sortable\\b|\\w+_sv_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_ta": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "ta",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_ta_[A-Z]{2}_sortable\\b|\\w+_ta_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_th": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "th",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_th_[A-Z]{2}_sortable\\b|\\w+_th_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_tr": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "tr",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_tr_[A-Z]{2}_sortable\\b|\\w+_tr_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_uk": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "uk",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_uk_[A-Z]{2}_sortable\\b|\\w+_uk_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_vi": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "vi",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_vi_[A-Z]{2}_sortable\\b|\\w+_vi_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_zh": {
+						"mapping": {
+							"fields": {
+								"raw": {
+									"store": true,
+									"type": "keyword"
+								}
+							},
+							"language": "zh",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_zh_[A-Z]{2}_sortable\\b|\\w+_zh_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
 					"template_string_sortable": {
 						"mapping": {
 							"store": true,

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/FieldValuesAssert.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/FieldValuesAssert.java
@@ -52,7 +52,7 @@ public class FieldValuesAssert {
 
 		AssertUtils.assertEquals(
 			message, _toStringValuesMap(expected),
-			_toLegacyFieldValuesMap(document));
+			_filterSortableFields(_toLegacyFieldValuesMap(document)));
 	}
 
 	public static void assertFieldValues(
@@ -77,7 +77,8 @@ public class FieldValuesAssert {
 				() -> StringBundler.concat(
 					searchResponse.getRequestString(), "->",
 					actualFieldValuesMap, "->", filteredFieldValuesMap),
-				expectedFieldValuesMap, filteredFieldValuesMap);
+				expectedFieldValuesMap,
+				_filterSortableFields(filteredFieldValuesMap));
 		}
 		else {
 			AssertUtils.assertEquals(
@@ -99,16 +100,18 @@ public class FieldValuesAssert {
 
 		AssertUtils.assertEquals(
 			message, _toStringValuesMap(expected),
-			_filterOnKey(
-				_toLegacyFieldValuesMap(document),
-				name -> name.startsWith(prefix)));
+			_filterSortableFields(
+				_filterOnKey(
+					_toLegacyFieldValuesMap(document),
+					name -> name.startsWith(prefix))));
 	}
 
 	public static void assertFieldValues(
 		String message, Document document, Map<?, ?> expected) {
 
 		AssertUtils.assertEquals(
-			message, expected, _toFieldValuesMap(document));
+			message, expected,
+			_filterSortableFields(_toFieldValuesMap(document)));
 	}
 
 	/**
@@ -121,7 +124,8 @@ public class FieldValuesAssert {
 
 		AssertUtils.assertEquals(
 			message, expected,
-			_filterOnKey(_toFieldValuesMap(document), keysPredicate));
+			_filterSortableFields(
+				_filterOnKey(_toFieldValuesMap(document), keysPredicate)));
 	}
 
 	private static void _addFields(
@@ -165,6 +169,32 @@ public class FieldValuesAssert {
 		).collect(
 			Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)
 		);
+	}
+
+	private static Map<String, String> _filterSortableFields(
+		Map<String, String> map) {
+
+		List<String> rawKeys = new ArrayList<>();
+
+		String sortableRawSuffix = StringBundler.concat(
+			StringPool.UNDERLINE,
+			com.liferay.portal.kernel.search.Field.SORTABLE_FIELD_SUFFIX,
+			_RAW_SUFFIX);
+
+		for (String key : map.keySet()) {
+			if (key.endsWith(sortableRawSuffix)) {
+				rawKeys.add(key);
+			}
+		}
+
+		for (String rawKey : rawKeys) {
+			String originalKey = rawKey.substring(
+				0, rawKey.length() - _RAW_SUFFIX.length());
+
+			map.put(originalKey, map.remove(rawKey));
+		}
+
+		return map;
 	}
 
 	private static <E> List<E> _sort(List<E> list) {
@@ -252,5 +282,7 @@ public class FieldValuesAssert {
 				entry -> entry.getKey(),
 				entry -> function.apply(entry.getValue())));
 	}
+
+	private static final String _RAW_SUFFIX = ".raw";
 
 }

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/DocumentCreationHelpers.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/DocumentCreationHelpers.java
@@ -78,6 +78,15 @@ public class DocumentCreationHelpers {
 		return document -> document.addText(fieldName, values);
 	}
 
+	public static DocumentCreationHelper singleTextSortable(
+		String fieldName, String fieldNameSortable, String... values) {
+
+		return document -> {
+			document.addText(fieldName, values);
+			document.addText(fieldNameSortable, values);
+		};
+	}
+
 	public static DocumentCreationHelper twoKeywords(
 		String fieldName1, String value1, String fieldName2, String value2) {
 

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseMultiLanguageSortTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseMultiLanguageSortTestCase.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test.util.sort;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.test.util.DocumentsAssert;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+import com.liferay.portal.search.test.util.indexing.DocumentCreationHelper;
+import com.liferay.portal.search.test.util.indexing.DocumentCreationHelpers;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.junit.Test;
+
+/**
+ * @author Vagner B.C
+ */
+public abstract class BaseMultiLanguageSortTestCase
+	extends BaseIndexingTestCase {
+
+	@Test
+	public void testEnglishCaseSensitive() {
+		testLocaleSort(
+			LocaleUtil.US, new String[] {"a", "E", "c", "O", "u", "A"},
+			"[a, A, c, E, O, u]");
+	}
+
+	@Test
+	public void testFrance() {
+		testLocaleSort(
+			LocaleUtil.FRANCE, new String[] {"e", "a", "d", "ç"},
+			"[a, ç, d, e]");
+	}
+
+	@Test
+	public void testGerman() {
+		testLocaleSort(
+			LocaleUtil.GERMANY,
+			new String[] {"a", "x", "ä", "ö", "o", "u", "ź"},
+			"[a, ä, o, ö, u, x, ź]");
+	}
+
+	@Test
+	public void testJapanHiragana() {
+		testLocaleSort(
+			LocaleUtil.JAPAN, new String[] {"え", "う", "い", "あ", "お"},
+			"[あ, い, う, え, お]");
+	}
+
+	@Test
+	public void testJapanKanji() {
+		testLocaleSort(LocaleUtil.JAPAN, new String[] {"色", "赤"}, "[赤, 色]");
+	}
+
+	@Test
+	public void testJapanKatana() {
+		testLocaleSort(
+			LocaleUtil.JAPAN, new String[] {"オ", "イ", "ア", "エ", "ウ"},
+			"[ア, イ, ウ, エ, オ]");
+	}
+
+	@Test
+	public void testPolish() {
+		testLocaleSort(
+			new Locale("pl", "PL"),
+			new String[] {"f", "ć", "ź", "d", "ł", "ś", "b"},
+			"[b, ć, d, f, ł, ś, ź]");
+	}
+
+	@Test
+	public void testPortuguese() {
+		testLocaleSort(
+			LocaleUtil.BRAZIL,
+			new String[] {
+				"a", "e", "c", "u", "à", "á", "é", "ã", "o", "õ", "ü", "ç"
+			},
+			"[a, á, à, ã, c, ç, e, é, o, õ, u, ü]");
+	}
+
+	@Test
+	public void testSpanish() {
+		testLocaleSort(
+			LocaleUtil.SPAIN,
+			new String[] {"a", "d", "c", "ch", "ll", "ñ", "p", "e"},
+			"[a, c, ch, d, e, ll, ñ, p]");
+	}
+
+	protected void addDocuments(
+		Function<Double, DocumentCreationHelper> function, double... values) {
+
+		for (double value : values) {
+			addDocument(function.apply(value));
+		}
+	}
+
+	protected void assertOrder(
+		Sort[] sorts, String fieldName, String expected, Locale locale) {
+
+		assertSearch(
+			indexingTestHelper -> {
+				indexingTestHelper.define(
+					searchContext -> {
+						searchContext.setSorts(sorts);
+						searchContext.setLocale(locale);
+					});
+
+				indexingTestHelper.search();
+
+				indexingTestHelper.verify(
+					hits -> DocumentsAssert.assertValues(
+						indexingTestHelper.getRequestString(), hits.getDocs(),
+						fieldName, expected));
+			});
+	}
+
+	protected void testLocaleSort(
+		Locale locale, String[] values, String expected) {
+
+		String fieldName = Field.TITLE;
+
+		String fieldNameSortable =
+			fieldName + StringPool.UNDERLINE + LocaleUtil.toLanguageId(locale) +
+				_SORTABLE;
+
+		addDocuments(
+			value -> DocumentCreationHelpers.singleTextSortable(
+				fieldName, fieldNameSortable, value),
+			Arrays.asList(values));
+
+		assertOrder(
+			new Sort[] {new Sort(fieldNameSortable, Sort.STRING_TYPE, false)},
+			fieldName, expected, locale);
+	}
+
+	private static final String _SORTABLE = "_sortable";
+
+}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseMultiLanguageSortTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseMultiLanguageSortTestCase.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.search.test.util.sort;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
@@ -112,8 +113,8 @@ public abstract class BaseMultiLanguageSortTestCase
 			indexingTestHelper -> {
 				indexingTestHelper.define(
 					searchContext -> {
-						searchContext.setSorts(sorts);
 						searchContext.setLocale(locale);
+						searchContext.setSorts(sorts);
 					});
 
 				indexingTestHelper.search();
@@ -130,9 +131,9 @@ public abstract class BaseMultiLanguageSortTestCase
 
 		String fieldName = Field.TITLE;
 
-		String fieldNameSortable =
-			fieldName + StringPool.UNDERLINE + LocaleUtil.toLanguageId(locale) +
-				_SORTABLE;
+		String fieldNameSortable = StringBundler.concat(
+			fieldName, StringPool.UNDERLINE, LocaleUtil.toLanguageId(locale),
+			StringPool.UNDERLINE, Field.SORTABLE_FIELD_SUFFIX);
 
 		addDocuments(
 			value -> DocumentCreationHelpers.singleTextSortable(
@@ -143,7 +144,5 @@ public abstract class BaseMultiLanguageSortTestCase
 			new Sort[] {new Sort(fieldNameSortable, Sort.STRING_TYPE, false)},
 			fieldName, expected, locale);
 	}
-
-	private static final String _SORTABLE = "_sortable";
 
 }

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseMultiLanguageSortTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseMultiLanguageSortTestCase.java
@@ -70,7 +70,7 @@ public abstract class BaseMultiLanguageSortTestCase
 	}
 
 	@Test
-	public void testJapanKatana() {
+	public void testJapanKatakana() {
 		testLocaleSort(
 			LocaleUtil.JAPAN, new String[] {"オ", "イ", "ア", "エ", "ウ"},
 			"[ア, イ, ウ, エ, オ]");

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseMultiLanguageSortTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseMultiLanguageSortTestCase.java
@@ -94,8 +94,10 @@ public abstract class BaseMultiLanguageSortTestCase
 	public void testSpanish() {
 		testLocaleSort(
 			LocaleUtil.SPAIN,
-			new String[] {"a", "d", "c", "ch", "ll", "ñ", "p", "e"},
-			"[a, c, ch, d, e, ll, ñ, p]");
+			new String[] {
+				"a", "é", "d", "c", "cu", "ch", "ll", "ña", "nu", "p", "e", "á"
+			},
+			"[a, á, c, ch, cu, d, e, é, ll, nu, ña, p]");
 	}
 
 	protected void addDocuments(

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseMultiLanguageSortTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseMultiLanguageSortTestCase.java
@@ -65,11 +65,6 @@ public abstract class BaseMultiLanguageSortTestCase
 	}
 
 	@Test
-	public void testJapanKanji() {
-		testLocaleSort(LocaleUtil.JAPAN, new String[] {"色", "赤"}, "[赤, 色]");
-	}
-
-	@Test
 	public void testJapanKatakana() {
 		testLocaleSort(
 			LocaleUtil.JAPAN, new String[] {"オ", "イ", "ア", "エ", "ウ"},

--- a/readme/BREAKING_CHANGES.markdown
+++ b/readme/BREAKING_CHANGES.markdown
@@ -988,3 +988,32 @@ Any installation that has configured the Google Cloud autotranslator service.
 No code changes are necessary. Administrators may need to reconfigure the Google Could autotranslator service.
 
 ---------------------------------------
+
+## Elasticsearch sortable type mappings were changed from keyword to icu_collation_keyword
+
+- **Date:** 2022-May-12
+- **JIRA Ticket:** [LPS-152937](https://issues.liferay.com/browse/LPS-152937)
+
+### What changed?
+
+The Elasticsearch type mapping of localized sortable `*_<languageId>_sortable` and nested `ddmFieldArray.ddmFieldValueText_<languageId>_String_sortable` fields were changed from `keyword` to `icu_collation_keyword`
+
+The indexed information of these fields is now stored in an encoded format, for example, the `entity title` text is now stored as `MkRQOlBaBFA6UEAyARABEAA=`
+
+This new `icu_collation_keyword` type allows sorting using the correct collation rules of each language for more information see https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/analysis-icu-collation-keyword-field.html
+
+For backward compatibility, a new nested `raw` field has been created to store the sortable field using the old `keyword` mapping type.
+
+If you update your existing Liferay installation, this change won't be applied until a full reindex is executed and Elasticsearch mappings are recreated.
+
+### Who is affected?
+
+If you are using the `*_<languageId>_sortable` and `ddmFieldArray.ddmFieldValueText_<languageId>_String_sortable` fields in your custom Elasticsearch queries:
+   - **To sort your results:** you will find that now they are sorted using the correct collation rules of each language.
+   - **To retrieve some information from the Elasticsearch index:** you will find that now the returned information is returned in an encoded format.
+
+### How should I update my code?
+
+If you want to maintain the old sort behavior or you need to retrieve data from these fields, you must use the new nested raw `*_<languageId>_sortable.raw` and `ddmFieldArray.ddmFieldValueText_<languageId>_String_sortable.raw` fields that contain the data in the old `keyword` mapping type.
+
+---------------------------------------


### PR DESCRIPTION
**Issue:** https://issues.liferay.com/browse/LPS-152937 - Elasticsearch sort doesn't work with accented words
See also https://issues.liferay.com/browse/PTR-3054

This issue was previously reported in https://issues.liferay.com/browse/LPS-93341 and some work was done in spike https://issues.liferay.com/browse/LPS-94561

The idea of that spike was to use the **icu_collation_keyword** from Elasticsearch ICU Plugin, see: https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-icu-collation-keyword-field.html 

In this PR I have used the code from that spike as the starting point (see https://github.com/brandizzi/liferay-portal/pull/813 PR and this branch https://github.com/brandizzi/liferay-portal/tree/LPS-94561 from @brandizzi repository)

**Original commits from LPS-94561 spike:** https://github.com/liferay-search/liferay-portal/commit/ceeefbecd5d2b3ecfc23e60d3cd9d693f22dd50c , https://github.com/liferay-search/liferay-portal/commit/35df586e3bf87e7fc65f124e0ead186d16123845, and https://github.com/liferay-search/liferay-portal/commit/fc9c4b462c027b22ae4df996398f3b57205c2932

I have done the following changes to this code:

**Changes 1: Tests added in BaseMultiLanguageSortTestCase** (from previous PR https://github.com/brandizzi/liferay-portal/pull/813)
   - https://github.com/liferay-search/liferay-portal/commit/640c3189a5b617a4898080c6e33d80d44e646dc3 fixes test name to testJapanKatakana
   - https://github.com/liferay-search/liferay-portal/commit/8509d70dc6ab212173a106ff83cd9bde74bef4a3 removes the Kanji sort test because it is not correct:
        - ICU library used by Elasticsearch doesn't support Kanji sorting, see: http://unicode.org/faq/collation.html#7
        - If you use this [ICU Collation Demo](https://icu4c-demos.unicode.org/icu-bin/collation.html), it returns different results than the expected in the removed test
        - In general, Japanese Kanji sorting seems to be a non-trivial task, read: http://www.localizingjapan.com/blog/2011/02/13/sorting-in-japanese-%E2%80%94-an-unsolved-problem/ or https://stackoverflow.com/questions/4895527/can-sorting-japanese-kanji-words-be-done-programmatically
        - It seems the author of that test (_Vagner Castro_) no longer works for Liferay, so I couldn't reach him to have more information about that test.
   - https://github.com/liferay-search/liferay-portal/commit/fa518c23f02e8f9c688360643be234a97fb68442 improves the Spanish test. As a native Spanish speaker, I detected that the original test had some missing checks related to the "ñ", "ch", and vowels with accents "á", "é"... 

**Changes 2: Elasticsearch mapping changes**
     - https://github.com/liferay-search/liferay-portal/commit/1ea1225a2fb52a04da24e8b499d5e0c6749048a5 => We must cover both regular `*_en_US_sortable` and nested `ddmFieldArray.ddmFieldValueText_en_US_String_sortable` fields
   - https://github.com/liferay-search/liferay-portal/commit/2ff477e2b1de9f8747be877b59ff2b6d5f17d19d => Replicate new mappings to all the existing locales. It is not necessary to specify the country because it is optional (see elasticsearch ICU plugin code: https://github.com/elastic/elasticsearch/blob/5aa174e6d3d280438822fc03c580bd9eac9faccf/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapper.java#L377-L391 )
   - https://github.com/liferay-search/liferay-portal/commit/e95c250a389e77b658996fa0b638a032b0a6f876 => Add de_AT (_Austrian German_) and fr_CA (_Canadian French_) country configurations as they have an specific collation configuration according to https://github.com/unicode-org/cldr/tree/main/common/collation

**Changes 3: Broken tests**
   - The Elasticsearch mapping changes break some existing tests because they compare the `_sortable `fields returned by Elasticsearch but now they are encoded in a strange way because we are using the **icu_collation_keyword** type:
```
expected:<...itle_de_DE_sortable=[entity title, localized_title_en_US=entity title, localized_title_en_US_sortable=entity title, localized_title_es_ES=entity title, localized_title_es_ES_sortable=entity title, localized_title_fi_FI=entity title, localized_title_fi_FI_sortable=entity title, localized_title_fr_FR=entity title, localized_title_fr_FR_sortable=entity title, localized_title_hu_HU=entitas neve, localized_title_hu_HU_sortable=entitas neve, localized_title_ja_JP=entity title, localized_title_ja_JP_sortable=entity title, localized_title_nl_NL=entity title, localized_title_nl_NL_sortable=entity title, localized_title_pt_BR=entity title, localized_title_pt_BR_sortable=entity title], localized_title_sv...> but was:<...itle_de_DE_sortable=[MkRQOlBaBFA6UEAyARABEAA=, localized_title_en_US=entity title, localized_title_en_US_sortable=MkRQOlBaBFA6UEAyARABEAA=, localized_title_es_ES=entity title, localized_title_es_ES_sortable=MkRQOlBaBFA6UEAyARABEAA=, localized_title_fi_FI=entity title, localized_title_fi_FI_sortable=entity title, localized_title_fr_FR=entity title, localized_title_fr_FR_sortable=MkRQOlBaBFA6UEAyARABEAA=, localized_title_hu_HU=entitas neve, localized_title_hu_HU_sortable=entitas neve, localized_title_ja_JP=entity title, localized_title_ja_JP_sortable=MkRQOlBaBFA6UEAyARABEAA=, localized_title_nl_NL=entity title, localized_title_nl_NL_sortable=entity title, localized_title_pt_BR=entity title, localized_title_pt_BR_sortable=MkRQOlBaBFA6UEAyARABEAA=]
```
   - In this example, the `entity title` text is encoded in the Elasticsearch side as `MkRQOlBaBFA6UEAyARABEAA=`
   - To solve this I am adding a new nested "raw" field in commit https://github.com/liferay-search/liferay-portal/commit/735cd5a27a305dd9607b39ff62f045a82e1c265f that stores the original _sortable value
   - https://github.com/liferay-search/liferay-portal/commit/ffea5d0c5dd508d61735a8d4e39b6151f1acb395 => I am modifying the **FieldValuesAssert** class where the returned and expected values are compared. I have added the _filterSortableFields method where the `_sortable.raw` fields are used to overwrite the `_sortable` ones that contain the encoded value. [After overwriting them](https://github.com/liferay-search/liferay-portal/commit/ffea5d0c5dd508d61735a8d4e39b6151f1acb395#diff-0209c19ec423285593c766e8cf8f37a02228eb4dc22bc2b86a13062a1f8d5c9aR190-R195), the comparison works correctly.

**Additional notes:**
   - In the end, we are only changing the mapping configurations, so this fix won't be applied to our existing customers until they execute a full reindex
   - On the other hand, If the customer updates to a version that contains this code, they won't detect any issue if they don't want to execute the full reindex, because their installation will continue to use the old mappings
   - **Warning:** :warning: If the customer has a custom development that uses the information stored in the _sortable fields, they will have problems, as now the information will be encoded. As a workaround, they can use the new `_sortable.raw` field.
   -  **We should add this information to the breaking changes documentation because the customer must be aware that they have to execute a full reindex to fix this issue and they have to review their custom developments just in case they query the `_sortable fields`**

**About the tests added in this PR:**
   - The tests are a bit incomplete. The major problem here is we need native speakers to add more tests in every supported language.
   - I have improved the Spanish test in this commit https://github.com/liferay-search/liferay-portal/commit/fa518c23f02e8f9c688360643be234a97fb68442 but I don't have the knowledge to improve any other language
   - Perhaps we can use the ICU Collation Demo (https://icu4c-demos.unicode.org/icu-bin/collation.html) or check the ICU information from https://github.com/unicode-org/cldr/tree/main/common/collation where there is information of every supported language, for example in the [pl.xml polish definition](https://github.com/unicode-org/cldr/blob/main/common/collation/pl.xml) you can see the precedence between every letter so, for example, `Z<ź<<<Ź<ż<<<Ż` means that `Ża, Ze, Źu` is sorted to `Ze, Źu, Ża`
   - Nevertheless, the best option is to double-check with native speakers (perhaps we can reach the people from this volunteer list https://liferay.slack.com/archives/CJ1ERLHUZ/p1650977876964469 )

Let me know if you have any questions about this PR

Regards,
Jorge

