### PR TITLE
LPS-151930 portal-kernel: Update class name for highlighted text

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/search-results/_highlight.scss
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/search-results/_highlight.scss
@@ -1,9 +1,3 @@
 .important {
 	font-weight: bold;
 }
-
-.highlight {
-	background: #ffc;
-	font-weight: bold;
-	margin: 0 1px;
-}

--- a/portal-kernel/src/com/liferay/portal/kernel/search/highlight/HighlightUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/highlight/HighlightUtil.java
@@ -36,7 +36,7 @@ public class HighlightUtil {
 	public static final String HIGHLIGHT_TAG_OPEN = "<liferay-hl>";
 
 	public static final String[] HIGHLIGHTS = {
-		"<span class=\"highlight\">", "</span>"
+		"<span class=\"highlight mark\">", "</span>"
 	};
 
 	public static void addSnippet(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-151930 Search results portlet highlighted results should be styled by Clay and the theme.

Updating the class to 'mark' instead of 'highlight' actually changes the highlighting slightly, so I included a side by side comparison. Also removed the styling involved with the 'highlight' class name since it would no longer be used! Let me know if there's anything else to change, thanks!

Before:
<img width="711" alt="Screen Shot 2022-12-12 at 3 18 04 PM" src="https://user-images.githubusercontent.com/14063502/207179989-18cac6e3-6a9f-4599-8039-2651f5fe55c6.png">
<img width="711" alt="Screen Shot 2022-12-12 at 3 19 50 PM" src="https://user-images.githubusercontent.com/14063502/207180520-e8c3ef6f-a051-4331-bc68-d8c126d592e6.png">

After:
<img width="707" alt="Screen Shot 2022-12-12 at 3 18 31 PM" src="https://user-images.githubusercontent.com/14063502/207180135-b0597ea6-31d9-4c42-b661-8ca7ad684751.png">
<img width="707" alt="Screen Shot 2022-12-12 at 3 19 13 PM" src="https://user-images.githubusercontent.com/14063502/207180361-b366db0a-92c6-4d2b-8bc9-d4d26d832534.png">

