### PR TITLE
[TS] LPS-152937 Elasticsearch sort doesn't work with accented words (2nd pull request)

### DIFF
--- a/modules/apps/archived/mail-reader-test/src/testIntegration/java/com/liferay/mail/reader/search/test/MailReaderIndexerReindexTest.java
+++ b/modules/apps/archived/mail-reader-test/src/testIntegration/java/com/liferay/mail/reader/search/test/MailReaderIndexerReindexTest.java
@@ -26,7 +26,9 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.users.admin.test.util.search.UserSearchFixture;
@@ -138,11 +140,13 @@ public class MailReaderIndexerReindexTest {
 	}
 
 	protected void setUpAccountIndexerFixture() {
-		_accountIndexerFixture = new IndexerFixture<>(Account.class);
+		_accountIndexerFixture = new IndexerFixture<>(
+			Account.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpFolderIndexerFixture() {
-		_folderIndexerFixture = new IndexerFixture<>(Folder.class);
+		_folderIndexerFixture = new IndexerFixture<>(
+			Folder.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpMailReaderFixture() {
@@ -154,7 +158,8 @@ public class MailReaderIndexerReindexTest {
 	}
 
 	protected void setUpMessageIndexerFixture() {
-		_messageIndexerFixture = new IndexerFixture<>(Message.class);
+		_messageIndexerFixture = new IndexerFixture<>(
+			Message.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpUserSearchFixture() throws Exception {
@@ -194,6 +199,9 @@ public class MailReaderIndexerReindexTest {
 
 	@DeleteAfterTestRun
 	private List<Message> _messages;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	private User _user;
 

--- a/modules/apps/archived/mail-reader-test/src/testIntegration/java/com/liferay/mail/reader/search/test/MessageIndexerIndexedFieldsTest.java
+++ b/modules/apps/archived/mail-reader-test/src/testIntegration/java/com/liferay/mail/reader/search/test/MessageIndexerIndexedFieldsTest.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.search.test.util.IndexedFieldsFixture;
 import com.liferay.portal.search.test.util.IndexerFixture;
@@ -100,7 +101,8 @@ public class MessageIndexerIndexedFieldsTest {
 	}
 
 	protected void setUpMessageIndexerFixture() {
-		messageIndexerFixture = new IndexerFixture<>(Message.class);
+		messageIndexerFixture = new IndexerFixture<>(
+			Message.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpUserSearchFixture() throws Exception {
@@ -191,6 +193,9 @@ public class MessageIndexerIndexedFieldsTest {
 
 	@DeleteAfterTestRun
 	private List<Message> _messages;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	private User _user;
 

--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/search/test/AssetCategoryIndexerIndexedFieldsTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/search/test/AssetCategoryIndexerIndexedFieldsTest.java
@@ -135,6 +135,8 @@ public class AssetCategoryIndexerIndexedFieldsTest {
 					AssetCategory.class
 				).queryString(
 					searchTerm
+				).fetchSource(
+					true
 				).build()));
 	}
 

--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/search/test/AssetVocabularyIndexerIndexedFieldsTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/search/test/AssetVocabularyIndexerIndexedFieldsTest.java
@@ -135,6 +135,8 @@ public class AssetVocabularyIndexerIndexedFieldsTest {
 					AssetVocabulary.class
 				).queryString(
 					searchTerm
+				).fetchSource(
+					true
 				).build()));
 	}
 

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/search/test/BlogsEntryIndexerIndexedFieldsTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/search/test/BlogsEntryIndexerIndexedFieldsTest.java
@@ -128,6 +128,8 @@ public class BlogsEntryIndexerIndexedFieldsTest {
 					MODEL_INDEXER_CLASS
 				).queryString(
 					searchTerm
+				).fetchSource(
+					true
 				).build()));
 	}
 

--- a/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/search/test/BookmarksEntryIndexerIndexedFieldsTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/search/test/BookmarksEntryIndexerIndexedFieldsTest.java
@@ -134,6 +134,8 @@ public class BookmarksEntryIndexerIndexedFieldsTest {
 					MODEL_INDEXER_CLASS
 				).queryString(
 					searchTerm
+				).fetchSource(
+					true
 				).build()));
 	}
 

--- a/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/search/test/BookmarksFolderIndexerIndexedFieldsTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/search/test/BookmarksFolderIndexerIndexedFieldsTest.java
@@ -136,6 +136,8 @@ public class BookmarksFolderIndexerIndexedFieldsTest {
 					BookmarksFolder.class
 				).queryString(
 					searchTerm
+				).fetchSource(
+					true
 				).build()));
 	}
 

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/search/test/BaseCalendarIndexerTestCase.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/search/test/BaseCalendarIndexerTestCase.java
@@ -44,6 +44,8 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.test.util.HitsAssert;
 import com.liferay.portal.search.test.util.IndexedFieldsFixture;
 import com.liferay.portal.search.test.util.SearchTestRule;
@@ -169,6 +171,27 @@ public abstract class BaseCalendarIndexerTestCase {
 			search(getSearchContext(keywords, locale)));
 	}
 
+	protected SearchResponse searchOnlyOneSearchResponse(
+		String keywords, Locale locale) {
+
+		SearchContext searchContext = getSearchContext(keywords, locale);
+
+		searchRequestBuilderFactory.builder(
+			searchContext
+		).fetchSource(
+			true
+		).build();
+
+		search(searchContext);
+
+		SearchResponse searchResponse =
+			(SearchResponse)searchContext.getAttribute("search.response");
+
+		HitsAssert.assertOnlyOne(searchResponse.getSearchHits());
+
+		return searchResponse;
+	}
+
 	protected void setIndexerClass(Class<?> clazz) {
 		_indexer = indexerRegistry.getIndexer(clazz);
 	}
@@ -187,6 +210,9 @@ public abstract class BaseCalendarIndexerTestCase {
 
 	@Inject
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
+
+	@Inject
+	protected SearchRequestBuilderFactory searchRequestBuilderFactory;
 
 	protected User user;
 

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/search/test/CalendarBookingIndexerIndexedFieldsTest.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/search/test/CalendarBookingIndexerIndexedFieldsTest.java
@@ -24,7 +24,6 @@ import com.liferay.calendar.model.CalendarResource;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.settings.LocalizedValuesMap;
@@ -35,6 +34,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.test.rule.Inject;
 
@@ -131,11 +131,10 @@ public class CalendarBookingIndexerIndexedFieldsTest
 
 		String keywords = "nev";
 
-		Document document = searchOnlyOne(keywords, LocaleUtil.HUNGARY);
+		SearchResponse searchResponse = searchOnlyOneSearchResponse(
+			keywords, LocaleUtil.HUNGARY);
 
-		indexedFieldsFixture.postProcessDocument(document);
-
-		FieldValuesAssert.assertFieldValues(map, document, keywords);
+		FieldValuesAssert.assertFieldValues(map, searchResponse);
 	}
 
 	protected CalendarBooking addCalendarBooking(

--- a/modules/apps/contacts/contacts-test/src/testIntegration/java/com/liferay/contacts/search/test/ContactIndexerIndexedFieldsTest.java
+++ b/modules/apps/contacts/contacts-test/src/testIntegration/java/com/liferay/contacts/search/test/ContactIndexerIndexedFieldsTest.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.search.test.util.IndexedFieldsFixture;
 import com.liferay.portal.search.test.util.IndexerFixture;
@@ -142,7 +143,8 @@ public class ContactIndexerIndexedFieldsTest {
 	}
 
 	protected void setUpContactIndexerFixture() {
-		contactIndexerFixture = new IndexerFixture<>(Contact.class);
+		contactIndexerFixture = new IndexerFixture<>(
+			Contact.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpIndexedFieldsFixture() {
@@ -183,6 +185,9 @@ public class ContactIndexerIndexedFieldsTest {
 
 	@DeleteAfterTestRun
 	private List<Group> _groups;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	@DeleteAfterTestRun
 	private List<User> _users;

--- a/modules/apps/contacts/contacts-test/src/testIntegration/java/com/liferay/contacts/search/test/ContactIndexerReindexTest.java
+++ b/modules/apps/contacts/contacts-test/src/testIntegration/java/com/liferay/contacts/search/test/ContactIndexerReindexTest.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.IndexerFixture;
 import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
@@ -103,7 +104,8 @@ public class ContactIndexerReindexTest {
 	}
 
 	protected void setUpContactIndexerFixture() {
-		contactIndexerFixture = new IndexerFixture<>(Contact.class);
+		contactIndexerFixture = new IndexerFixture<>(
+			Contact.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpUserSearchFixture() throws Exception {
@@ -134,6 +136,9 @@ public class ContactIndexerReindexTest {
 
 	@DeleteAfterTestRun
 	private List<Group> _groups;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	@DeleteAfterTestRun
 	private List<User> _users;

--- a/modules/apps/contacts/contacts-test/src/testIntegration/java/com/liferay/contacts/search/test/ContactMultiLanguageSearchTest.java
+++ b/modules/apps/contacts/contacts-test/src/testIntegration/java/com/liferay/contacts/search/test/ContactMultiLanguageSearchTest.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.search.test.util.IndexerFixture;
 import com.liferay.portal.search.test.util.SearchTestRule;
@@ -164,7 +165,8 @@ public class ContactMultiLanguageSearchTest {
 	}
 
 	protected void setUpContactIndexerFixture() {
-		contactIndexerFixture = new IndexerFixture<>(Contact.class);
+		contactIndexerFixture = new IndexerFixture<>(
+			Contact.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpUserSearchFixture() throws Exception {
@@ -199,6 +201,9 @@ public class ContactMultiLanguageSearchTest {
 
 	@DeleteAfterTestRun
 	private List<Group> _groups;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	@DeleteAfterTestRun
 	private List<User> _users;

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryIndexerIndexedFieldsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryIndexerIndexedFieldsTest.java
@@ -290,7 +290,7 @@ public class DLFileEntryIndexerIndexedFieldsTest extends BaseDLIndexerTestCase {
 		_populateLocalizedTitles(fileEntry, map);
 		_populateViewCount(fileEntry, map);
 
-		indexedFieldsFixture.populatePriority("0.0", map, true);
+		indexedFieldsFixture.populatePriority("0.0", map);
 		indexedFieldsFixture.populateRoleIdFields(
 			fileEntry.getCompanyId(), DLFileEntry.class.getName(),
 			fileEntry.getPrimaryKey(), fileEntry.getGroupId(), null, map);

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryIndexerIndexedFieldsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryIndexerIndexedFieldsTest.java
@@ -41,7 +41,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.search.document.Document;
+import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -111,15 +111,16 @@ public class DLFileEntryIndexerIndexedFieldsTest extends BaseDLIndexerTestCase {
 
 		long fileEntryId = _addFileEntry(fileName_jp);
 
-		Document document = dlSearchFixture.searchOnlyOneSearchHit(
-			searchTerm, LocaleUtil.JAPAN);
+		SearchResponse searchResponse =
+			dlSearchFixture.searchOnlyOneSearchResponse(
+				searchTerm, LocaleUtil.JAPAN);
 
 		Map<String, String> map = new HashMap<>();
 
 		_populateExpectedFieldValues(
 			dlAppLocalService.getFileEntry(fileEntryId), map);
 
-		FieldValuesAssert.assertFieldValues(searchTerm, document, map);
+		FieldValuesAssert.assertFieldValues(map, searchResponse);
 	}
 
 	private long _addFileEntry(String fileName) throws Exception {

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryMetadataDDMStructureIndexerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryMetadataDDMStructureIndexerTest.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.IndexerFixture;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -113,7 +114,8 @@ public class DLFileEntryMetadataDDMStructureIndexerTest
 	}
 
 	protected void setUpDLFileEntryIndexerFixture() {
-		indexerFixture = new IndexerFixture<>(DLFileEntry.class);
+		indexerFixture = new IndexerFixture<>(
+			DLFileEntry.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpFileEntryMetadataFixture() {
@@ -133,5 +135,8 @@ public class DLFileEntryMetadataDDMStructureIndexerTest
 
 	@Inject
 	private static MessageBus _messageBus;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFolderIndexerIndexedFieldsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFolderIndexerIndexedFieldsTest.java
@@ -23,7 +23,6 @@ import com.liferay.document.library.test.util.search.DLFolderSearchFixture;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -33,6 +32,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -104,16 +104,15 @@ public class DLFolderIndexerIndexedFieldsTest extends BaseDLIndexerTestCase {
 			parentFolder.getFolderId(), folderName,
 			RandomTestUtil.randomString(), serviceContext);
 
-		Document document = dlSearchFixture.searchOnlyOne(
-			folderName, LocaleUtil.US);
-
-		indexedFieldsFixture.postProcessDocument(document);
+		SearchResponse searchResponse =
+			dlSearchFixture.searchOnlyOneSearchResponse(
+				folderName, LocaleUtil.US);
 
 		Map<String, String> map = new HashMap<>();
 
 		populateExpectedFieldValues(childFolder, map);
 
-		FieldValuesAssert.assertFieldValues(map, document, folderName);
+		FieldValuesAssert.assertFieldValues(map, searchResponse);
 	}
 
 	protected ServiceContext getServiceContext() {

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLSearchFixture.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLSearchFixture.java
@@ -70,7 +70,7 @@ public class DLSearchFixture {
 			search(getSearchContext(keywords, locale)));
 	}
 
-	public com.liferay.portal.search.document.Document searchOnlyOneSearchHit(
+	public SearchResponse searchOnlyOneSearchResponse(
 			String keywords, Locale locale)
 		throws Exception {
 
@@ -88,7 +88,9 @@ public class DLSearchFixture {
 		SearchResponse searchResponse =
 			(SearchResponse)searchContext.getAttribute("search.response");
 
-		return HitsAssert.assertOnlyOne(searchResponse.getSearchHits());
+		HitsAssert.assertOnlyOne(searchResponse.getSearchHits());
+
+		return searchResponse;
 	}
 
 	public void setGroup(Group group) {

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/search/test/ExportImportIndexedFieldsTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/search/test/ExportImportIndexedFieldsTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.search.test.util.IndexedFieldsFixture;
 import com.liferay.portal.search.test.util.IndexerFixture;
@@ -101,7 +102,7 @@ public class ExportImportIndexedFieldsTest {
 
 	protected void setUpExportImportIndexerFixture() {
 		exportImportIndexerFixture = new IndexerFixture<>(
-			ExportImportConfiguration.class);
+			ExportImportConfiguration.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpUserSearchFixture() throws Exception {
@@ -226,6 +227,9 @@ public class ExportImportIndexedFieldsTest {
 
 	@DeleteAfterTestRun
 	private List<Group> _groups;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	@DeleteAfterTestRun
 	private List<User> _users;

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/search/test/ExportImportIndexerReindexTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/search/test/ExportImportIndexerReindexTest.java
@@ -25,7 +25,9 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.users.admin.test.util.search.UserSearchFixture;
@@ -100,7 +102,7 @@ public class ExportImportIndexerReindexTest {
 
 	protected void setUpExportImportIndexerFixture() {
 		exportImportIndexerFixture = new IndexerFixture<>(
-			ExportImportConfiguration.class);
+			ExportImportConfiguration.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpUserSearchFixture() throws Exception {
@@ -133,6 +135,9 @@ public class ExportImportIndexerReindexTest {
 
 	@DeleteAfterTestRun
 	private List<Group> _groups;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	@DeleteAfterTestRun
 	private List<User> _users;

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/search/test/ExportImportMultiLanguageSearchTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/search/test/ExportImportMultiLanguageSearchTest.java
@@ -28,9 +28,11 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.search.test.util.IndexerFixture;
 import com.liferay.portal.search.test.util.SearchTestRule;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.users.admin.test.util.search.UserSearchFixture;
@@ -118,7 +120,7 @@ public class ExportImportMultiLanguageSearchTest {
 
 	protected void setUpExportImportIndexerFixture() {
 		exportImportIndexerFixture = new IndexerFixture<>(
-			ExportImportConfiguration.class);
+			ExportImportConfiguration.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpUserSearchFixture() throws Exception {
@@ -179,6 +181,9 @@ public class ExportImportMultiLanguageSearchTest {
 
 	@DeleteAfterTestRun
 	private List<Group> _groups;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	@DeleteAfterTestRun
 	private List<User> _users;

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleDDMStructureIndexerTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleDDMStructureIndexerTest.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.IndexerFixture;
 import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
@@ -156,7 +157,8 @@ public class JournalArticleDDMStructureIndexerTest {
 	}
 
 	protected void setUpJournalArticleIndexerFixture() {
-		journalArticleIndexer = new IndexerFixture<>(JournalArticle.class);
+		journalArticleIndexer = new IndexerFixture<>(
+			JournalArticle.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpUserSearchFixture() throws Exception {
@@ -195,5 +197,8 @@ public class JournalArticleDDMStructureIndexerTest {
 
 	@Inject
 	private static MessageBus _messageBus;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 }

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleIndexerLocalizedContentTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleIndexerLocalizedContentTest.java
@@ -35,6 +35,8 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.search.test.util.IndexerFixture;
 import com.liferay.portal.search.test.util.SearchTestRule;
@@ -72,7 +74,8 @@ public class JournalArticleIndexerLocalizedContentTest {
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
 
-		_indexerFixture = new IndexerFixture<>(JournalArticle.class);
+		_indexerFixture = new IndexerFixture<>(
+			JournalArticle.class, _searchRequestBuilderFactory);
 
 		_journalArticleSearchFixture = new JournalArticleSearchFixture(
 			_journalArticleLocalService);
@@ -157,17 +160,18 @@ public class JournalArticleIndexerLocalizedContentTest {
 
 		String searchTerm = "nev";
 
-		Document document = _indexerFixture.searchOnlyOne(
-			searchTerm, LocaleUtil.HUNGARY);
+		SearchResponse searchResponse =
+			_indexerFixture.searchOnlyOneSearchResponse(
+				searchTerm, LocaleUtil.HUNGARY);
 
 		FieldValuesAssert.assertFieldValues(
-			titleStrings, "title_", document, searchTerm);
-
+			titleStrings, name -> name.startsWith("title_"), searchResponse);
 		FieldValuesAssert.assertFieldValues(
-			contentStrings, "content_", document, searchTerm);
-
+			contentStrings, name -> name.startsWith("content_"),
+			searchResponse);
 		FieldValuesAssert.assertFieldValues(
-			localizedTitleStrings, "localized_title", document, searchTerm);
+			localizedTitleStrings, name -> name.startsWith("localized_title"),
+			searchResponse);
 	}
 
 	@Test
@@ -255,20 +259,20 @@ public class JournalArticleIndexerLocalizedContentTest {
 
 		String searchTerm = articleId;
 
-		Document document = _indexerFixture.searchOnlyOne(
-			searchTerm, LocaleUtil.BRAZIL);
+		SearchResponse searchResponse =
+			_indexerFixture.searchOnlyOneSearchResponse(
+				searchTerm, LocaleUtil.BRAZIL);
 
 		FieldValuesAssert.assertFieldValues(
-			titleStrings, "title", document, searchTerm);
-
+			titleStrings, name -> name.startsWith("title"), searchResponse);
 		FieldValuesAssert.assertFieldValues(
-			contentStrings, "content", document, searchTerm);
-
+			contentStrings, name -> name.startsWith("content"), searchResponse);
 		FieldValuesAssert.assertFieldValues(
-			localizedTitleStrings, "localized_title", document, searchTerm);
-
+			localizedTitleStrings, name -> name.startsWith("localized_title"),
+			searchResponse);
 		FieldValuesAssert.assertFieldValues(
-			ddmContentStrings, "ddm__text", document, searchTerm);
+			ddmContentStrings, name -> name.startsWith("ddm__text"),
+			searchResponse);
 	}
 
 	@Test
@@ -332,18 +336,19 @@ public class JournalArticleIndexerLocalizedContentTest {
 			word1, word2, prefix1, prefix2
 		).forEach(
 			searchTerm -> {
-				Document document = _indexerFixture.searchOnlyOne(
-					searchTerm, LocaleUtil.JAPAN);
+				SearchResponse searchResponse =
+					_indexerFixture.searchOnlyOneSearchResponse(
+						searchTerm, LocaleUtil.JAPAN);
 
 				FieldValuesAssert.assertFieldValues(
-					titleStrings, "title_", document, searchTerm);
-
+					titleStrings, name -> name.startsWith("title_"),
+					searchResponse);
 				FieldValuesAssert.assertFieldValues(
-					contentStrings, "content_", document, searchTerm);
-
+					contentStrings, name -> name.startsWith("content_"),
+					searchResponse);
 				FieldValuesAssert.assertFieldValues(
-					localizedTitleStrings, "localized_title", document,
-					searchTerm);
+					localizedTitleStrings,
+					name -> name.startsWith("localized_title"), searchResponse);
 			}
 		);
 	}
@@ -446,5 +451,8 @@ public class JournalArticleIndexerLocalizedContentTest {
 	private List<JournalArticle> _journalArticles;
 
 	private JournalArticleSearchFixture _journalArticleSearchFixture;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 }

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutIndexerIndexedFieldsTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutIndexerIndexedFieldsTest.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.document.DocumentBuilderFactory;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.model.uid.UIDFactory;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.search.test.util.IndexedFieldsFixture;
@@ -124,7 +125,8 @@ public class LayoutIndexerIndexedFieldsTest {
 	}
 
 	protected void setUpLayoutIndexerFixture() {
-		layoutIndexerFixture = new IndexerFixture<>(Layout.class);
+		layoutIndexerFixture = new IndexerFixture<>(
+			Layout.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpUserSearchFixture() throws Exception {
@@ -245,6 +247,9 @@ public class LayoutIndexerIndexedFieldsTest {
 
 	@DeleteAfterTestRun
 	private List<Layout> _layouts;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	@DeleteAfterTestRun
 	private List<User> _users;

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutIndexerReindexTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutIndexerReindexTest.java
@@ -23,7 +23,9 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.users.admin.test.util.search.UserSearchFixture;
@@ -90,7 +92,8 @@ public class LayoutIndexerReindexTest {
 	}
 
 	protected void setUpLayoutIndexerFixture() {
-		layoutIndexerFixture = new IndexerFixture<>(Layout.class);
+		layoutIndexerFixture = new IndexerFixture<>(
+			Layout.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpUserSearchFixture() throws Exception {
@@ -116,6 +119,9 @@ public class LayoutIndexerReindexTest {
 
 	@DeleteAfterTestRun
 	private List<Layout> _layouts;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	@DeleteAfterTestRun
 	private List<User> _users;

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutMultiLanguageSearchTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutMultiLanguageSearchTest.java
@@ -26,8 +26,10 @@ import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.users.admin.test.util.search.UserSearchFixture;
@@ -117,7 +119,8 @@ public class LayoutMultiLanguageSearchTest {
 	}
 
 	protected void setUpLayoutIndexerFixture() {
-		layoutIndexerFixture = new IndexerFixture<>(Layout.class);
+		layoutIndexerFixture = new IndexerFixture<>(
+			Layout.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpUserSearchFixture() throws Exception {
@@ -198,6 +201,9 @@ public class LayoutMultiLanguageSearchTest {
 
 	@DeleteAfterTestRun
 	private List<Layout> _layouts;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	@DeleteAfterTestRun
 	private List<User> _users;

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutPublishedSearchTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutPublishedSearchTest.java
@@ -46,6 +46,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.IndexerFixture;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -167,7 +168,8 @@ public class LayoutPublishedSearchTest {
 	}
 
 	private void _setUpLayoutIndexerFixture() {
-		_layoutIndexerFixture = new IndexerFixture<>(Layout.class);
+		_layoutIndexerFixture = new IndexerFixture<>(
+			Layout.class, _searchRequestBuilderFactory);
 	}
 
 	private void _updateDraftLayout(Layout layout, String value)
@@ -258,6 +260,9 @@ public class LayoutPublishedSearchTest {
 		filter = "mvc.command.name=/layout_content_page_editor/publish_layout"
 	)
 	private MVCActionCommand _mvcActionCommand;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	@Inject
 	private SegmentsExperienceLocalService _segmentsExperienceLocalService;

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBCategoryIndexerIndexedFieldsTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBCategoryIndexerIndexedFieldsTest.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.search.test.util.IndexedFieldsFixture;
 import com.liferay.portal.search.test.util.IndexerFixture;
@@ -94,7 +95,8 @@ public class MBCategoryIndexerIndexedFieldsTest {
 	}
 
 	protected void setUpMBCategoryIndexerFixture() {
-		mbCategoryIndexerFixture = new IndexerFixture<>(MBCategory.class);
+		mbCategoryIndexerFixture = new IndexerFixture<>(
+			MBCategory.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpMBFixture() {
@@ -197,6 +199,9 @@ public class MBCategoryIndexerIndexedFieldsTest {
 
 	@DeleteAfterTestRun
 	private List<MBCategory> _mbCategories;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	private User _user;
 

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBCategoryIndexerReindexTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBCategoryIndexerReindexTest.java
@@ -24,8 +24,10 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.IndexerFixture;
 import com.liferay.portal.search.test.util.SearchTestRule;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.users.admin.test.util.search.UserSearchFixture;
@@ -83,7 +85,8 @@ public class MBCategoryIndexerReindexTest {
 	public SearchTestRule searchTestRule = new SearchTestRule();
 
 	protected void setUpMBCategoryIndexerFixture() {
-		mbCategoryIndexerFixture = new IndexerFixture<>(MBCategory.class);
+		mbCategoryIndexerFixture = new IndexerFixture<>(
+			MBCategory.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpMBFixture() {
@@ -111,6 +114,9 @@ public class MBCategoryIndexerReindexTest {
 
 	@DeleteAfterTestRun
 	private List<MBCategory> _mbCategories;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	private User _user;
 

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBMessageIndexerIndexedFieldsTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBMessageIndexerIndexedFieldsTest.java
@@ -26,7 +26,6 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.parsers.bbcode.BBCodeTranslatorUtil;
-import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -39,6 +38,8 @@ import com.liferay.portal.kernel.util.HtmlParser;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.search.test.util.IndexedFieldsFixture;
 import com.liferay.portal.search.test.util.IndexerFixture;
@@ -94,13 +95,12 @@ public class MBMessageIndexerIndexedFieldsTest {
 		MBMessage mbMessage = mbMessageFixture.createMBMessageWithCategory(
 			searchTerm);
 
-		Document document = mbMessageIndexerFixture.searchOnlyOne(
-			searchTerm, locale);
-
-		indexedFieldsFixture.postProcessDocument(document);
+		SearchResponse searchResponse =
+			mbMessageIndexerFixture.searchOnlyOneSearchResponse(
+				searchTerm, locale);
 
 		FieldValuesAssert.assertFieldValues(
-			_expectedFieldValues(mbMessage), document, searchTerm);
+			_expectedFieldValues(mbMessage), searchResponse);
 	}
 
 	@Rule
@@ -122,7 +122,8 @@ public class MBMessageIndexerIndexedFieldsTest {
 	}
 
 	protected void setUpMBMessageIndexerFixture() {
-		mbMessageIndexerFixture = new IndexerFixture<>(MBMessage.class);
+		mbMessageIndexerFixture = new IndexerFixture<>(
+			MBMessage.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpUserSearchFixture() throws Exception {
@@ -315,6 +316,9 @@ public class MBMessageIndexerIndexedFieldsTest {
 
 	@DeleteAfterTestRun
 	private List<MBThread> _mbThreads;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	private User _user;
 

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBMessageIndexerReindexTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBMessageIndexerReindexTest.java
@@ -26,8 +26,10 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.IndexerFixture;
 import com.liferay.portal.search.test.util.SearchTestRule;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.users.admin.test.util.search.UserSearchFixture;
@@ -123,7 +125,8 @@ public class MBMessageIndexerReindexTest {
 	}
 
 	protected void setUpMBMessageIndexerFixture() {
-		mbMessageIndexerFixture = new IndexerFixture<>(MBMessage.class);
+		mbMessageIndexerFixture = new IndexerFixture<>(
+			MBMessage.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpUserSearchFixture() throws Exception {
@@ -155,6 +158,9 @@ public class MBMessageIndexerReindexTest {
 
 	@DeleteAfterTestRun
 	private List<MBThread> _mbThreads;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	private User _user;
 

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBMessageIndexerSummaryTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBMessageIndexerSummaryTest.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.IndexerFixture;
 import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.search.test.util.SummaryFixture;
@@ -55,7 +56,8 @@ public class MBMessageIndexerSummaryTest {
 
 	@Before
 	public void setUp() throws Exception {
-		indexerFixture = new IndexerFixture<>(MBMessage.class);
+		indexerFixture = new IndexerFixture<>(
+			MBMessage.class, _searchRequestBuilderFactory);
 
 		summaryFixture = new SummaryFixture<>(
 			MBMessage.class,
@@ -130,5 +132,8 @@ public class MBMessageIndexerSummaryTest {
 
 	@Inject
 	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 }

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBThreadIndexerIndexedFieldsTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBThreadIndexerIndexedFieldsTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.search.test.util.IndexedFieldsFixture;
 import com.liferay.portal.search.test.util.IndexerFixture;
@@ -113,7 +114,8 @@ public class MBThreadIndexerIndexedFieldsTest {
 	}
 
 	protected void setUpMBThreadIndexerFixture() {
-		mbThreadIndexerFixture = new IndexerFixture<>(MBThread.class);
+		mbThreadIndexerFixture = new IndexerFixture<>(
+			MBThread.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpUserSearchFixture() throws Exception {
@@ -231,6 +233,9 @@ public class MBThreadIndexerIndexedFieldsTest {
 
 	@DeleteAfterTestRun
 	private List<MBThread> _mbThreads;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	private User _user;
 

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBThreadIndexerReindexTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBThreadIndexerReindexTest.java
@@ -26,8 +26,10 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.IndexerFixture;
 import com.liferay.portal.search.test.util.SearchTestRule;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.users.admin.test.util.search.UserSearchFixture;
@@ -142,7 +144,8 @@ public class MBThreadIndexerReindexTest {
 	}
 
 	protected void setUpMBThreadIndexerFixture() {
-		mbThreadIndexerFixture = new IndexerFixture<>(MBThread.class);
+		mbThreadIndexerFixture = new IndexerFixture<>(
+			MBThread.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpUserSearchFixture() throws Exception {
@@ -174,6 +177,9 @@ public class MBThreadIndexerReindexTest {
 
 	@DeleteAfterTestRun
 	private List<MBThread> _mbThreads;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	private User _user;
 

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBThreadMultiLanguageSearchTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBThreadMultiLanguageSearchTest.java
@@ -30,9 +30,11 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.search.test.util.IndexerFixture;
 import com.liferay.portal.search.test.util.SearchTestRule;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.users.admin.test.util.search.UserSearchFixture;
@@ -65,7 +67,8 @@ public class MBThreadMultiLanguageSearchTest {
 
 	@Before
 	public void setUp() throws Exception {
-		mbThreadIndexerFixture = new IndexerFixture<>(MBThread.class);
+		mbThreadIndexerFixture = new IndexerFixture<>(
+			MBThread.class, _searchRequestBuilderFactory);
 
 		_defaultLocale = LocaleThreadLocal.getDefaultLocale();
 	}
@@ -181,6 +184,9 @@ public class MBThreadMultiLanguageSearchTest {
 
 	@DeleteAfterTestRun
 	private List<MBThread> _mbThreads;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	private User _user;
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -23,6 +23,90 @@
 				}
 			},
 			{
+				"template_string_sortable_en": {
+					"mapping": {
+						"country": "US",
+						"language": "en",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "*_en_US_sortable",
+					"match_mapping_type": "string"
+				}
+			},
+			{
+				"template_string_sortable_fr": {
+					"mapping": {
+						"country": "FR",
+						"language": "fr",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "*_fr_FR_sortable",
+					"match_mapping_type": "string"
+				}
+			},
+			{
+				"template_string_sortable_de": {
+					"mapping": {
+						"country": "DE",
+						"language": "de",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "*_de_DE_sortable",
+					"match_mapping_type": "string"
+				}
+			},
+			{
+				"template_string_sortable_pl": {
+					"mapping": {
+						"country": "PL",
+						"language": "pl",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "*_pl_PL_sortable",
+					"match_mapping_type": "string"
+				}
+			},
+			{
+				"template_string_sortable_pt": {
+					"mapping": {
+						"country": "BR",
+						"language": "pt",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "*_pt_BR_sortable",
+					"match_mapping_type": "string"
+				}
+			},
+			{
+				"template_string_sortable_ja": {
+					"mapping": {
+						"country": "JP",
+						"language": "ja",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "*_ja_JP_sortable",
+					"match_mapping_type": "string"
+				}
+			},
+			{
+				"template_string_sortable_es": {
+					"mapping": {
+						"country": "ES",
+						"language": "es",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "*_es_ES_sortable",
+					"match_mapping_type": "string"
+				}
+			},
+			{
 				"template_string_sortable": {
 					"mapping": {
 						"store": true,

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -83,6 +83,19 @@
 				}
 			},
 			{
+				"template_string_sortable_de_AT": {
+					"mapping": {
+						"country": "AT",
+						"language": "de",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_de_AT_sortable\\b|\\w+_de_AT_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
 				"template_string_sortable_de": {
 					"mapping": {
 						"language": "de",
@@ -174,6 +187,19 @@
 						"type": "icu_collation_keyword"
 					},
 					"match": "\\w+_fi_[A-Z]{2}_sortable\\b|\\w+_fi_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_fr_CA": {
+					"mapping": {
+						"country": "CA",
+						"language": "fr",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_fr_CA_sortable\\b|\\w+_fr_CA_\\w+_sortable\\b",
 					"match_mapping_type": "string",
 					"match_pattern": "regex"
 				}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -23,27 +23,61 @@
 				}
 			},
 			{
-				"template_string_sortable_en": {
+				"template_string_sortable_ar": {
 					"mapping": {
-						"country": "US",
-						"language": "en",
+						"language": "ar",
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "\\w+_en_[A-Z]{2}_sortable\\b|\\w+_en_[A-Z]{2}_\\w+_sortable\\b",
+					"match": "\\w+_ar_[A-Z]{2}_sortable\\b|\\w+_ar_[A-Z]{2}_\\w+_sortable\\b",
 					"match_mapping_type": "string",
 					"match_pattern": "regex"
 				}
 			},
 			{
-				"template_string_sortable_fr": {
+				"template_string_sortable_bg": {
 					"mapping": {
-						"country": "FR",
-						"language": "fr",
+						"language": "bg",
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "\\w+_fr_[A-Z]{2}_sortable\\b|\\w+_fr_[A-Z]{2}_\\w+_sortable\\b",
+					"match": "\\w+_bg_[A-Z]{2}_sortable\\b|\\w+_bg_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_ca": {
+					"mapping": {
+						"language": "ca",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_ca_[A-Z]{2}_sortable\\b|\\w+_ca_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_cs": {
+					"mapping": {
+						"language": "cs",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_cs_[A-Z]{2}_sortable\\b|\\w+_cs_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_da": {
+					"mapping": {
+						"language": "da",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_da_[A-Z]{2}_sortable\\b|\\w+_da_[A-Z]{2}_\\w+_sortable\\b",
 					"match_mapping_type": "string",
 					"match_pattern": "regex"
 				}
@@ -51,7 +85,6 @@
 			{
 				"template_string_sortable_de": {
 					"mapping": {
-						"country": "DE",
 						"language": "de",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -62,9 +95,296 @@
 				}
 			},
 			{
+				"template_string_sortable_el": {
+					"mapping": {
+						"language": "el",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_el_[A-Z]{2}_sortable\\b|\\w+_el_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_en": {
+					"mapping": {
+						"language": "en",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_en_[A-Z]{2}_sortable\\b|\\w+_en_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_es": {
+					"mapping": {
+						"language": "es",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_es_[A-Z]{2}_sortable\\b|\\w+_es_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_et": {
+					"mapping": {
+						"language": "et",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_et_[A-Z]{2}_sortable\\b|\\w+_et_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_eu": {
+					"mapping": {
+						"language": "eu",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_eu_[A-Z]{2}_sortable\\b|\\w+_eu_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_fa": {
+					"mapping": {
+						"language": "fa",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_fa_[A-Z]{2}_sortable\\b|\\w+_fa_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_fi": {
+					"mapping": {
+						"language": "fi",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_fi_[A-Z]{2}_sortable\\b|\\w+_fi_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_fr": {
+					"mapping": {
+						"language": "fr",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_fr_[A-Z]{2}_sortable\\b|\\w+_fr_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_gl": {
+					"mapping": {
+						"language": "gl",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_gl_[A-Z]{2}_sortable\\b|\\w+_gl_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_hi": {
+					"mapping": {
+						"language": "hi",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_hi_[A-Z]{2}_sortable\\b|\\w+_hi_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_hr": {
+					"mapping": {
+						"language": "hr",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_hr_[A-Z]{2}_sortable\\b|\\w+_hr_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_hu": {
+					"mapping": {
+						"language": "hu",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_hu_[A-Z]{2}_sortable\\b|\\w+_hu_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_hy": {
+					"mapping": {
+						"language": "hy",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_hy_[A-Z]{2}_sortable\\b|\\w+_hy_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_in": {
+					"mapping": {
+						"language": "in",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_in_[A-Z]{2}_sortable\\b|\\w+_in_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_it": {
+					"mapping": {
+						"language": "it",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_it_[A-Z]{2}_sortable\\b|\\w+_it_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_ja": {
+					"mapping": {
+						"language": "ja",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_ja_[A-Z]{2}_sortable\\b|\\w+_ja_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_kk": {
+					"mapping": {
+						"language": "kk",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_kk_[A-Z]{2}_sortable\\b|\\w+_kk_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_ko": {
+					"mapping": {
+						"language": "ko",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_ko_[A-Z]{2}_sortable\\b|\\w+_ko_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_lo": {
+					"mapping": {
+						"language": "lo",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_lo_[A-Z]{2}_sortable\\b|\\w+_lo_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_lt": {
+					"mapping": {
+						"language": "lt",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_lt_[A-Z]{2}_sortable\\b|\\w+_lt_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_ms": {
+					"mapping": {
+						"language": "ms",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_ms_[A-Z]{2}_sortable\\b|\\w+_ms_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_nb": {
+					"mapping": {
+						"language": "nb",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_nb_[A-Z]{2}_sortable\\b|\\w+_nb_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_nl": {
+					"mapping": {
+						"language": "nl",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_nl_[A-Z]{2}_sortable\\b|\\w+_nl_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_no": {
+					"mapping": {
+						"language": "no",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_no_[A-Z]{2}_sortable\\b|\\w+_no_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
 				"template_string_sortable_pl": {
 					"mapping": {
-						"country": "PL",
 						"language": "pl",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -77,7 +397,6 @@
 			{
 				"template_string_sortable_pt": {
 					"mapping": {
-						"country": "BR",
 						"language": "pt",
 						"store": true,
 						"type": "icu_collation_keyword"
@@ -88,27 +407,145 @@
 				}
 			},
 			{
-				"template_string_sortable_ja": {
+				"template_string_sortable_ro": {
 					"mapping": {
-						"country": "JP",
-						"language": "ja",
+						"language": "ro",
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "\\w+_ja_[A-Z]{2}_sortable\\b|\\w+_ja_[A-Z]{2}_\\w+_sortable\\b",
+					"match": "\\w+_ro_[A-Z]{2}_sortable\\b|\\w+_ro_[A-Z]{2}_\\w+_sortable\\b",
 					"match_mapping_type": "string",
 					"match_pattern": "regex"
 				}
 			},
 			{
-				"template_string_sortable_es": {
+				"template_string_sortable_ru": {
 					"mapping": {
-						"country": "ES",
-						"language": "es",
+						"language": "ru",
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "\\w+_es_[A-Z]{2}_sortable\\b|\\w+_es_[A-Z]{2}_\\w+_sortable\\b",
+					"match": "\\w+_ru_[A-Z]{2}_sortable\\b|\\w+_ru_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_sk": {
+					"mapping": {
+						"language": "sk",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_sk_[A-Z]{2}_sortable\\b|\\w+_sk_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_sl": {
+					"mapping": {
+						"language": "sl",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_sl_[A-Z]{2}_sortable\\b|\\w+_sl_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_sr": {
+					"mapping": {
+						"language": "sr",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_sr_[A-Z]{2}_sortable\\b|\\w+_sr_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_sv": {
+					"mapping": {
+						"language": "sv",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_sv_[A-Z]{2}_sortable\\b|\\w+_sv_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_ta": {
+					"mapping": {
+						"language": "ta",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_ta_[A-Z]{2}_sortable\\b|\\w+_ta_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_th": {
+					"mapping": {
+						"language": "th",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_th_[A-Z]{2}_sortable\\b|\\w+_th_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_tr": {
+					"mapping": {
+						"language": "tr",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_tr_[A-Z]{2}_sortable\\b|\\w+_tr_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_uk": {
+					"mapping": {
+						"language": "uk",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_uk_[A-Z]{2}_sortable\\b|\\w+_uk_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_vi": {
+					"mapping": {
+						"language": "vi",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_vi_[A-Z]{2}_sortable\\b|\\w+_vi_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			},
+			{
+				"template_string_sortable_zh": {
+					"mapping": {
+						"language": "zh",
+						"store": true,
+						"type": "icu_collation_keyword"
+					},
+					"match": "\\w+_zh_[A-Z]{2}_sortable\\b|\\w+_zh_[A-Z]{2}_\\w+_sortable\\b",
 					"match_mapping_type": "string",
 					"match_pattern": "regex"
 				}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -30,8 +30,9 @@
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "*_en_US_sortable",
-					"match_mapping_type": "string"
+					"match": "\\w+_en_[A-Z]{2}_sortable\\b|\\w+_en_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
 				}
 			},
 			{
@@ -42,8 +43,9 @@
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "*_fr_FR_sortable",
-					"match_mapping_type": "string"
+					"match": "\\w+_fr_[A-Z]{2}_sortable\\b|\\w+_fr_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
 				}
 			},
 			{
@@ -54,8 +56,9 @@
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "*_de_DE_sortable",
-					"match_mapping_type": "string"
+					"match": "\\w+_de_[A-Z]{2}_sortable\\b|\\w+_de_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
 				}
 			},
 			{
@@ -66,8 +69,9 @@
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "*_pl_PL_sortable",
-					"match_mapping_type": "string"
+					"match": "\\w+_pl_[A-Z]{2}_sortable\\b|\\w+_pl_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
 				}
 			},
 			{
@@ -78,8 +82,9 @@
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "*_pt_BR_sortable",
-					"match_mapping_type": "string"
+					"match": "\\w+_pt_[A-Z]{2}_sortable\\b|\\w+_pt_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
 				}
 			},
 			{
@@ -90,8 +95,9 @@
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "*_ja_JP_sortable",
-					"match_mapping_type": "string"
+					"match": "\\w+_ja_[A-Z]{2}_sortable\\b|\\w+_ja_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
 				}
 			},
 			{
@@ -102,8 +108,9 @@
 						"store": true,
 						"type": "icu_collation_keyword"
 					},
-					"match": "*_es_ES_sortable",
-					"match_mapping_type": "string"
+					"match": "\\w+_es_[A-Z]{2}_sortable\\b|\\w+_es_[A-Z]{2}_\\w+_sortable\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
 				}
 			},
 			{

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/sort/ElasticsearchMultiLanguageSortTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/sort/ElasticsearchMultiLanguageSortTest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.sort;
+
+import com.liferay.portal.search.elasticsearch7.internal.LiferayElasticsearchIndexingFixtureFactory;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+import com.liferay.portal.search.test.util.sort.BaseMultiLanguageSortTestCase;
+
+/**
+ * @author Vagner B.C
+ */
+public class ElasticsearchMultiLanguageSortTest
+	extends BaseMultiLanguageSortTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() throws Exception {
+		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
+	}
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/sort/ElasticsearchMultiLanguageSortTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/sort/ElasticsearchMultiLanguageSortTest.java
@@ -17,12 +17,21 @@ package com.liferay.portal.search.elasticsearch7.internal.sort;
 import com.liferay.portal.search.elasticsearch7.internal.LiferayElasticsearchIndexingFixtureFactory;
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
 import com.liferay.portal.search.test.util.sort.BaseMultiLanguageSortTestCase;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
 
 /**
  * @author Vagner B.C
  */
 public class ElasticsearchMultiLanguageSortTest
 	extends BaseMultiLanguageSortTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
 
 	@Override
 	protected IndexingFixture createIndexingFixture() throws Exception {

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
@@ -24,6 +24,560 @@
 					}
 				},
 				{
+					"template_string_sortable_ar": {
+						"mapping": {
+							"language": "ar",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_ar_[A-Z]{2}_sortable\\b|\\w+_ar_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_bg": {
+						"mapping": {
+							"language": "bg",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_bg_[A-Z]{2}_sortable\\b|\\w+_bg_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_ca": {
+						"mapping": {
+							"language": "ca",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_ca_[A-Z]{2}_sortable\\b|\\w+_ca_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_cs": {
+						"mapping": {
+							"language": "cs",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_cs_[A-Z]{2}_sortable\\b|\\w+_cs_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_da": {
+						"mapping": {
+							"language": "da",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_da_[A-Z]{2}_sortable\\b|\\w+_da_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_de_AT": {
+						"mapping": {
+							"country": "AT",
+							"language": "de",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_de_AT_sortable\\b|\\w+_de_AT_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_de": {
+						"mapping": {
+							"language": "de",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_de_[A-Z]{2}_sortable\\b|\\w+_de_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_el": {
+						"mapping": {
+							"language": "el",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_el_[A-Z]{2}_sortable\\b|\\w+_el_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_en": {
+						"mapping": {
+							"language": "en",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_en_[A-Z]{2}_sortable\\b|\\w+_en_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_es": {
+						"mapping": {
+							"language": "es",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_es_[A-Z]{2}_sortable\\b|\\w+_es_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_et": {
+						"mapping": {
+							"language": "et",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_et_[A-Z]{2}_sortable\\b|\\w+_et_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_eu": {
+						"mapping": {
+							"language": "eu",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_eu_[A-Z]{2}_sortable\\b|\\w+_eu_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_fa": {
+						"mapping": {
+							"language": "fa",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_fa_[A-Z]{2}_sortable\\b|\\w+_fa_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_fi": {
+						"mapping": {
+							"language": "fi",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_fi_[A-Z]{2}_sortable\\b|\\w+_fi_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_fr_CA": {
+						"mapping": {
+							"country": "CA",
+							"language": "fr",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_fr_CA_sortable\\b|\\w+_fr_CA_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_fr": {
+						"mapping": {
+							"language": "fr",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_fr_[A-Z]{2}_sortable\\b|\\w+_fr_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_gl": {
+						"mapping": {
+							"language": "gl",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_gl_[A-Z]{2}_sortable\\b|\\w+_gl_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_hi": {
+						"mapping": {
+							"language": "hi",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_hi_[A-Z]{2}_sortable\\b|\\w+_hi_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_hr": {
+						"mapping": {
+							"language": "hr",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_hr_[A-Z]{2}_sortable\\b|\\w+_hr_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_hu": {
+						"mapping": {
+							"language": "hu",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_hu_[A-Z]{2}_sortable\\b|\\w+_hu_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_hy": {
+						"mapping": {
+							"language": "hy",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_hy_[A-Z]{2}_sortable\\b|\\w+_hy_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_in": {
+						"mapping": {
+							"language": "in",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_in_[A-Z]{2}_sortable\\b|\\w+_in_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_it": {
+						"mapping": {
+							"language": "it",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_it_[A-Z]{2}_sortable\\b|\\w+_it_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_ja": {
+						"mapping": {
+							"language": "ja",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_ja_[A-Z]{2}_sortable\\b|\\w+_ja_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_kk": {
+						"mapping": {
+							"language": "kk",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_kk_[A-Z]{2}_sortable\\b|\\w+_kk_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_ko": {
+						"mapping": {
+							"language": "ko",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_ko_[A-Z]{2}_sortable\\b|\\w+_ko_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_lo": {
+						"mapping": {
+							"language": "lo",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_lo_[A-Z]{2}_sortable\\b|\\w+_lo_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_lt": {
+						"mapping": {
+							"language": "lt",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_lt_[A-Z]{2}_sortable\\b|\\w+_lt_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_ms": {
+						"mapping": {
+							"language": "ms",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_ms_[A-Z]{2}_sortable\\b|\\w+_ms_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_nb": {
+						"mapping": {
+							"language": "nb",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_nb_[A-Z]{2}_sortable\\b|\\w+_nb_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_nl": {
+						"mapping": {
+							"language": "nl",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_nl_[A-Z]{2}_sortable\\b|\\w+_nl_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_no": {
+						"mapping": {
+							"language": "no",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_no_[A-Z]{2}_sortable\\b|\\w+_no_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_pl": {
+						"mapping": {
+							"language": "pl",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_pl_[A-Z]{2}_sortable\\b|\\w+_pl_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_pt": {
+						"mapping": {
+							"language": "pt",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_pt_[A-Z]{2}_sortable\\b|\\w+_pt_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_ro": {
+						"mapping": {
+							"language": "ro",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_ro_[A-Z]{2}_sortable\\b|\\w+_ro_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_ru": {
+						"mapping": {
+							"language": "ru",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_ru_[A-Z]{2}_sortable\\b|\\w+_ru_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_sk": {
+						"mapping": {
+							"language": "sk",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_sk_[A-Z]{2}_sortable\\b|\\w+_sk_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_sl": {
+						"mapping": {
+							"language": "sl",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_sl_[A-Z]{2}_sortable\\b|\\w+_sl_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_sr": {
+						"mapping": {
+							"language": "sr",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_sr_[A-Z]{2}_sortable\\b|\\w+_sr_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_sv": {
+						"mapping": {
+							"language": "sv",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_sv_[A-Z]{2}_sortable\\b|\\w+_sv_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_ta": {
+						"mapping": {
+							"language": "ta",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_ta_[A-Z]{2}_sortable\\b|\\w+_ta_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_th": {
+						"mapping": {
+							"language": "th",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_th_[A-Z]{2}_sortable\\b|\\w+_th_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_tr": {
+						"mapping": {
+							"language": "tr",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_tr_[A-Z]{2}_sortable\\b|\\w+_tr_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_uk": {
+						"mapping": {
+							"language": "uk",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_uk_[A-Z]{2}_sortable\\b|\\w+_uk_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_vi": {
+						"mapping": {
+							"language": "vi",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_vi_[A-Z]{2}_sortable\\b|\\w+_vi_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
+					"template_string_sortable_zh": {
+						"mapping": {
+							"language": "zh",
+							"store": true,
+							"type": "icu_collation_keyword"
+						},
+						"match": "\\w+_zh_[A-Z]{2}_sortable\\b|\\w+_zh_[A-Z]{2}_\\w+_sortable\\b",
+						"match_mapping_type": "string",
+						"match_pattern": "regex"
+					}
+				},
+				{
 					"template_string_sortable": {
 						"mapping": {
 							"store": true,

--- a/modules/apps/portal-search/portal-search-test-util/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search Test Utilities
 Bundle-SymbolicName: com.liferay.portal.search.test.util
-Bundle-Version: 6.0.15
+Bundle-Version: 7.0.0
 Export-Package:\
 	com.liferay.portal.search.test.util,\
 	com.liferay.portal.search.test.util.logging

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/FieldValuesAssert.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/FieldValuesAssert.java
@@ -19,6 +19,8 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.document.Document;
 import com.liferay.portal.search.document.Field;
+import com.liferay.portal.search.hits.SearchHit;
+import com.liferay.portal.search.hits.SearchHits;
 import com.liferay.portal.search.searcher.SearchResponse;
 
 import java.util.ArrayList;
@@ -72,6 +74,15 @@ public class FieldValuesAssert {
 
 			Map<String, String> filteredFieldValuesMap = _filterOnKey(
 				actualFieldValuesMap, keysPredicate);
+
+			Map<String, Object> sourcesMap = _getSourcesMap(searchResponse);
+
+			for (String key : filteredFieldValuesMap.keySet()) {
+				if (sourcesMap.containsKey(key)) {
+					filteredFieldValuesMap.put(
+						key, _toObjectString(sourcesMap.get(key)));
+				}
+			}
 
 			AssertUtils.assertEquals(
 				() -> StringBundler.concat(
@@ -165,6 +176,18 @@ public class FieldValuesAssert {
 		).collect(
 			Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)
 		);
+	}
+
+	private static Map<String, Object> _getSourcesMap(
+		SearchResponse searchResponse) {
+
+		SearchHits searchHits = searchResponse.getSearchHits();
+
+		List<SearchHit> searchHitList = searchHits.getSearchHits();
+
+		SearchHit searchHit = searchHitList.get(0);
+
+		return searchHit.getSourcesMap();
 	}
 
 	private static <E> List<E> _sort(List<E> list) {

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/IndexedFieldsFixture.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/IndexedFieldsFixture.java
@@ -91,7 +91,7 @@ public class IndexedFieldsFixture {
 	}
 
 	public void populatePriority(String priority, Map<String, String> map) {
-		populatePriority(priority, map, false);
+		populatePriority(priority, map, true);
 	}
 
 	public void populatePriority(

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/DocumentCreationHelpers.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/DocumentCreationHelpers.java
@@ -78,6 +78,15 @@ public class DocumentCreationHelpers {
 		return document -> document.addText(fieldName, values);
 	}
 
+	public static DocumentCreationHelper singleTextSortable(
+		String fieldName, String fieldNameSortable, String... values) {
+
+		return document -> {
+			document.addText(fieldName, values);
+			document.addText(fieldNameSortable, values);
+		};
+	}
+
 	public static DocumentCreationHelper twoKeywords(
 		String fieldName1, String value1, String fieldName2, String value2) {
 

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseMultiLanguageSortTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseMultiLanguageSortTestCase.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test.util.sort;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.test.util.DocumentsAssert;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+import com.liferay.portal.search.test.util.indexing.DocumentCreationHelper;
+import com.liferay.portal.search.test.util.indexing.DocumentCreationHelpers;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.junit.Test;
+
+/**
+ * @author Vagner B.C
+ */
+public abstract class BaseMultiLanguageSortTestCase
+	extends BaseIndexingTestCase {
+
+	@Test
+	public void testEnglishCaseSensitive() {
+		testLocaleSort(
+			LocaleUtil.US, new String[] {"a", "E", "c", "O", "u", "A"},
+			"[a, A, c, E, O, u]");
+	}
+
+	@Test
+	public void testFrance() {
+		testLocaleSort(
+			LocaleUtil.FRANCE, new String[] {"e", "a", "d", "ç"},
+			"[a, ç, d, e]");
+	}
+
+	@Test
+	public void testGerman() {
+		testLocaleSort(
+			LocaleUtil.GERMANY,
+			new String[] {"a", "x", "ä", "ö", "o", "u", "ź"},
+			"[a, ä, o, ö, u, x, ź]");
+	}
+
+	@Test
+	public void testJapanHiragana() {
+		testLocaleSort(
+			LocaleUtil.JAPAN, new String[] {"え", "う", "い", "あ", "お"},
+			"[あ, い, う, え, お]");
+	}
+
+	@Test
+	public void testJapanKanji() {
+		testLocaleSort(LocaleUtil.JAPAN, new String[] {"色", "赤"}, "[赤, 色]");
+	}
+
+	@Test
+	public void testJapanKatana() {
+		testLocaleSort(
+			LocaleUtil.JAPAN, new String[] {"オ", "イ", "ア", "エ", "ウ"},
+			"[ア, イ, ウ, エ, オ]");
+	}
+
+	@Test
+	public void testPolish() {
+		testLocaleSort(
+			new Locale("pl", "PL"),
+			new String[] {"f", "ć", "ź", "d", "ł", "ś", "b"},
+			"[b, ć, d, f, ł, ś, ź]");
+	}
+
+	@Test
+	public void testPortuguese() {
+		testLocaleSort(
+			LocaleUtil.BRAZIL,
+			new String[] {
+				"a", "e", "c", "u", "à", "á", "é", "ã", "o", "õ", "ü", "ç"
+			},
+			"[a, á, à, ã, c, ç, e, é, o, õ, u, ü]");
+	}
+
+	@Test
+	public void testSpanish() {
+		testLocaleSort(
+			LocaleUtil.SPAIN,
+			new String[] {"a", "d", "c", "ch", "ll", "ñ", "p", "e"},
+			"[a, c, ch, d, e, ll, ñ, p]");
+	}
+
+	protected void addDocuments(
+		Function<Double, DocumentCreationHelper> function, double... values) {
+
+		for (double value : values) {
+			addDocument(function.apply(value));
+		}
+	}
+
+	protected void assertOrder(
+		Sort[] sorts, String fieldName, String expected, Locale locale) {
+
+		assertSearch(
+			indexingTestHelper -> {
+				indexingTestHelper.define(
+					searchContext -> {
+						searchContext.setSorts(sorts);
+						searchContext.setLocale(locale);
+					});
+
+				indexingTestHelper.search();
+
+				indexingTestHelper.verify(
+					hits -> DocumentsAssert.assertValues(
+						indexingTestHelper.getRequestString(), hits.getDocs(),
+						fieldName, expected));
+			});
+	}
+
+	protected void testLocaleSort(
+		Locale locale, String[] values, String expected) {
+
+		String fieldName = Field.TITLE;
+
+		String fieldNameSortable =
+			fieldName + StringPool.UNDERLINE + LocaleUtil.toLanguageId(locale) +
+				_SORTABLE;
+
+		addDocuments(
+			value -> DocumentCreationHelpers.singleTextSortable(
+				fieldName, fieldNameSortable, value),
+			Arrays.asList(values));
+
+		assertOrder(
+			new Sort[] {new Sort(fieldNameSortable, Sort.STRING_TYPE, false)},
+			fieldName, expected, locale);
+	}
+
+	private static final String _SORTABLE = "_sortable";
+
+}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseMultiLanguageSortTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseMultiLanguageSortTestCase.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.search.test.util.sort;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
@@ -112,8 +113,8 @@ public abstract class BaseMultiLanguageSortTestCase
 			indexingTestHelper -> {
 				indexingTestHelper.define(
 					searchContext -> {
-						searchContext.setSorts(sorts);
 						searchContext.setLocale(locale);
+						searchContext.setSorts(sorts);
 					});
 
 				indexingTestHelper.search();
@@ -130,9 +131,9 @@ public abstract class BaseMultiLanguageSortTestCase
 
 		String fieldName = Field.TITLE;
 
-		String fieldNameSortable =
-			fieldName + StringPool.UNDERLINE + LocaleUtil.toLanguageId(locale) +
-				_SORTABLE;
+		String fieldNameSortable = StringBundler.concat(
+			fieldName, StringPool.UNDERLINE, LocaleUtil.toLanguageId(locale),
+			StringPool.UNDERLINE, Field.SORTABLE_FIELD_SUFFIX);
 
 		addDocuments(
 			value -> DocumentCreationHelpers.singleTextSortable(
@@ -143,7 +144,5 @@ public abstract class BaseMultiLanguageSortTestCase
 			new Sort[] {new Sort(fieldNameSortable, Sort.STRING_TYPE, false)},
 			fieldName, expected, locale);
 	}
-
-	private static final String _SORTABLE = "_sortable";
 
 }

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseMultiLanguageSortTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseMultiLanguageSortTestCase.java
@@ -70,7 +70,7 @@ public abstract class BaseMultiLanguageSortTestCase
 	}
 
 	@Test
-	public void testJapanKatana() {
+	public void testJapanKatakana() {
 		testLocaleSort(
 			LocaleUtil.JAPAN, new String[] {"オ", "イ", "ア", "エ", "ウ"},
 			"[ア, イ, ウ, エ, オ]");

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseMultiLanguageSortTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseMultiLanguageSortTestCase.java
@@ -94,8 +94,10 @@ public abstract class BaseMultiLanguageSortTestCase
 	public void testSpanish() {
 		testLocaleSort(
 			LocaleUtil.SPAIN,
-			new String[] {"a", "d", "c", "ch", "ll", "ñ", "p", "e"},
-			"[a, c, ch, d, e, ll, ñ, p]");
+			new String[] {
+				"a", "é", "d", "c", "cu", "ch", "ll", "ña", "nu", "p", "e", "á"
+			},
+			"[a, á, c, ch, cu, d, e, é, ll, nu, ña, p]");
 	}
 
 	protected void addDocuments(

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseMultiLanguageSortTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseMultiLanguageSortTestCase.java
@@ -65,11 +65,6 @@ public abstract class BaseMultiLanguageSortTestCase
 	}
 
 	@Test
-	public void testJapanKanji() {
-		testLocaleSort(LocaleUtil.JAPAN, new String[] {"色", "赤"}, "[赤, 色]");
-	}
-
-	@Test
 	public void testJapanKatakana() {
 		testLocaleSort(
 			LocaleUtil.JAPAN, new String[] {"オ", "イ", "ア", "エ", "ウ"},

--- a/modules/apps/portal-search/portal-search-test-util/src/main/resources/com/liferay/portal/search/test/util/packageinfo
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/resources/com/liferay/portal/search/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0

--- a/modules/apps/user-groups-admin/user-groups-admin-web-test/src/testIntegration/java/com/liferay/user/groups/admin/web/internal/search/test/UserGroupIndexerIndexedFieldsTest.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-web-test/src/testIntegration/java/com/liferay/user/groups/admin/web/internal/search/test/UserGroupIndexerIndexedFieldsTest.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.document.DocumentBuilderFactory;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.model.uid.UIDFactory;
 import com.liferay.portal.search.test.util.ExpandoTableSearchFixture;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
@@ -135,7 +136,8 @@ public class UserGroupIndexerIndexedFieldsTest {
 	}
 
 	protected void setUpUserGroupIndexerFixture() {
-		userGroupIndexerFixture = new IndexerFixture<>(UserGroup.class);
+		userGroupIndexerFixture = new IndexerFixture<>(
+			UserGroup.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpUserSearchFixture() throws Exception {
@@ -267,6 +269,9 @@ public class UserGroupIndexerIndexedFieldsTest {
 
 	@DeleteAfterTestRun
 	private List<Group> _groups;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	@DeleteAfterTestRun
 	private List<UserGroup> _userGroups;

--- a/modules/apps/user-groups-admin/user-groups-admin-web-test/src/testIntegration/java/com/liferay/user/groups/admin/web/internal/search/test/UserGroupMultiLanguageSearchTest.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-web-test/src/testIntegration/java/com/liferay/user/groups/admin/web/internal/search/test/UserGroupMultiLanguageSearchTest.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.search.test.util.IndexerFixture;
 import com.liferay.portal.search.test.util.SearchTestRule;
@@ -115,7 +116,8 @@ public class UserGroupMultiLanguageSearchTest {
 	}
 
 	protected void setUpUserGroupIndexerFixture() {
-		userGroupIndexerFixture = new IndexerFixture<>(UserGroup.class);
+		userGroupIndexerFixture = new IndexerFixture<>(
+			UserGroup.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpUserSearchFixture() throws Exception {
@@ -169,6 +171,9 @@ public class UserGroupMultiLanguageSearchTest {
 
 	@DeleteAfterTestRun
 	private List<Group> _groups;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	@DeleteAfterTestRun
 	private List<UserGroup> _userGroups;

--- a/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserIndexerIndexedFieldsTest.java
+++ b/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserIndexerIndexedFieldsTest.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.document.DocumentBuilderFactory;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.model.uid.UIDFactory;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.search.test.util.IndexedFieldsFixture;
@@ -225,7 +226,8 @@ public class UserIndexerIndexedFieldsTest {
 	}
 
 	protected void setUpIndexerFixture() {
-		indexerFixture = new IndexerFixture<>(User.class);
+		indexerFixture = new IndexerFixture<>(
+			User.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpUserSearchFixture() throws Exception {
@@ -450,6 +452,9 @@ public class UserIndexerIndexedFieldsTest {
 
 	@DeleteAfterTestRun
 	private List<Organization> _organizations;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	@DeleteAfterTestRun
 	private List<UserGroup> _userGroups = new ArrayList<>();

--- a/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserIndexerReindexTest.java
+++ b/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserIndexerReindexTest.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.IndexerFixture;
 import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
@@ -67,7 +68,8 @@ public class UserIndexerReindexTest {
 
 		_groupSearchFixture = groupSearchFixture;
 
-		_indexerFixture = new IndexerFixture<>(User.class);
+		_indexerFixture = new IndexerFixture<>(
+			User.class, _searchRequestBuilderFactory);
 
 		_users = userSearchFixture.getUsers();
 
@@ -113,6 +115,9 @@ public class UserIndexerReindexTest {
 
 	private GroupSearchFixture _groupSearchFixture;
 	private IndexerFixture<User> _indexerFixture;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	@DeleteAfterTestRun
 	private List<User> _users;

--- a/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserMultiLanguageSearchTest.java
+++ b/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserMultiLanguageSearchTest.java
@@ -26,9 +26,11 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.search.test.util.IndexerFixture;
 import com.liferay.portal.search.test.util.SearchTestRule;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.users.admin.test.util.search.GroupBlueprint;
@@ -145,7 +147,8 @@ public class UserMultiLanguageSearchTest {
 	}
 
 	protected void setUpIndexerFixture() {
-		indexerFixture = new IndexerFixture<>(User.class);
+		indexerFixture = new IndexerFixture<>(
+			User.class, _searchRequestBuilderFactory);
 	}
 
 	protected void setUpUserSearchFixture() throws Exception {
@@ -178,6 +181,9 @@ public class UserMultiLanguageSearchTest {
 
 	@DeleteAfterTestRun
 	private List<Group> _groups;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	@DeleteAfterTestRun
 	private List<User> _users;

--- a/readme/BREAKING_CHANGES.markdown
+++ b/readme/BREAKING_CHANGES.markdown
@@ -988,3 +988,32 @@ Any installation that has configured the Google Cloud autotranslator service.
 No code changes are necessary. Administrators may need to reconfigure the Google Could autotranslator service.
 
 ---------------------------------------
+
+## Elasticsearch sortable type mappings were changed from keyword to icu_collation_keyword
+
+- **Date:** 2022-May-12
+- **JIRA Ticket:** [LPS-152937](https://issues.liferay.com/browse/LPS-152937)
+
+### What changed?
+
+The Elasticsearch type mapping of localized sortable `*_<languageId>_sortable` and nested `ddmFieldArray.ddmFieldValueText_<languageId>_String_sortable` fields were changed from `keyword` to `icu_collation_keyword`
+
+The indexed information of these fields is now stored in an encoded format, for example, the `entity title` text is now stored as `MkRQOlBaBFA6UEAyARABEAA=`
+
+This new `icu_collation_keyword` type allows sorting using the correct collation rules of each language for more information see https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/analysis-icu-collation-keyword-field.html
+
+If you update your existing Liferay installation, this change won't be applied until a full reindex is executed and Elasticsearch mappings are recreated.
+
+### Who is affected?
+
+If you are using the `*_<languageId>_sortable` and `ddmFieldArray.ddmFieldValueText_<languageId>_String_sortable` fields in your custom Elasticsearch queries:
+   - **To sort your results:** you will find that now they are sorted using the correct collation rules of each language.
+   - **To retrieve some information from the Elasticsearch index:** you will find that now the returned information is returned in an encoded format.
+
+### How should I update my code?
+
+If you want to maintain the old sort behavior, you will have to customize the Elasticsearch mappings, removing the `icu_collation_keyword`. For more information about how to personalize them, see: https://learn.liferay.com/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/advanced-configuration-of-the-liferay-elasticsearch-connector.html
+
+If you need to retrieve data from these fields, you can get the same information from the _source field of Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/7.17/mapping-source-field.html or you can also remove the `icu_collation_keyword` as it is explained in the previous paragraph.
+
+---------------------------------------


### PR DESCRIPTION
This PR is similar to https://github.com/liferay-search/liferay-portal/pull/434 but instead of adding a new nested "raw" mapping, I have fixed every failing test, using the "_source" field, see **Changes 3** section.

----

**Issue:** https://issues.liferay.com/browse/LPS-152937 - Elasticsearch sort doesn't work with accented words
See also https://issues.liferay.com/browse/PTR-3054

This issue was previously reported in https://issues.liferay.com/browse/LPS-93341 and some work was done in spike https://issues.liferay.com/browse/LPS-94561

The idea of that spike was to use the **icu_collation_keyword** from Elasticsearch ICU Plugin, see: https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-icu-collation-keyword-field.html 

In this PR I have used the code from that spike as the starting point (see https://github.com/brandizzi/liferay-portal/pull/813 PR and this branch https://github.com/brandizzi/liferay-portal/tree/LPS-94561 from @brandizzi repository)

**Original commits from LPS-94561 spike:** https://github.com/liferay-search/liferay-portal/commit/77ed5fcf9e9a269801049390661ff7898656240c , https://github.com/liferay-search/liferay-portal/commit/352d72a2fa70a3729b7e118165eb77e0e8a051d6, and https://github.com/liferay-search/liferay-portal/commit/fbdfd8ccd12a491bcbe698d82bcb3faaa0fe32e4

I have done the following changes to this code:

**Changes 1: Tests added in BaseMultiLanguageSortTestCase** (from previous PR https://github.com/brandizzi/liferay-portal/pull/813)
   - https://github.com/liferay-search/liferay-portal/commit/9da34ea57b398aad665ea5a5276790554a354385 fixes test name to testJapanKatakana
   - https://github.com/liferay-search/liferay-portal/commit/ca619b0db81b0c3948c1b1016bba4fbb44b7c79f removes the Kanji sort test because it is not correct:
        - ICU library used by Elasticsearch doesn't support Kanji sorting, see: http://unicode.org/faq/collation.html#7
        - If you use this [ICU Collation Demo](https://icu4c-demos.unicode.org/icu-bin/collation.html), it returns different results than the expected in the removed test
        - In general, Japanese Kanji sorting seems to be a non-trivial task, read: http://www.localizingjapan.com/blog/2011/02/13/sorting-in-japanese-%E2%80%94-an-unsolved-problem/ or https://stackoverflow.com/questions/4895527/can-sorting-japanese-kanji-words-be-done-programmatically
        - It seems the author of that test (_Vagner Castro_) no longer works for Liferay, so I couldn't reach him to have more information about that test.
   - https://github.com/liferay-search/liferay-portal/commit/b0eab6b0edcc0f18de7671bc37837accc19344a5 improves the Spanish test. As a native Spanish speaker, I detected that the original test had some missing checks related to the "ñ", "ch", and vowels with accents "á", "é"... 

**Changes 2: Elasticsearch mapping changes**
     - https://github.com/liferay-search/liferay-portal/commit/ca3d0fa71e85a3d56798a37974c187172e276fd0 => We must cover both regular `*_en_US_sortable` and nested `ddmFieldArray.ddmFieldValueText_en_US_String_sortable` fields
   - https://github.com/liferay-search/liferay-portal/commit/31bce6bcd6629df3e78099e258be843f4d51b2f5 => Replicate new mappings to all the existing locales. It is not necessary to specify the country because it is optional (see elasticsearch ICU plugin code: https://github.com/elastic/elasticsearch/blob/5aa174e6d3d280438822fc03c580bd9eac9faccf/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapper.java#L377-L391 )
   - https://github.com/liferay-search/liferay-portal/commit/b8db5a4053e94f867b48c5970a849ed9357ce806 => Add de_AT (_Austrian German_) and fr_CA (_Canadian French_) country configurations as they have an specific collation configuration according to https://github.com/unicode-org/cldr/tree/main/common/collation

**Changes 3: Broken tests**
The Elasticsearch mapping changes break some existing tests because they compare the `_sortable `fields returned by Elasticsearch but now they are encoded in a strange way because we are using the **icu_collation_keyword** type:
```
expected:<...itle_de_DE_sortable=[entity title, localized_title_en_US=entity title, localized_title_en_US_sortable=entity title, localized_title_es_ES=entity title, localized_title_es_ES_sortable=entity title, localized_title_fi_FI=entity title, localized_title_fi_FI_sortable=entity title, localized_title_fr_FR=entity title, localized_title_fr_FR_sortable=entity title, localized_title_hu_HU=entitas neve, localized_title_hu_HU_sortable=entitas neve, localized_title_ja_JP=entity title, localized_title_ja_JP_sortable=entity title, localized_title_nl_NL=entity title, localized_title_nl_NL_sortable=entity title, localized_title_pt_BR=entity title, localized_title_pt_BR_sortable=entity title], localized_title_sv...> but was:<...itle_de_DE_sortable=[MkRQOlBaBFA6UEAyARABEAA=, localized_title_en_US=entity title, localized_title_en_US_sortable=MkRQOlBaBFA6UEAyARABEAA=, localized_title_es_ES=entity title, localized_title_es_ES_sortable=MkRQOlBaBFA6UEAyARABEAA=, localized_title_fi_FI=entity title, localized_title_fi_FI_sortable=entity title, localized_title_fr_FR=entity title, localized_title_fr_FR_sortable=MkRQOlBaBFA6UEAyARABEAA=, localized_title_hu_HU=entitas neve, localized_title_hu_HU_sortable=entitas neve, localized_title_ja_JP=entity title, localized_title_ja_JP_sortable=MkRQOlBaBFA6UEAyARABEAA=, localized_title_nl_NL=entity title, localized_title_nl_NL_sortable=entity title, localized_title_pt_BR=entity title, localized_title_pt_BR_sortable=MkRQOlBaBFA6UEAyARABEAA=]
```
In this example, the `entity title` text is encoded in the Elasticsearch side as `MkRQOlBaBFA6UEAyARABEAA=`
To solve this:
   - https://github.com/liferay-search/liferay-portal/commit/fd6cfe28904e208fc61418aa105a54730a187e9f commit: I am getting the information from the sources map of `searchResponse` and overwrite the value in `filteredFieldValuesMap` with the value from `sourcesMap` if it exists. **Note:** the `sourcesMap` can be empty if you don't set the fetchSource flag in the request.
   - In order to get the source we need the `searchResponse` so in https://github.com/liferay-search/liferay-portal/commit/0031230294f1f0ff967c0d9984e8df539a1584dd and https://github.com/liferay-search/liferay-portal/commit/0acf6e42a48aa50b0ebd340da276b4bb5f00a0ea I have created a new **searchOnlyOneSearchResponse** method that is similar to the existing **searchOnlyOne** but it returns a SearchResponse object instead of the Document and we use the `_searchRequestBuilderFactory` to set the fetchSource to true.
   - https://github.com/liferay-search/liferay-portal/commit/d3b0c616e1fcedbf75343a187d9ab464598ee39f commit: we have to add the SearchRequestBuilderFactory parameter to the **new IndexerFixture<>(...)** call in every test. This is necessary inside the IndexerFixture class to be able to set the fetchSource to true.
   - https://github.com/liferay-search/liferay-portal/commit/cba33e2d74526aee0d091bc09e62d243a0e7aa97 commit: Replace the usages of searchOnlyOne with searchOnlyOneSearchResponse in every test that fails after the mapping changes.
   - https://github.com/liferay-search/liferay-portal/commit/65c2c94fe29ac324c4def8345e7fe87ca4d5c827 commit: Set the fetchSource to true in every failing test that is already using the `searchResponse` object when it calls the assertFieldValues method.
   - https://github.com/liferay-search/liferay-portal/commit/90cde330a35a74791505958b08762a458a8965dc commit: The new code always expect having the priority_sortable set, so I am changing it to true by default.

**Additional notes:**
   - In the end, we are only changing the mapping configurations, so this fix won't be applied to our existing customers until they execute a full reindex
   - On the other hand, If the customer updates to a version that contains this code, they won't detect any issue if they don't want to execute the full reindex, because their installation will continue to use the old mappings
   - **Warning:** :warning: If the customer has a custom development that uses the information stored in the _sortable fields, they will have problems, as now the information will be encoded. As a workaround, they can use the information stored in the _source internal field or they can change the mappings.
   -  I have updated the breaking changes document, see https://github.com/liferay-search/liferay-portal/commit/2c6126cb7e407864208d84b2f2d61868afcfaeb3 we must include it in the release notes of the update that will include this LPS.

**About the tests added in this PR:**
   - The tests are a bit incomplete. The major problem here is we need native speakers to add more tests in every supported language.
   - I have improved the Spanish test in this commit https://github.com/liferay-search/liferay-portal/commit/fa518c23f02e8f9c688360643be234a97fb68442 but I don't have the knowledge to improve any other language
   - Perhaps we can use the ICU Collation Demo (https://icu4c-demos.unicode.org/icu-bin/collation.html) or check the ICU information from https://github.com/unicode-org/cldr/tree/main/common/collation where there is information of every supported language, for example in the [pl.xml polish definition](https://github.com/unicode-org/cldr/blob/main/common/collation/pl.xml) you can see the precedence between every letter so, for example, `Z<ź<<<Ź<ż<<<Ż` means that `Ża, Ze, Źu` is sorted to `Ze, Źu, Ża`
   - Nevertheless, the best option is to double-check with native speakers (perhaps we can reach the people from this volunteer list https://liferay.slack.com/archives/CJ1ERLHUZ/p1650977876964469 )

Let me know if you have any questions about this PR

Regards,
Jorge

