### PR TITLE
LPS-173294 Address several frontend warnings in search modules

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/FieldList.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/FieldList.js
@@ -154,7 +154,11 @@ function FieldList({
 	};
 
 	const _handleReplaceField = (index) => (newValue) => {
-		onChange(value.map((item, i) => (i === index ? newValue : item)));
+		onChange(
+			value.map((item, i) =>
+				i === index ? {id: item.id, ...newValue} : item
+			)
+		);
 	};
 
 	return (

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/FieldList.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/FieldList.js
@@ -84,6 +84,7 @@ function Field({children, index, onDelete, showDeleteButton, showDragButton}) {
 				>
 					{showDragButton && (
 						<ClayButton
+							aria-label={Liferay.Language.get('move')}
 							borderless
 							className="drag-handle"
 							displayType="secondary"
@@ -100,6 +101,7 @@ function Field({children, index, onDelete, showDeleteButton, showDragButton}) {
 				{showDeleteButton && (
 					<ClayInput.GroupItem shrink>
 						<ClayButton
+							aria-label={Liferay.Language.get('delete')}
 							borderless
 							displayType="secondary"
 							monospaced
@@ -188,6 +190,7 @@ function FieldList({
 
 				{showAddButton && (
 					<ClayButton
+						aria-label={addButtonLabel}
 						displayType="secondary"
 						onClick={_handleAddField}
 					>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBarConfigurationSuggestions.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBarConfigurationSuggestions.js
@@ -225,6 +225,7 @@ function SXPBlueprintAttributes({onBlur, onChange, touched, value}) {
 
 						{sxpBlueprint.title && (
 							<ClayButton
+								aria-label={Liferay.Language.get('remove')}
 								className="remove-sxp-blueprint"
 								displayType="secondary"
 								onClick={_handleSXPBlueprintSelectorClickRemove}

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/select_sxp_blueprint_modal/ManagementToolbar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/select_sxp_blueprint_modal/ManagementToolbar.js
@@ -40,6 +40,9 @@ const ManagementToolbar = ({
 						items={filterItems}
 						trigger={
 							<ClayButton
+								aria-label={Liferay.Language.get(
+									'filter-and-order'
+								)}
 								className="nav-link"
 								disabled={loading}
 								displayType="unstyled"
@@ -66,6 +69,11 @@ const ManagementToolbar = ({
 
 					<FrontendManagementToolbar.Item>
 						<ClayButton
+							aria-label={
+								sortOrder === 'asc'
+									? Liferay.Language.get('ascending')
+									: Liferay.Language.get('descending')
+							}
 							className="nav-link nav-link-monospaced"
 							disabled={loading}
 							displayType="unstyled"
@@ -104,6 +112,7 @@ const ManagementToolbar = ({
 
 							<ClayInput.GroupInsetItem after tag="span">
 								<ClayButtonWithIcon
+									aria-label={Liferay.Language.get('clear')}
 									className="navbar-breakpoint-d-none"
 									displayType="unstyled"
 									onClick={() => setSearchMobile(false)}
@@ -111,6 +120,7 @@ const ManagementToolbar = ({
 								/>
 
 								<ClayButtonWithIcon
+									aria-label={Liferay.Language.get('search')}
 									disabled={loading}
 									displayType="unstyled"
 									onClick={() => onSearch(searchInputValue)}
@@ -124,6 +134,7 @@ const ManagementToolbar = ({
 				<FrontendManagementToolbar.ItemList>
 					<FrontendManagementToolbar.Item className="navbar-breakpoint-d-none">
 						<ClayButton
+							aria-label={Liferay.Language.get('search')}
 							className="nav-link nav-link-monospaced"
 							displayType="unstyled"
 							onClick={() => setSearchMobile(true)}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/add_sxp_element_sidebar/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/add_sxp_element_sidebar/index.js
@@ -69,6 +69,11 @@ const SXPElementList = ({
 		<>
 			{!!category && (
 				<ClayButton
+					aria-label={
+						showList
+							? Liferay.Language.get('collapse')
+							: Liferay.Language.get('expand')
+					}
 					className="panel-header sidebar-dt"
 					displayType="unstyled"
 					onClick={() => setShowList(!showList)}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/SearchableTypesModal.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/SearchableTypesModal.js
@@ -20,12 +20,13 @@ import React, {useState} from 'react';
 import sub from '../../utils/language/sub';
 
 function SearchableTypesModal({
+	children,
 	onFetchSearchableTypes,
 	onFrameworkConfigChange,
 	searchableTypes,
 	selectedTypes,
-	setVisible,
 }) {
+	const [visible, setVisible] = useState(false);
 	const [modalSelectedTypes, setModalSelectedTypes] = useState(selectedTypes);
 
 	const {observer, onClose} = useModal({
@@ -55,159 +56,176 @@ function SearchableTypesModal({
 	};
 
 	return (
-		<ClayModal
-			className="modal-height-xl sxp-searchable-types-modal-root"
-			observer={observer}
-			size="lg"
-		>
-			<ClayModal.Header>
-				{Liferay.Language.get('select-types')}
-			</ClayModal.Header>
+		<>
+			{visible && (
+				<ClayModal
+					className="modal-height-xl sxp-searchable-types-modal-root"
+					observer={observer}
+					size="lg"
+				>
+					<ClayModal.Header>
+						{Liferay.Language.get('select-types')}
+					</ClayModal.Header>
 
-			{searchableTypes.length ? (
-				<>
-					<ManagementToolbar.Container
-						className={
-							!!modalSelectedTypes.length &&
-							'management-bar-primary'
-						}
-					>
-						<div className="navbar-form navbar-form-autofit navbar-overlay">
-							<ManagementToolbar.ItemList>
-								<ManagementToolbar.Item>
-									<ClayCheckbox
-										checked={!!modalSelectedTypes.length}
-										indeterminate={
-											!!modalSelectedTypes.length &&
-											modalSelectedTypes.length !==
-												searchableTypes.length
-										}
-										onChange={() =>
-											setModalSelectedTypes(
-												!modalSelectedTypes.length
-													? searchableTypesClassNames
-													: []
-											)
-										}
-									/>
-								</ManagementToolbar.Item>
+					{searchableTypes.length ? (
+						<>
+							<ManagementToolbar.Container
+								className={
+									!!modalSelectedTypes.length &&
+									'management-bar-primary'
+								}
+							>
+								<div className="navbar-form navbar-form-autofit navbar-overlay">
+									<ManagementToolbar.ItemList>
+										<ManagementToolbar.Item>
+											<ClayCheckbox
+												checked={
+													!!modalSelectedTypes.length
+												}
+												indeterminate={
+													!!modalSelectedTypes.length &&
+													modalSelectedTypes.length !==
+														searchableTypes.length
+												}
+												onChange={() =>
+													setModalSelectedTypes(
+														!modalSelectedTypes.length
+															? searchableTypesClassNames
+															: []
+													)
+												}
+											/>
+										</ManagementToolbar.Item>
 
-								<ManagementToolbar.Item>
-									{modalSelectedTypes.length ? (
-										<>
-											<span className="component-text">
-												{sub(
-													Liferay.Language.get(
-														'x-of-x-selected'
-													),
-													[
-														modalSelectedTypes.length,
-														searchableTypes.length,
-													],
-													false
-												)}
-											</span>
+										<ManagementToolbar.Item>
+											{modalSelectedTypes.length ? (
+												<>
+													<span className="component-text">
+														{sub(
+															Liferay.Language.get(
+																'x-of-x-selected'
+															),
+															[
+																modalSelectedTypes.length,
+																searchableTypes.length,
+															],
+															false
+														)}
+													</span>
 
-											{modalSelectedTypes.length <
-												searchableTypes.length && (
-												<ClayButton
-													displayType="link"
-													onClick={() => {
-														setModalSelectedTypes(
-															searchableTypesClassNames
-														);
-													}}
-													small
-												>
+													{modalSelectedTypes.length <
+														searchableTypes.length && (
+														<ClayButton
+															displayType="link"
+															onClick={() => {
+																setModalSelectedTypes(
+																	searchableTypesClassNames
+																);
+															}}
+															small
+														>
+															{Liferay.Language.get(
+																'select-all'
+															)}
+														</ClayButton>
+													)}
+												</>
+											) : (
+												<span className="component-text">
 													{Liferay.Language.get(
 														'select-all'
 													)}
-												</ClayButton>
+												</span>
 											)}
-										</>
-									) : (
-										<span className="component-text">
-											{Liferay.Language.get('select-all')}
-										</span>
-									)}
-								</ManagementToolbar.Item>
-							</ManagementToolbar.ItemList>
-						</div>
-					</ManagementToolbar.Container>
+										</ManagementToolbar.Item>
+									</ManagementToolbar.ItemList>
+								</div>
+							</ManagementToolbar.Container>
 
-					<ClayModal.Body scrollable>
-						<ClayTable>
-							<ClayTable.Body>
-								{searchableTypes.map(
-									({className, displayName}) => {
-										const isSelected = modalSelectedTypes.includes(
-											className
-										);
-
-										return (
-											<ClayTable.Row
-												active={isSelected}
-												key={className}
-												onClick={_handleRowCheck(
+							<ClayModal.Body scrollable>
+								<ClayTable>
+									<ClayTable.Body>
+										{searchableTypes.map(
+											({className, displayName}) => {
+												const isSelected = modalSelectedTypes.includes(
 													className
-												)}
-											>
-												<ClayTable.Cell>
-													<ClayCheckbox
-														checked={isSelected}
-														onChange={_handleRowCheck(
+												);
+
+												return (
+													<ClayTable.Row
+														active={isSelected}
+														key={className}
+														onClick={_handleRowCheck(
 															className
 														)}
-													/>
-												</ClayTable.Cell>
+													>
+														<ClayTable.Cell>
+															<ClayCheckbox
+																checked={
+																	isSelected
+																}
+																onChange={_handleRowCheck(
+																	className
+																)}
+															/>
+														</ClayTable.Cell>
 
-												<ClayTable.Cell
-													expanded
-													headingTitle
-												>
-													{displayName}
-												</ClayTable.Cell>
-											</ClayTable.Row>
-										);
-									}
+														<ClayTable.Cell
+															expanded
+															headingTitle
+														>
+															{displayName}
+														</ClayTable.Cell>
+													</ClayTable.Row>
+												);
+											}
+										)}
+									</ClayTable.Body>
+								</ClayTable>
+							</ClayModal.Body>
+						</>
+					) : (
+						<ClayModal.Body>
+							<ClayEmptyState
+								description={Liferay.Language.get(
+									'an-error-has-occurred-and-we-were-unable-to-load-the-results'
 								)}
-							</ClayTable.Body>
-						</ClayTable>
-					</ClayModal.Body>
-				</>
-			) : (
-				<ClayModal.Body>
-					<ClayEmptyState
-						description={Liferay.Language.get(
-							'an-error-has-occurred-and-we-were-unable-to-load-the-results'
-						)}
-						imgSrc="/o/admin-theme/images/states/empty_state.gif"
-						title={Liferay.Language.get('no-items-were-found')}
-					>
-						<ClayButton
-							displayType="secondary"
-							onClick={onFetchSearchableTypes}
-						>
-							{Liferay.Language.get('refresh')}
-						</ClayButton>
-					</ClayEmptyState>
-				</ClayModal.Body>
+								imgSrc="/o/admin-theme/images/states/empty_state.gif"
+								title={Liferay.Language.get(
+									'no-items-were-found'
+								)}
+							>
+								<ClayButton
+									displayType="secondary"
+									onClick={onFetchSearchableTypes}
+								>
+									{Liferay.Language.get('refresh')}
+								</ClayButton>
+							</ClayEmptyState>
+						</ClayModal.Body>
+					)}
+
+					<ClayModal.Footer
+						last={
+							<ClayButton.Group spaced>
+								<ClayButton
+									displayType="secondary"
+									onClick={onClose}
+								>
+									{Liferay.Language.get('cancel')}
+								</ClayButton>
+
+								<ClayButton onClick={_handleModalDone}>
+									{Liferay.Language.get('done')}
+								</ClayButton>
+							</ClayButton.Group>
+						}
+					/>
+				</ClayModal>
 			)}
 
-			<ClayModal.Footer
-				last={
-					<ClayButton.Group spaced>
-						<ClayButton displayType="secondary" onClick={onClose}>
-							{Liferay.Language.get('cancel')}
-						</ClayButton>
-
-						<ClayButton onClick={_handleModalDone}>
-							{Liferay.Language.get('done')}
-						</ClayButton>
-					</ClayButton.Group>
-				}
-			/>
-		</ClayModal>
+			<span onClick={() => setVisible(!visible)}>{children}</span>
+		</>
 	);
 }
 

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/SelectTypes.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/SelectTypes.js
@@ -12,7 +12,7 @@
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayTable from '@clayui/table';
-import React, {useContext, useState} from 'react';
+import React, {useContext} from 'react';
 
 import ThemeContext from '../../shared/ThemeContext';
 import SearchableTypesModal from './SearchableTypesModal';
@@ -24,8 +24,6 @@ function SelectTypes({
 	selectedTypes = [],
 }) {
 	const {locale} = useContext(ThemeContext);
-
-	const [visible, setVisible] = useState(false);
 
 	const searchableTypesSorted = searchableTypes.sort((a, b) =>
 		a.displayName.localeCompare(b.displayName, locale.replace('_', '-'))
@@ -41,16 +39,20 @@ function SelectTypes({
 
 	return (
 		<>
-			<ClayButton
-				className="select-types-button"
-				displayType="secondary"
-				onClick={() => {
-					setVisible(true);
-				}}
-				small
+			<SearchableTypesModal
+				onFetchSearchableTypes={onFetchSearchableTypes}
+				onFrameworkConfigChange={onFrameworkConfigChange}
+				searchableTypes={searchableTypesSorted}
+				selectedTypes={selectedTypes}
 			>
-				{Liferay.Language.get('select-asset-types')}
-			</ClayButton>
+				<ClayButton
+					className="select-types-button"
+					displayType="secondary"
+					small
+				>
+					{Liferay.Language.get('select-asset-types')}
+				</ClayButton>
+			</SearchableTypesModal>
 
 			{!!selectedTypes.length && (
 				<ClayTable>
@@ -82,16 +84,6 @@ function SelectTypes({
 							))}
 					</ClayTable.Body>
 				</ClayTable>
-			)}
-
-			{visible && (
-				<SearchableTypesModal
-					onFetchSearchableTypes={onFetchSearchableTypes}
-					onFrameworkConfigChange={onFrameworkConfigChange}
-					searchableTypes={searchableTypesSorted}
-					selectedTypes={selectedTypes}
-					setVisible={setVisible}
-				/>
 			)}
 		</>
 	);

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
@@ -656,6 +656,9 @@ function EditSXPElementForm({
 							<div className="sxp-element-header">
 								{!readOnly && (
 									<ClayButton
+										aria-label={Liferay.Language.get(
+											'predefined-variables'
+										)}
 										borderless
 										className={getCN({
 											active: showVariablesSidebar,
@@ -689,6 +692,7 @@ function EditSXPElementForm({
 								</div>
 
 								<ClayButton
+									aria-label={Liferay.Language.get('info')}
 									borderless
 									className={getCN({active: showInfoSidebar})}
 									displayType="secondary"

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/EditTitleModal.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/EditTitleModal.js
@@ -14,7 +14,7 @@ import ClayButton from '@clayui/button';
 import ClayForm from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLocalizedInput from '@clayui/localized-input';
-import ClayModal, {useModal} from '@clayui/modal';
+import ClayModal from '@clayui/modal';
 import getCN from 'classnames';
 import React, {useContext, useRef, useState} from 'react';
 
@@ -40,14 +40,11 @@ export default function EditTitleModal({
 	fieldFocus,
 	initialDescription,
 	initialTitle,
+	observer,
+	onClose,
 	onSubmit,
-	setVisible,
 }) {
 	const {availableLanguages, defaultLocale} = useContext(ThemeContext);
-
-	const {observer, onClose} = useModal({
-		onClose: () => setVisible(false),
-	});
 
 	// Converts the availableLanguages into the list expected for
 	// Clay's localized input. Positions defaultLocale first in order

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PageToolbar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PageToolbar.js
@@ -13,6 +13,7 @@ import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClayLink from '@clayui/link';
+import {useModal} from '@clayui/modal';
 import ClayNavigationBar from '@clayui/navigation-bar';
 import ClayToolbar from '@clayui/toolbar';
 import {ClayTooltipProvider} from '@clayui/tooltip';
@@ -78,6 +79,10 @@ export default function PageToolbar({
 	const [modalFieldFocus, setModalFieldFocus] = useState('title');
 	const [modalVisible, setModalVisible] = useState(false);
 
+	const {observer, onClose} = useModal({
+		onClose: () => setModalVisible(false),
+	});
+
 	const displayLocale = getDisplayLocale(
 		title,
 		locale,
@@ -107,8 +112,9 @@ export default function PageToolbar({
 									fieldFocus={modalFieldFocus}
 									initialDescription={description}
 									initialTitle={title}
+									observer={observer}
+									onClose={onClose}
 									onSubmit={onTitleAndDescriptionChange}
-									setVisible={setModalVisible}
 								/>
 							)}
 

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/SearchInput.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/SearchInput.js
@@ -45,6 +45,7 @@ function SearchInput({disabled, onChange, onEnter}) {
 				{value && !onEnter ? (
 					<ClayInput.GroupInsetItem after tag="span">
 						<ClayButton
+							aria-label={Liferay.Language.get('clear')}
 							displayType="unstyled"
 							onClick={() => {
 								onChange('');
@@ -58,6 +59,7 @@ function SearchInput({disabled, onChange, onEnter}) {
 				) : (
 					<ClayInput.GroupInsetItem after tag="span">
 						<ClayButton
+							aria-label={Liferay.Language.get('search')}
 							disabled={disabled}
 							displayType="unstyled"
 							onClick={onEnter}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_options/js/configuration/ManagementToolbar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_options/js/configuration/ManagementToolbar.js
@@ -38,6 +38,9 @@ const ManagementToolbar = ({
 						items={filterItems}
 						trigger={
 							<ClayButton
+								aria-label={Liferay.Language.get(
+									'filter-and-order'
+								)}
 								className="nav-link"
 								disabled={loading}
 								displayType="unstyled"
@@ -64,6 +67,11 @@ const ManagementToolbar = ({
 
 					<FrontendManagementToolbar.Item>
 						<ClayButton
+							aria-label={
+								sortOrder === 'asc'
+									? Liferay.Language.get('ascending')
+									: Liferay.Language.get('descending')
+							}
 							className="nav-link nav-link-monospaced"
 							disabled={loading}
 							displayType="unstyled"
@@ -102,6 +110,7 @@ const ManagementToolbar = ({
 
 							<ClayInput.GroupInsetItem after tag="span">
 								<ClayButtonWithIcon
+									aria-label={Liferay.Language.get('clear')}
 									className="navbar-breakpoint-d-none"
 									displayType="unstyled"
 									onClick={() => setSearchMobile(false)}
@@ -109,6 +118,7 @@ const ManagementToolbar = ({
 								/>
 
 								<ClayButtonWithIcon
+									aria-label={Liferay.Language.get('search')}
 									disabled={loading}
 									displayType="unstyled"
 									onClick={() => onSearch(searchInputValue)}
@@ -122,6 +132,7 @@ const ManagementToolbar = ({
 				<FrontendManagementToolbar.ItemList>
 					<FrontendManagementToolbar.Item className="navbar-breakpoint-d-none">
 						<ClayButton
+							aria-label={Liferay.Language.get('search')}
 							className="nav-link nav-link-monospaced"
 							displayType="unstyled"
 							onClick={() => setSearchMobile(true)}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-173294 - Address frontend-related warnings from button accessibility and unmounted component

For both search-web and search-experiences-web, this addresses several irksome browser console warnings and `yarn test` warnings. Some are out of search module's scope, but at least these changes help reduce the number of warnings:

> Warning: Button Accessibility: Component has only the Icon declared. Define an `aria-label` or `aria-labelledby` attribute that labels the interactive button that screen readers can read. The `title` attribute is optional but consult your design team. 

(From SearchableTypesModal and EditTitleModal):
> Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.

Also cherry-picked an older commit from Kevin to address this warning regarding SearchBarConfigurationSuggestions, when switching from sxp blueprint to basic, related to the `_handleReplaceField` method (see https://github.com/liferay-search/liferay-portal/pull/611/commits/db1486082785c3da58eeba7b39c4fcc6ea61bfaf):

> Warning: Each child in a list should have a unique "key" prop.