### PR TITLE
LPS-166657 LPS-168351 Disable Test Config button

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/TestConfigurationButton.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/TestConfigurationButton.js
@@ -12,6 +12,7 @@
 import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
+import {ClayTooltipProvider} from '@clayui/tooltip';
 import {fetch, sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
@@ -27,6 +28,7 @@ function TestConfigurationButton({
 	cacheTimeout,
 	embeddingVectorDimensions,
 	enableGPU,
+	errors,
 	huggingFaceAccessToken,
 	languageIds,
 	maxCharacterCount,
@@ -261,22 +263,49 @@ function TestConfigurationButton({
 			});
 	};
 
+	const isMissingRequiredFields = () => {
+		if (
+			sentenceTransformProvider ===
+			SENTENCE_TRANSFORM_PROVIDER_TYPES.HUGGING_FACE
+		) {
+			return (
+				errors.huggingFaceAccessToken ||
+				errors.model ||
+				errors.modelTimeout
+			);
+		}
+
+		return false;
+	};
+
 	return (
 		<div className="test-configuration-button-root">
-			<ClayButton
-				aria-label={Liferay.Language.get('test-configuration')}
-				disabled={loading}
-				displayType="secondary"
-				onClick={_handleTestConfigurationButtonClick}
-			>
-				{loading && (
-					<span className="inline-item inline-item-before">
-						<ClayLoadingIndicator small />
-					</span>
-				)}
+			<ClayTooltipProvider>
+				<ClayButton
+					aria-disabled={loading || isMissingRequiredFields()}
+					aria-label={Liferay.Language.get('test-configuration')}
+					className={
+						loading || isMissingRequiredFields() ? 'disabled' : ''
+					}
+					displayType="secondary"
+					onClick={_handleTestConfigurationButtonClick}
+					{...(isMissingRequiredFields()
+						? {
+								title: Liferay.Language.get(
+									'required-fields-missing'
+								),
+						  }
+						: {})}
+				>
+					{loading && (
+						<span className="inline-item inline-item-before">
+							<ClayLoadingIndicator small />
+						</span>
+					)}
 
-				{Liferay.Language.get('test-configuration')}
-			</ClayButton>
+					{Liferay.Language.get('test-configuration')}
+				</ClayButton>
+			</ClayTooltipProvider>
 
 			{!!testResultsMessage.message && (
 				<ClayAlert

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/index.js
@@ -207,6 +207,7 @@ export default function ({
 			txtaiHostAddress,
 		},
 		validate: _handleFormikValidate,
+		validateOnMount: true,
 	});
 
 	const _handleCheckboxChange = (name) => (event) => {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/index.js
@@ -372,6 +372,7 @@ export default function ({
 						formik.values.embeddingVectorDimensions
 					}
 					enableGPU={formik.values.enableGPU}
+					errors={formik.errors}
 					huggingFaceAccessToken={
 						formik.values.huggingFaceAccessToken
 					}


### PR DESCRIPTION
@thektan
Continued from https://github.com/liferay-search/liferay-portal/pull/664

https://issues.liferay.com/browse/LPS-168351

Disables the Test Configuration button if any of the required fields don't pass validation. Uses the same form validation.

Also shows a tooltip when hovered over the button while disabled.

![image](https://user-images.githubusercontent.com/14063502/202041673-f6c93875-d953-4c6c-804c-9667cea71e37.png)

Just added a small commit to validate immediately, since when the user first hits the semantic search form, the test connection button is still enabled.