### PR TITLE
LPS-142523 Error uploading files if the Index Registry buffer is disabled

### DIFF
--- a/modules/apps/asset/asset-entry-rel-service/src/main/java/com/liferay/asset/entry/rel/service/impl/AssetEntryAssetCategoryRelLocalServiceImpl.java
+++ b/modules/apps/asset/asset-entry-rel-service/src/main/java/com/liferay/asset/entry/rel/service/impl/AssetEntryAssetCategoryRelLocalServiceImpl.java
@@ -22,6 +22,8 @@ import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ClassedModel;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.SearchException;
@@ -236,11 +238,16 @@ public class AssetEntryAssetCategoryRelLocalServiceImpl
 
 			Object assetObject = assetRenderer.getAssetObject();
 
-			if (assetObject == null) {
-				return;
+			if (assetObject instanceof BaseModel) {
+				indexer.reindex(assetObject);
 			}
+			else if (assetObject instanceof ClassedModel) {
+				ClassedModel classedModel = (ClassedModel)assetObject;
 
-			indexer.reindex(assetObject);
+				indexer.reindex(
+					assetEntry.getClassName(),
+					(Long)classedModel.getPrimaryKeyObj());
+			}
 		}
 		catch (SearchException searchException) {
 			_log.error("Unable to reindex asset entry", searchException);

--- a/modules/apps/portal-search/portal-search-api/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search API
 Bundle-SymbolicName: com.liferay.portal.search.api
-Bundle-Version: 5.6.1
+Bundle-Version: 6.0.0
 Export-Package:\
 	com.liferay.portal.search.aggregation,\
 	com.liferay.portal.search.aggregation.bucket,\

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/configuration/IndexerRegistryConfiguration.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/configuration/IndexerRegistryConfiguration.java
@@ -32,9 +32,6 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface IndexerRegistryConfiguration {
 
-	@Meta.AD(deflt = "true", name = "buffered", required = false)
-	public boolean buffered();
-
 	@Meta.AD(
 		deflt = "DEFAULT", name = "buffered-execution-mode", required = false
 	)

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/configuration/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 3.3.5
+version 4.0.0

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexerRegistryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexerRegistryImpl.java
@@ -323,9 +323,7 @@ public class IndexerRegistryImpl implements IndexerRegistry {
 
 		IndexerRequestBuffer indexerRequestBuffer = IndexerRequestBuffer.get();
 
-		if ((indexerRequestBuffer == null) ||
-			!_indexerRegistryConfiguration.buffered()) {
-
+		if (indexerRequestBuffer == null) {
 			return indexer;
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-142523

I have opened https://issues.liferay.com/browse/PTR-3111 but I have finally decided to send a PR with my solution.

**Root cause of the issue:**

The error is produced in this line [com.liferay.asset.entry.rel.service.impl.AssetEntryAssetCategoryRelLocalServiceImpl](https://github.com/liferay/liferay-portal/blob/4416c97701203c4ca4ec1933224213c9c770d45a/modules/apps/asset/asset-entry-rel-service/src/main/java/com/liferay/asset/entry/rel/service/impl/AssetEntryAssetCategoryRelLocalServiceImpl.java#L243) with document and media files because they implement the com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry class.

This **com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry** class doesn't implement the `com.liferay.portal.kernel.model.BaseModel` model but it implements the {{com.liferay.portal.kernel.model.ClassedModel}}

When the buffer is enabled, the BufferedIndexerInvocationHandler intercepts the calls and if the object is a instance of ClassedModel, it converts the reindex request to a safe `indexer.reindex(className, primaryKey)` call, see: [com.liferay.portal.search.internal.buffer.BufferedIndexerInvocationHandler](https://github.com/liferay/liferay-portal/blob/4416c97701203c4ca4ec1933224213c9c770d45a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BufferedIndexerInvocationHandler.java#L96-L109)

When the buffer is disabled, the BufferedIndexerInvocationHandler logic is not executed and the `indexer.reindex(object)` fails because the DefaultIndexer expects a BaseModel model.

**Solution:**

Commit https://github.com/liferay/liferay-portal/commit/539b76be3adb0b504f0ce60e95ab41d5ba8fb4ab I am avoiding the ClassCastException checking that the assetObject is a instance of BaseModel and as fallback in case it is a ClassedModel, I am doing a similar logic than the BufferedIndexerInvocationHandler.

Commit https://github.com/liferay/liferay-portal/commit/a6afc3056a9cfab62b1b9d51054b0e83fafb149c I am removing the option of disabling the index buffered because disabling it is always a bad idea:
  - The search tests are not executed with the index buffer disabled, so any customer that changes this option can detect unexpected errors because this option is not tested.
  - The customers that disables it they will also detect the problems that the index buffer solved when it was created, for example [LPS-56593](https://issues.liferay.com/browse/LPS-56593) or [LPS-69361](https://issues.liferay.com/browse/LPS-69361)

If somebody wants to disable the buffer by its own, out of the Liferay support, they can always blacklist the **com.liferay.portal.search.internal.buffer.IndexerRequestBufferTransactionLifecycleListener** component, this will have the same effect than current option. 
The customer can also leave the buffer enabled but changing its size to zero.

Let me know if you have any question