### PR TITLE
LPS-169841 portal-search-web: Pass in current scope when fetching suggestions

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -56,7 +56,7 @@ export default function SearchBar({
 	const alignElementRef = useRef();
 	const dropdownRef = useRef();
 
-	const _fetchSuggestions = (value) => {
+	const _fetchSuggestions = (value, currentScope) => {
 		fetch(
 			addParams(
 				{
@@ -66,7 +66,7 @@ export default function SearchBar({
 						: '/search',
 					groupId: Liferay.ThemeDisplay.getScopeGroupId(),
 					plid: Liferay.ThemeDisplay.getPlid(),
-					scope,
+					scope: currentScope,
 					search: value,
 				},
 				suggestionsURL
@@ -133,7 +133,7 @@ export default function SearchBar({
 			if (value.trim() !== autocompleteSearchValue) {
 				setLoading(true);
 
-				fetchSuggestionsDebounced(value.trim());
+				fetchSuggestionsDebounced(value.trim(), scope);
 			}
 
 			setActive(true);

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -56,7 +56,7 @@ export default function SearchBar({
 	const alignElementRef = useRef();
 	const dropdownRef = useRef();
 
-	const _fetchSuggestions = (value, currentScope) => {
+	const _fetchSuggestions = (searchValue, scopeValue) => {
 		fetch(
 			addParams(
 				{
@@ -66,8 +66,8 @@ export default function SearchBar({
 						: '/search',
 					groupId: Liferay.ThemeDisplay.getScopeGroupId(),
 					plid: Liferay.ThemeDisplay.getPlid(),
-					scope: currentScope,
-					search: value,
+					scope: scopeValue,
+					search: searchValue,
 				},
 				suggestionsURL
 			),
@@ -128,7 +128,7 @@ export default function SearchBar({
 
 			// Immediately show loading spinner unless the value hasn't changed.
 			// If the value hasn't changed, no new request will be made and the
-			// loading spinner will never be hidden.
+			// loading spinner will not be shown.
 
 			if (value.trim() !== autocompleteSearchValue) {
 				setLoading(true);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-169841 - "Let the User Choose" search bar scope is not honored with the search bar suggestions

Keeps the scope inside the fetch call up to date by directly passing it in. 