### PR TITLE
LPS-153101 The Search Results didn't show results at the first time if add Search Results to page via JSON-WS

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchRequestImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchRequestImpl.java
@@ -28,10 +28,12 @@ import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.search.web.constants.SearchBarPortletKeys;
 import com.liferay.portal.search.web.internal.display.context.PortletRequestThemeDisplaySupplier;
 import com.liferay.portal.search.web.internal.display.context.ThemeDisplaySupplier;
 import com.liferay.portal.search.web.internal.portlet.preferences.PortletPreferencesLookup;
@@ -218,6 +220,18 @@ public class PortletSharedSearchRequestImpl
 			(LayoutTypePortlet)layout.getLayoutType();
 
 		List<Portlet> portlets = layoutTypePortlet.getAllPortlets(false);
+
+		if (!ListUtil.exists(
+				portlets,
+				portlet -> Objects.equals(
+					portlet.getRootPortletId(),
+					SearchBarPortletKeys.SEARCH_BAR))) {
+
+			Portlet searchBarPortlet = portletLocalService.fetchPortletById(
+				companyId, SearchBarPortletKeys.SEARCH_BAR);
+
+			portlets.add(searchBarPortlet);
+		}
 
 		if (Objects.equals(layout.getType(), LayoutConstants.TYPE_PORTLET)) {
 			return portlets;


### PR DESCRIPTION
## Motivation

https://issues.liferay.com/browse/LPS-153101

## Proposed solution

The issue is that when you add a portlet via the Layout JSON-WS API, the page does not render, and so any embedded portlets that are on the page do not have their portlet preferences initialized, and so Liferay does not know that those embedded portlets are present.

The workaround that's been added is to make it so that search always assumes that the search bar portlet is present and embedded, even if it hasn't been explicitly found as embedded or present on the page, and to contribute its settings. This prevents the blank search results.

## Steps to verify

Please see linked LPS.