### PR TITLE
LPS-154344 portal-search-web: Fix search insights' copy to clipboard on virtual instances

### DIFF
--- a/modules/apps/portal-search/portal-search-web/package.json
+++ b/modules/apps/portal-search/portal-search-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"clipboard": "2.0.4",
 		"codemirror": "^5.59.0",
 		"moment": "^2.24.0"
 	},

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/utils/initializeClipboard.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/utils/initializeClipboard.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClipboardJS from 'clipboard';
+import {openToast} from 'frontend-js-web';
+
+export default function initializeClipboard({selector}) {
+	const clipboardJS = new ClipboardJS(selector);
+
+	clipboardJS.on('success', () => {
+		openToast({
+			message: Liferay.Language.get('copied-to-clipboard'),
+			title: Liferay.Language.get('success'),
+			type: 'success',
+		});
+	});
+
+	clipboardJS.on('error', () => {
+		openToast({
+			message: Liferay.Language.get('an-unexpected-error-occurred'),
+			title: Liferay.Language.get('error'),
+			type: 'danger',
+		});
+	});
+
+	return () => {
+		clipboardJS.destroy();
+	};
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/utils/initializeClipboard.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/utils/initializeClipboard.js
@@ -34,7 +34,7 @@ export default function initializeClipboard({selector}) {
 		});
 	});
 
-	return () => {
+	Liferay.once('beforeNavigate', () => {
 		clipboardJS.destroy();
-	};
+	});
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/insights/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/insights/view.jsp
@@ -18,8 +18,7 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
-taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
@@ -54,6 +53,15 @@ String insightsResponseId = liferayPortletResponse.getNamespace() + "insightsRes
 	</c:when>
 	<c:otherwise>
 		<div class="full-query">
+			<liferay-frontend:component
+				context='<%=
+					HashMapBuilder.<String, Object>put(
+						"selector", ".search-insights-copy-to-clipboard"
+					).build()
+				%>'
+				module="js/utils/initializeClipboard"
+			/>
+
 			<liferay-ui:panel-container
 				extended="<%= true %>"
 				id='<%= liferayPortletResponse.getNamespace() + "insightsPanelContainer" %>'
@@ -68,10 +76,11 @@ String insightsResponseId = liferayPortletResponse.getNamespace() + "insightsRes
 					title="request-string"
 				>
 					<clay:button
+						cssClass="search-insights-copy-to-clipboard"
+						data-clipboard-text="<%= HtmlUtil.escape(searchInsightsDisplayContext.getRequestString()) %>"
 						displayType="secondary"
 						icon="copy"
 						label="copy-to-clipboard"
-						onClick='<%= liferayPortletResponse.getNamespace() + "copyToClipboard('" + insightsRequestId + "');" %>'
 						small="<%= true %>"
 					/>
 
@@ -97,10 +106,11 @@ String insightsResponseId = liferayPortletResponse.getNamespace() + "insightsRes
 					title="response-string"
 				>
 					<clay:button
+						cssClass="search-insights-copy-to-clipboard"
+						data-clipboard-text="<%= HtmlUtil.escape(searchInsightsDisplayContext.getResponseString()) %>"
 						displayType="secondary"
 						icon="copy"
 						label="copy-to-clipboard"
-						onClick='<%= liferayPortletResponse.getNamespace() + "copyToClipboard('" + insightsResponseId + "');" %>'
 						small="<%= true %>"
 					/>
 
@@ -121,25 +131,3 @@ String insightsResponseId = liferayPortletResponse.getNamespace() + "insightsRes
 		</div>
 	</c:otherwise>
 </c:choose>
-
-<aui:script>
-	function <portlet:namespace />copyToClipboard(id) {
-		const text = document.getElementById(id).value;
-
-		navigator.clipboard.writeText(text).then(
-			() => {
-				Liferay.Util.openToast({
-					message: '<liferay-ui:message key="copied-to-clipboard" />',
-					type: 'success',
-				});
-			},
-			() => {
-				Liferay.Util.openToast({
-					message:
-						'<liferay-ui:message key="an-unexpected-error-occurred" />',
-					type: 'danger',
-				});
-			}
-		);
-	}
-</aui:script>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-154344 - Search Insights widget "Copy to Clipboard" buttons not working on virtual instance

Solution was to import Clipboard https://clipboardjs.com/, which is done with the new `initializeClipboard.js` util file! 📄 