### PR TITLE
LPS-155317 Search Bar Suggestions does not work for authenticated users when the Service Access Policy is disabled

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -61,10 +61,12 @@ export default function SearchBar({
 	const {resource} = useResource({
 		fetchOptions: {
 			body: suggestionsContributorConfiguration,
+			credentials: 'include',
 			headers: new Headers({
 				'Accept': 'application/json',
 				'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
 				'Content-Type': 'application/json',
+				'x-csrf-token': Liferay.authToken,
 			}),
 			method: 'POST',
 		},


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-155317

Credentials with fetch are included using `x-csrf-token` (see https://github.com/liferay/liferay-portal/blob/d775bd4197ff8d8a3524035066aff9aafb0350e0/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/fetch.es.js#L54-L55) so I've included the authentication this way as well instead of using `p_auth`.