### PR TITLE
LPS-155716 SXPElement field localization breaks with nested fields

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/FieldMappingInfoResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/FieldMappingInfoResourceImpl.java
@@ -127,7 +127,8 @@ public class FieldMappingInfoResourceImpl
 				int languageIdPosition = -1;
 
 				if (!Validator.isBlank(languageId)) {
-					languageIdPosition = fieldName.lastIndexOf(languageId);
+					languageIdPosition = fieldPath.lastIndexOf(languageId);
+
 					fieldPath = StringUtil.removeSubstring(
 						fieldPath, languageId);
 				}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/_field_row_dropdown.scss
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/_field_row_dropdown.scss
@@ -14,9 +14,13 @@
 	.type {
 		color: $mainLighten52;
 		font-size: 12px;
+		max-width: 56px;
+		overflow: hidden;
 		position: absolute;
 		right: 16px;
+		text-overflow: ellipsis;
 		top: 50%;
 		transform: translateY(-50%);
+		white-space: nowrap;
 	}
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/FieldRow.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/FieldRow.js
@@ -49,6 +49,14 @@ function filterAndSortIndexFields(indexFields, field) {
 		});
 }
 
+/**
+ * Displays a single item in the autocomplete dropdown.
+ * @param {object} indexField A field mapping object containing
+ * 	{languageIdPosition, name, type}.
+ * 	@see FieldMappingInfoResourceImpl#_addFieldMappingInfo
+ * @param {String} match The current input value.
+ * @param {Function} onClick
+ */
 function AutocompleteItem({indexField, match = '', onClick}) {
 	const fuzzyMatch = fuzzy.match(match, indexField.name, {
 		post: '</strong>',
@@ -69,7 +77,14 @@ function AutocompleteItem({indexField, match = '', onClick}) {
 
 			{indexField.languageIdPosition > -1 && <ClayIcon symbol="globe" />}
 
-			<span className="type">{indexField.type}</span>
+			<span
+				className="type"
+				{...(indexField.type?.length > 7
+					? {title: indexField.type}
+					: {})}
+			>
+				{indexField.type}
+			</span>
 		</ClayDropDown.Item>
 	);
 }
@@ -83,6 +98,7 @@ function AutocompleteItem({indexField, match = '', onClick}) {
  * 	name: 'ddmTemplateKey',
  * 	type: 'keyword'
  * }
+ * @see FieldMappingInfoResourceImpl#_addFieldMappingInfo
  */
 function FieldRow({
 	boost = 1,


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-155716

Also fixed the overlapping text in the autocomplete dropdown:

Before:
![Screen Shot 2022-09-14 at 4 09 03 PM](https://user-images.githubusercontent.com/4496722/190287195-af77a38f-68e3-4df1-8192-17c6b6ba437b.png)

After:
![Screen Shot 2022-09-14 at 5 25 16 PM](https://user-images.githubusercontent.com/4496722/190287225-f0aba569-1329-424f-a57a-4e8bb2e04a9a.png)

Truncated text will show full text on hover.
