### PR TITLE
LPS-153251 search-experiences-web: Remove feature flag of json autocompletion (blueprints configuration)

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/edit_sxp_blueprint.jsp
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/edit_sxp_blueprint.jsp
@@ -44,8 +44,6 @@ renderResponse.setTitle(LanguageUtil.get(request, "edit-blueprint"));
 			).put(
 				"defaultLocale", LocaleUtil.toLanguageId(LocaleUtil.getDefault())
 			).put(
-				"featureFlagLps143720", GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-143720"))
-			).put(
 				"featureFlagLps148749", GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-148749"))
 			).put(
 				"learnMessages", LearnMessageUtil.getJSONObject("search-experiences-web")

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/configuration_tab/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/configuration_tab/index.js
@@ -12,7 +12,7 @@
 import ClayForm from '@clayui/form';
 import ClayLayout from '@clayui/layout';
 import getCN from 'classnames';
-import React, {useContext} from 'react';
+import React from 'react';
 
 import advancedConfigurationSchema from '../../../schemas/advanced-configuration.schema.json';
 import aggregationConfigurationSchema from '../../../schemas/aggregation-configuration.schema.json';
@@ -21,7 +21,6 @@ import parameterConfigurationSchema from '../../../schemas/parameter-configurati
 import sortConfigurationSchema from '../../../schemas/sort-configuration.schema.json';
 import CodeMirrorEditor from '../../shared/CodeMirrorEditor';
 import LearnMessage from '../../shared/LearnMessage';
-import ThemeContext from '../../shared/ThemeContext';
 
 const CONFIGURATION_SCHEMAS = {
 	advancedConfig: advancedConfigurationSchema,
@@ -42,8 +41,6 @@ function ConfigurationTab({
 	sortConfig,
 	touched,
 }) {
-	const {featureFlagLps143720} = useContext(ThemeContext);
-
 	const _renderEditor = (configName, configValue) => (
 		<div
 			className={getCN({
@@ -52,11 +49,7 @@ function ConfigurationTab({
 			onBlur={() => setFieldTouched(configName)}
 		>
 			<CodeMirrorEditor
-				autocompleteSchema={
-					featureFlagLps143720
-						? CONFIGURATION_SCHEMAS[configName]
-						: null
-				}
+				autocompleteSchema={CONFIGURATION_SCHEMAS[configName]}
 				onChange={(value) => setFieldValue(configName, value)}
 				value={configValue}
 			/>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/index.js
@@ -22,7 +22,6 @@ import EditSXPBlueprintForm from './EditSXPBlueprintForm';
 export default function ({
 	contextPath,
 	defaultLocale,
-	featureFlagLps143720,
 	featureFlagLps148749,
 	learnMessages,
 	locale,
@@ -54,7 +53,6 @@ export default function ({
 				availableLanguages: Liferay.Language.available,
 				contextPath,
 				defaultLocale,
-				featureFlagLps143720,
 				featureFlagLps148749,
 				learnMessages,
 				locale,

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/ThemeContext.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/ThemeContext.js
@@ -15,7 +15,6 @@ export default React.createContext({
 	availableLanguages: {},
 	contextPath: '/o/search-experiences-web',
 	defaultLocale: 'en_US',
-	featureFlagLps143720: false, // JSON autocomplete for configurations
 	featureFlagLps148749: false, // JSON autocomplete for query elements
 	learnMessages: {},
 	locale: 'en_US',


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-153251 - Remove Feature Flag and enable JSON auto-completion (Blueprints Configuration)

Removing `featureFlagLps143720` so that [LPS-143720](https://issues.liferay.com/browse/LPS-143720) is no longer behind a feature flag. Looked for all instances of it, but me know if there's anything else to take out!