### PR TITLE
LPS-162509 portal-search-rest-impl: Translate displayGroupName inside suggestion resource

### DIFF
--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SuggestionResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SuggestionResourceImpl.java
@@ -16,6 +16,7 @@ package com.liferay.portal.search.rest.internal.resource.v1_0;
 
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.LiferayRenderRequest;
@@ -99,9 +100,10 @@ public class SuggestionResourceImpl extends BaseSuggestionResourceImpl {
 						{
 							attributes =
 								suggestionsContributorResult.getAttributes();
-							displayGroupName =
+							displayGroupName = _language.get(
+								contextAcceptLanguage.getPreferredLocale(),
 								suggestionsContributorResult.
-									getDisplayGroupName();
+									getDisplayGroupName());
 							suggestions = transformToArray(
 								suggestionsContributorResult.getSuggestions(),
 								suggestion -> new Suggestion() {
@@ -223,6 +225,9 @@ public class SuggestionResourceImpl extends BaseSuggestionResourceImpl {
 			throw new RuntimeException(portalException);
 		}
 	}
+
+	@Reference
+	private Language _language;
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;

--- a/portal-web/test/functional/com/liferay/portalweb/macros/SearchBarSuggestions.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/SearchBarSuggestions.macro
@@ -63,7 +63,7 @@ definition {
 
 	macro gotoSuggestionResultDetails {
 		if (!(isSet(suggestionContributorDisplayGroupName))) {
-			var suggestionContributorDisplayGroupName = "suggestions";
+			var suggestionContributorDisplayGroupName = "Suggestions";
 		}
 
 		Click.mouseDownMouseUp(
@@ -78,7 +78,7 @@ definition {
 
 	macro viewNoResultAssetTitle {
 		if (!(isSet(suggestionContributorDisplayGroupName))) {
-			var suggestionContributorDisplayGroupName = "suggestions";
+			var suggestionContributorDisplayGroupName = "Suggestions";
 		}
 
 		AssertElementNotPresent(
@@ -95,7 +95,7 @@ definition {
 
 	macro viewSuggestions {
 		if (!(isSet(suggestionContributorDisplayGroupName))) {
-			var suggestionContributorDisplayGroupName = "suggestions";
+			var suggestionContributorDisplayGroupName = "Suggestions";
 		}
 
 		AssertTextEquals.assertPartialText(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchBarSuggestions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchBarSuggestions.testcase
@@ -239,7 +239,7 @@ definition {
 		SearchBarSuggestions.viewSuggestions(
 			searchAssetDescription = "Page: Home",
 			searchAssetTitle = "Home",
-			suggestionContributorDisplayGroupName = "suggestions");
+			suggestionContributorDisplayGroupName = "Suggestions");
 	}
 
 	@priority = "5"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-162509 Search Bar does not use available translations for custom lang keys used as "Display Group Name" in suggestions

It turns out there aren't any translations being done for any key, regardless of custom key. I wasn't sure if there was a way to process variable language keys on the javascript side, so these lines were added inside `SuggestionResourceImpl`. Source formatting discouraged from using `LanguageUtil` https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/java_osgi_reference_check.markdown so opted to create `_language`. 

Let me know if there's any concerns, thanks!