### PR TITLE
[TS] LPS-166969 When creating or updating a Webcontent or any other ResourcedModel, the IndexerRequestBuffer stores and executes two index requests

### DIFF
--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/IndexerRequestBufferTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/IndexerRequestBufferTest.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.journal.test.util.search.JournalArticleBlueprint;
+import com.liferay.journal.test.util.search.JournalArticleContent;
+import com.liferay.journal.test.util.search.JournalArticleSearchFixture;
+import com.liferay.journal.test.util.search.JournalArticleTitle;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.test.util.SearchTestRule;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Objects;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+
+/**
+ * @author Jorge Díaz
+ */
+@RunWith(Arquillian.class)
+public class IndexerRequestBufferTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() {
+		TransactionConfig.Builder builder = new TransactionConfig.Builder();
+
+		builder.setPropagation(Propagation.REQUIRED);
+		builder.setRollbackForClasses(Exception.class);
+
+		_transactionConfig = builder.build();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_journalArticleSearchFixture = new JournalArticleSearchFixture(
+			_journalArticleLocalService);
+
+		_journalArticleSearchFixture.setUp();
+	}
+
+	@Test
+	public void testJournalArticleIndexedOnlyOnce() throws Throwable {
+		TransactionInvokerUtil.invoke(
+			_transactionConfig,
+			() -> {
+				_addJournalArticle();
+
+				Assert.assertEquals(1, _getIndexerRequestBufferSize());
+
+				return null;
+			});
+	}
+
+	@Rule
+	public SearchTestRule searchTestRule = new SearchTestRule();
+
+	private void _addJournalArticle() throws Exception {
+		_journalArticleSearchFixture.addArticle(
+			new JournalArticleBlueprint() {
+				{
+					setGroupId(_group.getGroupId());
+					setJournalArticleContent(new JournalArticleContent());
+					setJournalArticleTitle(
+						new JournalArticleTitle() {
+							{
+								put(
+									LocaleUtil.US,
+									RandomTestUtil.randomString());
+							}
+						});
+				}
+			});
+	}
+
+	private Bundle _getBundle(String bundleName) throws Exception {
+		Bundle bundle = FrameworkUtil.getBundle(getClass());
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		for (Bundle curBundle : bundleContext.getBundles()) {
+			if (Objects.equals(curBundle.getSymbolicName(), bundleName)) {
+				return curBundle;
+			}
+		}
+
+		return null;
+	}
+
+	private int _getIndexerRequestBufferSize() throws Exception {
+		Bundle bundle = _getBundle("com.liferay.portal.search");
+
+		Class<?> indexerRequestBufferClass = bundle.loadClass(
+			"com.liferay.portal.search.internal.buffer.IndexerRequestBuffer");
+
+		Object indexerRequestBuffer = ReflectionTestUtil.invoke(
+			indexerRequestBufferClass, "get", new Class<?>[0]);
+
+		return (int)ReflectionTestUtil.invoke(
+			indexerRequestBuffer, "size", new Class<?>[0]);
+	}
+
+	@Inject
+	private static JournalArticleLocalService _journalArticleLocalService;
+
+	private static TransactionConfig _transactionConfig;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private JournalArticleSearchFixture _journalArticleSearchFixture;
+
+}

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/IndexerRequestBufferTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/IndexerRequestBufferTest.java
@@ -30,11 +30,10 @@ import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.module.util.BundleUtil;
 import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-
-import java.util.Objects;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -45,7 +44,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 
 /**
@@ -113,22 +111,11 @@ public class IndexerRequestBufferTest {
 			});
 	}
 
-	private Bundle _getBundle(String bundleName) throws Exception {
+	private int _getIndexerRequestBufferSize() throws Exception {
 		Bundle bundle = FrameworkUtil.getBundle(getClass());
 
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		for (Bundle curBundle : bundleContext.getBundles()) {
-			if (Objects.equals(curBundle.getSymbolicName(), bundleName)) {
-				return curBundle;
-			}
-		}
-
-		return null;
-	}
-
-	private int _getIndexerRequestBufferSize() throws Exception {
-		Bundle bundle = _getBundle("com.liferay.portal.search");
+		bundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "com.liferay.portal.search");
 
 		Class<?> indexerRequestBufferClass = bundle.loadClass(
 			"com.liferay.portal.search.internal.buffer.IndexerRequestBuffer");

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexerRegistryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexerRegistryImpl.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerPostProcessor;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.dummy.DummyIndexer;
+import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistry;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.search.configuration.IndexerRegistryConfiguration;
@@ -338,8 +339,8 @@ public class IndexerRegistryImpl implements IndexerRegistry {
 
 			BufferedIndexerInvocationHandler bufferedIndexerInvocationHandler =
 				new BufferedIndexerInvocationHandler(
-					indexer, _indexStatusManager,
-					_indexerRegistryConfiguration);
+					indexer, _indexStatusManager, _indexerRegistryConfiguration,
+					_persistedModelLocalServiceRegistry);
 
 			if (_indexerRequestBufferOverflowHandler == null) {
 				bufferedIndexerInvocationHandler.
@@ -386,6 +387,10 @@ public class IndexerRegistryImpl implements IndexerRegistry {
 
 	@Reference
 	private IndexStatusManager _indexStatusManager;
+
+	@Reference
+	private PersistedModelLocalServiceRegistry
+		_persistedModelLocalServiceRegistry;
 
 	private final Map<String, Indexer<? extends Object>> _proxiedIndexers =
 		new ConcurrentHashMap<>();

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BufferedIndexerInvocationHandler.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BufferedIndexerInvocationHandler.java
@@ -14,7 +14,6 @@
 
 package com.liferay.portal.search.internal.buffer;
 
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
@@ -138,21 +137,18 @@ public class BufferedIndexerInvocationHandler implements InvocationHandler {
 					getPersistedModelLocalService(className);
 
 			try {
-				Object obj = persistedModelLocalService.getPersistedModel(
+				Object object = persistedModelLocalService.getPersistedModel(
 					classPK);
 
-				if (obj instanceof ResourcedModel) {
-					ResourcedModel resourcedModel = (ResourcedModel)obj;
+				if (object instanceof ResourcedModel) {
+					ResourcedModel resourcedModel = (ResourcedModel)object;
 
 					classPK = resourcedModel.getResourcePrimKey();
 				}
 			}
 			catch (Exception exception) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(
-						StringBundler.concat(
-							"Unable to get resource primary key for class ",
-							className, " with primary key ", classPK));
+				if (_log.isTraceEnabled()) {
+					_log.trace(exception);
 				}
 			}
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BufferedIndexerInvocationHandler.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BufferedIndexerInvocationHandler.java
@@ -14,13 +14,17 @@
 
 package com.liferay.portal.search.internal.buffer;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.ClassedModel;
+import com.liferay.portal.kernel.model.ResourcedModel;
 import com.liferay.portal.kernel.search.Bufferable;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.PersistedModelLocalService;
+import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistry;
 import com.liferay.portal.kernel.util.MethodKey;
 import com.liferay.portal.search.configuration.IndexerRegistryConfiguration;
 import com.liferay.portal.search.index.IndexStatusManager;
@@ -40,11 +44,14 @@ public class BufferedIndexerInvocationHandler implements InvocationHandler {
 
 	public BufferedIndexerInvocationHandler(
 		Indexer<?> indexer, IndexStatusManager indexStatusManager,
-		IndexerRegistryConfiguration indexerRegistryConfiguration) {
+		IndexerRegistryConfiguration indexerRegistryConfiguration,
+		PersistedModelLocalServiceRegistry persistedModelLocalServiceRegistry) {
 
 		_indexer = indexer;
 		_indexStatusManager = indexStatusManager;
 		_indexerRegistryConfiguration = indexerRegistryConfiguration;
+		_persistedModelLocalServiceRegistry =
+			persistedModelLocalServiceRegistry;
 	}
 
 	@Override
@@ -103,6 +110,12 @@ public class BufferedIndexerInvocationHandler implements InvocationHandler {
 
 			Long classPK = (Long)classedModel.getPrimaryKeyObj();
 
+			if (args[0] instanceof ResourcedModel) {
+				ResourcedModel resourcedModel = (ResourcedModel)args[0];
+
+				classPK = resourcedModel.getResourcePrimKey();
+			}
+
 			bufferRequest(
 				methodKey, classedModel.getModelClassName(), classPK,
 				indexerRequestBuffer);
@@ -119,6 +132,29 @@ public class BufferedIndexerInvocationHandler implements InvocationHandler {
 
 			String className = (String)args[0];
 			Long classPK = (Long)args[1];
+
+			PersistedModelLocalService persistedModelLocalService =
+				_persistedModelLocalServiceRegistry.
+					getPersistedModelLocalService(className);
+
+			try {
+				Object obj = persistedModelLocalService.getPersistedModel(
+					classPK);
+
+				if (obj instanceof ResourcedModel) {
+					ResourcedModel resourcedModel = (ResourcedModel)obj;
+
+					classPK = resourcedModel.getResourcePrimKey();
+				}
+			}
+			catch (Exception exception) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						StringBundler.concat(
+							"Unable to get resource primary key for class ",
+							className, " with primary key ", classPK));
+				}
+			}
 
 			bufferRequest(methodKey, className, classPK, indexerRequestBuffer);
 		}
@@ -219,5 +255,7 @@ public class BufferedIndexerInvocationHandler implements InvocationHandler {
 	private volatile IndexerRequestBufferOverflowHandler
 		_indexerRequestBufferOverflowHandler;
 	private final IndexStatusManager _indexStatusManager;
+	private final PersistedModelLocalServiceRegistry
+		_persistedModelLocalServiceRegistry;
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-166969

When creating or updating a Webcontent or any other ResourcedModel, the IndexerRequestBuffer stores and executes two index requests, so two index operations are executed.

This is a regression caused by LPS-105011:

 - It was detected after updating from 7.1 to 7.4, but it is also reproduced in 7.3
 - The bug was originally fixed by LPS-67703
 - But its code changes were reverted in this commit https://github.com/brianchandotcom/liferay-portal/pull/83458/commits/c8cff1f258f90931e25360ae324d7ac2782194fa

This is problematic for customers who bulk import web content objects, as the indexing operation is duplicated, it takes twice the time to index them.

We have done some tests with a script that creates 1000 Webcontents and we had these times:

 - Before LPS-166969: 228 seconds
 - After LPS-166969: 168 seconds

To solve the issue, I am just doing a partial revert of the LPS-105011 commit that caused the problem.

I think we can implement a test to check that only one webcontent is sent to Elasticsearch.

   - My idea is to do a test that creates a database transaction, inside this transaction, create a webcontent and check the content of the Index Buffer.
   - I will be on PTO next week, I can implement the test when I am back.


Let me know if you need any information.

/cc @jcampoy

----

**Update:**

The old code generates a SF error.

I have fixed it here: https://github.com/liferay-search/liferay-portal/pull/626/commits/09089e263e8515faedce1b9cbcf1341426d326c0

- obj variable must be called "object"
- We must use the "exception" object in the try...catch but everytime a reindex is done using resourcePrimKey, we will get an exception that can be ignored. 
- To avoid having lots of exceptions that are safe to ignore in the DEBUG log level, I have changed it to TRACE level.