### PR TITLE
LPS-164852 portal-search-web: Format destination URL for suggestions call

### DIFF
--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SuggestionResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SuggestionResourceImpl.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.search.rest.internal.resource.v1_0;
 
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
@@ -91,7 +93,7 @@ public class SuggestionResourceImpl extends BaseSuggestionResourceImpl {
 					RenderResponseFactory.create(
 						contextHttpServletResponse, liferayRenderRequest),
 					_createSearchContext(
-						destinationFriendlyURL, _getGroupId(groupId),
+						_slashify(destinationFriendlyURL), _getGroupId(groupId),
 						keywordsParameterName, scope, search,
 						suggestionsContributorConfigurations)),
 				suggestionsContributorResult ->
@@ -226,6 +228,14 @@ public class SuggestionResourceImpl extends BaseSuggestionResourceImpl {
 		catch (PortalException portalException) {
 			throw new RuntimeException(portalException);
 		}
+	}
+
+	private String _slashify(String s) {
+		if (s.charAt(0) == CharPool.SLASH) {
+			return s;
+		}
+
+		return StringPool.SLASH.concat(s);
 	}
 
 	@Reference


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-164852 - Suggestion results should be clickable even when Destination Page doesn't start with "/"

To fix this, there's just a new function that formats the destinationFriendlyURL to trim and append a `/` in the front of the string (if no slash is provided), which was what the suggestions call needed. If left blank, the destination URL defaults to `/search` as before. Let me know if I should make other changes, thanks!