### PR TITLE
LPS-173427 portal-impl: Group (Site) level spell-check and query suggestions are not supported since 7.0, remove instructions from portal.properties

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -5424,16 +5424,13 @@
     #
     # Set the location of the query suggestion dictionary files for specific
     # locales. Specify a comma delimited list of files if a locale has more than
-    # one dictionary file. A group ID (e.g. 123456) can also be added to specify
-    # a dictionary that only applies to one group.
+    # one dictionary file.
     #
     # Env: LIFERAY_INDEX_PERIOD_SEARCH_PERIOD_QUERY_PERIOD_SUGGESTION_PERIOD_DICTIONARY_OPENBRACKET_EN_UNDERLINE__UPPERCASEU__UPPERCASES__CLOSEBRACKET_
-    # Env: LIFERAY_INDEX_PERIOD_SEARCH_PERIOD_QUERY_PERIOD_SUGGESTION_PERIOD_DICTIONARY_OPENBRACKET_EN_UNDERLINE__UPPERCASEU__UPPERCASES__CLOSEBRACKET__OPENBRACKET__NUMBER1__NUMBER2__NUMBER3__NUMBER4__NUMBER5__NUMBER6__CLOSEBRACKET_
     # Env: LIFERAY_INDEX_PERIOD_SEARCH_PERIOD_QUERY_PERIOD_SUGGESTION_PERIOD_DICTIONARY_OPENBRACKET_ES_UNDERLINE__UPPERCASEE__UPPERCASES__CLOSEBRACKET_
     #
     #index.search.query.suggestion.dictionary[en_US]=com/liferay/portal/search/dependencies/querysuggestions/en_US.txt
     #index.search.query.suggestion.dictionary[es_ES]=com/liferay/portal/search/dependencies/querysuggestions/es_ES.txt
-    #index.search.query.suggestion.dictionary[en_US][123456]=com/liferay/portal/search/dependencies/querysuggestions/en_US_123456.txt
 
     #
     # Set this to true to enable query suggestion if insufficient scoring or no
@@ -5471,16 +5468,13 @@
     #
     # Set the location of the spell checker dictionary files for specific
     # locales. Specify a comma delimited list of files if a locale has more than
-    # one dictionary file. A group ID (e.g. 123456) can also be added to specify
-    # a dictionary that only applies to one group.
+    # one dictionary file.
     #
     # Env: LIFERAY_INDEX_PERIOD_SEARCH_PERIOD_SPELL_PERIOD_CHECKER_PERIOD_DICTIONARY_OPENBRACKET_EN_UNDERLINE__UPPERCASEU__UPPERCASES__CLOSEBRACKET_
-    # Env: LIFERAY_INDEX_PERIOD_SEARCH_PERIOD_SPELL_PERIOD_CHECKER_PERIOD_DICTIONARY_OPENBRACKET_EN_UNDERLINE__UPPERCASEU__UPPERCASES__CLOSEBRACKET__OPENBRACKET__NUMBER1__NUMBER2__NUMBER3__NUMBER4__NUMBER5__NUMBER6__CLOSEBRACKET_
     # Env: LIFERAY_INDEX_PERIOD_SEARCH_PERIOD_SPELL_PERIOD_CHECKER_PERIOD_DICTIONARY_OPENBRACKET_ES_UNDERLINE__UPPERCASEE__UPPERCASES__CLOSEBRACKET_
     #
     index.search.spell.checker.dictionary[en_US]=com/liferay/portal/search/dependencies/spellchecker/en_US.txt
     index.search.spell.checker.dictionary[es_ES]=com/liferay/portal/search/dependencies/spellchecker/es_ES.txt
-    #index.search.spell.checker.dictionary[en_US][123456]=com/liferay/portal/search/dependencies/spellchecker/en_US_123456.txt
 
     #
     # Specify the locales supported by the spell checker. This is used by the


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-173427

Hi Brian,

**Task**

I'm removing the related instructions from the `portal.properties`, but leave the underlying indexing code intact. Therefore, updating the breaking changes MD can be skipped imo, but let me know if you think otherwise. I can backport this update all the way down to 7.0.x.

**Background**

The portal-ext configuration has been promising the ability to define group-level spell-check and query suggestion settings see https://github.com/liferay/liferay-portal/blob/7.4.3.60-ga60/portal-impl/src/portal.properties#L5424-L5436 and https://github.com/liferay/liferay-portal/blob/7.4.3.60-ga60/portal-impl/src/portal.properties#L5471-L5494

However, it stopped working with 7.0 when the platform switched to Elasticsearch search suggester:

On 6.2.x, https://github.com/liferay/liferay-portal/blob/6.2.x/portal-impl/src/com/liferay/portal/search/lucene/LuceneQuerySuggester.java#L223-L256 the spell-check query was different and it considered the groupId from the context introduced in [LPS-38682](https://issues.liferay.com/browse/LPS-38682).
* Interestingly, this `[groupId]` filtering only works for Live Sites (sites with Staging enabled), see https://github.com/liferay/liferay-portal/blob/6.2.x/portal-service/src/com/liferay/portal/kernel/search/BaseSpellCheckIndexWriter.java#L307 and https://github.com/liferay/liferay-portal/blob/6.2.x/portal-impl/src/custom-sql/portal.xml#L206-L222. (Maybe Mike's assumption was that the `getLiveGroups` service call returns all sites without staging enabled too. :thinking:)
     
On 7.x, we are using [Elasticsearch Suggester](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/search-suggesters.html) (like `Term suggester`, `Phrase Suggester`) which are not supporting filtering.
* `Context Suggester` could be an option though. ([doc](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/search-suggesters.html#context-suggester), [example](https://discuss.elastic.co/t/how-can-i-filter-on-my-suggest-list/140989)) in the future. The Liferay Search Java APIs do not support this suggester type currently. We may revisit group-level settings later.

**Note**

Technically, one could write its own Context Suggester query using Elasticsearch's DSL directly to query the indexed dictionary files like that, however, considering that the Liferay Search Java APIs do not support this suggester type currently this is considered to be unlikely.

/cc @peerkar 