### PR TITLE
LPS-162653 Adding a language selector to edit element form

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/_edit_title_modal.scss
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/_edit_title_modal.scss
@@ -1,4 +1,4 @@
-.sxp-blueprint-edit-title-modal .modal-body {
+.sxp-edit-title-modal .modal-body {
 	.form-check-card {
 		height: calc(100% - 1.5rem);
 
@@ -47,6 +47,16 @@
 
 	.edit-title,
 	.edit-description {
+		&.disabled {
+			.input-group-item-shrink {
+				display: none;
+			}
+
+			textarea {
+				resize: none;
+			}
+		}
+
 		.form-text {
 			display: none;
 		}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/_page_toolbar.scss
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/_page_toolbar.scss
@@ -37,6 +37,11 @@
 		font-size: 18px;
 		font-weight: 700;
 		line-height: 1;
+
+		.entry-title-blank {
+			color: $secondary;
+			font-style: italic;
+		}
 	}
 
 	.tbar-divider {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/index.js
@@ -16,7 +16,11 @@ import ErrorBoundary from '../shared/ErrorBoundary';
 import ThemeContext from '../shared/ThemeContext';
 import {COPY_BUTTON_CSS_CLASS} from '../utils/constants';
 import {fetchData} from '../utils/fetch';
-import {renameKeys} from '../utils/language';
+import {
+	formatLocaleWithUnderscores,
+	renameKeys,
+	transformLocale,
+} from '../utils/language';
 import {openInitialSuccessToast} from '../utils/toasts';
 import EditSXPElementForm from './EditSXPElementForm';
 
@@ -33,30 +37,31 @@ import EditSXPElementForm from './EditSXPElementForm';
  * @returns {object}
  */
 const getDescriptionI18n = (sxpElementResponse, defaultLocale) => {
-	let descriptionObject = sxpElementResponse.description_i18n || {
-		[defaultLocale]: sxpElementResponse.description,
-	};
+	let descriptionObject = renameKeys(
+		sxpElementResponse.description_i18n,
+		transformLocale
+	);
 
 	if (!Object.keys(descriptionObject).length) {
 		descriptionObject = {[defaultLocale]: ''};
 	}
 
-	return renameKeys(descriptionObject, (str) => str.replace('-', '_'));
+	return renameKeys(descriptionObject, formatLocaleWithUnderscores);
 };
 
 /**
  * See `getDescriptionI18n`.
  * @param {object} sxpElementResponse The response object from the GET
  * 	sxp-elements
- * @param {string} defaultLocale The default locale
  * @returns {object}
  */
-const getTitleI18n = (sxpElementResponse, defaultLocale) => {
-	const titleObject = sxpElementResponse.title_i18n || {
-		[defaultLocale]: sxpElementResponse.title,
-	};
+const getTitleI18n = (sxpElementResponse) => {
+	const titleObject = renameKeys(
+		sxpElementResponse.title_i18n,
+		transformLocale
+	);
 
-	return renameKeys(titleObject, (str) => str.replace('-', '_'));
+	return renameKeys(titleObject, formatLocaleWithUnderscores);
 };
 
 /**
@@ -72,7 +77,7 @@ const transformToSXPElementExportFormat = (
 	return {
 		description_i18n: getDescriptionI18n(sxpElementResponse, defaultLocale),
 		elementDefinition: sxpElementResponse.elementDefinition,
-		title_i18n: getTitleI18n(sxpElementResponse, defaultLocale),
+		title_i18n: getTitleI18n(sxpElementResponse),
 		type: sxpElementResponse.type,
 	};
 };
@@ -126,15 +131,7 @@ export default function ({
 			<div className="edit-sxp-element-root">
 				<ErrorBoundary>
 					<EditSXPElementForm
-						initialDescription={getDescriptionI18n(
-							sxpElementResponse,
-							defaultLocale
-						)}
 						initialElementJSONEditorValue={transformToSXPElementExportFormat(
-							sxpElementResponse,
-							defaultLocale
-						)}
-						initialTitle={getTitleI18n(
 							sxpElementResponse,
 							defaultLocale
 						)}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/hooks/useDebounceCallback.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/hooks/useDebounceCallback.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import {cancelDebounce, debounce} from 'frontend-js-web';
+import {useRef} from 'react';
+
+export default function useDebounceCallback(callback, milliseconds) {
+	const callbackRef = useRef(debounce(callback, milliseconds));
+
+	return [callbackRef.current, () => cancelDebounce(callbackRef.current)];
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PageToolbar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PageToolbar.js
@@ -24,7 +24,11 @@ import getCN from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useContext, useRef, useState} from 'react';
 
-import {formatLocaleWithDashes, sub} from '../utils/language';
+import {
+	formatLocaleWithDashes,
+	formatLocaleWithUnderscores,
+	sub,
+} from '../utils/language';
 import {removeDuplicates} from '../utils/utils';
 import ThemeContext from './ThemeContext';
 
@@ -48,9 +52,10 @@ const convertLocaleStringToObject = (locale) => ({
  * @param {Object} title Titles in all available locales
  * @param {string} locale
  * @param {string} defaultLocale
+ * @param {Object} availableLanguages
  * @returns {string}
  */
-const getDisplayLocale = (title, locale, defaultLocale) => {
+const getDisplayLocale = (title, locale, defaultLocale, availableLanguages) => {
 	if (title[formatLocaleWithDashes(locale)]) {
 		return formatLocaleWithDashes(locale);
 	}
@@ -59,7 +64,12 @@ const getDisplayLocale = (title, locale, defaultLocale) => {
 		return formatLocaleWithDashes(defaultLocale);
 	}
 
-	if (Object.keys(title).length) {
+	if (
+		Object.keys(title).length &&
+		Object.keys(availableLanguages).includes(
+			formatLocaleWithUnderscores(Object.keys(title)[0])
+		)
+	) {
 		return Object.keys(title)[0];
 	}
 
@@ -90,7 +100,12 @@ function EditTitleModal({
 
 	const [selectedLocale, setSelectedLocale] = useState(
 		convertLocaleStringToObject(
-			getDisplayLocale(initialTitle, locale, defaultLocale)
+			getDisplayLocale(
+				initialTitle,
+				locale,
+				defaultLocale,
+				availableLanguages
+			)
 		)
 	);
 
@@ -268,7 +283,9 @@ export default function PageToolbar({
 	tabs,
 	title,
 }) {
-	const {defaultLocale, locale} = useContext(ThemeContext);
+	const {availableLanguages, defaultLocale, locale} = useContext(
+		ThemeContext
+	);
 
 	const [modalFieldFocus, setModalFieldFocus] = useState('title');
 	const [modalVisible, setModalVisible] = useState(false);
@@ -277,7 +294,12 @@ export default function PageToolbar({
 		onClose: () => setModalVisible(false),
 	});
 
-	const displayLocale = getDisplayLocale(title, locale, defaultLocale);
+	const displayLocale = getDisplayLocale(
+		title,
+		locale,
+		defaultLocale,
+		availableLanguages
+	);
 
 	const _handleClickEdit = (fieldFocus) => () => {
 		setModalFieldFocus(fieldFocus);

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PageToolbar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PageToolbar.js
@@ -9,6 +9,7 @@
  * distribution rights of the Software.
  */
 
+import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
 import ClayForm from '@clayui/form';
 import ClayIcon from '@clayui/icon';
@@ -66,6 +67,7 @@ const getDisplayLocale = (title, locale, defaultLocale) => {
 };
 
 function EditTitleModal({
+	disabled,
 	initialDescription,
 	initialTitle,
 	modalFieldFocus,
@@ -147,17 +149,32 @@ function EditTitleModal({
 
 	return (
 		<ClayModal
-			className="sxp-blueprint-edit-title-modal"
+			className="sxp-edit-title-modal"
 			observer={observer}
 			size="md"
 		>
 			<ClayForm onSubmit={_handleSubmit}>
 				<ClayModal.Body>
+					{disabled && (
+						<ClayAlert
+							displayType="danger"
+							title={Liferay.Language.get('error')}
+						>
+							{sub(Liferay.Language.get('x-is-invalid'), [
+								Liferay.Language.get('element-source-json'),
+							])}
+						</ClayAlert>
+					)}
+
 					<div
-						className={getCN('edit-title', {'has-error': hasError})}
+						className={getCN('edit-title', {
+							disabled,
+							'has-error': hasError,
+						})}
 					>
 						<ClayLocalizedInput
 							autoFocus={modalFieldFocus === 'title'}
+							disabled={disabled}
 							id="title"
 							label={_getTitleLabel()}
 							locales={localesForSelector}
@@ -169,7 +186,7 @@ function EditTitleModal({
 							placeholder=""
 							ref={titleInputRef}
 							selectedLocale={selectedLocale}
-							translations={title}
+							translations={disabled ? {} : title}
 						/>
 
 						{hasError && (
@@ -188,10 +205,15 @@ function EditTitleModal({
 						)}
 					</div>
 
-					<div className="edit-description">
+					<div
+						className={getCN('edit-description', {
+							disabled,
+						})}
+					>
 						<ClayLocalizedInput
 							autoFocus={modalFieldFocus === 'description'}
 							component="textarea"
+							disabled={disabled}
 							id="description"
 							label={Liferay.Language.get('description')}
 							locales={localesForSelector}
@@ -202,7 +224,7 @@ function EditTitleModal({
 							placeholder=""
 							ref={descriptionInputRef}
 							selectedLocale={selectedLocale}
-							translations={description}
+							translations={disabled ? {} : description}
 						/>
 					</div>
 				</ClayModal.Body>
@@ -217,7 +239,11 @@ function EditTitleModal({
 								{Liferay.Language.get('cancel')}
 							</ClayButton>
 
-							<ClayButton displayType="primary" type="submit">
+							<ClayButton
+								disabled={disabled}
+								displayType="primary"
+								type="submit"
+							>
 								{Liferay.Language.get('done')}
 							</ClayButton>
 						</ClayButton.Group>
@@ -231,11 +257,13 @@ function EditTitleModal({
 export default function PageToolbar({
 	children,
 	description,
+	disableModal = false,
 	isSubmitting,
 	onCancel,
 	onChangeTab,
 	onChangeTitleAndDescription,
 	onSubmit,
+	readOnly = false,
 	tab,
 	tabs,
 	title,
@@ -268,6 +296,7 @@ export default function PageToolbar({
 						<ClayToolbar.Item className="text-left" expand>
 							{modalVisible && (
 								<EditTitleModal
+									disabled={disableModal}
 									initialDescription={description}
 									initialTitle={title}
 									modalFieldFocus={modalFieldFocus}
@@ -277,35 +306,18 @@ export default function PageToolbar({
 								/>
 							)}
 
-							<div>
-								<ClayButton
-									aria-label={Liferay.Language.get(
-										'edit-title'
-									)}
-									className="entry-heading-edit-button"
-									displayType="unstyled"
-									monospaced={false}
-									onClick={_handleClickEdit('title')}
-								>
+							{readOnly ? (
+								<div>
 									<div className="entry-title text-truncate">
-										{title[displayLocale]}
-
-										<ClayIcon
-											className="entry-heading-edit-icon"
-											symbol="pencil"
-										/>
+										{title[displayLocale] || (
+											<span className="entry-title-blank">
+												{Liferay.Language.get(
+													'untitled'
+												)}
+											</span>
+										)}
 									</div>
-								</ClayButton>
 
-								<ClayButton
-									aria-label={Liferay.Language.get(
-										'edit-description'
-									)}
-									className="entry-heading-edit-button"
-									displayType="unstyled"
-									monospaced={false}
-									onClick={_handleClickEdit('description')}
-								>
 									<ClayTooltipProvider>
 										<div
 											className="entry-description text-truncate"
@@ -319,15 +331,72 @@ export default function PageToolbar({
 													)}
 												</span>
 											)}
+										</div>
+									</ClayTooltipProvider>
+								</div>
+							) : (
+								<div>
+									<ClayButton
+										aria-label={Liferay.Language.get(
+											'edit-title'
+										)}
+										className="entry-heading-edit-button"
+										displayType="unstyled"
+										monospaced={false}
+										onClick={_handleClickEdit('title')}
+									>
+										<div className="entry-title text-truncate">
+											{title[displayLocale] || (
+												<span className="entry-title-blank">
+													{Liferay.Language.get(
+														'untitled'
+													)}
+												</span>
+											)}
 
 											<ClayIcon
 												className="entry-heading-edit-icon"
 												symbol="pencil"
 											/>
 										</div>
-									</ClayTooltipProvider>
-								</ClayButton>
-							</div>
+									</ClayButton>
+
+									<ClayButton
+										aria-label={Liferay.Language.get(
+											'edit-description'
+										)}
+										className="entry-heading-edit-button"
+										displayType="unstyled"
+										monospaced={false}
+										onClick={_handleClickEdit(
+											'description'
+										)}
+									>
+										<ClayTooltipProvider>
+											<div
+												className="entry-description text-truncate"
+												data-tooltip-align="bottom"
+												title={
+													description[displayLocale]
+												}
+											>
+												{description[displayLocale] || (
+													<span className="entry-description-blank">
+														{Liferay.Language.get(
+															'no-description'
+														)}
+													</span>
+												)}
+
+												<ClayIcon
+													className="entry-heading-edit-icon"
+													symbol="pencil"
+												/>
+											</div>
+										</ClayTooltipProvider>
+									</ClayButton>
+								</div>
+							)}
 						</ClayToolbar.Item>
 
 						{children}
@@ -338,26 +407,40 @@ export default function PageToolbar({
 							</ClayToolbar.Item>
 						)}
 
-						<ClayToolbar.Item>
-							<ClayLink
-								displayType="secondary"
-								href={onCancel}
-								outline="secondary"
-							>
-								{Liferay.Language.get('cancel')}
-							</ClayLink>
-						</ClayToolbar.Item>
+						{readOnly ? (
+							<ClayToolbar.Item>
+								<ClayLink
+									displayType="secondary"
+									href={onCancel}
+									outline="secondary"
+								>
+									{Liferay.Language.get('close')}
+								</ClayLink>
+							</ClayToolbar.Item>
+						) : (
+							<>
+								<ClayToolbar.Item>
+									<ClayLink
+										displayType="secondary"
+										href={onCancel}
+										outline="secondary"
+									>
+										{Liferay.Language.get('cancel')}
+									</ClayLink>
+								</ClayToolbar.Item>
 
-						<ClayToolbar.Item>
-							<ClayButton
-								disabled={isSubmitting}
-								onClick={onSubmit}
-								small
-								type="submit"
-							>
-								{Liferay.Language.get('save')}
-							</ClayButton>
-						</ClayToolbar.Item>
+								<ClayToolbar.Item>
+									<ClayButton
+										disabled={isSubmitting}
+										onClick={onSubmit}
+										small
+										type="submit"
+									>
+										{Liferay.Language.get('save')}
+									</ClayButton>
+								</ClayToolbar.Item>
+							</>
+						)}
 					</ClayToolbar.Nav>
 				</ClayLayout.ContainerFluid>
 			</ClayToolbar>
@@ -385,11 +468,13 @@ export default function PageToolbar({
 
 PageToolbar.propTypes = {
 	description: PropTypes.object,
+	disableModal: PropTypes.bool,
 	isSubmitting: PropTypes.bool,
 	onCancel: PropTypes.string.isRequired,
 	onChangeTab: PropTypes.func,
 	onChangeTitleAndDescription: PropTypes.func,
 	onSubmit: PropTypes.func.isRequired,
+	readOnly: PropTypes.bool,
 	tab: PropTypes.string,
 	tabs: PropTypes.object,
 	title: PropTypes.object,

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/language.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/language.js
@@ -178,6 +178,15 @@ export function getLocalizedText(value, locale) {
 	else if (value[Liferay.ThemeDisplay.getDefaultLanguageId()]) {
 		return value[Liferay.ThemeDisplay.getDefaultLanguageId()];
 	}
+	else if (
+		value[
+			formatLocaleWithDashes(Liferay.ThemeDisplay.getDefaultLanguageId())
+		]
+	) {
+		return value[
+			formatLocaleWithDashes(Liferay.ThemeDisplay.getDefaultLanguageId())
+		];
+	}
 	else if (Object.keys(value).length) {
 		return value[Object.keys(value)[0]];
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-162653 - Blueprints Element title and description are localizable through the UI using a language selector

These changes allows the user to add translations in a variety of available languages using the same edit modal that was added for the Blueprints editor. If using the editor, the toolbar will update as the title and description are typed. If using the modal, the editor text will update with the new title and description once 'Done' is clicked. The modal will not allow edits if the JSON is invalid!

<img width="924" alt="Screen Shot 2022-09-15 at 11 56 40 AM" src="https://user-images.githubusercontent.com/14063502/190486734-d6e39504-de0d-4443-a262-0c29d3e8e3b1.png">
<img width="922" alt="Screen Shot 2022-09-15 at 11 57 33 AM" src="https://user-images.githubusercontent.com/14063502/190486890-cdfb0c48-1ea9-4fdd-a6f7-f994d7bbbef1.png">

<img width="675" alt="Screen Shot 2022-09-15 at 11 54 47 AM" src="https://user-images.githubusercontent.com/14063502/190486499-b267b1a6-6e40-4a92-91b5-46460df5be83.png">

Dev notes:
- `useDebounceCallback` hook was added to prevent immediate validation of JSON when typing
- New states were added to keep track of the most recent valid element JSON object and whether the editor value is currently valid, which helps cut down on needing to parse again before previewing or submitting
- PageToolbar was updated to include readOnly, disableModal (so the user cannot edit if the JSON is invalid)
- `initialTitle` and `initialDescription` props were removed in favor of keeping track of everything within the new element JSON object state, which contains a valid `title_i18n` and `description_i18n` (which are what the PageToolbar displays)


Sample Demo: 
https://user-images.githubusercontent.com/14063502/190482354-042b7cc0-ee47-488b-a60e-6a2a113b610a.mp4

