### PR TITLE
LPS-166989 LPS-167392 txtai sentence transformer configuration supports connection using Basic Auth

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/configuration/SemanticSearchConfiguration.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/configuration/SemanticSearchConfiguration.java
@@ -59,7 +59,7 @@ public interface SemanticSearchConfiguration {
 		deflt = "", description = "sentence-transformer-txtai-username-help",
 		name = "username", required = false
 	)
-	public String txtaiUsername();
+	public String txtaiUserName();
 
 	@Meta.AD(
 		deflt = "", description = "sentence-transformer-txtai-password-help",

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SentenceTransformerValidationResultResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SentenceTransformerValidationResultResourceImpl.java
@@ -92,7 +92,7 @@ public class SentenceTransformerValidationResultResourceImpl
 		).put(
 			"txtaiPassword", jsonObject.getString("txtaiPassword")
 		).put(
-			"txtaiUsername", jsonObject.getString("txtaiUsername")
+			"txtaiUserName", jsonObject.getString("txtaiUserName")
 		).build();
 	}
 

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/ml/sentence/embedding/TXTAISentenceTransformer.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/ml/sentence/embedding/TXTAISentenceTransformer.java
@@ -75,7 +75,7 @@ public class TXTAISentenceTransformer
 			Http.Options options = new Http.Options();
 
 			if (!Validator.isBlank(
-					semanticSearchConfiguration.txtaiUsername())) {
+					semanticSearchConfiguration.txtaiUserName())) {
 
 				_setAuthOptions(options, semanticSearchConfiguration);
 			}
@@ -114,7 +114,7 @@ public class TXTAISentenceTransformer
 		options.setAuth(
 			HttpComponentsUtil.getDomain(
 				semanticSearchConfiguration.txtaiHostAddress()),
-			-1, null, semanticSearchConfiguration.txtaiUsername(),
+			-1, null, semanticSearchConfiguration.txtaiUserName(),
 			semanticSearchConfiguration.txtaiPassword());
 	}
 

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/configuration/admin/display/SemanticSearchConfigurationFormRenderer.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/configuration/admin/display/SemanticSearchConfigurationFormRenderer.java
@@ -189,7 +189,7 @@ public class SemanticSearchConfigurationFormRenderer
 		semanticSearchCompanyConfigurationDisplayContext.setTxtaiPassword(
 			_semanticSearchConfiguration.txtaiPassword());
 		semanticSearchCompanyConfigurationDisplayContext.setTxtaiUserName(
-			_semanticSearchConfiguration.txtaiUsername());
+			_semanticSearchConfiguration.txtaiUserName());
 
 		httpServletRequest.setAttribute(
 			SemanticSearchCompanyConfigurationDisplayContext.class.getName(),

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/configuration/admin/display/SemanticSearchConfigurationFormRenderer.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/configuration/admin/display/SemanticSearchConfigurationFormRenderer.java
@@ -111,6 +111,12 @@ public class SemanticSearchConfigurationFormRenderer
 		).put(
 			"txtaiHostAddress",
 			ParamUtil.getString(httpServletRequest, "txtaiHostAddress")
+		).put(
+			"txtaiPassword",
+			ParamUtil.getString(httpServletRequest, "txtaiPassword")
+		).put(
+			"txtaiUserName",
+			ParamUtil.getString(httpServletRequest, "txtaiUserName")
 		).build();
 	}
 
@@ -180,6 +186,10 @@ public class SemanticSearchConfigurationFormRenderer
 				_semanticSearchConfiguration.textTruncationStrategy());
 		semanticSearchCompanyConfigurationDisplayContext.setTxtaiHostAddress(
 			_semanticSearchConfiguration.txtaiHostAddress());
+		semanticSearchCompanyConfigurationDisplayContext.setTxtaiPassword(
+			_semanticSearchConfiguration.txtaiPassword());
+		semanticSearchCompanyConfigurationDisplayContext.setTxtaiUserName(
+			_semanticSearchConfiguration.txtaiUsername());
 
 		httpServletRequest.setAttribute(
 			SemanticSearchCompanyConfigurationDisplayContext.class.getName(),

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/SemanticSearchCompanyConfigurationDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/SemanticSearchCompanyConfigurationDisplayContext.java
@@ -86,6 +86,14 @@ public class SemanticSearchCompanyConfigurationDisplayContext {
 		return _txtaiHostAddress;
 	}
 
+	public String getTxtaiPassword() {
+		return _txtaiPassword;
+	}
+
+	public String getTxtaiUserName() {
+		return _txtaiUserName;
+	}
+
 	public boolean isSentenceTransformerEnabled() {
 		return _sentenceTransformerEnabled;
 	}
@@ -172,6 +180,14 @@ public class SemanticSearchCompanyConfigurationDisplayContext {
 		_txtaiHostAddress = txtaiHostAddress;
 	}
 
+	public void setTxtaiPassword(String txtaiPassword) {
+		_txtaiPassword = txtaiPassword;
+	}
+
+	public void setTxtaiUserName(String txtaiUserName) {
+		_txtaiUserName = txtaiUserName;
+	}
+
 	private List<String> _assetEntryClassNames;
 	private Map<String, String> _availableAssetEntryClassNames;
 	private List<String> _availableEmbeddingVectorDimensions;
@@ -189,5 +205,7 @@ public class SemanticSearchCompanyConfigurationDisplayContext {
 	private String _sentenceTransformProvider;
 	private String _textTruncationStrategy;
 	private String _txtaiHostAddress;
+	private String _txtaiPassword;
+	private String _txtaiUserName;
 
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/configuration.jsp
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/configuration.jsp
@@ -69,6 +69,10 @@ SemanticSearchCompanyConfigurationDisplayContext semanticSearchCompanyConfigurat
 				"textTruncationStrategy", semanticSearchCompanyConfigurationDisplayContext.getTextTruncationStrategy()
 			).put(
 				"txtaiHostAddress", semanticSearchCompanyConfigurationDisplayContext.getTxtaiHostAddress()
+			).put(
+				"txtaiPassword", semanticSearchCompanyConfigurationDisplayContext.getTxtaiPassword()
+			).put(
+				"txtaiUserName", semanticSearchCompanyConfigurationDisplayContext.getTxtaiUserName()
 			).build()
 		%>'
 	/>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/Input.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/Input.js
@@ -110,7 +110,7 @@ function Input({
 						onBlur={onBlur}
 						onChange={_handleEventChange}
 						required={required}
-						type="text"
+						type={type || 'text'}
 						value={value || ''}
 					/>
 				);

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/index.js
@@ -75,6 +75,8 @@ export default function ({
 	sentenceTransformerEnabled,
 	textTruncationStrategy,
 	txtaiHostAddress,
+	txtaiPassword,
+	txtaiUserName,
 }) {
 	const _handleFormikValidate = (values) => {
 		const errors = {};
@@ -205,6 +207,8 @@ export default function ({
 			sentenceTransformerEnabled,
 			textTruncationStrategy,
 			txtaiHostAddress,
+			txtaiPassword,
+			txtaiUserName,
 		},
 		validate: _handleFormikValidate,
 		validateOnMount: true,
@@ -261,17 +265,44 @@ export default function ({
 
 				{formik.values.sentenceTransformProvider ===
 					SENTENCE_TRANSFORM_PROVIDER_TYPES.TXTAI && (
-					<Input
-						error={formik.errors.txtaiHostAddress}
-						helpText={Liferay.Language.get(
-							'sentence-transformer-txtai-host-address-help'
-						)}
-						label={Liferay.Language.get('txtai-host-address')}
-						name={`${namespace}txtaiHostAddress`}
-						onBlur={_handleInputBlur('txtaiHostAddress')}
-						onChange={_handleInputChange('txtaiHostAddress')}
-						value={formik.values.txtaiHostAddress}
-					/>
+					<>
+						<Input
+							error={formik.errors.txtaiHostAddress}
+							helpText={Liferay.Language.get(
+								'sentence-transformer-txtai-host-address-help'
+							)}
+							label={Liferay.Language.get('txtai-host-address')}
+							name={`${namespace}txtaiHostAddress`}
+							onBlur={_handleInputBlur('txtaiHostAddress')}
+							onChange={_handleInputChange('txtaiHostAddress')}
+							value={formik.values.txtaiHostAddress}
+						/>
+
+						<Input
+							error={formik.errors.txtaiUserName}
+							helpText={Liferay.Language.get(
+								'sentence-transformer-txtai-username-help'
+							)}
+							label={Liferay.Language.get('username')}
+							name={`${namespace}txtaiUserName`}
+							onBlur={_handleInputBlur('txtaiUserName')}
+							onChange={_handleInputChange('txtaiUserName')}
+							value={formik.values.txtaiUserName}
+						/>
+
+						<Input
+							error={formik.errors.txtaiPassword}
+							helpText={Liferay.Language.get(
+								'sentence-transformer-txtai-password-help'
+							)}
+							label={Liferay.Language.get('password')}
+							name={`${namespace}txtaiPassword`}
+							onBlur={_handleInputBlur('txtaiPassword')}
+							onChange={_handleInputChange('txtaiPassword')}
+							type="password"
+							value={formik.values.txtaiPassword}
+						/>
+					</>
 				)}
 
 				{formik.values.sentenceTransformProvider ===


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-167392

Fixed rebase conflicts. The `gradle baseline` commit was already made on master and running it locally again was successful (no changes). So I'll run ci again just to test if it's a local issue that it's not updating or to confirm if baseline doesn't need to be run again.

---

**Comment from original PR:**

### Notes
I did notice that in https://github.com/liferay/liferay-portal/commit/cd0a4f27d2b346b2f3d412c719b3c7faa244f7d0 `txtaiUserName` was renamed to `txtaiUsername`, but in `search-experiences-web`, there is an SF error forcing the CamelCased `*Name` format. To keep the variable name consistent, I renamed all places back to the CamelCased `txtaiUserName`. This is the formatter rule enforced: "Variable names ending with name should be CamelCase" https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/camel_case_name_check.markdown 

### Screenshots
![Screenshot 2022-11-10 at 5 44 07 PM](https://user-images.githubusercontent.com/4496722/201243988-d65ccd11-f60a-4a40-b73c-0dc97e776700.png)
