### PR TITLE
LPS-164684 Add character threshold for blueprints suggestions contributor configuration

### DIFF
--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Chapter
 chapters=Chapters
 character-options=Character Options
+character-threshold=Character Threshold
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions
 characters=Characters
 characters-blacklist=Characters Blacklist

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=يمكن تعيين القنوات إلى منشأة و
 chapter=فصل
 chapters=فصول
 character-options=خيارات الحروف
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=حد الحرف لعرض الاقتراحات
 characters=الحروف
 characters-blacklist=قائمة الأحرف السوداء

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Глава
 chapters=Глави
 character-options=Опции за знаци (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Знак за черни букви (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Els canals només es poden assignar a una sola propieta
 chapter=Capítol
 chapters=Capítols
 character-options=Opcions de caràcters
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Límit de caràcters per mostrar suggeriments
 characters=Caràcters
 characters-blacklist=Llista negra de caràcters

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Kapitola
 chapters=Kapitoly
 character-options=Character Options (Automatic Copy)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Characters Blacklist (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Chapter (Automatic Copy)
 chapters=Chapters (Automatic Copy)
 character-options=Indstillinger for tegn (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Tegn Sortliste (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Kanäle können immer nur einer Eigenschaft zugewiesen 
 chapter=Kapitel
 chapters=Kapitel
 character-options=Zeichenoptionen
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Zeichenschwellenwert für die Anzeige von Vorschlägen
 characters=Zeichen
 characters-blacklist=Zeichen-Blacklist

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Κεφάλαιο
 chapters=Κεφάλαια
 character-options=Επιλογές χαρακτήρων (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Χαρακτήρες Μαύρη λίστα (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Chapter
 chapters=Chapters
 character-options=Character Options
+character-threshold=Character Threshold
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions
 characters=Characters
 characters-blacklist=Characters Blacklist

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Chapter (Automatic Copy)
 chapters=Chapters (Automatic Copy)
 character-options=Character Options (Automatic Copy)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Characters Blacklist (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Chapter (Automatic Copy)
 chapters=Chapters (Automatic Copy)
 character-options=Character Options (Automatic Copy)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Characters Blacklist (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Cada canal solo puede asignarse a una única propiedad.
 chapter=Capítulo
 chapters=Capítulos
 character-options=Opciones de caracteres
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Umbral de caracteres para mostrar sugerencias
 characters=Caracteres
 characters-blacklist=Lista negra de caracteres

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Capítulo
 chapters=Capítulos
 character-options=Opciones de caracteres
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Umbral de caracteres para mostrar sugerencias
 characters=Caracteres
 characters-blacklist=Lista negra de caracteres

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Capítulo
 chapters=Capítulos
 character-options=Opciones de caracteres
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Umbral de caracteres para mostrar sugerencias
 characters=Caracteres
 characters-blacklist=Lista negra de caracteres

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Capítulo
 chapters=Capítulos
 character-options=Opciones de caracteres
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Umbral de caracteres para mostrar sugerencias
 characters=Caracteres
 characters-blacklist=Lista negra de caracteres

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Peatükk
 chapters=Peatükid
 character-options=Märgisuvandid (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Märgid Must nimekiri (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Atala
 chapters=Atalak
 character-options=Character Options (Automatic Copy)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Characters Blacklist (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=سرفصل
 chapters=سرفصل ها
 character-options=گزینه های کاراکتر (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=لیست سیاه کاراکترها

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Kanavia voi määrittää vain yhdelle ominaisuudelle k
 chapter=Kappale
 chapters=Kappaleet
 character-options=Merkkivalinnat
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Merkkiraja ehdotusten näyttämiselle
 characters=Merkit
 characters-blacklist=Merkkien Musta Lista

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Les canaux ne peuvent être attribués qu'à une seule 
 chapter=Chapitre
 chapters=Chapitres
 character-options=Options de caractère
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Seuil de caractères pour l'affichage des suggestions
 characters=Caractères
 characters-blacklist=Liste noire des caractères

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Chapitre
 chapters=Chapitres
 character-options=Options de caractère
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Liste noire des caractères

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Capítulo
 chapters=Capítulos
 character-options=Character Options (Automatic Copy)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Characters Blacklist (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=चॅप्टर
 chapters=चॅप्टरस
 character-options=चरित्र विकल्प (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=वर्ण ब्लैकलिस्ट (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Poglavlje
 chapters=Poglavlja
 character-options=Character Options (Automatic Copy)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Characters Blacklist (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=A csatornák egyszerre csak egy tulajdonsághoz rendelh
 chapter=Fejezet
 chapters=Fejezetek
 character-options=Karakterek lehetőségei
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=A javaslatok megjelenítésének karakter-küszöbértéke
 characters=Karakterek
 characters-blacklist=Karakterek feketelistája

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Bab
 chapters=Bab
 character-options=Opsi Karakter (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Daftar Hitam Karakter (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -3050,6 +3050,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Capitolo
 chapters=Capitoli
 character-options=Opzioni carattere (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Personaggi Lista nera (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=פרק
 chapters=פרקים
 character-options=אפשרויות תו (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=רשימה שחורה של תווים

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=チャンネルは同時に 1 つのプロパティに�
 chapter=章
 chapters=章
 character-options=文字オプション
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=提案を表示する際の文字しきい値
 characters=文字
 characters-blacklist=ブラックリストに追加された文字

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Chapter (Automatic Copy)
 chapters=Chapters (Automatic Copy)
 character-options=Character Options (Automatic Copy)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Characters Blacklist (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=지부
 chapters=지부
 character-options=문자 옵션
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=제안 표시를 위한 문자 기준값
 characters=Characters (Automatic Copy)
 characters-blacklist=문자 블랙리스트

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=ບົດທີ່
 chapters=ບົດທີ່ຕ່າງໆ
 character-options=Character Options (Automatic Copy)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Characters Blacklist (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Skyrius (Automatic Translation)
 chapters=Skyriai (Automatic Translation)
 character-options=Simbolių parinktys (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Simbolių juodasis sąrašas (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Bab (Automatic Translation)
 chapters=Bab (Automatic Translation)
 character-options=Opsyen Aksara (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Senarai Hitam Aksara (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Kapittel
 chapters=Kapitler
 character-options=Alternativer for tegn (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Svartelistede tegn

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Aan kanalen kan slechts één eigenschap tegelijk worde
 chapter=Hoofdstuk
 chapters=Hoofdstukken
 character-options=Tekenopties
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Tekenlimiet voor het weergeven van suggesties
 characters=Tekens
 characters-blacklist=Zwarte lijst tekens

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Hoofdstuk
 chapters=Hoofdstukken
 character-options=Character Options (Automatic Copy)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Characters Blacklist (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Rozdział
 chapters=Rozdziały
 character-options=Opcje znaków (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Czarne listy postaci (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Canais só podem ser atribuídos a uma única proprieda
 chapter=Capítulo
 chapters=Capítulos
 character-options=Opções de caracteres
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Limite de caracteres para a exibição de sugestões
 characters=Caracteres
 characters-blacklist=Lista de bloqueios de caracteres

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Capítulo
 chapters=Capítulos
 character-options=Opções de caracteres (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Personagens Lista Negra (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Capitol
 chapters=Capitole
 character-options=Opțiuni caracter (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Lista neagră a caracterelor (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Глава
 chapters=Главы
 character-options=Параметры символов (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Черный список персонажей (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Kapitola
 chapters=Kapitoly
 character-options=Možnosti znakov (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Čierny zoznam znakov (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Poglavje
 chapters=Poglavja
 character-options=Možnosti znakov (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Znaki Črni seznam (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Поглавље
 chapters=Поглавља
 character-options=Character Options (Automatic Copy)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Characters Blacklist (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Poglavlje
 chapters=Poglavlja
 character-options=Character Options (Automatic Copy)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Characters Blacklist (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Kanaler kan bara tilldelas till en resurs åt gången. 
 chapter=Kapitel
 chapters=Kapitel
 character-options=Teckenalternativ
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Tröskelvärde för tecken för att visa förslag
 characters=Tecken
 characters-blacklist=Svartlista för tecken

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=அத்தியாயம்
 chapters=அத்தியாயங்கள்
 character-options=Character Options (Automatic Copy)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Characters Blacklist (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=บท
 chapters=บท
 character-options=ตัวเลือกตัวอักษร
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=เกณฑ์การวัดตัวอักษรเพื่อแสดงคำแนะนำ
 characters=Characters (Automatic Copy)
 characters-blacklist=ความประพฤติบัญชีดำ

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Bölüm
 chapters=Bölümler
 character-options=Karakter Seçenekleri (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Karakterler Kara Listesi (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Розділ
 chapters=Розділи
 character-options=Параметри символів (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Чорний список символів (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=Chương
 chapters=Các chương
 character-options=Tùy chọn Ký tự (Automatic Translation)
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=Danh sách đen nhân vật (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=渠道一次只可以分配至一个属性。选择渠�
 chapter=章节
 chapters=章节
 character-options=字符选项
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=显示建议的字符阈值
 characters=字符
 characters-blacklist=字符黑名单

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -3051,6 +3051,7 @@ channels-tab-description=Channels can only be assigned to a single property at a
 chapter=章節
 chapters=章節
 character-options=字元選項
+character-threshold=Character Threshold (Automatic Copy)
 character-threshold-for-displaying-suggestions=Character Threshold for Displaying Suggestions (Automatic Copy)
 characters=Characters (Automatic Copy)
 characters-blacklist=字元黑名單

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/_search_bar.scss
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/_search_bar.scss
@@ -25,10 +25,6 @@
 		}
 
 		.input-group-item {
-			&.include-input {
-				max-width: 172px;
-			}
-
 			&.size-input {
 				max-width: 136px;
 			}

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -56,11 +56,14 @@ export default function SearchBar({
 	const alignElementRef = useRef();
 	const dropdownRef = useRef();
 
-	// If the blueprint suggestions contributor does not set its own threshold,
-	// the suggestions display threshold will default to the global one.
+	/**
+	 * Returns the lowest suggestions display threshold available.
+	 * If no blueprint suggestions contributor sets its own threshold,
+	 * this value will default to the global one.
+	 */
 
 	const _getLowestSuggestionsDisplayThreshold = useCallback(() => {
-		const characterThresholds = JSON.parse(
+		const characterThresholdArray = JSON.parse(
 			suggestionsContributorConfiguration
 		)
 			.filter((config) => config.attributes?.characterThreshold)
@@ -68,8 +71,8 @@ export default function SearchBar({
 				parseInt(config.attributes.characterThreshold, 10)
 			);
 
-		return characterThresholds.length
-			? Math.min(...characterThresholds)
+		return characterThresholdArray.length
+			? Math.min(...characterThresholdArray)
 			: parseInt(suggestionsDisplayThreshold, 10);
 	}, [suggestionsContributorConfiguration, suggestionsDisplayThreshold]);
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -56,6 +56,17 @@ export default function SearchBar({
 	const alignElementRef = useRef();
 	const dropdownRef = useRef();
 
+	const characterThresholds = JSON.parse(suggestionsContributorConfiguration)
+		.filter((config) => config.attributes?.characterThreshold)
+		.map((config) => parseInt(config.attributes.characterThreshold, 10));
+
+	// If the blueprint suggestions contributor does not set its own threshold,
+	// the suggestions display threshold will default to the global one.
+
+	const finalSuggestionsDisplayThreshold = characterThresholds.length
+		? Math.min(...characterThresholds)
+		: parseInt(suggestionsDisplayThreshold, 10);
+
 	const _fetchSuggestions = (searchValue, scopeValue) => {
 		fetch(
 			addParams(
@@ -108,6 +119,16 @@ export default function SearchBar({
 		setScope(event.target.value);
 	};
 
+	const _handleFocus = () => {
+		if (finalSuggestionsDisplayThreshold === 0 && inputValue === '') {
+			setLoading(true);
+
+			_fetchSuggestions(inputValue, scope);
+
+			setActive(true);
+		}
+	};
+
 	const _handleSubmit = (event) => {
 		event.preventDefault();
 		event.stopPropagation();
@@ -124,7 +145,7 @@ export default function SearchBar({
 
 		setInputValue(value);
 
-		if (value.trim().length > parseInt(suggestionsDisplayThreshold, 10)) {
+		if (value.trim().length >= finalSuggestionsDisplayThreshold) {
 
 			// Immediately show loading spinner unless the value hasn't changed.
 			// If the value hasn't changed, no new request will be made and the
@@ -158,6 +179,7 @@ export default function SearchBar({
 					data-qa-id="searchInput"
 					name={keywordsParameterName}
 					onChange={_handleValueChange}
+					onFocus={_handleFocus}
 					onKeyDown={_handleKeyDown}
 					placeholder={Liferay.Language.get('search-...')}
 					title={Liferay.Language.get('search')}
@@ -195,6 +217,7 @@ export default function SearchBar({
 							data-qa-id="searchInput"
 							name={keywordsParameterName}
 							onChange={_handleValueChange}
+							onFocus={_handleFocus}
 							onKeyDown={_handleKeyDown}
 							placeholder={Liferay.Language.get('search-...')}
 							type="text"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBarConfigurationSuggestions.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBarConfigurationSuggestions.js
@@ -31,6 +31,7 @@ const CONTRIBUTORS = {
 };
 
 const DEFAULT_ATTRIBUTES = {
+	characterThreshold: '',
 	fields: [],
 	includeAssetSearchSummary: true,
 	includeAssetURL: true,
@@ -241,8 +242,22 @@ function SXPBlueprintAttributes({onBlur, onChange, touched, value}) {
 						</ClayButton>
 					</div>
 				</ClayInput.GroupItem>
+			</div>
 
-				<ClayInput.GroupItem className="include-input">
+			<div className="form-group-autofit">
+				<ClayInput.GroupItem>
+					<label>{Liferay.Language.get('character-threshold')}</label>
+
+					<ClayInput
+						aria-label={Liferay.Language.get('character-threshold')}
+						min="0"
+						onChange={_handleChangeAttribute('characterThreshold')}
+						type="number"
+						value={value.attributes?.characterThreshold || ''}
+					/>
+				</ClayInput.GroupItem>
+
+				<ClayInput.GroupItem>
 					<label>{Liferay.Language.get('include-asset-url')}</label>
 
 					<ClaySelect
@@ -262,7 +277,7 @@ function SXPBlueprintAttributes({onBlur, onChange, touched, value}) {
 					</ClaySelect>
 				</ClayInput.GroupItem>
 
-				<ClayInput.GroupItem className="include-input">
+				<ClayInput.GroupItem>
 					<label>
 						{Liferay.Language.get('include-asset-summary')}
 					</label>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-166050 When using a Blueprint to drive Search Bar suggestions, I can configure a character threshold that applies to this group

This story introduces a new item `characterThreshold` into the `attributes` object within blueprints suggestions contributor configurations. Setting this value will override the global display threshold (input "Character Threshold for Displaying Suggestions"). Querying for suggestions begins when keyword length is "equal or greater than" the character threshold, so a threshold of 0 should query for suggestions upon click. Attached a short demo to show the varying suggestions populating.

<img width="1017" alt="Screen Shot 2022-12-06 at 4 58 30 PM" src="https://user-images.githubusercontent.com/14063502/206592946-69f95da9-36c6-4989-a92a-843d0f5c5dd1.png">

https://user-images.githubusercontent.com/14063502/206592432-07d07d2a-ae1d-4964-b3bc-480eecaaa88d.mp4

