### PR TITLE
LPS-165919 portal-search-web: Prevent invoking suggestions endpoint immediately

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -44,17 +44,19 @@ export default function SearchBar({
 	const [autocompleteSearchValue, setAutocompleteSearchValue] = useState('');
 	const [inputValue, setInputValue] = useState(keywords);
 	const [loading, setLoading] = useState(false);
-	const [resourceItems, setResourceItems] = useState([]);
 	const [scope, setScope] = useState(
 		selectedEverythingSearchScope
 			? scopeParameterStringEverything
 			: scopeParameterStringCurrentSite
 	);
+	const [suggestionsResponseItems, setSuggestionsResponseItems] = useState(
+		[]
+	);
 
 	const alignElementRef = useRef();
 	const dropdownRef = useRef();
 
-	const _handleFetchSuggestions = (value) => {
+	const _fetchSuggestions = (value) => {
 		fetch(
 			addParams(
 				{
@@ -81,19 +83,18 @@ export default function SearchBar({
 		)
 			.then((response) => response.json())
 			.then((data) => {
-				setLoading(false);
-
-				setResourceItems(data?.items || []);
+				setSuggestionsResponseItems(data?.items || []);
 			})
 			.catch(() => {
+				setSuggestionsResponseItems([]);
+			})
+			.finally(() => {
 				setLoading(false);
-
-				setResourceItems([]);
 			});
 	};
 
-	const [handleFetchSuggestionsDebounced] = useDebounceCallback(
-		_handleFetchSuggestions,
+	const [fetchSuggestionsDebounced] = useDebounceCallback(
+		_fetchSuggestions,
 		500
 	);
 
@@ -132,7 +133,7 @@ export default function SearchBar({
 			if (value.trim() !== autocompleteSearchValue) {
 				setLoading(true);
 
-				handleFetchSuggestionsDebounced(value.trim());
+				fetchSuggestionsDebounced(value.trim());
 			}
 
 			setActive(true);
@@ -281,7 +282,7 @@ export default function SearchBar({
 			</ClayInput.Group>
 
 			<ClayDropDown.Menu
-				active={active && !!resourceItems.length}
+				active={active && !!suggestionsResponseItems.length}
 				alignElementRef={alignElementRef}
 				autoBestAlign={false}
 				className="search-bar-suggestions-dropdown-menu"
@@ -294,7 +295,7 @@ export default function SearchBar({
 						alignElementRef.current.clientWidth + 'px',
 				}}
 			>
-				{resourceItems.map((group, groupIndex) => (
+				{suggestionsResponseItems.map((group, groupIndex) => (
 					<ClayDropDown.ItemList
 						className="search-bar-suggestions-results-list"
 						key={groupIndex}

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/hooks/useDebounceCallback.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/hooks/useDebounceCallback.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {cancelDebounce, debounce} from 'frontend-js-web';
+import {useRef} from 'react';
+
+export default function useDebounceCallback(callback, milliseconds) {
+	const callbackRef = useRef(debounce(callback, milliseconds));
+
+	return [callbackRef.current, () => cancelDebounce(callbackRef.current)];
+}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-165919 - /suggestions endpoint is invoked on each page load without actual search

Basically, this opts for a fetch function instead of relying on `useResource`, as one of its features is that it fetches upon mount. By defining a fetch function, it would only get called when the user types a new, unique value into the searchbar. Included a hook for debounce as well. Also I think `suggestionsContributorConfiguration` is usually in an array, so updated the default value for that. Let me know if there's anything else, thanks!