### PR TITLE
LPS-157748 Unable to change search bar display template when suggestions are enabled

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -92,6 +92,9 @@ export default function SearchBar({
 
 	const _handleKeyDown = (event) => {
 		if (event.key === 'Enter') {
+			event.preventDefault();
+			event.stopPropagation();
+
 			_handleSubmit();
 		}
 	};

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
@@ -56,64 +56,66 @@ SearchBarPortletDisplayContext searchBarPortletDisplayContext = (SearchBarPortle
 		</div>
 	</c:when>
 	<c:otherwise>
-		<c:choose>
-			<c:when test="<%= searchBarPortletDisplayContext.isSuggestionsEnabled() %>">
-				<react:component
-					module="js/components/SearchBar"
-					props='<%=
-						HashMapBuilder.<String, Object>put(
-							"emptySearchEnabled", searchBarPortletDisplayContext.isEmptySearchEnabled()
-						).put(
-							"initialScope", searchBarPortletDisplayContext.getScopeParameterValue()
-						).put(
-							"keywords", searchBarPortletDisplayContext.getKeywords()
-						).put(
-							"keywordsParameterName", searchBarPortletDisplayContext.getKeywordsParameterName()
-						).put(
-							"letUserChooseScope", searchBarPortletDisplayContext.isLetTheUserChooseTheSearchScope()
-						).put(
-							"paginationStartParameterName", searchBarPortletDisplayContext.getPaginationStartParameterName()
-						).put(
-							"scopeParameterName", searchBarPortletDisplayContext.getScopeParameterName()
-						).put(
-							"scopeParameterStringCurrentSite", searchBarPortletDisplayContext.getCurrentSiteSearchScopeParameterString()
-						).put(
-							"scopeParameterStringEverything", searchBarPortletDisplayContext.getEverythingSearchScopeParameterString()
-						).put(
-							"searchURL", searchBarPortletDisplayContext.getSearchURL()
-						).put(
-							"suggestionsContributorConfiguration", searchBarPortletDisplayContext.getSuggestionsContributorConfiguration()
-						).put(
-							"suggestionsDisplayThreshold", searchBarPortletDisplayContext.getSuggestionsDisplayThreshold()
-						).put(
-							"suggestionsURL", searchBarPortletDisplayContext.getSuggestionsURL()
-						).build()
-					%>'
-				/>
-			</c:when>
-			<c:otherwise>
-				<aui:form action="<%= searchBarPortletDisplayContext.getSearchURL() %>" method="get" name="fm">
-					<c:if test="<%= !Validator.isBlank(searchBarPortletDisplayContext.getPaginationStartParameterName()) %>">
-						<input class="search-bar-reset-start-page" name="<%= searchBarPortletDisplayContext.getPaginationStartParameterName() %>" type="hidden" value="0" />
-					</c:if>
+		<aui:form action="<%= searchBarPortletDisplayContext.getSearchURL() %>" method="get" name="fm">
+			<c:if test="<%= !Validator.isBlank(searchBarPortletDisplayContext.getPaginationStartParameterName()) %>">
+				<input class="search-bar-reset-start-page" name="<%= searchBarPortletDisplayContext.getPaginationStartParameterName() %>" type="hidden" value="0" />
+			</c:if>
 
-					<%
-					SearchBarPortletInstanceConfiguration searchBarPortletInstanceConfiguration = searchBarPortletDisplayContext.getSearchBarPortletInstanceConfiguration();
-					%>
+			<%
+			SearchBarPortletInstanceConfiguration searchBarPortletInstanceConfiguration = searchBarPortletDisplayContext.getSearchBarPortletInstanceConfiguration();
+			%>
 
-					<liferay-ddm:template-renderer
-						className="<%= SearchBarPortletDisplayContext.class.getName() %>"
-						contextObjects='<%=
-							HashMapBuilder.<String, Object>put(
-								"namespace", liferayPortletResponse.getNamespace()
-							).put(
-								"searchBarPortletDisplayContext", searchBarPortletDisplayContext
-							).build()
-						%>'
-						displayStyle="<%= searchBarPortletInstanceConfiguration.displayStyle() %>"
-						displayStyleGroupId="<%= searchBarPortletDisplayContext.getDisplayStyleGroupId() %>"
-						entries="<%= new ArrayList<>() %>"
-					>
+			<liferay-ddm:template-renderer
+				className="<%= SearchBarPortletDisplayContext.class.getName() %>"
+				contextObjects='<%=
+					HashMapBuilder.<String, Object>put(
+						"namespace", liferayPortletResponse.getNamespace()
+					).put(
+						"searchBarPortletDisplayContext", searchBarPortletDisplayContext
+					).build()
+				%>'
+				displayStyle="<%= searchBarPortletInstanceConfiguration.displayStyle() %>"
+				displayStyleGroupId="<%= searchBarPortletDisplayContext.getDisplayStyleGroupId() %>"
+				entries="<%= new ArrayList<>() %>"
+			>
+				<c:choose>
+					<c:when test="<%= searchBarPortletDisplayContext.isSuggestionsEnabled() %>">
+						<div id="<portlet:namespace />reactSearchBar">
+							<react:component
+								module="js/components/SearchBar"
+								props='<%=
+									HashMapBuilder.<String, Object>put(
+										"emptySearchEnabled", searchBarPortletDisplayContext.isEmptySearchEnabled()
+									).put(
+										"initialScope", searchBarPortletDisplayContext.getScopeParameterValue()
+									).put(
+										"keywords", searchBarPortletDisplayContext.getKeywords()
+									).put(
+										"keywordsParameterName", searchBarPortletDisplayContext.getKeywordsParameterName()
+									).put(
+										"letUserChooseScope", searchBarPortletDisplayContext.isLetTheUserChooseTheSearchScope()
+									).put(
+										"paginationStartParameterName", searchBarPortletDisplayContext.getPaginationStartParameterName()
+									).put(
+										"scopeParameterName", searchBarPortletDisplayContext.getScopeParameterName()
+									).put(
+										"scopeParameterStringCurrentSite", searchBarPortletDisplayContext.getCurrentSiteSearchScopeParameterString()
+									).put(
+										"scopeParameterStringEverything", searchBarPortletDisplayContext.getEverythingSearchScopeParameterString()
+									).put(
+										"searchURL", searchBarPortletDisplayContext.getSearchURL()
+									).put(
+										"suggestionsContributorConfiguration", searchBarPortletDisplayContext.getSuggestionsContributorConfiguration()
+									).put(
+										"suggestionsDisplayThreshold", searchBarPortletDisplayContext.getSuggestionsDisplayThreshold()
+									).put(
+										"suggestionsURL", searchBarPortletDisplayContext.getSuggestionsURL()
+									).build()
+								%>'
+							/>
+						</div>
+					</c:when>
+					<c:otherwise>
 						<div class="search-bar">
 							<aui:input cssClass="search-bar-empty-search-input" name="emptySearchEnabled" type="hidden" value="<%= searchBarPortletDisplayContext.isEmptySearchEnabled() %>" />
 
@@ -158,13 +160,15 @@ SearchBarPortletDisplayContext searchBarPortletDisplayContext = (SearchBarPortle
 								</c:choose>
 							</div>
 						</div>
-					</liferay-ddm:template-renderer>
-				</aui:form>
-
-				<aui:script use="liferay-search-bar">
-					new Liferay.Search.SearchBar(A.one('#<portlet:namespace />fm'));
-				</aui:script>
-			</c:otherwise>
-		</c:choose>
+					</c:otherwise>
+				</c:choose>
+			</liferay-ddm:template-renderer>
+		</aui:form>
 	</c:otherwise>
 </c:choose>
+
+<aui:script use="liferay-search-bar">
+	if (!A.one('#<portlet:namespace />reactSearchBar')) {
+		new Liferay.Search.SearchBar(A.one('#<portlet:namespace />fm'));
+	}
+</aui:script>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-157748

- This puts the react component inside of the `liferay-ddm:template-renderer` tags so it can be replaced with a different display template when suggestions are enabled.
- I had to add both `event.preventDefault()` and `event.stopPropagation()` or else the hidden inputs `${namespace}_formDate` and `start` would have been added to the URL (meaning the default browser form submission was taking place instead of the JS navigation). 
- Added a div id `<portlet:namespace />reactSearchBar` to not initialize the AUI `Liferay.Search.SearchBar` component when the react component is being used