### PR TITLE
LPS-163242 Blueprints EntryClassNames

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/search/request/body/contributor/GeneralSXPSearchRequestBodyContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/search/request/body/contributor/GeneralSXPSearchRequestBodyContributor.java
@@ -76,6 +76,9 @@ public class GeneralSXPSearchRequestBodyContributor
 		}
 
 		if (generalConfiguration.getSearchableAssetTypes() != null) {
+			searchRequestBuilder.entryClassNames(
+				generalConfiguration.getSearchableAssetTypes());
+
 			searchRequestBuilder.modelIndexerClassNames(
 				generalConfiguration.getSearchableAssetTypes());
 		}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/test/java/com/liferay/search/experiences/internal/blueprint/search/request/enhancer/body/contributor/GeneralSXPSearchRequestBodyContributorTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/test/java/com/liferay/search/experiences/internal/blueprint/search/request/enhancer/body/contributor/GeneralSXPSearchRequestBodyContributorTest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.internal.blueprint.search.request.enhancer.body.contributor;
+
+import com.liferay.portal.search.internal.searcher.SearchRequestBuilderFactoryImpl;
+import com.liferay.portal.search.searcher.SearchRequest;
+import com.liferay.portal.search.searcher.SearchRequestBuilder;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.search.experiences.internal.blueprint.search.request.body.contributor.GeneralSXPSearchRequestBodyContributor;
+import com.liferay.search.experiences.rest.dto.v1_0.Configuration;
+import com.liferay.search.experiences.rest.dto.v1_0.GeneralConfiguration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Joshua Cords
+ */
+public class GeneralSXPSearchRequestBodyContributorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		_generalSXPSearchRequestBodyContributor =
+			new GeneralSXPSearchRequestBodyContributor();
+
+		SearchRequestBuilderFactory searchRequestBuilderFactory =
+			new SearchRequestBuilderFactoryImpl();
+
+		_searchRequestBuilder = searchRequestBuilderFactory.builder();
+	}
+
+	@Test
+	public void testSearchableAssetTypes() {
+		List<String> searchableAssetTypes = new ArrayList<>();
+
+		searchableAssetTypes.add("com.liferay.journal.model.JournalArticle");
+
+		GeneralConfiguration generalConfiguration = new GeneralConfiguration();
+
+		generalConfiguration.setSearchableAssetTypes(
+			searchableAssetTypes.toArray(new String[1]));
+
+		Configuration configuration = new Configuration();
+
+		configuration.setGeneralConfiguration(generalConfiguration);
+
+		_generalSXPSearchRequestBodyContributor.contribute(
+			configuration, _searchRequestBuilder, null);
+
+		SearchRequest searchRequest = _searchRequestBuilder.build();
+
+		Assert.assertEquals(
+			"Expected asset types to be set in searchRequest." +
+				"getEntryClassNames",
+			searchableAssetTypes, searchRequest.getEntryClassNames());
+
+		Assert.assertEquals(
+			"Expected asset types to be set in searchRequest." +
+				"modelIndexerClassNames",
+			searchableAssetTypes, searchRequest.getModelIndexerClassNames());
+	}
+
+	private GeneralSXPSearchRequestBodyContributor
+		_generalSXPSearchRequestBodyContributor;
+	private SearchRequestBuilder _searchRequestBuilder;
+
+}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-163242

[FacetSearcherImpl._getEntryClassNames()](https://github.com/liferay/liferay-portal/blob/e8228f189ea81d15cdb7b781a9ee3ab07fca7825/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/FacetedSearcherImpl.java#L241-L259) will use the modelIndexerClassNames if searchRequest.getEntryClassNames() is not set, this is why the preview works. However, when it is set, modelIndexerClassNames is skipped.

A different fix would be to change the order of _getEntryClassName logic.

**Author:** @joshuacords 