### PR TITLE
LPS-156832 Search Bar Suggestions shows HTML as plain text

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/asset/model/LayoutAssetRenderer.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/asset/model/LayoutAssetRenderer.java
@@ -88,7 +88,7 @@ public class LayoutAssetRenderer extends BaseJSPAssetRenderer<Layout> {
 		sb.append("<strong>");
 		sb.append(LanguageUtil.get(locale, "page"));
 		sb.append(":</strong> ");
-		sb.append(_layout.getHTMLTitle(locale));
+		sb.append(HtmlUtil.escape(_layout.getHTMLTitle(locale)));
 
 		if (_layout.isTypeContent() &&
 			(_layout.isDenied() || _layout.isPending())) {

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -302,10 +302,14 @@ export default function SearchBar({
 											{attributes.assetSearchSummary && (
 												<div className="suggestion-item-description">
 													<div className="text-truncate-inline">
-														<div className="text-truncate">
-															{attributes.assetSearchSummary ||
-																''}
-														</div>
+														<div
+															className="text-truncate"
+															dangerouslySetInnerHTML={{
+																__html:
+																	attributes.assetSearchSummary ||
+																	'',
+															}}
+														></div>
 													</div>
 												</div>
 											)}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-156832

I had to escape the titles directly in the `LayoutAssetRenderer` otherwise attempting to render the `<strong>` tags would render any potential tags in the title as well.

`dangerouslySetInnerHTML` is also safe against any security issues since even if it did process `<script>` tags, they wouldn't be executed, but in this case it is properly rendered as the page title is.

![Screen Shot 2022-06-23 at 4 58 00 PM](https://user-images.githubusercontent.com/4496722/175435902-3d69af9a-bda7-402c-81d7-1ab853051b6c.png)

