### PR TITLE
[TS] LPS-172622 Cannot perform empty searches after a non-empty search

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -286,7 +286,7 @@ export default function SearchBar({
 	const _updateQueryString = (queryString) => {
 		const searchParams = new URLSearchParams(queryString);
 
-		if (inputValue) {
+		if (inputValue || emptySearchEnabled) {
 			searchParams.set(
 				keywordsParameterName,
 				inputValue.replace(/^\s+|\s+$/, '')


### PR DESCRIPTION
Hi Team,
Please help me review this ticket.

https://issues.liferay.com/browse/LPS-172622

Solution:
The problem cause javascript doesn't update the search link when inputValue is blank. Adding an emptySearchEnabled condition to update the search link when inputValue is blank will solve this problem.

Thanks,
Loc
cc:@ces-huynguyen