### PR TITLE
LPS-166989 LPS-169452 search-experiences-web: Add txtai credentials to validation request for 'Test Configuration' button

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/TestConfigurationButton.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/TestConfigurationButton.js
@@ -36,6 +36,8 @@ function TestConfigurationButton({
 	sentenceTransformer,
 	textTruncationStrategy,
 	txtaiHostAddress,
+	txtaiPassword,
+	txtaiUsername,
 }) {
 	const [loading, setLoading] = useState(false);
 	const [testResultsMessage, setTestResultsMessage] = useState({}); // {message, type}
@@ -57,6 +59,8 @@ function TestConfigurationButton({
 		sentenceTransformer,
 		textTruncationStrategy,
 		txtaiHostAddress,
+		txtaiPassword,
+		txtaiUsername,
 	]);
 
 	/**
@@ -80,6 +84,8 @@ function TestConfigurationButton({
 		if (sentenceTransformer === SENTENCE_TRANSFORMER_TYPES.TXTAI) {
 			return {
 				txtaiHostAddress,
+				txtaiPassword,
+				txtaiUsername,
 			};
 		}
 

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/index.js
@@ -422,6 +422,8 @@ export default function ({
 						formik.values.textTruncationStrategy
 					}
 					txtaiHostAddress={formik.values.txtaiHostAddress}
+					txtaiPassword={formik.values.txtaiPassword}
+					txtaiUsername={formik.values.txtaiUsername}
 				/>
 			</div>
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-169452 - [FE] Add txtai credentials to validation request for 'Test Configuration' button (subtask of https://issues.liferay.com/browse/LPS-166989)

Short update to add the username and password to the validate configuration request. Let me know if there's anything that's missing, thanks!