### PR TITLE
LPS-134492 Add language selector to blueprints

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/_edit_title_modal.scss
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/_edit_title_modal.scss
@@ -37,6 +37,21 @@
 		}
 	}
 
+	.edit-title {
+		margin-bottom: 1.5rem;
+
+		.form-group {
+			margin-bottom: 0;
+		}
+	}
+
+	.edit-title,
+	.edit-description {
+		.form-text {
+			display: none;
+		}
+	}
+
 	.form-group:last-of-type {
 		margin-bottom: 0;
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -33,6 +33,7 @@ import ThemeContext from '../shared/ThemeContext';
 import {DEFAULT_ERROR, SIDEBARS} from '../utils/constants';
 import {fetchData, fetchPreviewSearch} from '../utils/fetch';
 import {INPUT_TYPES} from '../utils/inputTypes';
+import {formatLocaleWithUnderscores, renameKeys} from '../utils/language';
 import {setStorageAddSXPElementSidebar} from '../utils/sessionStorage';
 import {TEST_IDS} from '../utils/testIds';
 import {
@@ -175,9 +176,13 @@ function EditSXPBlueprintForm({
 					{
 						body: JSON.stringify({
 							configuration,
-							description_i18n: formik.values.description,
+							description_i18n: renameKeys(
+								formik.values.description,
+								formatLocaleWithUnderscores
+							),
 							elementInstances,
-							title_i18n: formik.values.title,
+							title_i18n: renameKeys(formik.values.title,
+								formatLocaleWithUnderscores),
 						}),
 						headers: new Headers({
 							'Content-Type': 'application/json',
@@ -200,9 +205,15 @@ function EditSXPBlueprintForm({
 				{
 					body: JSON.stringify({
 						configuration,
-						description_i18n: formik.values.description,
+						description_i18n: renameKeys(
+							formik.values.description,
+							formatLocaleWithUnderscores
+						),
 						elementInstances,
-						title_i18n: formik.values.title,
+						title_i18n: renameKeys(
+							formik.values.title,
+							formatLocaleWithUnderscores
+						),
 					}),
 					headers: new Headers({
 						'Content-Type': 'application/json',

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -33,7 +33,6 @@ import ThemeContext from '../shared/ThemeContext';
 import {DEFAULT_ERROR, SIDEBARS} from '../utils/constants';
 import {fetchData, fetchPreviewSearch} from '../utils/fetch';
 import {INPUT_TYPES} from '../utils/inputTypes';
-import {getLocalizedText} from '../utils/language';
 import {setStorageAddSXPElementSidebar} from '../utils/sessionStorage';
 import {TEST_IDS} from '../utils/testIds';
 import {
@@ -81,7 +80,7 @@ function EditSXPBlueprintForm({
 	initialTitle = {},
 	sxpBlueprintId,
 }) {
-	const {defaultLocale, locale, redirectURL} = useContext(ThemeContext);
+	const {locale, redirectURL} = useContext(ThemeContext);
 
 	const formRef = useRef();
 	const sxpElementIdCounterRef = useRef(
@@ -176,11 +175,9 @@ function EditSXPBlueprintForm({
 					{
 						body: JSON.stringify({
 							configuration,
-							description_i18n: {
-								[defaultLocale]: formik.values.description,
-							},
+							description_i18n: formik.values.description,
 							elementInstances,
-							title_i18n: {[defaultLocale]: formik.values.title},
+							title_i18n: formik.values.title,
 						}),
 						headers: new Headers({
 							'Content-Type': 'application/json',
@@ -203,16 +200,9 @@ function EditSXPBlueprintForm({
 				{
 					body: JSON.stringify({
 						configuration,
-
-						// Update defaultLocale in title_i18n and description_i18n in
-						// case the instance defaultLocale differs from the original
-						// entry's defaultLocale.
-
-						description_i18n: {
-							[defaultLocale]: formik.values.description,
-						},
+						description_i18n: formik.values.description,
 						elementInstances,
-						title_i18n: {[defaultLocale]: formik.values.title},
+						title_i18n: formik.values.title,
 					}),
 					headers: new Headers({
 						'Content-Type': 'application/json',
@@ -368,7 +358,7 @@ function EditSXPBlueprintForm({
 			),
 			applyIndexerClauses:
 				initialConfiguration.queryConfiguration?.applyIndexerClauses,
-			description: getLocalizedText(initialDescription, defaultLocale),
+			description: initialDescription,
 			elementInstances: initialSXPElementInstances.map(
 				(elementInstance, index) => ({
 					...elementInstance,
@@ -394,7 +384,7 @@ function EditSXPBlueprintForm({
 				null,
 				'\t'
 			),
-			title: getLocalizedText(initialTitle, defaultLocale),
+			title: initialTitle,
 		},
 		onSubmit: _handleFormikSubmit,
 		validate: _handleFormikValidate,

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/index.js
@@ -16,6 +16,7 @@ import ErrorBoundary from '../shared/ErrorBoundary';
 import ThemeContext from '../shared/ThemeContext';
 import {COPY_BUTTON_CSS_CLASS} from '../utils/constants';
 import {fetchData} from '../utils/fetch';
+import {renameKeys, transformLocale} from '../utils/language';
 import {openInitialSuccessToast} from '../utils/toasts';
 import EditSXPBlueprintForm from './EditSXPBlueprintForm';
 
@@ -64,9 +65,15 @@ export default function ({
 					<EditSXPBlueprintForm
 						entityJSON={resource.entityJSON}
 						initialConfiguration={resource.configuration}
-						initialDescription={resource.description_i18n}
+						initialDescription={renameKeys(
+							resource.description_i18n,
+							transformLocale
+						)}
 						initialSXPElementInstances={resource.elementInstances}
-						initialTitle={resource.title_i18n}
+						initialTitle={renameKeys(
+							resource.title_i18n,
+							transformLocale
+						)}
 						sxpBlueprintId={sxpBlueprintId}
 					/>
 				</ErrorBoundary>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/index.js
@@ -64,17 +64,9 @@ export default function ({
 					<EditSXPBlueprintForm
 						entityJSON={resource.entityJSON}
 						initialConfiguration={resource.configuration}
-						initialDescription={
-							resource.description_i18n || {
-								[defaultLocale]: resource.description,
-							}
-						}
+						initialDescription={resource.description_i18n}
 						initialSXPElementInstances={resource.elementInstances}
-						initialTitle={
-							resource.title_i18n || {
-								[defaultLocale]: resource.title,
-							}
-						}
+						initialTitle={resource.title_i18n}
 						sxpBlueprintId={sxpBlueprintId}
 					/>
 				</ErrorBoundary>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/index.js
@@ -36,7 +36,8 @@ export default function ({
 		openInitialSuccessToast();
 
 		fetchData(
-			`/o/search-experiences-rest/v1.0/sxp-blueprints/${sxpBlueprintId}`
+			`/o/search-experiences-rest/v1.0/sxp-blueprints/${sxpBlueprintId}`,
+			{headers: {'X-Liferay-Accept-All-Languages': true}}
 		)
 			.then((responseContent) => setResource(responseContent))
 			.catch(() => setResource({}));

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PageToolbar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PageToolbar.js
@@ -53,9 +53,11 @@ const getDisplayLocale = (title, locale, defaultLocale) => {
 	if (title[formatLocaleWithDashes(locale)]) {
 		return formatLocaleWithDashes(locale);
 	}
+
 	if (title[formatLocaleWithDashes(defaultLocale)]) {
 		return formatLocaleWithDashes(defaultLocale);
 	}
+
 	if (Object.keys(title).length) {
 		return Object.keys(title)[0];
 	}
@@ -108,7 +110,7 @@ function EditTitleModal({
 		}
 	};
 
-	const _handleChangeLocale = (inputRef) => (value) => {
+	const _handleSelectedLocaleChange = (inputRef) => (value) => {
 		setSelectedLocale(value);
 		inputRef.current.focus();
 	};
@@ -160,7 +162,7 @@ function EditTitleModal({
 							label={_getTitleLabel()}
 							locales={localesForSelector}
 							onBlur={_handleBlur}
-							onSelectedLocaleChange={_handleChangeLocale(
+							onSelectedLocaleChange={_handleSelectedLocaleChange(
 								titleInputRef
 							)}
 							onTranslationsChange={setTitle}
@@ -193,7 +195,7 @@ function EditTitleModal({
 							id="description"
 							label={Liferay.Language.get('description')}
 							locales={localesForSelector}
-							onSelectedLocaleChange={_handleChangeLocale(
+							onSelectedLocaleChange={_handleSelectedLocaleChange(
 								descriptionInputRef
 							)}
 							onTranslationsChange={setDescription}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PageToolbar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PageToolbar.js
@@ -10,16 +10,58 @@
  */
 
 import ClayButton from '@clayui/button';
-import ClayForm, {ClayInput} from '@clayui/form';
+import ClayForm from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClayLink from '@clayui/link';
+import ClayLocalizedInput from '@clayui/localized-input';
 import ClayModal, {useModal} from '@clayui/modal';
 import ClayNavigationBar from '@clayui/navigation-bar';
 import ClayToolbar from '@clayui/toolbar';
 import {ClayTooltipProvider} from '@clayui/tooltip';
+import getCN from 'classnames';
 import PropTypes from 'prop-types';
-import React, {useRef, useState} from 'react';
+import React, {useContext, useRef, useState} from 'react';
+
+import {sub} from '../utils/language';
+import {removeDuplicates} from '../utils/utils';
+import ThemeContext from './ThemeContext';
+
+/**
+ * Turns a basic locale into an object with original locale (label) and icon
+ * for flag (symbol), used for Clay's localized input.
+ * @param {string} locale Language identifier
+ * @returns {Object}
+ */
+const convertLocaleStringToObject = (locale) => ({
+	label: locale,
+	symbol: locale.replace('_', '-').toLocaleLowerCase(),
+});
+
+/**
+ * Determines which language to display the title and description, by
+ * checking what's available in title. This prevents title and description
+ * from being displayed in two different languages. Preference is given to
+ * the locale language, then the defaultLanguage. If neither are available,
+ * it chooses the first available language.
+ * @param {Object} title Titles in all available locales
+ * @param {string} locale
+ * @param {string} defaultLocale
+ * @returns {string}
+ */
+const getDisplayLocale = (title, locale, defaultLocale) => {
+	if (title[locale]) {
+		return locale;
+	}
+	if (title[defaultLocale]) {
+		return defaultLocale;
+	}
+	if (Object.keys(title).length) {
+		return Object.keys(title)[0];
+	}
+
+	return defaultLocale;
+};
 
 function EditTitleModal({
 	initialDescription,
@@ -29,16 +71,50 @@ function EditTitleModal({
 	onClose,
 	onSubmit,
 }) {
+	const {availableLanguages, defaultLocale, locale} = useContext(
+		ThemeContext
+	);
+
+	// Converts the availableLanguages into the list expected for
+	// Clay's localized input. Positions defaultLocale first in order
+	// to view it as the 'default' option.
+
+	const localesForSelector = removeDuplicates([
+		defaultLocale,
+		...Object.keys(availableLanguages),
+	]).map(convertLocaleStringToObject);
+
+	const [selectedLocale, setSelectedLocale] = useState(
+		convertLocaleStringToObject(
+			getDisplayLocale(initialTitle, locale, defaultLocale)
+		)
+	);
+
 	const [description, setDescription] = useState(initialDescription);
 	const [hasError, setHasError] = useState(false);
 	const [title, setTitle] = useState(initialTitle);
 
+	const descriptionInputRef = useRef();
 	const titleInputRef = useRef();
+
+	const _handleBlur = (event) => {
+		if (selectedLocale.label === defaultLocale) {
+			setHasError(!event.currentTarget.value);
+		}
+		else {
+			setHasError(!title[defaultLocale]);
+		}
+	};
+
+	const _handleChangeLocale = (inputRef) => (value) => {
+		setSelectedLocale(value);
+		inputRef.current.focus();
+	};
 
 	const _handleSubmit = (event) => {
 		event.preventDefault();
 
-		if (!title) {
+		if (!title[defaultLocale]) {
 			setHasError(true);
 
 			titleInputRef.current.focus();
@@ -50,36 +126,46 @@ function EditTitleModal({
 		}
 	};
 
+	const _getTitleLabel = () => (
+		<>
+			{Liferay.Language.get('title')}
+
+			{selectedLocale.label === defaultLocale && (
+				<ClayIcon
+					className="ml-1 reference-mark"
+					focusable="false"
+					role="presentation"
+					symbol="asterisk"
+				/>
+			)}
+		</>
+	);
+
 	return (
 		<ClayModal
-			className="entry-edit-title-modal"
+			className="sxp-blueprint-edit-title-modal"
 			observer={observer}
 			size="md"
 		>
 			<ClayForm onSubmit={_handleSubmit}>
 				<ClayModal.Body>
-					<ClayForm.Group className={hasError ? 'has-error' : ''}>
-						<label htmlFor="title">
-							{Liferay.Language.get('title')}
-
-							<ClayIcon
-								className="ml-1 reference-mark"
-								focusable="false"
-								role="presentation"
-								symbol="asterisk"
-							/>
-						</label>
-
-						<ClayInput
+					<div
+						className={getCN('edit-title', {'has-error': hasError})}
+					>
+						<ClayLocalizedInput
 							autoFocus={modalFieldFocus === 'title'}
 							id="title"
-							onBlur={({currentTarget}) => {
-								setHasError(!currentTarget.value);
-							}}
-							onChange={({target: {value}}) => setTitle(value)}
+							label={_getTitleLabel()}
+							locales={localesForSelector}
+							onBlur={_handleBlur}
+							onSelectedLocaleChange={_handleChangeLocale(
+								titleInputRef
+							)}
+							onTranslationsChange={setTitle}
+							placeholder=""
 							ref={titleInputRef}
-							type="text"
-							value={title}
+							selectedLocale={selectedLocale}
+							translations={title}
 						/>
 
 						{hasError && (
@@ -87,30 +173,34 @@ function EditTitleModal({
 								<ClayForm.FeedbackItem>
 									<ClayForm.FeedbackIndicator symbol="exclamation-full" />
 
-									{Liferay.Language.get(
-										'this-field-is-required'
+									{sub(
+										Liferay.Language.get(
+											'please-enter-a-valid-title-for-the-default-language-x'
+										),
+										[defaultLocale]
 									)}
 								</ClayForm.FeedbackItem>
 							</ClayForm.FeedbackGroup>
 						)}
-					</ClayForm.Group>
+					</div>
 
-					<ClayForm.Group>
-						<label htmlFor="description">
-							{Liferay.Language.get('description')}
-						</label>
-
-						<ClayInput
+					<div className="edit-description">
+						<ClayLocalizedInput
 							autoFocus={modalFieldFocus === 'description'}
 							component="textarea"
 							id="description"
-							onChange={({target: {value}}) =>
-								setDescription(value)
-							}
-							type="text"
-							value={description}
+							label={Liferay.Language.get('description')}
+							locales={localesForSelector}
+							onSelectedLocaleChange={_handleChangeLocale(
+								descriptionInputRef
+							)}
+							onTranslationsChange={setDescription}
+							placeholder=""
+							ref={descriptionInputRef}
+							selectedLocale={selectedLocale}
+							translations={description}
 						/>
-					</ClayForm.Group>
+					</div>
 				</ClayModal.Body>
 
 				<ClayModal.Footer
@@ -146,12 +236,16 @@ export default function PageToolbar({
 	tabs,
 	title,
 }) {
+	const {defaultLocale, locale} = useContext(ThemeContext);
+
 	const [modalFieldFocus, setModalFieldFocus] = useState('title');
 	const [modalVisible, setModalVisible] = useState(false);
 
 	const {observer, onClose} = useModal({
 		onClose: () => setModalVisible(false),
 	});
+
+	const displayLocale = getDisplayLocale(title, locale, defaultLocale);
 
 	const _handleClickEdit = (fieldFocus) => () => {
 		setModalFieldFocus(fieldFocus);
@@ -190,7 +284,7 @@ export default function PageToolbar({
 									onClick={_handleClickEdit('title')}
 								>
 									<div className="entry-title text-truncate">
-										{title}
+										{title[displayLocale]}
 
 										<ClayIcon
 											className="entry-heading-edit-icon"
@@ -212,9 +306,9 @@ export default function PageToolbar({
 										<div
 											className="entry-description text-truncate"
 											data-tooltip-align="bottom"
-											title={description}
+											title={description[displayLocale]}
 										>
-											{description || (
+											{description[displayLocale] || (
 												<span className="entry-description-blank">
 													{Liferay.Language.get(
 														'no-description'
@@ -286,7 +380,7 @@ export default function PageToolbar({
 }
 
 PageToolbar.propTypes = {
-	description: PropTypes.string,
+	description: PropTypes.object,
 	isSubmitting: PropTypes.bool,
 	onCancel: PropTypes.string.isRequired,
 	onChangeTab: PropTypes.func,
@@ -294,5 +388,5 @@ PageToolbar.propTypes = {
 	onSubmit: PropTypes.func.isRequired,
 	tab: PropTypes.string,
 	tabs: PropTypes.object,
-	title: PropTypes.string,
+	title: PropTypes.object,
 };

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PageToolbar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PageToolbar.js
@@ -23,7 +23,7 @@ import getCN from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useContext, useRef, useState} from 'react';
 
-import {sub} from '../utils/language';
+import {formatLocaleWithDashes, sub} from '../utils/language';
 import {removeDuplicates} from '../utils/utils';
 import ThemeContext from './ThemeContext';
 
@@ -34,8 +34,8 @@ import ThemeContext from './ThemeContext';
  * @returns {Object}
  */
 const convertLocaleStringToObject = (locale) => ({
-	label: locale,
-	symbol: locale.replace('_', '-').toLocaleLowerCase(),
+	label: formatLocaleWithDashes(locale),
+	symbol: formatLocaleWithDashes(locale).toLocaleLowerCase(),
 });
 
 /**
@@ -50,17 +50,17 @@ const convertLocaleStringToObject = (locale) => ({
  * @returns {string}
  */
 const getDisplayLocale = (title, locale, defaultLocale) => {
-	if (title[locale]) {
-		return locale;
+	if (title[formatLocaleWithDashes(locale)]) {
+		return formatLocaleWithDashes(locale);
 	}
-	if (title[defaultLocale]) {
-		return defaultLocale;
+	if (title[formatLocaleWithDashes(defaultLocale)]) {
+		return formatLocaleWithDashes(defaultLocale);
 	}
 	if (Object.keys(title).length) {
 		return Object.keys(title)[0];
 	}
 
-	return defaultLocale;
+	return formatLocaleWithDashes(defaultLocale);
 };
 
 function EditTitleModal({
@@ -90,6 +90,8 @@ function EditTitleModal({
 		)
 	);
 
+	const defaultLocaleBCP47 = formatLocaleWithDashes(defaultLocale);
+
 	const [description, setDescription] = useState(initialDescription);
 	const [hasError, setHasError] = useState(false);
 	const [title, setTitle] = useState(initialTitle);
@@ -98,11 +100,11 @@ function EditTitleModal({
 	const titleInputRef = useRef();
 
 	const _handleBlur = (event) => {
-		if (selectedLocale.label === defaultLocale) {
+		if (selectedLocale.label === defaultLocaleBCP47) {
 			setHasError(!event.currentTarget.value);
 		}
 		else {
-			setHasError(!title[defaultLocale]);
+			setHasError(!title[defaultLocaleBCP47]);
 		}
 	};
 
@@ -114,7 +116,7 @@ function EditTitleModal({
 	const _handleSubmit = (event) => {
 		event.preventDefault();
 
-		if (!title[defaultLocale]) {
+		if (!title[defaultLocaleBCP47]) {
 			setHasError(true);
 
 			titleInputRef.current.focus();
@@ -130,7 +132,7 @@ function EditTitleModal({
 		<>
 			{Liferay.Language.get('title')}
 
-			{selectedLocale.label === defaultLocale && (
+			{selectedLocale.label === defaultLocaleBCP47 && (
 				<ClayIcon
 					className="ml-1 reference-mark"
 					focusable="false"
@@ -177,7 +179,7 @@ function EditTitleModal({
 										Liferay.Language.get(
 											'please-enter-a-valid-title-for-the-default-language-x'
 										),
-										[defaultLocale]
+										[defaultLocaleBCP47]
 									)}
 								</ClayForm.FeedbackItem>
 							</ClayForm.FeedbackGroup>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/fetch.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/fetch.js
@@ -14,12 +14,13 @@ import {fetch} from 'frontend-js-web';
 import {DEFAULT_ERROR} from './constants';
 import {openErrorToast} from './toasts';
 
-const DEFAULT_HEADERS = new Headers({
+const DEFAULT_HEADERS_OBJECT = {
 	'Accept': 'application/json',
 	'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
 	'Content-Type': 'application/json',
-});
+};
 
+const DEFAULT_HEADERS = new Headers(DEFAULT_HEADERS_OBJECT);
 const DEFAULT_METHOD = 'GET';
 
 /**
@@ -31,9 +32,9 @@ const DEFAULT_METHOD = 'GET';
  * @param {Object=} init An optional object containing custom configuration.
  * @return {Promise} A Promise that resolves to a Response object.
  */
-export function fetchData(resource = '', init) {
+export function fetchData(resource = '', {headers, ...init} = {}) {
 	return fetch(resource, {
-		headers: DEFAULT_HEADERS,
+		headers: new Headers({...DEFAULT_HEADERS_OBJECT, ...headers}),
 		method: DEFAULT_METHOD,
 		...init,
 	})

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/language.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/language.js
@@ -40,6 +40,22 @@ export function formatLocaleWithUnderscores(locale) {
 }
 
 /**
+ * Converts some of the more unique regional locales that differ from
+ * the expected format.
+ *
+ * @param {string} locale Language identifier
+ * @returns {string}
+ */
+export function transformLocale(locale) {
+	const languages = {
+		'zh-Hans-CN': 'zh-CN',
+		'zh-Hant-TW': 'zh-TW',
+	};
+
+	return languages[locale] || locale;
+}
+
+/**
  * Function to return a new object with renamed keys.
  *
  * Example:

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/language.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/language.js
@@ -10,6 +10,36 @@
  */
 
 /**
+ * Formats locale from default pattern with underscore to pattern with
+ * dashes (BCP47).
+ *
+ * Example:
+ * formatLocaleWithDashes("en_US")
+ * => "en-US"
+ *
+ * @param {string} locale Language identifier
+ * @returns {string}
+ */
+export function formatLocaleWithDashes(locale) {
+	return locale.replaceAll('_', '-');
+}
+
+/**
+ * Formats locale from pattern with dashes (BCP47) to default pattern
+ * with underscore.
+ *
+ * Example:
+ * formatLocaleWithUnderscore("en-US")
+ * => "en_US"
+ *
+ * @param {string} locale Language identifier
+ * @returns {string}
+ */
+export function formatLocaleWithUnderscores(locale) {
+	return locale.replaceAll('-', '_');
+}
+
+/**
  * Function to return a new object with renamed keys.
  *
  * Example:
@@ -123,8 +153,8 @@ export function getLocalizedText(value, locale) {
 	else if (value[locale]) {
 		return value[locale];
 	}
-	else if (value[locale.replace('_', '-')]) {
-		return value[locale.replace('_', '-')];
+	else if (value[formatLocaleWithDashes(locale)]) {
+		return value[formatLocaleWithDashes(locale)];
 	}
 	else if (typeof value === 'string' || value instanceof String) {
 		return value;

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/utils.js
@@ -13,7 +13,7 @@ import moment from 'moment';
 
 import {CONFIG_PREFIX, DEFAULT_ERROR} from './constants';
 import {INPUT_TYPES} from './inputTypes';
-import {renameKeys} from './language';
+import {formatLocaleWithUnderscores, renameKeys} from './language';
 
 /**
  * Function to get valid classNames and return them sorted.
@@ -558,8 +558,9 @@ export function getSXPElementJSON(sxpElement, uiConfigurationValues) {
 	const {category, configuration, icon} = elementDefinition;
 
 	return {
-		description_i18n: renameKeys(description_i18n, (str) =>
-			str.replace('-', '_')
+		description_i18n: renameKeys(
+			description_i18n,
+			formatLocaleWithUnderscores
 		),
 		elementDefinition: {
 			category,
@@ -571,7 +572,7 @@ export function getSXPElementJSON(sxpElement, uiConfigurationValues) {
 				: configuration,
 			icon,
 		},
-		title_i18n: renameKeys(title_i18n, (str) => str.replace('-', '_')),
+		title_i18n: renameKeys(title_i18n, formatLocaleWithUnderscores),
 	};
 }
 

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -66,7 +66,7 @@ function renderEditSXPBlueprintForm(props) {
 			initialDescription={{}}
 			initialSXPElementInstances={[]}
 			initialTitle={{
-				en_US: 'Test Title',
+				'en-US': 'Test Title',
 			}}
 			sxpBlueprintId="0"
 			{...props}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/shared/PageToolbar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/shared/PageToolbar.js
@@ -34,12 +34,12 @@ const context = {
 };
 
 const title = {
-	en_US: 'Title in English',
-	es_ES: 'Titulo en Espanol',
+	'en-US': 'Title in English',
+	'es-ES': 'Titulo en Espanol',
 };
 const description = {
-	en_US: 'Description in English',
-	es_ES: 'Descripcion en Espanol',
+	'en-US': 'Description in English',
+	'es-ES': 'Descripcion en Espanol',
 };
 
 function PageToolbarComponent(props) {
@@ -82,13 +82,13 @@ describe('PageToolbar', () => {
 	it('renders the title', () => {
 		const {getByText} = renderPageToolbar();
 
-		getByText(title.en_US);
+		getByText(title['en-US']);
 	});
 
 	it('calls onChangeTitleAndDescription when updating title', () => {
 		const {getByLabelText, getByText} = renderPageToolbar();
 
-		getByText(title.en_US);
+		getByText(title['en-US']);
 
 		fireEvent.click(getByLabelText('edit-title'));
 
@@ -108,7 +108,7 @@ describe('PageToolbar', () => {
 	it('calls onChangeTitleAndDescription when updating description', () => {
 		const {getByLabelText, getByText} = renderPageToolbar();
 
-		getByText(description.en_US);
+		getByText(description['en-US']);
 
 		fireEvent.click(getByLabelText('edit-description'));
 
@@ -171,8 +171,8 @@ describe('PageToolbar', () => {
 			locale: 'es_ES',
 		});
 
-		getByText(title.es_ES);
-		getByText(description.es_ES);
+		getByText(title['es-ES']);
+		getByText(description['es-ES']);
 	});
 
 	it('switches locales in modal with language selector', () => {
@@ -190,9 +190,9 @@ describe('PageToolbar', () => {
 
 		fireEvent.click(getAllByTitle('Open Localizations')[0]);
 
-		fireEvent.click(getAllByText('es_ES')[0]);
+		fireEvent.click(getAllByText('es-ES')[0]);
 
-		getByDisplayValue(title.es_ES);
-		getByText(description.es_ES);
+		getByDisplayValue(title['es-ES']);
+		getByText(description['es-ES']);
 	});
 });


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-134492 - Blueprint title and description are localizable through the UI using a language selector

Some notes I learned along the way:
- Add `'X-Liferay-Accept-All-Languages': true` to the header to see the title and description map in the response.
- Throughout the editor, the title and description are now saved in BCP47 form (like `en-US`) since portal uses that form for the language selector. However, they are submitted in the general `en_US` form, as expected for backend. Utils `formatLocaleWithUnderscores` and `formatLocaleWithDashes` have been added to make it easier to convert back and forth.
- The Chinese locales `zh-Hans-CN` and `zh-Hant-TW` need to be adapted to `zh-CN` and `zh-TW` in order to be viewable on language selector and submittable.
- Language selector is based off `Liferay.Language.available`. If a blueprint has certain titles/descriptions that are not part of availableLanguages, they do not show up in the language selector (backend filters them out for the getSXPBlueprint response) and they would not be saved.

Let me know if there's any questions/things to add! Thanks!