### PR TITLE
LPS-155753 Search Bar Suggestions doesn't work with "Everything" scope

### DIFF
--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/search/bar/portlet/shared/search/test/DepotSearchBarPortletSharedSearchContributorTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/search/bar/portlet/shared/search/test/DepotSearchBarPortletSharedSearchContributorTest.java
@@ -351,6 +351,11 @@ public class DepotSearchBarPortletSharedSearchContributorTest {
 			}
 
 			@Override
+			public Optional<String> getScope() {
+				return null;
+			}
+
+			@Override
 			public Optional<String> getScopeParameterName() {
 				return Optional.empty();
 			}
@@ -394,6 +399,10 @@ public class DepotSearchBarPortletSharedSearchContributorTest {
 			@Override
 			public void setPaginationStartParameterName(
 				String paginationStartParameterName) {
+			}
+
+			@Override
+			public void setScope(String scope) {
 			}
 
 			@Override

--- a/modules/apps/portal-search/portal-search-web-api/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-web-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search Web API
 Bundle-SymbolicName: com.liferay.portal.search.web.api
-Bundle-Version: 5.1.1
+Bundle-Version: 5.2.0
 Export-Package:\
 	com.liferay.portal.search.web.application.list.constants,\
 	com.liferay.portal.search.web.constants,\

--- a/modules/apps/portal-search/portal-search-web-api/src/main/java/com/liferay/portal/search/web/search/request/SearchSettings.java
+++ b/modules/apps/portal-search/portal-search-web-api/src/main/java/com/liferay/portal/search/web/search/request/SearchSettings.java
@@ -50,6 +50,8 @@ public interface SearchSettings {
 
 	public QueryConfig getQueryConfig();
 
+	public Optional<String> getScope();
+
 	public Optional<String> getScopeParameterName();
 
 	public SearchContext getSearchContext();
@@ -69,6 +71,8 @@ public interface SearchSettings {
 
 	public void setPaginationStartParameterName(
 		String paginationStartParameterName);
+
+	public void setScope(String scope);
 
 	public void setScopeParameterName(String scopeParameterName);
 

--- a/modules/apps/portal-search/portal-search-web-api/src/main/resources/com/liferay/portal/search/web/portlet/shared/search/packageinfo
+++ b/modules/apps/portal-search/portal-search-web-api/src/main/resources/com/liferay/portal/search/web/portlet/shared/search/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 4.2.0

--- a/modules/apps/portal-search/portal-search-web-api/src/main/resources/com/liferay/portal/search/web/search/request/packageinfo
+++ b/modules/apps/portal-search/portal-search-web-api/src/main/resources/com/liferay/portal/search/web/search/request/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 3.2.0

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchSettingsImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchSettingsImpl.java
@@ -147,6 +147,11 @@ public class PortletSharedSearchSettingsImpl
 	}
 
 	@Override
+	public Optional<String> getScope() {
+		return _searchSettings.getScope();
+	}
+
+	@Override
 	public Optional<String> getScopeParameterName() {
 		return _searchSettings.getScopeParameterName();
 	}
@@ -200,6 +205,11 @@ public class PortletSharedSearchSettingsImpl
 
 		_searchSettings.setPaginationStartParameterName(
 			paginationStartParameterName);
+	}
+
+	@Override
+	public void setScope(String scope) {
+		_searchSettings.setScope(scope);
 	}
 
 	@Override

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
@@ -277,7 +277,6 @@ public class SearchBarPortletDisplayContextFactory {
 
 	protected SearchScopePreference getSearchScopePreference(
 		PortletPreferencesLookup portletPreferencesLookup,
-		String scopeParameterValue,
 		SearchBarPrecedenceHelper searchBarPrecedenceHelper,
 		SearchBarPortletPreferences searchBarPortletPreferences,
 		SearchSettings searchSettings, ThemeDisplay themeDisplay) {
@@ -301,11 +300,6 @@ public class SearchBarPortletDisplayContextFactory {
 						optional.get());
 				}
 			}
-		}
-
-		if (scopeParameterValue != null) {
-			return SearchScopePreference.getSearchScopePreference(
-				scopeParameterValue);
 		}
 
 		SearchScopePreference searchScopePreference =
@@ -427,19 +421,33 @@ public class SearchBarPortletDisplayContextFactory {
 		SearchSettings searchSettings, ThemeDisplay themeDisplay) {
 
 		SearchScopePreference searchScopePreference = getSearchScopePreference(
-			portletPreferencesLookup, scopeParameterValue,
-			searchBarPrecedenceHelper, searchBarPortletPreferences,
-			searchSettings, themeDisplay);
-
-		if (searchScopePreference == SearchScopePreference.EVERYTHING) {
-			searchBarPortletDisplayContext.setSelectedEverythingSearchScope(
-				true);
-		}
+			portletPreferencesLookup, searchBarPrecedenceHelper,
+			searchBarPortletPreferences, searchSettings, themeDisplay);
 
 		if (searchScopePreference ==
 				SearchScopePreference.LET_THE_USER_CHOOSE) {
 
 			searchBarPortletDisplayContext.setLetTheUserChooseTheSearchScope(
+				true);
+
+			if (scopeParameterValue != null) {
+				SearchScope searchScope = SearchScope.getSearchScope(
+					scopeParameterValue);
+
+				if (searchScope == SearchScope.EVERYTHING) {
+					searchBarPortletDisplayContext.
+						setSelectedEverythingSearchScope(true);
+				}
+
+				if (searchScope == SearchScope.THIS_SITE) {
+					searchBarPortletDisplayContext.
+						setSelectedCurrentSiteSearchScope(true);
+				}
+			}
+		}
+
+		if (searchScopePreference == SearchScopePreference.EVERYTHING) {
+			searchBarPortletDisplayContext.setSelectedEverythingSearchScope(
 				true);
 		}
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
@@ -182,8 +182,10 @@ public class SearchBarPortletDisplayContextFactory {
 			searchBarPortletInstanceConfiguration);
 
 		_setSelectedSearchScope(
-			searchBarPortletDisplayContext, searchScopePreference,
-			scopeParameterValueOptional.orElse(null));
+			portletPreferencesLookup, scopeParameterValueOptional.orElse(null),
+			searchBarPortletDisplayContext, searchBarPrecedenceHelper,
+			searchScopePreference,
+			portletSharedSearchResponse.getSearchSettings(), themeDisplay);
 
 		if (searchBarPortletPreferences.isInvisible()) {
 			searchBarPortletDisplayContext.setRenderNothing(true);
@@ -284,8 +286,31 @@ public class SearchBarPortletDisplayContextFactory {
 	}
 
 	protected SearchScope getSearchScope(
+		PortletPreferencesLookup portletPreferencesLookup,
+		String scopeParameterValue,
+		SearchBarPrecedenceHelper searchBarPrecedenceHelper,
 		SearchScopePreference searchScopePreference,
-		String scopeParameterValue) {
+		SearchSettings searchSettings, ThemeDisplay themeDisplay) {
+
+		Portlet headerSearchBarPortlet =
+			searchBarPrecedenceHelper.findHeaderSearchBarPortlet(themeDisplay);
+
+		if (headerSearchBarPortlet != null) {
+			Optional<PortletPreferences> headerPortletPreferencesOptional =
+				portletPreferencesLookup.fetchPreferences(
+					headerSearchBarPortlet, themeDisplay);
+
+			if (headerPortletPreferencesOptional.isPresent() &&
+				SearchBarPortletDestinationUtil.isSameDestination(
+					headerPortletPreferencesOptional.get(), themeDisplay)) {
+
+				Optional<String> optional = searchSettings.getScope();
+
+				if (optional.isPresent()) {
+					return SearchScope.getSearchScope(optional.get());
+				}
+			}
+		}
 
 		if (scopeParameterValue != null) {
 			return SearchScope.getSearchScope(scopeParameterValue);
@@ -401,12 +426,17 @@ public class SearchBarPortletDisplayContextFactory {
 	}
 
 	private void _setSelectedSearchScope(
+		PortletPreferencesLookup portletPreferencesLookup,
+		String scopeParameterValue,
 		SearchBarPortletDisplayContext searchBarPortletDisplayContext,
+		SearchBarPrecedenceHelper searchBarPrecedenceHelper,
 		SearchScopePreference searchScopePreference,
-		String scopeParameterValue) {
+		SearchSettings searchSettings, ThemeDisplay themeDisplay) {
 
 		SearchScope searchScope = getSearchScope(
-			searchScopePreference, scopeParameterValue);
+			portletPreferencesLookup, scopeParameterValue,
+			searchBarPrecedenceHelper, searchScopePreference, searchSettings,
+			themeDisplay);
 
 		if (searchScope == SearchScope.EVERYTHING) {
 			searchBarPortletDisplayContext.setSelectedEverythingSearchScope(

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
@@ -147,16 +147,6 @@ public class SearchBarPortletDisplayContextFactory {
 				searchBarPrecedenceHelper, searchBarPortletPreferences,
 				themeDisplay));
 
-		SearchScopePreference searchScopePreference =
-			searchBarPortletPreferences.getSearchScopePreference();
-
-		if (searchScopePreference ==
-				SearchScopePreference.LET_THE_USER_CHOOSE) {
-
-			searchBarPortletDisplayContext.setLetTheUserChooseTheSearchScope(
-				true);
-		}
-
 		searchBarPortletDisplayContext.setPaginationStartParameterName(
 			Optional.ofNullable(
 				searchRequest.getPaginationStartParameterName()
@@ -181,10 +171,10 @@ public class SearchBarPortletDisplayContextFactory {
 		searchBarPortletDisplayContext.setSearchBarPortletInstanceConfiguration(
 			searchBarPortletInstanceConfiguration);
 
-		_setSelectedSearchScope(
+		_setSelectedSearchScopePreference(
 			portletPreferencesLookup, scopeParameterValueOptional.orElse(null),
 			searchBarPortletDisplayContext, searchBarPrecedenceHelper,
-			searchScopePreference,
+			searchBarPortletPreferences,
 			portletSharedSearchResponse.getSearchSettings(), themeDisplay);
 
 		if (searchBarPortletPreferences.isInvisible()) {
@@ -285,11 +275,11 @@ public class SearchBarPortletDisplayContextFactory {
 		}
 	}
 
-	protected SearchScope getSearchScope(
+	protected SearchScopePreference getSearchScopePreference(
 		PortletPreferencesLookup portletPreferencesLookup,
 		String scopeParameterValue,
 		SearchBarPrecedenceHelper searchBarPrecedenceHelper,
-		SearchScopePreference searchScopePreference,
+		SearchBarPortletPreferences searchBarPortletPreferences,
 		SearchSettings searchSettings, ThemeDisplay themeDisplay) {
 
 		Portlet headerSearchBarPortlet =
@@ -307,22 +297,25 @@ public class SearchBarPortletDisplayContextFactory {
 				Optional<String> optional = searchSettings.getScope();
 
 				if (optional.isPresent()) {
-					return SearchScope.getSearchScope(optional.get());
+					return SearchScopePreference.getSearchScopePreference(
+						optional.get());
 				}
 			}
 		}
 
 		if (scopeParameterValue != null) {
-			return SearchScope.getSearchScope(scopeParameterValue);
+			return SearchScopePreference.getSearchScopePreference(
+				scopeParameterValue);
 		}
 
-		SearchScope searchScope = searchScopePreference.getSearchScope();
+		SearchScopePreference searchScopePreference =
+			searchBarPortletPreferences.getSearchScopePreference();
 
-		if (searchScope != null) {
-			return searchScope;
+		if (searchScopePreference != null) {
+			return searchScopePreference;
 		}
 
-		return SearchScope.THIS_SITE;
+		return SearchScopePreference.THIS_SITE;
 	}
 
 	protected boolean isAvailableEverythingSearchScope() {
@@ -425,25 +418,32 @@ public class SearchBarPortletDisplayContextFactory {
 		return searchRequest.isEmptySearchEnabled();
 	}
 
-	private void _setSelectedSearchScope(
+	private void _setSelectedSearchScopePreference(
 		PortletPreferencesLookup portletPreferencesLookup,
 		String scopeParameterValue,
 		SearchBarPortletDisplayContext searchBarPortletDisplayContext,
 		SearchBarPrecedenceHelper searchBarPrecedenceHelper,
-		SearchScopePreference searchScopePreference,
+		SearchBarPortletPreferences searchBarPortletPreferences,
 		SearchSettings searchSettings, ThemeDisplay themeDisplay) {
 
-		SearchScope searchScope = getSearchScope(
+		SearchScopePreference searchScopePreference = getSearchScopePreference(
 			portletPreferencesLookup, scopeParameterValue,
-			searchBarPrecedenceHelper, searchScopePreference, searchSettings,
-			themeDisplay);
+			searchBarPrecedenceHelper, searchBarPortletPreferences,
+			searchSettings, themeDisplay);
 
-		if (searchScope == SearchScope.EVERYTHING) {
+		if (searchScopePreference == SearchScopePreference.EVERYTHING) {
 			searchBarPortletDisplayContext.setSelectedEverythingSearchScope(
 				true);
 		}
 
-		if (searchScope == SearchScope.THIS_SITE) {
+		if (searchScopePreference ==
+				SearchScopePreference.LET_THE_USER_CHOOSE) {
+
+			searchBarPortletDisplayContext.setLetTheUserChooseTheSearchScope(
+				true);
+		}
+
+		if (searchScopePreference == SearchScopePreference.THIS_SITE) {
 			searchBarPortletDisplayContext.setSelectedCurrentSiteSearchScope(
 				true);
 		}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/shared/search/SearchBarPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/shared/search/SearchBarPortletSharedSearchContributor.java
@@ -79,6 +79,8 @@ public class SearchBarPortletSharedSearchContributor
 			searchRequestBuilder, searchBarPortletPreferences,
 			portletSharedSearchSettings);
 
+		_setScope(searchBarPortletPreferences, portletSharedSearchSettings);
+
 		_setScopeParameterName(
 			searchBarPortletPreferences, portletSharedSearchSettings);
 
@@ -229,6 +231,17 @@ public class SearchBarPortletSharedSearchContributor
 			searchContext -> searchContext.setAttribute(
 				SearchContextAttributes.ATTRIBUTE_KEY_LUCENE_SYNTAX,
 				Boolean.TRUE));
+	}
+
+	private void _setScope(
+		SearchBarPortletPreferences searchBarPortletPreferences,
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		SearchScopePreference searchScopePreference =
+			searchBarPortletPreferences.getSearchScopePreference();
+
+		portletSharedSearchSettings.setScope(
+			searchScopePreference.getPreferenceString());
 	}
 
 	private void _setScopeParameterName(

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/request/SearchSettingsImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/request/SearchSettingsImpl.java
@@ -101,6 +101,11 @@ public class SearchSettingsImpl implements SearchSettings {
 	}
 
 	@Override
+	public Optional<String> getScope() {
+		return Optional.ofNullable(_scope);
+	}
+
+	@Override
 	public Optional<String> getScopeParameterName() {
 		return Optional.ofNullable(_scopeParameterName);
 	}
@@ -150,6 +155,11 @@ public class SearchSettingsImpl implements SearchSettings {
 	}
 
 	@Override
+	public void setScope(String scope) {
+		_scope = scope;
+	}
+
+	@Override
 	public void setScopeParameterName(String scopeParameterName) {
 		_scopeParameterName = scopeParameterName;
 	}
@@ -170,6 +180,7 @@ public class SearchSettingsImpl implements SearchSettings {
 	private String _paginationDeltaParameterName;
 	private Integer _paginationStart;
 	private String _paginationStartParameterName;
+	private String _scope;
 	private String _scopeParameterName;
 	private final SearchContext _searchContext;
 	private final SearchRequestBuilder _searchRequestBuilder;

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -26,7 +26,7 @@ import React, {useRef, useState} from 'react';
 
 export default function SearchBar({
 	emptySearchEnabled,
-	initialScope = '',
+	isSelectedEverythingSearchScope = false,
 	keywords = '',
 	keywordsParameterName = 'q',
 	letUserChooseScope = false,
@@ -52,7 +52,11 @@ export default function SearchBar({
 		loading: false,
 		networkStatus: 4,
 	}));
-	const [scope, setScope] = useState(initialScope);
+	const [scope, setScope] = useState(
+		isSelectedEverythingSearchScope
+			? scopeParameterStringEverything
+			: scopeParameterStringCurrentSite
+	);
 
 	const alignElementRef = useRef();
 	const dropdownRef = useRef();

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -253,7 +253,7 @@ export default function SearchBar({
 			searchParams.delete(paginationStartParameterName);
 		}
 
-		if (scope) {
+		if (letUserChooseScope) {
 			searchParams.set(scopeParameterName, scope);
 		}
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
@@ -64,7 +64,7 @@ SearchBarPortletDisplayContext searchBarPortletDisplayContext = (SearchBarPortle
 						HashMapBuilder.<String, Object>put(
 							"emptySearchEnabled", searchBarPortletDisplayContext.isEmptySearchEnabled()
 						).put(
-							"initialScope", searchBarPortletDisplayContext.getScopeParameterValue()
+							"isSelectedEverythingSearchScope", searchBarPortletDisplayContext.isSelectedEverythingSearchScope()
 						).put(
 							"keywords", searchBarPortletDisplayContext.getKeywords()
 						).put(

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
@@ -210,23 +210,16 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testSearchScope() throws ReadOnlyException {
+	public void testSearchScopePreference() throws ReadOnlyException {
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(null);
 
-		SearchBarPortletDisplayContext searchBarPortletDisplayContext =
-			searchBarPortletDisplayContextFactory.create(
-				_portletPreferencesLookup, _portletSharedSearchRequest,
-				_searchBarPrecedenceHelper);
-
 		Assert.assertEquals(
-			SearchScope.EVERYTHING,
-			searchBarPortletDisplayContextFactory.getSearchScope(
-				_portletPreferencesLookup,
-				searchBarPortletDisplayContext.getScopeParameterValue(),
-				_searchBarPrecedenceHelper, SearchScopePreference.THIS_SITE,
-				_searchSettings, _themeDisplay));
+			SearchScopePreference.THIS_SITE,
+			searchBarPortletDisplayContextFactory.getSearchScopePreference(
+				_portletPreferencesLookup, _searchBarPrecedenceHelper,
+				_searchBarPortletPreferences, _searchSettings, _themeDisplay));
 	}
 
 	protected HttpServletRequest getHttpServletRequest() {
@@ -433,6 +426,8 @@ public class SearchBarPortletDisplayContextFactoryTest {
 		Mockito.mock(PortletPreferencesLookup.class);
 	private final PortletSharedSearchRequest _portletSharedSearchRequest =
 		Mockito.mock(PortletSharedSearchRequest.class);
+	private final SearchBarPortletPreferences _searchBarPortletPreferences =
+		Mockito.mock(SearchBarPortletPreferences.class);
 	private final SearchBarPrecedenceHelper _searchBarPrecedenceHelper =
 		Mockito.mock(SearchBarPrecedenceHelper.class);
 	private final SearchSettings _searchSettings = Mockito.mock(

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.search.web.internal.search.bar.portlet.display.context
 import com.liferay.portal.search.web.internal.search.bar.portlet.helper.SearchBarPrecedenceHelper;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchRequest;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchResponse;
+import com.liferay.portal.search.web.search.request.SearchSettings;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portlet.PortletPreferencesImpl;
 
@@ -222,8 +223,10 @@ public class SearchBarPortletDisplayContextFactoryTest {
 		Assert.assertEquals(
 			SearchScope.EVERYTHING,
 			searchBarPortletDisplayContextFactory.getSearchScope(
-				SearchScopePreference.THIS_SITE,
-				searchBarPortletDisplayContext.getScopeParameterValue()));
+				_portletPreferencesLookup,
+				searchBarPortletDisplayContext.getScopeParameterValue(),
+				_searchBarPrecedenceHelper, SearchScopePreference.THIS_SITE,
+				_searchSettings, _themeDisplay));
 	}
 
 	protected HttpServletRequest getHttpServletRequest() {
@@ -432,6 +435,8 @@ public class SearchBarPortletDisplayContextFactoryTest {
 		Mockito.mock(PortletSharedSearchRequest.class);
 	private final SearchBarPrecedenceHelper _searchBarPrecedenceHelper =
 		Mockito.mock(SearchBarPrecedenceHelper.class);
+	private final SearchSettings _searchSettings = Mockito.mock(
+		SearchSettings.class);
 	private final ThemeDisplay _themeDisplay = Mockito.mock(ThemeDisplay.class);
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-155753

Follow-up from https://github.com/BryanEngler/liferay-portal/pull/651

**Changes**
- Fixed the search bar react widget to use the scope preference configuration (`isSelectedEverythingSearchScope`/`isSelectedCurrentSiteSearchScope`) instead of the scope URL parameter.
- The search page's embedded search bar wasn't getting the header's scope preference configuration so an additional check was added to grab the header search bar portlet configuration.

**Changes from last PR**
- [The bug that Josh Chong found](https://github.com/BryanEngler/liferay-portal/pull/651#issuecomment-1170515456) was that the scope value grabbed from the header search bar is the Scope Preference ("Current Site"/"Everything"/"Let The User Choose") and it was using `SearchScope.getSearchScope(optional.get());` instead of `SearchScopePreference.getSearchScopePreference(optional.get());`
- Now, `getSearchScope` was returning both `SearchScopePreference` and `SearchScope`. And from my understanding, the `scopeParameterValue` (the scope URL parameter value), only takes affect if the scope preference is "Let The User Choose." The scope preference needed to be checked first, so:
  - I changed `getSearchScope` to `getSearchScopePreference`
  - I changed `_setSelectedSearchScope` to `_setSelectedSearchScopePreference` and am doing the logic of setting `setLetTheUserChooseTheSearchScope`/`setSelectedEverythingSearchScope`/`setSelectedCurrentSiteSearchScope` inside there first based on the scope preference.

