### PR TITLE
LPS-168920 Address the long delay with "view raw request" JSON

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/_code_mirror.scss
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/_code_mirror.scss
@@ -42,3 +42,9 @@
 		font-size: 13px;
 	}
 }
+
+.codemirror-loading-state {
+	align-items: center;
+	display: flex;
+	height: 300px;
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/_edit_sxp_element.scss
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/_edit_sxp_element.scss
@@ -105,6 +105,10 @@ $sxpElementHeaderHeight: 48px;
 			}
 		}
 
+		.codemirror-loading-state {
+			height: 100%;
+		}
+
 		.codemirror-editor-wrapper {
 			border-width: 0;
 			height: 100%;

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/_preview_modal.scss
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/_preview_modal.scss
@@ -6,4 +6,8 @@
 	.CodeMirror {
 		height: 600px;
 	}
+
+	.codemirror-loading-state {
+		height: 600px;
+	}
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/preview_sidebar/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/preview_sidebar/index.js
@@ -170,7 +170,6 @@ function PreviewSidebar({
 				<ManagementToolbar.Item>
 					<PreviewModalWithCopyDownload
 						fileName="raw_request.json"
-						folded
 						lineWrapping={false}
 						size="lg"
 						text={parseAndPrettifyJSON(requestString)}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/preview_sidebar/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/preview_sidebar/index.js
@@ -190,6 +190,7 @@ function PreviewSidebar({
 				<ManagementToolbar.Item>
 					<PreviewModalWithCopyDownload
 						fileName="raw_response.json"
+						foldInitializationDelay={200}
 						folded
 						lineWrapping={false}
 						size="lg"

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/hooks/useAsyncCall.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/hooks/useAsyncCall.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import {useEffect, useState} from 'react';
+
+/**
+ * Hook for providing an asynchronous function to be completed before performing
+ * an action. Returns a loading state that is set to false at the end.
+ * @param {function} action Function to be called after async
+ * object.
+ * @param {number=} timeout An optional number for timeout
+ * @return {Object}
+ */
+function useAsyncCall(action, timeout = 2000) {
+	const [loading, setLoading] = useState(true);
+
+	const asyncCall = (timeout) => {
+		return new Promise((resolve) => setTimeout(resolve, timeout));
+	};
+
+	useEffect(() => {
+		asyncCall(timeout)
+			.then(action)
+			.finally(() => {
+				setLoading(false);
+			});
+	}, []); //eslint-disable-line
+
+	return [loading, setLoading];
+}
+
+export default useAsyncCall;

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/CodeMirrorEditor.js
@@ -661,6 +661,7 @@ const CodeMirrorEditor = React.forwardRef(
 		{
 			autocompleteSchema,
 			folded = false,
+			foldInitializationDelay = 0,
 			lineWrapping = true,
 			onChange = () => {},
 			mode = 'json',
@@ -686,7 +687,7 @@ const CodeMirrorEditor = React.forwardRef(
 					}
 				});
 			}
-		}, 200);
+		}, foldInitializationDelay);
 
 		useEffect(() => {
 			if (editorWrapperRef.current) {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PreviewModal.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PreviewModal.js
@@ -47,6 +47,7 @@ const PreviewModal = ({body, children, size = 'md', title}) => {
 export function PreviewModalWithCopyDownload({
 	children,
 	fileName,
+	foldInitializationDelay,
 	folded = false,
 	lineWrapping,
 	readOnly = true,
@@ -97,6 +98,7 @@ export function PreviewModalWithCopyDownload({
 					</ClayButton.Group>
 
 					<CodeMirrorEditor
+						foldInitializationDelay={foldInitializationDelay}
 						folded={folded}
 						lineWrapping={lineWrapping}
 						readOnly={readOnly}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-168920 - Within a Blueprints Preview, sometimes there is a long delay after clicking "View Raw Request" before the modal with the JSON appears

It turns out that the reason why the CodeMirror is taking a while to load is a for loop that folds every line of the JSON after the first level. In order to put the user at ease, a loading indicator has been added to the general CodeMirror component (an `useAsyncCall` hook was added). The Raw Request has also been default set to being unfolded, for both performance and convenience (there is deep nesting in that JSON).


https://user-images.githubusercontent.com/14063502/204878408-03b39554-1486-4c79-861e-e0e9a41440c4.mp4



Let me know if there's anything to add, thanks!