### PR TITLE
LPS-169866: Fix SXPBlueprintLocalServiceTest and SXPElementLocalServiceTest updating elemnts with the same ERC

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/test/SXPBlueprintLocalServiceTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/test/SXPBlueprintLocalServiceTest.java
@@ -24,8 +24,6 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.test.log.LogCapture;
-import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -37,8 +35,6 @@ import com.liferay.search.experiences.service.SXPBlueprintLocalService;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import javax.persistence.PersistenceException;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -127,6 +123,36 @@ public class SXPBlueprintLocalServiceTest {
 
 	@Test
 	public void testUpdateSXPBlueprint() throws Exception {
+		SXPBlueprint sxpBlueprint = _addSXPBlueprint(
+			RandomTestUtil.randomString());
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		sxpBlueprint.setExternalReferenceCode(externalReferenceCode);
+
+		sxpBlueprint = _sxpBlueprintLocalService.updateSXPBlueprint(
+			sxpBlueprint);
+
+		Assert.assertEquals(
+			externalReferenceCode, sxpBlueprint.getExternalReferenceCode());
+
+		sxpBlueprint = _sxpBlueprintLocalService.updateSXPBlueprint(
+			sxpBlueprint.getUserId(), sxpBlueprint.getSXPBlueprintId(),
+			sxpBlueprint.getConfigurationJSON(),
+			sxpBlueprint.getDescriptionMap(),
+			sxpBlueprint.getElementInstancesJSON(),
+			sxpBlueprint.getSchemaVersion(), sxpBlueprint.getTitleMap(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(
+			externalReferenceCode, sxpBlueprint.getExternalReferenceCode());
+		Assert.assertEquals("1.1", sxpBlueprint.getVersion());
+	}
+
+	@Test(expected = DuplicateSXPBlueprintExternalReferenceCodeException.class)
+	public void testUpdateSXPBlueprintWithSameExternalReferenceCode()
+		throws Exception {
+
 		SXPBlueprint sxpBlueprint1 = _addSXPBlueprint(
 			RandomTestUtil.randomString());
 		SXPBlueprint sxpBlueprint2 = _addSXPBlueprint(
@@ -135,56 +161,7 @@ public class SXPBlueprintLocalServiceTest {
 		sxpBlueprint2.setExternalReferenceCode(
 			sxpBlueprint1.getExternalReferenceCode());
 
-		try (LogCapture logCapture1 = LoggerTestUtil.configureLog4JLogger(
-				"org.hibernate.engine.jdbc.batch.internal.BatchingBatch",
-				LoggerTestUtil.ERROR);
-			LogCapture logCapture2 = LoggerTestUtil.configureLog4JLogger(
-				"org.hibernate.engine.jdbc.spi.SqlExceptionHelper",
-				LoggerTestUtil.ERROR)) {
-
-			try {
-				_sxpBlueprintLocalService.updateSXPBlueprint(sxpBlueprint2);
-
-				Assert.fail();
-			}
-			catch (PersistenceException persistenceException) {
-				Assert.assertNotNull(persistenceException);
-			}
-		}
-
-		String externalReferenceCode = RandomTestUtil.randomString();
-
-		sxpBlueprint1.setExternalReferenceCode(externalReferenceCode);
-
-		sxpBlueprint1 = _sxpBlueprintLocalService.updateSXPBlueprint(
-			sxpBlueprint1);
-
-		Assert.assertEquals(
-			externalReferenceCode, sxpBlueprint1.getExternalReferenceCode());
-
-		sxpBlueprint1 = _sxpBlueprintLocalService.updateSXPBlueprint(
-			sxpBlueprint1.getUserId(), sxpBlueprint1.getSXPBlueprintId(),
-			sxpBlueprint1.getConfigurationJSON(),
-			sxpBlueprint1.getDescriptionMap(),
-			sxpBlueprint1.getElementInstancesJSON(),
-			sxpBlueprint1.getSchemaVersion(), sxpBlueprint1.getTitleMap(),
-			ServiceContextTestUtil.getServiceContext());
-
-		Assert.assertEquals(
-			externalReferenceCode, sxpBlueprint1.getExternalReferenceCode());
-		Assert.assertEquals("1.1", sxpBlueprint1.getVersion());
-
-		sxpBlueprint1 = _sxpBlueprintLocalService.updateSXPBlueprint(
-			sxpBlueprint1.getUserId(), sxpBlueprint1.getSXPBlueprintId(),
-			sxpBlueprint1.getConfigurationJSON(),
-			sxpBlueprint1.getDescriptionMap(),
-			sxpBlueprint1.getElementInstancesJSON(),
-			sxpBlueprint1.getSchemaVersion(), sxpBlueprint1.getTitleMap(),
-			ServiceContextTestUtil.getServiceContext());
-
-		Assert.assertEquals(
-			externalReferenceCode, sxpBlueprint1.getExternalReferenceCode());
-		Assert.assertEquals("1.2", sxpBlueprint1.getVersion());
+		_sxpBlueprintLocalService.updateSXPBlueprint(sxpBlueprint2);
 	}
 
 	private SXPBlueprint _addSXPBlueprint(String externalReferenceCode)

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/test/SXPElementLocalServiceTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/test/SXPElementLocalServiceTest.java
@@ -24,8 +24,6 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.test.log.LogCapture;
-import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -37,8 +35,6 @@ import com.liferay.search.experiences.service.SXPElementLocalService;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import javax.persistence.PersistenceException;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -126,59 +122,40 @@ public class SXPElementLocalServiceTest {
 
 	@Test
 	public void testUpdateSXPElement() throws Exception {
+		SXPElement sxpElement = _addSXPElement(RandomTestUtil.randomString());
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		sxpElement.setExternalReferenceCode(externalReferenceCode);
+
+		sxpElement = _sxpElementLocalService.updateSXPElement(sxpElement);
+
+		Assert.assertEquals(
+			externalReferenceCode, sxpElement.getExternalReferenceCode());
+
+		sxpElement = _sxpElementLocalService.updateSXPElement(
+			sxpElement.getUserId(), sxpElement.getSXPElementId(),
+			sxpElement.getDescriptionMap(),
+			sxpElement.getElementDefinitionJSON(), sxpElement.isHidden(),
+			sxpElement.getSchemaVersion(), sxpElement.getTitleMap(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(
+			externalReferenceCode, sxpElement.getExternalReferenceCode());
+		Assert.assertEquals("1.1", sxpElement.getVersion());
+	}
+
+	@Test(expected = DuplicateSXPElementExternalReferenceCodeException.class)
+	public void testUpdateSXPElementWithSameExternalReferenceCode()
+		throws Exception {
+
 		SXPElement sxpElement1 = _addSXPElement(RandomTestUtil.randomString());
 		SXPElement sxpElement2 = _addSXPElement(RandomTestUtil.randomString());
 
 		sxpElement2.setExternalReferenceCode(
 			sxpElement1.getExternalReferenceCode());
 
-		try (LogCapture logCapture1 = LoggerTestUtil.configureLog4JLogger(
-				"org.hibernate.engine.jdbc.batch.internal.BatchingBatch",
-				LoggerTestUtil.ERROR);
-			LogCapture logCapture2 = LoggerTestUtil.configureLog4JLogger(
-				"org.hibernate.engine.jdbc.spi.SqlExceptionHelper",
-				LoggerTestUtil.ERROR)) {
-
-			try {
-				_sxpElementLocalService.updateSXPElement(sxpElement2);
-
-				Assert.fail();
-			}
-			catch (PersistenceException persistenceException) {
-				Assert.assertNotNull(persistenceException);
-			}
-		}
-
-		String externalReferenceCode = RandomTestUtil.randomString();
-
-		sxpElement1.setExternalReferenceCode(externalReferenceCode);
-
-		sxpElement1 = _sxpElementLocalService.updateSXPElement(sxpElement1);
-
-		Assert.assertEquals(
-			externalReferenceCode, sxpElement1.getExternalReferenceCode());
-
-		sxpElement1 = _sxpElementLocalService.updateSXPElement(
-			sxpElement1.getUserId(), sxpElement1.getSXPElementId(),
-			sxpElement1.getDescriptionMap(),
-			sxpElement1.getElementDefinitionJSON(), sxpElement1.isHidden(),
-			sxpElement1.getSchemaVersion(), sxpElement1.getTitleMap(),
-			ServiceContextTestUtil.getServiceContext());
-
-		Assert.assertEquals(
-			externalReferenceCode, sxpElement1.getExternalReferenceCode());
-		Assert.assertEquals("1.1", sxpElement1.getVersion());
-
-		sxpElement1 = _sxpElementLocalService.updateSXPElement(
-			sxpElement1.getUserId(), sxpElement1.getSXPElementId(),
-			sxpElement1.getDescriptionMap(),
-			sxpElement1.getElementDefinitionJSON(), sxpElement1.isHidden(),
-			sxpElement1.getSchemaVersion(), sxpElement1.getTitleMap(),
-			ServiceContextTestUtil.getServiceContext());
-
-		Assert.assertEquals(
-			externalReferenceCode, sxpElement1.getExternalReferenceCode());
-		Assert.assertEquals("1.2", sxpElement1.getVersion());
+		_sxpElementLocalService.updateSXPElement(sxpElement2);
 	}
 
 	private SXPElement _addSXPElement(String externalReferenceCode)


### PR DESCRIPTION
**What is new?**
- Creating new test case, expecting to throw a `Duplicate<EntityName>ExternalReferenceCodeException.`

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-169866