### PR TITLE
LPS-168259 portal-search-web: Prevent browser from persisting value of checkbox by setting autocomplete to 'off'

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/category/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/category/facet/view.jsp
@@ -93,6 +93,7 @@ CategoryFacetPortletInstanceConfiguration categoryFacetPortletInstanceConfigurat
 										<div class="custom-checkbox custom-control">
 											<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
 												<input
+													autocomplete="off"
 													<%= assetCategoriesSearchFacetTermDisplayContext.isSelected() ? "checked" : StringPool.BLANK %>
 													class="custom-control-input facet-term"
 													data-term-id="<%= assetCategoriesSearchFacetTermDisplayContext.getAssetCategoryId() %>"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/folder/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/folder/facet/view.jsp
@@ -93,6 +93,7 @@ FolderFacetPortletInstanceConfiguration folderFacetPortletInstanceConfiguration 
 										<div class="custom-checkbox custom-control">
 											<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
 												<input
+													autocomplete="off"
 													class="custom-control-input facet-term"
 													data-term-id="<%= bucketDisplayContext.getFilterValue() %>"
 													disabled

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/site/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/site/facet/view.jsp
@@ -93,6 +93,7 @@ SiteFacetPortletInstanceConfiguration siteFacetPortletInstanceConfiguration = sc
 										<div class="custom-checkbox custom-control">
 											<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
 												<input
+													autocomplete="off"
 													class="custom-control-input facet-term"
 													data-term-id="<%= scopeSearchFacetTermDisplayContext.getGroupId() %>"
 													disabled

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/tag/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/tag/facet/view.jsp
@@ -93,6 +93,7 @@ TagFacetPortletInstanceConfiguration tagFacetPortletInstanceConfiguration = asse
 										<div class="custom-checkbox custom-control">
 											<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
 												<input
+													autocomplete="off"
 													<%= bucketDisplayContext.isSelected() ? "checked" : StringPool.BLANK %>
 													class="custom-control-input facet-term"
 													data-term-id="<%= HtmlUtil.escapeAttribute(bucketDisplayContext.getFilterValue()) %>"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/view.jsp
@@ -93,6 +93,7 @@ TypeFacetPortletInstanceConfiguration typeFacetPortletInstanceConfiguration = as
 										<div class="custom-checkbox custom-control">
 											<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
 												<input
+													autocomplete="off"
 													class="custom-control-input facet-term"
 													data-term-id="<%= assetEntriesSearchFacetTermDisplayContext.getAssetType() %>"
 													disabled

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/user/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/user/facet/view.jsp
@@ -93,6 +93,7 @@ UserFacetPortletInstanceConfiguration userFacetPortletInstanceConfiguration = us
 										<div class="custom-checkbox custom-control">
 											<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
 												<input
+													autocomplete="off"
 													<%= userSearchFacetTermDisplayContext.isSelected() ? "checked" : StringPool.BLANK %>
 													class="custom-control-input facet-term"
 													data-term-id="<%= HtmlUtil.escapeAttribute(userSearchFacetTermDisplayContext.getUserName()) %>"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/category/facet/portlet/display/template/dependencies/portlet_display_template_vocabulary.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/category/facet/portlet/display/template/dependencies/portlet_display_template_vocabulary.ftl
@@ -50,6 +50,7 @@
 								<div class="custom-checkbox custom-control">
 									<label>
 										<input
+											autocomplete="off"
 											${selected?then("checked", "")}
 											class="custom-control-input facet-term"
 											data-term-id=${id}

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/modified/facet/portlet/display/template/dependencies/portlet_display_template_radio.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/modified/facet/portlet/display/template/dependencies/portlet_display_template_radio.ftl
@@ -19,6 +19,7 @@
 						<div class="custom-control custom-radio">
 							<label class="facet-checkbox-label" for="${entry.getLabel()}">
 								<input
+									autocomplete="off"
 									${(entry.isSelected())?then("checked", "")}
 									class="custom-control-input facet-term"
 									disabled
@@ -48,6 +49,7 @@
 				<div class="custom-control custom-radio">
 					<label class="facet-checkbox-label" for="${customRangeModifiedFacetTermDisplayContext.getLabel()}">
 						<input
+							autocomplete="off"
 							${(customRangeModifiedFacetTermDisplayContext.isSelected())?then("checked", "")}
 							class="custom-control-input facet-term"
 							disabled


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-168259 - In Safari, facet selection and search results do not match when using browser's back button

It seems like this bug involves checkbox inputs. Based on several StackOverflow answers and this article about Checkboxes from MDN, a checked checkbox will persist its value across page loads, like when hitting the back button. By setting `autocomplete` to `off`, this lets the browser forget that value. Hopefully this fixes the bug across the browsers mentioned, as it's been mentioned in separate articles to have happened with Safari, Chrome, and Firefox.

https://stackoverflow.com/questions/33731067/checkbox-still-checked-hitting-the-back-button-but-it-has-no-checked-attribut
https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox