### PR TITLE
LPS-155753 Search Bar Suggestions doesn't work with "Everything" scope

### DIFF
--- a/modules/apps/portal-search/portal-search-web-api/src/main/java/com/liferay/portal/search/web/search/request/SearchSettings.java
+++ b/modules/apps/portal-search/portal-search-web-api/src/main/java/com/liferay/portal/search/web/search/request/SearchSettings.java
@@ -50,6 +50,8 @@ public interface SearchSettings {
 
 	public QueryConfig getQueryConfig();
 
+	public Optional<String> getScope();
+
 	public Optional<String> getScopeParameterName();
 
 	public SearchContext getSearchContext();
@@ -69,6 +71,8 @@ public interface SearchSettings {
 
 	public void setPaginationStartParameterName(
 		String paginationStartParameterName);
+
+	public void setScope(String scope);
 
 	public void setScopeParameterName(String scopeParameterName);
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchSettingsImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchSettingsImpl.java
@@ -147,6 +147,11 @@ public class PortletSharedSearchSettingsImpl
 	}
 
 	@Override
+	public Optional<String> getScope() {
+		return _searchSettings.getScope();
+	}
+
+	@Override
 	public Optional<String> getScopeParameterName() {
 		return _searchSettings.getScopeParameterName();
 	}
@@ -200,6 +205,11 @@ public class PortletSharedSearchSettingsImpl
 
 		_searchSettings.setPaginationStartParameterName(
 			paginationStartParameterName);
+	}
+
+	@Override
+	public void setScope(String scope) {
+		_searchSettings.setScope(scope);
 	}
 
 	@Override

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
@@ -183,8 +183,10 @@ public class SearchBarPortletDisplayContextFactory {
 			searchBarPortletInstanceConfiguration);
 
 		_setSelectedSearchScope(
-			searchBarPortletDisplayContext, searchScopePreference,
-			scopeParameterValueOptional.orElse(null));
+			portletPreferencesLookup, scopeParameterValueOptional.orElse(null),
+			searchBarPortletDisplayContext, searchBarPrecedenceHelper,
+			searchScopePreference,
+			portletSharedSearchResponse.getSearchSettings(), themeDisplay);
 
 		if (searchBarPortletPreferences.isInvisible()) {
 			searchBarPortletDisplayContext.setRenderNothing(true);
@@ -285,8 +287,31 @@ public class SearchBarPortletDisplayContextFactory {
 	}
 
 	protected SearchScope getSearchScope(
+		PortletPreferencesLookup portletPreferencesLookup,
+		String scopeParameterValue,
+		SearchBarPrecedenceHelper searchBarPrecedenceHelper,
 		SearchScopePreference searchScopePreference,
-		String scopeParameterValue) {
+		SearchSettings searchSettings, ThemeDisplay themeDisplay) {
+
+		Portlet headerSearchBarPortlet =
+			searchBarPrecedenceHelper.findHeaderSearchBarPortlet(themeDisplay);
+
+		if (headerSearchBarPortlet != null) {
+			Optional<PortletPreferences> headerPortletPreferencesOptional =
+				portletPreferencesLookup.fetchPreferences(
+					headerSearchBarPortlet, themeDisplay);
+
+			if (headerPortletPreferencesOptional.isPresent() &&
+				SearchBarPortletDestinationUtil.isSameDestination(
+					headerPortletPreferencesOptional.get(), themeDisplay)) {
+
+				Optional<String> optional = searchSettings.getScope();
+
+				if (optional.isPresent()) {
+					return SearchScope.getSearchScope(optional.get());
+				}
+			}
+		}
 
 		if (scopeParameterValue != null) {
 			return SearchScope.getSearchScope(scopeParameterValue);
@@ -402,12 +427,17 @@ public class SearchBarPortletDisplayContextFactory {
 	}
 
 	private void _setSelectedSearchScope(
+		PortletPreferencesLookup portletPreferencesLookup,
+		String scopeParameterValue,
 		SearchBarPortletDisplayContext searchBarPortletDisplayContext,
+		SearchBarPrecedenceHelper searchBarPrecedenceHelper,
 		SearchScopePreference searchScopePreference,
-		String scopeParameterValue) {
+		SearchSettings searchSettings, ThemeDisplay themeDisplay) {
 
 		SearchScope searchScope = getSearchScope(
-			searchScopePreference, scopeParameterValue);
+			portletPreferencesLookup, scopeParameterValue,
+			searchBarPrecedenceHelper, searchScopePreference, searchSettings,
+			themeDisplay);
 
 		if (searchScope == SearchScope.EVERYTHING) {
 			searchBarPortletDisplayContext.setSelectedEverythingSearchScope(

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/shared/search/SearchBarPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/shared/search/SearchBarPortletSharedSearchContributor.java
@@ -79,6 +79,8 @@ public class SearchBarPortletSharedSearchContributor
 			searchRequestBuilder, searchBarPortletPreferences,
 			portletSharedSearchSettings);
 
+		_setScope(searchBarPortletPreferences, portletSharedSearchSettings);
+
 		_setScopeParameterName(
 			searchBarPortletPreferences, portletSharedSearchSettings);
 
@@ -229,6 +231,17 @@ public class SearchBarPortletSharedSearchContributor
 			searchContext -> searchContext.setAttribute(
 				SearchContextAttributes.ATTRIBUTE_KEY_LUCENE_SYNTAX,
 				Boolean.TRUE));
+	}
+
+	private void _setScope(
+		SearchBarPortletPreferences searchBarPortletPreferences,
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		SearchScopePreference searchScopePreference =
+			searchBarPortletPreferences.getSearchScopePreference();
+
+		portletSharedSearchSettings.setScope(
+			searchScopePreference.getPreferenceString());
 	}
 
 	private void _setScopeParameterName(

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/request/SearchSettingsImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/request/SearchSettingsImpl.java
@@ -101,6 +101,11 @@ public class SearchSettingsImpl implements SearchSettings {
 	}
 
 	@Override
+	public Optional<String> getScope() {
+		return Optional.ofNullable(_scope);
+	}
+
+	@Override
 	public Optional<String> getScopeParameterName() {
 		return Optional.ofNullable(_scopeParameterName);
 	}
@@ -150,6 +155,11 @@ public class SearchSettingsImpl implements SearchSettings {
 	}
 
 	@Override
+	public void setScope(String scope) {
+		_scope = scope;
+	}
+
+	@Override
 	public void setScopeParameterName(String scopeParameterName) {
 		_scopeParameterName = scopeParameterName;
 	}
@@ -170,6 +180,7 @@ public class SearchSettingsImpl implements SearchSettings {
 	private String _paginationDeltaParameterName;
 	private Integer _paginationStart;
 	private String _paginationStartParameterName;
+	private String _scope;
 	private String _scopeParameterName;
 	private final SearchContext _searchContext;
 	private final SearchRequestBuilder _searchRequestBuilder;

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -252,7 +252,7 @@ export default function SearchBar({
 			searchParams.delete(paginationStartParameterName);
 		}
 
-		if (scope) {
+		if (letUserChooseScope) {
 			searchParams.set(scopeParameterName, scope);
 		}
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -27,7 +27,7 @@ import React, {useRef, useState} from 'react';
 export default function SearchBar({
 	destinationFriendlyURL,
 	emptySearchEnabled,
-	initialScope = '',
+	isSelectedEverythingSearchScope = false,
 	keywords = '',
 	keywordsParameterName = 'q',
 	letUserChooseScope = false,
@@ -53,7 +53,11 @@ export default function SearchBar({
 		loading: false,
 		networkStatus: 4,
 	}));
-	const [scope, setScope] = useState(initialScope);
+	const [scope, setScope] = useState(
+		isSelectedEverythingSearchScope
+			? scopeParameterStringEverything
+			: scopeParameterStringCurrentSite
+	);
 
 	const alignElementRef = useRef();
 	const dropdownRef = useRef();

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
@@ -66,7 +66,7 @@ SearchBarPortletDisplayContext searchBarPortletDisplayContext = (SearchBarPortle
 						).put(
 							"emptySearchEnabled", searchBarPortletDisplayContext.isEmptySearchEnabled()
 						).put(
-							"initialScope", searchBarPortletDisplayContext.getScopeParameterValue()
+							"isSelectedEverythingSearchScope", searchBarPortletDisplayContext.isSelectedEverythingSearchScope()
 						).put(
 							"keywords", searchBarPortletDisplayContext.getKeywords()
 						).put(

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.search.web.internal.search.bar.portlet.display.context
 import com.liferay.portal.search.web.internal.search.bar.portlet.helper.SearchBarPrecedenceHelper;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchRequest;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchResponse;
+import com.liferay.portal.search.web.search.request.SearchSettings;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portlet.PortletPreferencesImpl;
 
@@ -222,8 +223,10 @@ public class SearchBarPortletDisplayContextFactoryTest {
 		Assert.assertEquals(
 			SearchScope.EVERYTHING,
 			searchBarPortletDisplayContextFactory.getSearchScope(
-				SearchScopePreference.THIS_SITE,
-				searchBarPortletDisplayContext.getScopeParameterValue()));
+				_portletPreferencesLookup,
+				searchBarPortletDisplayContext.getScopeParameterValue(),
+				_searchBarPrecedenceHelper, SearchScopePreference.THIS_SITE,
+				_searchSettings, _themeDisplay));
 	}
 
 	protected HttpServletRequest getHttpServletRequest() {
@@ -432,6 +435,8 @@ public class SearchBarPortletDisplayContextFactoryTest {
 		Mockito.mock(PortletSharedSearchRequest.class);
 	private final SearchBarPrecedenceHelper _searchBarPrecedenceHelper =
 		Mockito.mock(SearchBarPrecedenceHelper.class);
+	private final SearchSettings _searchSettings = Mockito.mock(
+		SearchSettings.class);
 	private final ThemeDisplay _themeDisplay = Mockito.mock(ThemeDisplay.class);
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-155753

**Additional Notes**
- Only checking `isSelectedEverythingSearchScope` since the only 2 scope choices are "everything" and "this site".
- Added an additional change to only add the `scope` URL parameter if the "Let The User Choose" scope selector is present. The original search bar JS function also does this by checking if the select element is present. https://github.com/liferay/liferay-portal/blob/13b0e2b835e528ca701c5d6bc22c8fcc7b98aa12/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/search_bar.js#L108-L113