### PR TITLE
[TS] LPS-160922 Add ability to configure search results template

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/settings/definition/SearchResultsPortletInstanceConfigurationBeanDeclaration.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/settings/definition/SearchResultsPortletInstanceConfigurationBeanDeclaration.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.web.internal.search.results.portlet.settings.definition;
+
+import com.liferay.portal.kernel.settings.definition.ConfigurationBeanDeclaration;
+import com.liferay.portal.search.web.internal.search.results.configuration.SearchResultsPortletInstanceConfiguration;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Noor Najjar
+ */
+@Component(service = ConfigurationBeanDeclaration.class)
+public class SearchResultsPortletInstanceConfigurationBeanDeclaration
+	implements ConfigurationBeanDeclaration {
+
+	@Override
+	public Class<?> getConfigurationBeanClass() {
+		return SearchResultsPortletInstanceConfiguration.class;
+	}
+
+}


### PR DESCRIPTION
Hi Search Team,

Can you help review this PR?

**Notes from @noornajj:**

> https://issues.liferay.com/browse/LPS-160922
> 
> The issue here is that the Search Results portlet couldn't be configured to a custom template through the system settings.
> 
> To fix this issue, I added a bean declaration for the SearchResultsPortletInstanceConfiguration class.

Please let us know if you have any questions.
Thanks!