### PR TITLE
[TS] LPS-166095 Feature requested by a DXP 7.4 customer: add a configuration to enable the 'DFS Query Then Fetch' search type to get consistent scoring between nodes

### DIFF
--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -5196,6 +5196,8 @@ device-help=Object that represents the device currently used to access the site.
 device-rule-does-not-exist=Device rule does not exist.
 device-type=Device Type
 devices=Devices
+dfs-query-then-fetch=Enable 'DFS Query Then Fetch' search type
+dfs-query-then-fetch-help=The DFS stands for Distributed Frequency Search. When 'DFS Query Then Fetch' is enabled (search_type=dfs_query_then_fetch), the distributed term frequencies are calculated globally, using information gathered from all shards running the search. While this option increases the accuracy of scoring, it adds a round-trip to each shard, which can result in slower searches.
 diagram=Diagram
 diagram-file=Diagram File
 diagram-mapping=Diagram Mapping

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-api/src/main/java/com/liferay/portal/search/elasticsearch7/configuration/ElasticsearchConfiguration.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-api/src/main/java/com/liferay/portal/search/elasticsearch7/configuration/ElasticsearchConfiguration.java
@@ -159,6 +159,18 @@ public interface ElasticsearchConfiguration {
 	public RESTClientLoggerLevel restClientLoggerLevel();
 
 	@Meta.AD(
+		deflt = "false", description = "dfs-query-then-fetch-help",
+		name = "dfs-query-then-fetch", required = false
+	)
+	public boolean dfsQueryThenFetch();
+
+	@Meta.AD(
+		deflt = "true", description = "track-total-hits-help",
+		name = "track-total-hits", required = false
+	)
+	public boolean trackTotalHits();
+
+	@Meta.AD(
 		deflt = "LiferayElasticsearchCluster",
 		description = "cluster-name-help", name = "cluster-name",
 		required = false
@@ -221,12 +233,6 @@ public interface ElasticsearchConfiguration {
 		name = "network-publish-host", required = false
 	)
 	public String networkPublishHost();
-
-	@Meta.AD(
-		deflt = "true", description = "track-total-hits-help",
-		name = "track-total-hits", required = false
-	)
-	public boolean trackTotalHits();
 
 	@Meta.AD(
 		deflt = "", description = "transport-tcp-port-help",
@@ -321,11 +327,5 @@ public interface ElasticsearchConfiguration {
 		name = "proxy-password", required = false, type = Meta.Type.Password
 	)
 	public String proxyPassword();
-
-	@Meta.AD(
-		deflt = "false", description = "dfs-query-then-fetch-help",
-		name = "dfs-query-then-fetch", required = false
-	)
-	public boolean dfsQueryThenFetch();
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-api/src/main/java/com/liferay/portal/search/elasticsearch7/configuration/ElasticsearchConfiguration.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-api/src/main/java/com/liferay/portal/search/elasticsearch7/configuration/ElasticsearchConfiguration.java
@@ -322,4 +322,10 @@ public interface ElasticsearchConfiguration {
 	)
 	public String proxyPassword();
 
+	@Meta.AD(
+		deflt = "false", description = "dfs-query-then-fetch-help",
+		name = "dfs-query-then-fetch", required = false
+	)
+	public boolean dfsQueryThenFetch();
+
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchIndexSearcher.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchIndexSearcher.java
@@ -438,6 +438,8 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 
 		baseSearchRequest.addComplexQueryParts(
 			searchRequest.getComplexQueryParts());
+		baseSearchRequest.setDfsQueryThenFetchEnabled(
+			_elasticsearchConfigurationWrapper.dfsQueryThenFetch());
 		baseSearchRequest.setExplain(searchRequest.isExplain());
 		baseSearchRequest.setHighlight(searchRequest.getHighlight());
 		baseSearchRequest.setIncludeResponseString(

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/configuration/ElasticsearchConfigurationWrapper.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/configuration/ElasticsearchConfigurationWrapper.java
@@ -90,6 +90,10 @@ public class ElasticsearchConfigurationWrapper
 		return -1;
 	}
 
+	public boolean dfsQueryThenFetch() {
+		return _elasticsearchConfiguration.dfsQueryThenFetch();
+	}
+
 	/**
 	 * @deprecated As of Athanasius (7.3.x)
 	 */

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/search/SearchSearchRequestExecutorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/search/SearchSearchRequestExecutorImpl.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -49,6 +50,10 @@ public class SearchSearchRequestExecutorImpl
 
 		if (searchSearchRequest.isRequestCache()) {
 			searchRequest.requestCache(searchSearchRequest.isRequestCache());
+		}
+
+		if (searchSearchRequest.isDfsQueryThenFetchEnabled()) {
+			searchRequest.searchType(SearchType.DFS_QUERY_THEN_FETCH);
 		}
 
 		SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/search/BaseSearchRequest.java
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/search/BaseSearchRequest.java
@@ -159,6 +159,10 @@ public abstract class BaseSearchRequest extends CrossClusterRequest {
 		return _basicFacetSelection;
 	}
 
+	public boolean isDfsQueryThenFetchEnabled() {
+		return _dfsQueryThenFetchEnabled;
+	}
+
 	public boolean isExplain() {
 		if (_explain != null) {
 			return _explain;
@@ -197,6 +201,10 @@ public abstract class BaseSearchRequest extends CrossClusterRequest {
 
 	public void setBasicFacetSelection(boolean basicFacetSelection) {
 		_basicFacetSelection = basicFacetSelection;
+	}
+
+	public void setDfsQueryThenFetchEnabled(boolean dfsQueryThenFetchEnabled) {
+		_dfsQueryThenFetchEnabled = dfsQueryThenFetchEnabled;
 	}
 
 	public void setExplain(Boolean explain) {
@@ -272,6 +280,7 @@ public abstract class BaseSearchRequest extends CrossClusterRequest {
 		new LinkedHashMap<>();
 	private boolean _basicFacetSelection;
 	private final List<ComplexQueryPart> _complexQueryParts = new ArrayList<>();
+	private boolean _dfsQueryThenFetchEnabled;
 	private Boolean _explain;
 	private final Map<String, Facet> _facets = new LinkedHashMap<>();
 	private Highlight _highlight;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-166095

This is a feature requested by a DXP 7.4 customer, they are complaining that they are getting inconsistent scoring between Elasticsearch nodes.

To solve this, you can enable the 'DFS Query Then Fetch' search type, for more information see https://www.elastic.co/blog/understanding-query-then-fetch-vs-dfs-query-then-fetch , https://www.elastic.co/guide/en/elasticsearch/reference/7.17/consistent-scoring.html and https://www.elastic.co/guide/en/elasticsearch/reference/7.17/search-search.html#search-type

See also https://issues.liferay.com/browse/LPS-166095 description.

I am sending this PR because this feature is very easy to implement, just create a new ElasticsearchConfiguration setting that enables this 'search type' and adds a call to `searchRequest.searchType(SearchType.DFS_QUERY_THEN_FETCH)` before executing the search.

The implementation is similar to existing **trackTotalHits** setting, that is also configured in ElasticsearchConfiguration and it is set to every search query.
