### PR TITLE
LPS-153813 LPS-166841 [FE] In the blueprint preview, fallback to using "id" if "assetTitle" property is blank or doesn't exist

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/preview_sidebar/ResultListItem.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/preview_sidebar/ResultListItem.js
@@ -94,7 +94,9 @@ function ResultListItem({explanation = '', fields, id, score = 0}) {
 			</ClayList.ItemField>
 
 			<ClayList.ItemField expand>
-				<ClayList.ItemTitle>{fields.assetTitle}</ClayList.ItemTitle>
+				<ClayList.ItemTitle>
+					{fields.assetTitle || id}
+				</ClayList.ItemTitle>
 
 				{getResultDefaultKeys(locale).map((property) =>
 					_renderListRow(property, fields[property])


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-166841