### PR TITLE
search poc: learn-resource for category-facet-field-configuration

### DIFF
--- a/learn-resources/portal-search-api.json
+++ b/learn-resources/portal-search-api.json
@@ -1,0 +1,8 @@
+{
+	"category-facet-field-configuration": {
+		"en_US": {
+			"message": "Learn more, including whether a reindex is required.",
+			"url": "https://learn.liferay.com/dxp/latest/en/using-search/search-pages-and-widgets/search-facets/category-facet.html#filter-facet-terms-categories-by-vocabulary"
+		}
+	}
+}

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/configuration/CategoryFacetFieldConfiguration.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/configuration/CategoryFacetFieldConfiguration.java
@@ -23,7 +23,11 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * @author Bryan Engler
  */
-@ExtendedObjectClassDefinition(category = "search")
+@ExtendedObjectClassDefinition(
+	category = "search",
+	liferayLearnMessageKey = "category-facet-field-configuration",
+	liferayLearnMessageResource = "portal-search-api"
+)
 @Meta.OCD(
 	id = "com.liferay.portal.search.configuration.CategoryFacetFieldConfiguration",
 	localization = "content/Language",


### PR DESCRIPTION
I think this would work to add a link to the Cat Facet Field configuration entry in Sys Settings: I tested using an existing learn-resources file and it rendered correctly. If you think it's good I can create a ticket (LRDOCS or LPS?) and send a PR for real.

@BryanEngler @lipusz 