### PR TITLE
LPS-155273 Search Bar Suggestions shows HTML as plain text

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/suggestions/spi/BasicSuggestionsContributor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/suggestions/spi/BasicSuggestionsContributor.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -246,7 +247,7 @@ public class BasicSuggestionsContributor implements SuggestionsContributor {
 			if (assetRenderer != null) {
 				suggestionBuilder.attribute(
 					"assetSearchSummary",
-					assetRenderer.getSearchSummary(locale));
+					HtmlUtil.stripHtml(assetRenderer.getSearchSummary(locale)));
 				suggestionBuilder.attribute(
 					"assetURL",
 					_getAssetURL(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-155273

Went with removing the HTML since it could expose an XSS issue if the HTML was rendered. Also the rendered HTML could cause issues to the suggestions UI display.

Screenshot with the HTML removed:
![Screen Shot 2022-06-09 at 4 39 28 PM](https://user-images.githubusercontent.com/4496722/172962544-34c41814-efda-48a7-badc-acd8f9b98810.png)

