### PR TITLE
LPS-152073 search-experiences-web: Fix capitalization bug with elements' predefined variables

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
@@ -179,7 +179,11 @@ function EditSXPElementForm({
 			predefinedVariables.map((variable) => {
 				const category = variable.templateVariable.match(/\w+/g)[0];
 
-				if (variable.description.toLowerCase().includes(value)) {
+				if (
+					variable.description
+						.toLowerCase()
+						.includes(value.toLowerCase())
+				) {
 					filteredCategories[category] = [
 						...(filteredCategories[category] || []),
 						variable,


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-152073 - Searching with capitalization in the predefined variable search bar yields no results

Not sure if there was anything else to consider, but let me know what you think!