### PR TITLE
LPS-152515 search-experiences-web: Add js unit tests for JSON autocompletion

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
@@ -61,6 +61,7 @@ const AUTOCOMPLETE_EXCLUDED_KEYS = new Set([
 	'Shift',
 ]);
 
+const CSS_CLASS_HINT_NAME = 'hint-name';
 const CSS_CLASS_HINT_TYPE = 'hint-type';
 
 const LANGUAGE_ID = 'LanguageId';
@@ -72,7 +73,7 @@ const MODES = {
 	},
 };
 
-function getCodeMirrorHints(cm, autocompleteSchema, availableLanguages) {
+export function getCodeMirrorHints(cm, autocompleteSchema, availableLanguages) {
 	const cursor = cm.getCursor();
 	const token = cm.getTokenAt(cursor);
 
@@ -203,7 +204,7 @@ function getCodeMirrorHints(cm, autocompleteSchema, availableLanguages) {
 
 	if (token.type === 'string') {
 		const property = list.find(
-			(item) => item.name === currentProperty.at(-1)
+			(item) => item.name === currentProperty[currentProperty.length - 1]
 		);
 
 		if (property?.enum) {
@@ -258,11 +259,12 @@ function getCodeMirrorHints(cm, autocompleteSchema, availableLanguages) {
 					);
 
 					const name = document.createElement('span');
-					name.innerText = propertyName;
+					name.className = CSS_CLASS_HINT_NAME;
+					name.textContent = propertyName;
 
 					const type = document.createElement('span');
 					type.className = CSS_CLASS_HINT_TYPE;
-					type.innerText = propertyType;
+					type.textContent = propertyType;
 
 					element.appendChild(name);
 					element.appendChild(type);

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/shared/CodeMirrorEditor.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/shared/CodeMirrorEditor.js
@@ -28,6 +28,10 @@ const availableLanguages = {
 	fr_FR: 'French (France)',
 };
 
+// Prevents `TypeError: document.body.createTextRange is not a function`
+// error, since CodeMirror expects to be running in a browser.
+// See https://github.com/neo4j-contrib/cypher-editor/issues/19
+
 global.document.body.createTextRange = () => {
 	return {
 		getBoundingClientRect: () => {},
@@ -53,7 +57,7 @@ function createCodeMirrorEditor(props) {
 }
 
 describe('CodeMirrorEditor', () => {
-	it('gets the correct hints', () => {
+	it('gets hints at the root level of an object', () => {
 		const codeMirror = createCodeMirrorEditor({value: '{"'});
 
 		const {list} = getCodeMirrorHints(

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/shared/CodeMirrorEditor.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/shared/CodeMirrorEditor.js
@@ -1,0 +1,312 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import {render} from '@testing-library/react';
+import CodeMirror from 'codemirror';
+import React from 'react';
+
+import '@testing-library/jest-dom/extend-expect';
+
+import {getCodeMirrorHints} from '../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor';
+import aggregationConfigurationSchema from '../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/aggregation-configuration.schema.json';
+import parameterConfigurationSchema from '../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/parameter-configuration.schema.json';
+import sortConfigurationSchema from '../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/sort-configuration.schema.json';
+import sxpQueryElementSchema from '../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/schemas/sxp-query-element.schema.json';
+
+const availableLanguages = {
+	de_DE: 'German (Germany)',
+	en_US: 'English (United States)',
+	es_ES: 'Spanish (Spain)',
+	fr_FR: 'French (France)',
+};
+
+global.document.body.createTextRange = () => {
+	return {
+		getBoundingClientRect: () => {},
+		getClientRects: () => [],
+	};
+};
+
+function createCodeMirrorEditor(props) {
+	document.createElement('div');
+
+	const codeMirror = CodeMirror(document.body, {
+		hintOptions: {
+			completeSingle: false,
+		},
+		mode: {globalVars: true, name: 'application/json'},
+		value: '',
+		...props,
+	});
+
+	codeMirror.execCommand('goLineEnd');
+
+	return codeMirror;
+}
+
+describe('CodeMirrorEditor', () => {
+	it('gets the correct hints', () => {
+		const codeMirror = createCodeMirrorEditor({value: '{"'});
+
+		const {list} = getCodeMirrorHints(
+			codeMirror,
+			sxpQueryElementSchema,
+			availableLanguages
+		);
+
+		expect(list.map(({displayText}) => displayText)).toEqual([
+			'description_i18n#object',
+			'elementDefinition#object',
+			'title_i18n#object',
+		]);
+	});
+
+	it('filters hints for matched strings', () => {
+		const codeMirror = createCodeMirrorEditor({value: '{"desc'});
+
+		const {list} = getCodeMirrorHints(
+			codeMirror,
+			sxpQueryElementSchema,
+			availableLanguages
+		);
+
+		expect(list.map(({displayText}) => displayText)).toEqual([
+			'description_i18n#object',
+		]);
+	});
+
+	it('gets hints when property has an enum array', () => {
+		const codeMirror = createCodeMirrorEditor({
+			value:
+				'{"elementDefinition": {"uiConfiguration": {"fieldSets": [ {"fields": [{"type":"',
+		});
+
+		const {list} = getCodeMirrorHints(
+			codeMirror,
+			sxpQueryElementSchema,
+			availableLanguages
+		);
+
+		expect(list.map(({displayText}) => displayText)).toEqual([
+			'date',
+			'fieldMapping',
+			'fieldMappingList',
+			'json',
+			'keywords',
+			'multiselect',
+			'number',
+			'searchableType',
+			'select',
+			'slider',
+			'text',
+		]);
+	});
+
+	it('gets hints when property uses language IDs', () => {
+		const codeMirror = createCodeMirrorEditor({
+			value: '{"description_i18n": {"',
+		});
+
+		const {list} = getCodeMirrorHints(
+			codeMirror,
+			sxpQueryElementSchema,
+			availableLanguages
+		);
+
+		expect(list.map(({displayText}) => displayText)).toEqual(
+			Object.keys(availableLanguages).map(
+				(language) => `${language}#string`
+			)
+		);
+	});
+
+	it('gets hints from both individual properties and `allOf` property', () => {
+		const codeMirror = createCodeMirrorEditor({
+			value: '{"sorts": [{"_geo_distance": {"',
+		});
+
+		const {list} = getCodeMirrorHints(
+			codeMirror,
+			sortConfigurationSchema,
+			availableLanguages
+		);
+
+		expect(list.map(({displayText}) => displayText)).toEqual([
+			'distance_type#string',
+			'field#string',
+			'locations#array',
+			'unit#string',
+			'missing#string',
+			'mode#string',
+			'nested#object',
+			'order#string',
+		]);
+	});
+
+	it('gets hints when schema path uses `additionalProperties`', () => {
+		const codeMirror = createCodeMirrorEditor({
+			value: '{"parameters": {"param_name": {"',
+		});
+
+		const {list} = getCodeMirrorHints(
+			codeMirror,
+			parameterConfigurationSchema,
+			availableLanguages
+		);
+
+		expect(list.map(({displayText}) => displayText)).toEqual([
+			'defaultValue#object',
+			'format#string',
+			'max#object',
+			'min#object',
+			'type#string',
+		]);
+	});
+
+	it('displays the hint name and single type when rendered', () => {
+		const {container} = render(<div />);
+
+		const codeMirror = createCodeMirrorEditor({
+			value: '{"',
+		});
+
+		const {list} = getCodeMirrorHints(
+			codeMirror,
+			sxpQueryElementSchema,
+			availableLanguages
+		);
+
+		list[0].render(container, codeMirror, list[0]);
+
+		expect(container.querySelector('.hint-name')).toHaveTextContent(
+			'description_i18n'
+		);
+		expect(container.querySelector('.hint-type')).toHaveTextContent(
+			'object'
+		);
+	});
+
+	it('displays the hint name and multiple types when rendered', () => {
+		const {container} = render(<div />);
+
+		const codeMirror = createCodeMirrorEditor({
+			value:
+				'{"elementDefinition": {"uiConfiguration": {"fieldSets": [{"fields": [{"defaultValue',
+		});
+
+		const {list} = getCodeMirrorHints(
+			codeMirror,
+			sxpQueryElementSchema,
+			availableLanguages
+		);
+
+		list[0].render(container, codeMirror, list[0]);
+
+		expect(container.querySelector('.hint-name')).toHaveTextContent(
+			'defaultValue'
+		);
+		expect(container.querySelector('.hint-type')).toHaveTextContent(
+			'array|number|object|string'
+		);
+	});
+
+	it('autocompletes with [] for array type', () => {
+		const codeMirror = createCodeMirrorEditor({
+			value:
+				'{"elementDefinition": {"configuration": {"queryConfiguration": {"qu',
+		});
+
+		const {from, list, to} = getCodeMirrorHints(
+			codeMirror,
+			sxpQueryElementSchema,
+			availableLanguages
+		);
+
+		list[0].hint(codeMirror, {from, to}, {});
+
+		expect(codeMirror.getDoc().getValue()).toEqual(
+			'{"elementDefinition": {"configuration": {"queryConfiguration": {"queryEntries": []'
+		);
+	});
+
+	it('autocompletes with {} for object type', () => {
+		const codeMirror = createCodeMirrorEditor({
+			value: '{"elementDefinition": {"configuration": {"qu',
+		});
+
+		const {from, list, to} = getCodeMirrorHints(
+			codeMirror,
+			sxpQueryElementSchema,
+			availableLanguages
+		);
+
+		list[0].hint(codeMirror, {from, to}, {});
+
+		expect(codeMirror.getDoc().getValue()).toEqual(
+			'{"elementDefinition": {"configuration": {"queryConfiguration": {}'
+		);
+	});
+
+	it('autocompletes with "" for string type', () => {
+		const codeMirror = createCodeMirrorEditor({
+			value: '{"elementDefinition": {"ca',
+		});
+
+		const {from, list, to} = getCodeMirrorHints(
+			codeMirror,
+			sxpQueryElementSchema,
+			availableLanguages
+		);
+
+		list[0].hint(codeMirror, {from, to}, {});
+
+		expect(codeMirror.getDoc().getValue()).toEqual(
+			'{"elementDefinition": {"category": ""'
+		);
+	});
+
+	it('autocompletes minimally for other type', () => {
+		const codeMirror = createCodeMirrorEditor({
+			value:
+				'{"elementDefinition": {"configuration": {"queryConfiguration": {"queryEntries": [{"en',
+		});
+
+		const {from, list, to} = getCodeMirrorHints(
+			codeMirror,
+			sxpQueryElementSchema,
+			availableLanguages
+		);
+
+		list[0].hint(codeMirror, {from, to}, {});
+
+		expect(codeMirror.getDoc().getValue()).toEqual(
+			'{"elementDefinition": {"configuration": {"queryConfiguration": {"queryEntries": [{"enabled": '
+		);
+	});
+
+	it('autocompletes with specific text for special aggregation case', () => {
+		const codeMirror = createCodeMirrorEditor({
+			value: '{"aggs',
+		});
+
+		const {from, list, to} = getCodeMirrorHints(
+			codeMirror,
+			aggregationConfigurationSchema,
+			availableLanguages
+		);
+
+		list[0].hint(codeMirror, {from, to}, {});
+
+		expect(codeMirror.getDoc().getValue()).toEqual(
+			'{"aggs": {\n\t"NAME": {\n\t\t"AGG_TYPE": {}\n\t}\n}'
+		);
+	});
+});


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-152515 - Add js-unit test for JSON auto-completion feature in LPS-148749

Test cases are confined to the CodeMirrorEditor and use the `getCodeMirrorHints` function! There were some small updates made to `CodeMirrorEditor.js` (export function, remove usage of `.at()` function, change `innerText` to `textContent` assignment) to get the tests to pass.

Test coverage includes:
 - getting simple hints
 - hints for matched string
 - hints for enum
 - hints with languageId as a ref
 - hints when using `allOf`
 - hints when using `additionalProperties`
 - display the hint with name/type(s)
 - autocompletion for different types (array, object, string, `aggs`)

Let me know what you think!