### PR TITLE
[TS] LPS-161173 | Search bar widget configuration is not propagated from Master Page Template

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortlet.java
@@ -14,6 +14,9 @@
 
 package com.liferay.portal.search.web.internal.search.bar.portlet;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.Portal;
@@ -73,21 +76,31 @@ public class SearchBarPortlet extends MVCPortlet {
 		throws IOException, PortletException {
 
 		SearchBarPortletDisplayContextFactory
+			searchBarPortletDisplayContextFactory = null;
+
+		try {
 			searchBarPortletDisplayContextFactory =
 				new SearchBarPortletDisplayContextFactory(
 					layoutLocalService, portal, renderRequest);
 
-		SearchBarPortletDisplayContext searchBarPortletDisplayContext =
-			searchBarPortletDisplayContextFactory.create(
-				portletPreferencesLookup, portletSharedSearchRequest,
-				searchBarPrecedenceHelper);
+			SearchBarPortletDisplayContext searchBarPortletDisplayContext =
+				searchBarPortletDisplayContextFactory.create(
+					portletPreferencesLookup, portletSharedSearchRequest,
+					searchBarPrecedenceHelper);
 
-		renderRequest.setAttribute(
-			WebKeys.PORTLET_DISPLAY_CONTEXT, searchBarPortletDisplayContext);
-
-		if (searchBarPortletDisplayContext.isRenderNothing()) {
 			renderRequest.setAttribute(
-				WebKeys.PORTLET_CONFIGURATOR_VISIBILITY, Boolean.TRUE);
+				WebKeys.PORTLET_DISPLAY_CONTEXT,
+				searchBarPortletDisplayContext);
+
+			if (searchBarPortletDisplayContext.isRenderNothing()) {
+				renderRequest.setAttribute(
+					WebKeys.PORTLET_CONFIGURATOR_VISIBILITY, Boolean.TRUE);
+			}
+		}
+		catch (ConfigurationException configurationException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(configurationException);
+			}
 		}
 
 		super.render(renderRequest, renderResponse);
@@ -107,5 +120,8 @@ public class SearchBarPortlet extends MVCPortlet {
 
 	@Reference
 	protected SearchBarPrecedenceHelper searchBarPrecedenceHelper;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SearchBarPortlet.class);
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/configuration/SearchBarPortletInstanceConfiguration.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/configuration/SearchBarPortletInstanceConfiguration.java
@@ -57,7 +57,7 @@ public interface SearchBarPortletInstanceConfiguration {
 	)
 	public int suggestionsDisplayThreshold();
 
-	@Meta.AD(deflt = "/page", name = "destination", required = false)
+	@Meta.AD(deflt = "/search", name = "destination", required = false)
 	public String destination();
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/configuration/SearchBarPortletInstanceConfiguration.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/configuration/SearchBarPortletInstanceConfiguration.java
@@ -57,4 +57,7 @@ public interface SearchBarPortletInstanceConfiguration {
 	)
 	public int suggestionsDisplayThreshold();
 
+	@Meta.AD(deflt = "/page", name = "destination", required = false)
+	public String destination();
+
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
@@ -63,12 +63,22 @@ import javax.servlet.http.HttpServletRequest;
 public class SearchBarPortletDisplayContextFactory {
 
 	public SearchBarPortletDisplayContextFactory(
-		LayoutLocalService layoutLocalService, Portal portal,
-		RenderRequest renderRequest) {
+			LayoutLocalService layoutLocalService, Portal portal,
+			RenderRequest renderRequest)
+		throws ConfigurationException {
 
 		_layoutLocalService = layoutLocalService;
 		_portal = portal;
 		_renderRequest = renderRequest;
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		_searchBarPortletInstanceConfiguration =
+			portletDisplay.getPortletInstanceConfiguration(
+				SearchBarPortletInstanceConfiguration.class);
 	}
 
 	public SearchBarPortletDisplayContext create(
@@ -79,15 +89,11 @@ public class SearchBarPortletDisplayContextFactory {
 		SearchBarPortletDisplayContext searchBarPortletDisplayContext =
 			new SearchBarPortletDisplayContext();
 
-		SearchBarPortletPreferences searchBarPortletPreferences =
-			new SearchBarPortletPreferencesImpl(
-				Optional.ofNullable(_renderRequest.getPreferences()));
-
 		ThemeDisplay themeDisplay = (ThemeDisplay)_renderRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
 		String destinationString =
-			searchBarPortletPreferences.getDestinationString();
+			_searchBarPortletInstanceConfiguration.destination();
 
 		if (Validator.isBlank(destinationString)) {
 			searchBarPortletDisplayContext.setSearchURL(
@@ -106,6 +112,10 @@ public class SearchBarPortletDisplayContextFactory {
 
 			searchBarPortletDisplayContext.setSearchURL(destinationURL);
 		}
+
+		SearchBarPortletPreferences searchBarPortletPreferences =
+			new SearchBarPortletPreferencesImpl(
+				Optional.ofNullable(_renderRequest.getPreferences()));
 
 		PortletSharedSearchResponse portletSharedSearchResponse =
 			portletSharedSearchRequest.search(_renderRequest);
@@ -486,5 +496,7 @@ public class SearchBarPortletDisplayContextFactory {
 	private final LayoutLocalService _layoutLocalService;
 	private final Portal _portal;
 	private final RenderRequest _renderRequest;
+	private final SearchBarPortletInstanceConfiguration
+		_searchBarPortletInstanceConfiguration;
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -79,7 +80,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testDestinationBlank() throws PortletException {
+	public void testDestinationBlank()
+		throws ConfigurationException, PortletException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(StringPool.BLANK);
@@ -94,7 +97,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testDestinationNull() throws PortletException {
+	public void testDestinationNull()
+		throws ConfigurationException, PortletException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(null);
@@ -109,7 +114,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testDestinationUnreachable() throws PortletException {
+	public void testDestinationUnreachable()
+		throws ConfigurationException, PortletException {
+
 		String destination = RandomTestUtil.randomString();
 
 		_whenLayoutLocalServiceFetchLayoutByFriendlyURL(destination, null);
@@ -185,7 +192,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testSamePageNoDestination() throws PortletException {
+	public void testSamePageNoDestination()
+		throws ConfigurationException, PortletException {
+
 		Mockito.doReturn(
 			"http://example.com/web/guest/home?param=arg"
 		).when(
@@ -209,7 +218,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testScopeParameterName() throws ReadOnlyException {
+	public void testScopeParameterName()
+		throws ConfigurationException, ReadOnlyException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(null, "sp", null);
@@ -224,7 +235,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testScopeParameterNameDefault() throws ReadOnlyException {
+	public void testScopeParameterNameDefault()
+		throws ConfigurationException, ReadOnlyException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(null, null, null);
@@ -240,7 +253,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testSearchScopePreferenceDefault() throws ReadOnlyException {
+	public void testSearchScopePreferenceDefault()
+		throws ConfigurationException, ReadOnlyException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(null, null, null);
@@ -249,7 +264,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testSearchScopePreferenceEverything() throws ReadOnlyException {
+	public void testSearchScopePreferenceEverything()
+		throws ConfigurationException, ReadOnlyException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(
@@ -260,7 +277,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 	@Test
 	public void testSearchScopePreferenceLetTheUserChooseEverything()
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
@@ -272,7 +289,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 	@Test
 	public void testSearchScopePreferenceLetTheUserChooseInvalidScopeParam()
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		expectedException.expect(IllegalArgumentException.class);
 		expectedException.expectMessage(
@@ -289,7 +306,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 	@Test
 	public void testSearchScopePreferenceLetTheUserChooseNoScopeParam()
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
@@ -301,7 +318,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 	@Test
 	public void testSearchScopePreferenceLetTheUserChooseThisSite()
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
@@ -312,7 +329,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testSearchScopePreferenceThisSite() throws ReadOnlyException {
+	public void testSearchScopePreferenceThisSite()
+		throws ConfigurationException, ReadOnlyException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(
@@ -395,7 +414,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 	private SearchBarPortletDisplayContextFactory
 			_createSearchBarPortletDisplayContextFactory(String destination)
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		return _createSearchBarPortletDisplayContextFactory(
 			destination, null, null, null);
@@ -405,7 +424,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 			_createSearchBarPortletDisplayContextFactory(
 				String scope, String scopeParameterName,
 				String scopeParameterValue)
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		return _createSearchBarPortletDisplayContextFactory(
 			null, scope, scopeParameterName, scopeParameterValue);
@@ -415,7 +434,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 			_createSearchBarPortletDisplayContextFactory(
 				String destination, String scope, String scopeParameterName,
 				String scopeParameterValue)
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		RenderRequest renderRequest = Mockito.mock(RenderRequest.class);
 

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
@@ -438,6 +438,12 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 		RenderRequest renderRequest = Mockito.mock(RenderRequest.class);
 
+		Mockito.when(
+			renderRequest.getAttribute(WebKeys.THEME_DISPLAY)
+		).thenReturn(
+			_themeDisplay
+		);
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				new SearchBarPortletDisplayContextFactory(
@@ -450,6 +456,12 @@ public class SearchBarPortletDisplayContextFactoryTest {
 			destination);
 		portletPreferences.setValue(
 			SearchBarPortletPreferences.PREFERENCE_KEY_SEARCH_SCOPE, scope);
+
+		Mockito.when(
+			_searchBarPortletInstanceConfiguration.destination()
+		).thenReturn(
+			destination
+		);
 
 		if (scopeParameterName != null) {
 			portletPreferences.setValue(
@@ -469,12 +481,6 @@ public class SearchBarPortletDisplayContextFactoryTest {
 			renderRequest.getPreferences()
 		).thenReturn(
 			portletPreferences
-		);
-
-		Mockito.when(
-			renderRequest.getAttribute(WebKeys.THEME_DISPLAY)
-		).thenReturn(
-			_themeDisplay
 		);
 
 		PortletSharedSearchResponse portletSharedSearchResponse = Mockito.mock(
@@ -561,7 +567,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 			Mockito.when(
 				_portletDisplay.getPortletInstanceConfiguration(Mockito.any())
 			).thenReturn(
-				Mockito.mock(SearchBarPortletInstanceConfiguration.class)
+				_searchBarPortletInstanceConfiguration
 			);
 		}
 		catch (Exception exception) {
@@ -615,6 +621,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 		Mockito.mock(PortletPreferencesLookup.class);
 	private final PortletSharedSearchRequest _portletSharedSearchRequest =
 		Mockito.mock(PortletSharedSearchRequest.class);
+	private final SearchBarPortletInstanceConfiguration
+		_searchBarPortletInstanceConfiguration = Mockito.mock(
+			SearchBarPortletInstanceConfiguration.class);
 	private final SearchBarPrecedenceHelper _searchBarPrecedenceHelper =
 		Mockito.mock(SearchBarPrecedenceHelper.class);
 	private final SearchSuggestionsCompanyConfiguration


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-161173
Thank you!

-----

**Reproduction Steps:**

1.   Go to Site Builder --> Pages
2.  Create a widget page (check its friendly URL)
3.  Go to Design --> Page Templates --> Master Pages
4.  Create a Master Template
    1. Add a search bar widget to it
    2. Configure the search bar widget to have the search page "/search" as the "Destination Page"
    3. Publish the Master Template
5.  Go to Site Builder --> Pages
6.  Create a content page named "my content page" based on the Master Template and publish it
7.  Go to the "my content page" page
8.  Type in the search bar "test" then click the search icon
 **Checkpoint:** We are directed to the search page displaying the search results. Expected behavior.
9. Go to Design --> Page Templates --> Master Pages
10. Edit the created Master Template
      1. Configure the search bar widget to have the widget page as the "Destination Page"
      4.  Publish the page (You will see a popup stating that the changes will be propagated, press OK)
11.  Go to the "my content page" page
12.  Type "test" the search bar

**Expected behavior:** The widget page opens
 **Actual behaviour:** The search page opens

 I used the method to fix the issue recommended on the following PTR: https://issues.liferay.com/browse/PTR-3316

I fixed the failing tests from the previous pull.

previous pulls: #588 #590