### PR TITLE
LPS-143720 search-experiences-web: Add specific autocompletion for "aggs"

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
@@ -292,19 +292,37 @@ function getCustomHintProperties(item, endToken) {
 			// Check characters after if any property value is defined already.
 
 			if (endToken.string?.startsWith('"') || endToken.string === '') {
-				switch (item.type) {
-					case 'array':
-						text = `${item.name}": []`;
-						break;
-					case 'object':
-						text = `${item.name}": {}`;
-						break;
-					case 'string':
-						text = `${item.name}": ""`;
-						break;
-					default:
-						text = `${item.name}": `;
-						break;
+
+				// For special case "aggs" within aggregation configuration, autofill
+				// with this snippet to show how aggregation types are structured.
+
+				if (item.name === 'aggs') {
+					const indentedTabs =
+						endToken.state.indented / cm.getOption('indentUnit');
+
+					const aggsText = JSON.stringify(
+						{NAME: {AGG_TYPE: {}}},
+						null,
+						'\t'
+					).replace(/\n/g, '\n' + '\t'.repeat(indentedTabs));
+
+					text = `aggs": ${aggsText}`;
+				}
+				else {
+					switch (item.type) {
+						case 'array':
+							text = `${item.name}": []`;
+							break;
+						case 'object':
+							text = `${item.name}": {}`;
+							break;
+						case 'string':
+							text = `${item.name}": ""`;
+							break;
+						default:
+							text = `${item.name}": `;
+							break;
+					}
 				}
 			}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-143720 - When editing my Blueprint's Configurations JSON, I am aided by schema-driven auto-completion

This formatted, indented snippet gets added for the special case of "aggs", where a custom name is situated in the level between "aggs" and aggregation types.

<img width="925" alt="Screen Shot 2022-05-17 at 2 36 18 PM" src="https://user-images.githubusercontent.com/14063502/168914150-34a9ce8c-cb0e-4af4-92d3-1b6a65082d05.png">

