### PR TITLE
LPS-156708 portal-search-web: Validate for negative numbers in search suggestions

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBarConfigurationSuggestions.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBarConfigurationSuggestions.js
@@ -388,7 +388,8 @@ function Inputs({onChange, onReplace, contributorOptions, value = {}}) {
 
 				<ClayInput.GroupItem
 					className={getCN('size-input', {
-						'has-error': !value.size && touched.size,
+						'has-error':
+							(!value.size || value.size < 0) && touched.size,
 					})}
 				>
 					<label>
@@ -401,12 +402,26 @@ function Inputs({onChange, onReplace, contributorOptions, value = {}}) {
 
 					<ClayInput
 						aria-label={Liferay.Language.get('size')}
+						min="0"
 						onBlur={_handleBlur('size')}
 						onChange={_handleChange('size')}
 						required
 						type="number"
 						value={value.size || ''}
 					/>
+
+					{value.size < 0 && touched.size && (
+						<div className="form-feedback-group">
+							<div className="form-feedback-item">
+								{Liferay.Util.sub(
+									Liferay.Language.get(
+										'please-enter-a-value-greater-than-or-equal-to-x'
+									),
+									'0'
+								)}
+							</div>
+						</div>
+					)}
 				</ClayInput.GroupItem>
 			</div>
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/configuration.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/configuration.jsp
@@ -109,7 +109,9 @@ String suggestionsContributorConfiguration = StringBundler.concat(StringPool.OPE
 					<aui:input label="enable-suggestions" name="<%= PortletPreferencesJspUtil.getInputName(SearchBarPortletPreferences.PREFERENCE_KEY_SUGGESTIONS_ENABLED) %>" type="checkbox" value="<%= searchBarPortletPreferences.isSuggestionsEnabled() %>" />
 
 					<div class="options-container <%= !searchBarPortletPreferences.isSuggestionsEnabled() ? "hide" : StringPool.BLANK %>" id="<portlet:namespace />suggestionsOptionsContainer">
-						<aui:input label="character-threshold-for-displaying-suggestions" name="<%= PortletPreferencesJspUtil.getInputName(SearchBarPortletPreferences.PREFERENCE_KEY_SUGGESTIONS_DISPLAY_THRESHOLD) %>" size="10" type="number" value="<%= searchBarPortletInstanceConfiguration.suggestionsDisplayThreshold() %>" />
+						<aui:input label="character-threshold-for-displaying-suggestions" min="0" name="<%= PortletPreferencesJspUtil.getInputName(SearchBarPortletPreferences.PREFERENCE_KEY_SUGGESTIONS_DISPLAY_THRESHOLD) %>" size="10" type="number" value="<%= searchBarPortletInstanceConfiguration.suggestionsDisplayThreshold() %>">
+							<aui:validator name="min">0</aui:validator>
+						</aui:input>
 
 						<div>
 							<span aria-hidden="true" class="loading-animation loading-animation-sm mt-4"></span>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-156708 - Negative numbers are allowed for Search Suggestions Configurations

Notes:
- An error message will be shown for suggestion configuration sizes below 0 (react component)
- An error message will be shown for any suggestions display threshold below 0 (inside JSP, using `aui:validator` - thanks for the tip!)
- Submission is not possible if these values are negative

<img width="935" alt="Screen Shot 2022-06-23 at 3 14 13 PM" src="https://user-images.githubusercontent.com/14063502/175588864-9be3c558-d0d6-4276-882a-db1956414cf1.png">


Let me know if there's anything else to include, thanks!