### PR TITLE
LPS-153747 Search Result message is in plural when only one result returns

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_card.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_card.ftl
@@ -1,5 +1,9 @@
 <div class="search-total-label">
-	${languageUtil.format(locale, "x-results-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
+	<#if searchContainer.getTotal() == 1>
+		${languageUtil.format(locale, "x-result-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
+	<#else>
+		${languageUtil.format(locale, "x-results-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
+	</#if>
 </div>
 
 <div class="display-card">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_compact.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_compact.ftl
@@ -1,5 +1,9 @@
 <div class="search-total-label">
-	${languageUtil.format(locale, "x-results-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
+	<#if searchContainer.getTotal() == 1>
+		${languageUtil.format(locale, "x-result-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
+	<#else>
+		${languageUtil.format(locale, "x-results-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
+	</#if>
 </div>
 
 <div class="display-compact">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_list.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_list.ftl
@@ -1,5 +1,9 @@
 <div class="search-total-label">
-	${languageUtil.format(locale, "x-results-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
+	<#if searchContainer.getTotal() == 1>
+		${languageUtil.format(locale, "x-result-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
+	<#else>
+		${languageUtil.format(locale, "x-results-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
+	</#if>
 </div>
 
 <div class="display-list">

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/elasticsearch/Elasticsearch7.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/elasticsearch/Elasticsearch7.testcase
@@ -610,7 +610,7 @@ definition {
 
 		AssertTextEquals.assertPartialText(
 			locator1 = "SearchResults#RESULTS_PORTLET_SEARCH_QUERY",
-			value1 = "1 results for bicycle");
+			value1 = "1 result for bicycle");
 	}
 
 	@priority = "4"


### PR DESCRIPTION
In this PR I made changes in the search results templates. I put a condition to show the `x-result-for-x` message when there is only one result and `x-results-for-x` when there is more. In [brianchandotcom#120548](https://github.com/brianchandotcom/liferay-portal/pull/120548) I sent this with a ternary operator inside the function, now i used an if/else like the ones used in most other templates. I just didn't understand how to use the `emptyResultsMessage` as it is reserved for empty search results, which is not the case with this ticket.