### PR TITLE
LPS-172811 ModelSearchDefinitions for Object Definitions leak to other Virtual Instances

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -153,6 +153,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 					objectDefinition, _objectEntryDisplayContextFactory,
 					_objectEntryService, _servletContext),
 				HashMapDictionaryBuilder.<String, Object>put(
+					"company.id", objectDefinition.getCompanyId()
+				).put(
 					"javax.portlet.name", objectDefinition.getPortletId()
 				).build()),
 			_bundleContext.registerService(

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/display/context/builder/AssetEntriesSearchFacetDisplayContextBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/display/context/builder/AssetEntriesSearchFacetDisplayContextBuilder.java
@@ -295,6 +295,10 @@ public class AssetEntriesSearchFacetDisplayContextBuilder
 					ObjectDefinitionLocalServiceUtil.fetchObjectDefinition(
 						Long.valueOf(parts[1]));
 
+				if (objectDefinition == null) {
+					continue;
+				}
+
 				typeName = objectDefinition.getLabel(_themeDisplay.getLocale());
 			}
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/asset/SearchableAssetClassNamesProviderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/asset/SearchableAssetClassNamesProviderImpl.java
@@ -45,19 +45,18 @@ public class SearchableAssetClassNamesProviderImpl
 			String className = assetRendererFactory.getClassName();
 
 			if (assetRendererFactory.isSearchable()) {
-
 				if (ArrayUtil.contains(
 						searchEngineHelper.getEntryClassNames(), className,
 						false)) {
 
 					classNames.add(className);
 				}
-			} else if (className.startsWith(
-				"com.liferay.object.model.ObjectDefinition#")) {
+			}
+			else if (className.startsWith(
+						"com.liferay.object.model.ObjectDefinition#")) {
 
 				classNames.add(className);
 			}
-
 		}
 
 		return classNames.toArray(new String[0]);

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/asset/SearchableAssetClassNamesProviderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/asset/SearchableAssetClassNamesProviderImpl.java
@@ -42,8 +42,9 @@ public class SearchableAssetClassNamesProviderImpl
 		for (AssetRendererFactory<?> assetRendererFactory :
 				assetRendererFactories) {
 
+			String className = assetRendererFactory.getClassName();
+
 			if (assetRendererFactory.isSearchable()) {
-				String className = assetRendererFactory.getClassName();
 
 				if (ArrayUtil.contains(
 						searchEngineHelper.getEntryClassNames(), className,
@@ -51,17 +52,12 @@ public class SearchableAssetClassNamesProviderImpl
 
 					classNames.add(className);
 				}
+			} else if (className.startsWith(
+				"com.liferay.object.model.ObjectDefinition#")) {
+
+				classNames.add(className);
 			}
-		}
 
-		for (String searchEngineHelperEntryClassName :
-				searchEngineHelper.getEntryClassNames()) {
-
-			if (searchEngineHelperEntryClassName.startsWith(
-					"com.liferay.object.model.ObjectDefinition#")) {
-
-				classNames.add(searchEngineHelperEntryClassName);
-			}
 		}
 
 		return classNames.toArray(new String[0]);

--- a/portal-kernel/src/com/liferay/asset/kernel/AssetRendererFactoryRegistryUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/AssetRendererFactoryRegistryUtil.java
@@ -139,12 +139,14 @@ public class AssetRendererFactoryRegistryUtil {
 				assetRendererFactories.getService(key);
 
 			if (key.startsWith("com.liferay.object.model.ObjectDefinition#")) {
-
-				if (key.split("#")[2].equals(Long.toString(companyId))) {
-					filteredAssetRendererFactories.put(key, assetRendererFactory);
+				if (key.split("#")[2].equals(String.valueOf(companyId))) {
+					filteredAssetRendererFactories.put(
+						key, assetRendererFactory);
 				}
-			} else if (assetRendererFactory.isActive(companyId) &&
-				(!filterSelectable || assetRendererFactory.isSelectable())) {
+			}
+			else if (assetRendererFactory.isActive(companyId) &&
+					 (!filterSelectable ||
+					  assetRendererFactory.isSelectable())) {
 
 				filteredAssetRendererFactories.put(key, assetRendererFactory);
 			}
@@ -172,9 +174,16 @@ public class AssetRendererFactoryRegistryUtil {
 
 					String className = assetRendererFactory.getClassName();
 
-					if (className.startsWith("com.liferay.object.model.ObjectDefinition#")) {
-						emitter.emit(className + "#" + GetterUtil.getLong(serviceReference.getProperty("company.id")));
-					} else {
+					if (className.startsWith(
+							"com.liferay.object.model.ObjectDefinition#")) {
+
+						emitter.emit(
+							className + "#" +
+								GetterUtil.getLong(
+									serviceReference.getProperty(
+										"company.id")));
+					}
+					else {
 						emitter.emit(className);
 					}
 				});

--- a/portal-kernel/src/com/liferay/asset/kernel/AssetRendererFactoryRegistryUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/AssetRendererFactoryRegistryUtil.java
@@ -41,7 +41,8 @@ public class AssetRendererFactoryRegistryUtil {
 
 		return ListUtil.fromMapValues(
 			_filterAssetRendererFactories(
-				companyId, _classNameAssetRenderFactoriesServiceTrackerMap,
+				companyId,
+				_classNameAssetRenderFactoriesByCompanyIdServiceTrackerMap,
 				false));
 	}
 
@@ -50,7 +51,8 @@ public class AssetRendererFactoryRegistryUtil {
 
 		return ListUtil.fromMapValues(
 			_filterAssetRendererFactories(
-				companyId, _classNameAssetRenderFactoriesServiceTrackerMap,
+				companyId,
+				_classNameAssetRenderFactoriesByCompanyIdServiceTrackerMap,
 				filterSelectable));
 	}
 
@@ -92,7 +94,8 @@ public class AssetRendererFactoryRegistryUtil {
 		if (companyId > 0) {
 			Map<String, AssetRendererFactory<?>> assetRenderFactories =
 				_filterAssetRendererFactories(
-					companyId, _classNameAssetRenderFactoriesServiceTrackerMap,
+					companyId,
+					_classNameAssetRenderFactoriesByCompanyIdServiceTrackerMap,
 					filterSelectable);
 
 			long[] classNameIds = new long[assetRenderFactories.size()];
@@ -138,17 +141,21 @@ public class AssetRendererFactoryRegistryUtil {
 			AssetRendererFactory<?> assetRendererFactory =
 				assetRendererFactories.getService(key);
 
-			if (key.startsWith("com.liferay.object.model.ObjectDefinition#")) {
-				if (key.split("#")[2].equals(String.valueOf(companyId))) {
+			if (assetRendererFactory.isActive(companyId) &&
+				(!filterSelectable || assetRendererFactory.isSelectable())) {
+
+				if (key.startsWith(
+						"com.liferay.object.model.ObjectDefinition#")) {
+
+					if (key.split("#")[2].equals(String.valueOf(companyId))) {
+						filteredAssetRendererFactories.put(
+							key, assetRendererFactory);
+					}
+				}
+				else {
 					filteredAssetRendererFactories.put(
 						key, assetRendererFactory);
 				}
-			}
-			else if (assetRendererFactory.isActive(companyId) &&
-					 (!filterSelectable ||
-					  assetRendererFactory.isSelectable())) {
-
-				filteredAssetRendererFactories.put(key, assetRendererFactory);
 			}
 		}
 
@@ -162,7 +169,7 @@ public class AssetRendererFactoryRegistryUtil {
 		SystemBundleUtil.getBundleContext();
 
 	private static final ServiceTrackerMap<String, AssetRendererFactory<?>>
-		_classNameAssetRenderFactoriesServiceTrackerMap =
+		_classNameAssetRenderFactoriesByCompanyIdServiceTrackerMap =
 			ServiceTrackerMapFactory.openSingleValueMap(
 				_bundleContext,
 				(Class<AssetRendererFactory<?>>)
@@ -186,6 +193,20 @@ public class AssetRendererFactoryRegistryUtil {
 					else {
 						emitter.emit(className);
 					}
+				});
+
+	private static final ServiceTrackerMap<String, AssetRendererFactory<?>>
+		_classNameAssetRenderFactoriesServiceTrackerMap =
+			ServiceTrackerMapFactory.openSingleValueMap(
+				_bundleContext,
+				(Class<AssetRendererFactory<?>>)
+					(Class<?>)AssetRendererFactory.class,
+				null,
+				(serviceReference, emitter) -> {
+					AssetRendererFactory<?> assetRendererFactory =
+						_bundleContext.getService(serviceReference);
+
+					emitter.emit(assetRendererFactory.getClassName());
 				});
 
 	private static final ServiceTrackerMap<String, AssetRendererFactory<?>>

--- a/portal-kernel/src/com/liferay/asset/kernel/AssetRendererFactoryRegistryUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/AssetRendererFactoryRegistryUtil.java
@@ -18,6 +18,7 @@ import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 
@@ -137,7 +138,12 @@ public class AssetRendererFactoryRegistryUtil {
 			AssetRendererFactory<?> assetRendererFactory =
 				assetRendererFactories.getService(key);
 
-			if (assetRendererFactory.isActive(companyId) &&
+			if (key.startsWith("com.liferay.object.model.ObjectDefinition#")) {
+
+				if (key.split("#")[2].equals(Long.toString(companyId))) {
+					filteredAssetRendererFactories.put(key, assetRendererFactory);
+				}
+			} else if (assetRendererFactory.isActive(companyId) &&
 				(!filterSelectable || assetRendererFactory.isSelectable())) {
 
 				filteredAssetRendererFactories.put(key, assetRendererFactory);
@@ -164,7 +170,13 @@ public class AssetRendererFactoryRegistryUtil {
 					AssetRendererFactory<?> assetRendererFactory =
 						_bundleContext.getService(serviceReference);
 
-					emitter.emit(assetRendererFactory.getClassName());
+					String className = assetRendererFactory.getClassName();
+
+					if (className.startsWith("com.liferay.object.model.ObjectDefinition#")) {
+						emitter.emit(className + "#" + GetterUtil.getLong(serviceReference.getProperty("company.id")));
+					} else {
+						emitter.emit(className);
+					}
 				});
 
 	private static final ServiceTrackerMap<String, AssetRendererFactory<?>>


### PR DESCRIPTION
Issue: https://issues.liferay.com/browse/LPS-172811

That issue was caused by: https://issues.liferay.com/browse/LPS-157577

Revert the LPS-157577 is not interesting because it will cause regression bugs, so I adapted the logic to consider the new use case with DB Partition

