### PR TITLE
LPS-173765 Adds default mapping for viewCount as long, also add it to Solr to keep consistency

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -1675,6 +1675,10 @@
 				"store": true,
 				"type": "keyword"
 			},
+			"viewCount": {
+				"store": true,
+				"type": "long"
+			},
 			"visible": {
 				"store": true,
 				"type": "keyword"

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
@@ -1686,6 +1686,10 @@
 					"store": true,
 					"type": "keyword"
 				},
+				"viewCount": {
+					"store": true,
+					"type": "long"
+				},
 				"visible": {
 					"store": true,
 					"type": "keyword"

--- a/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/main/resources/META-INF/resources/schema.xml
+++ b/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/main/resources/META-INF/resources/schema.xml
@@ -583,6 +583,7 @@
 		<field docValues="true" indexed="true" name="userName" stored="true" type="string" />
 		<field indexed="true" name="userName.text" stored="false" type="text_lowercase" />
 		<field indexed="true" name="version" stored="true" type="string" />
+		<field indexed="true" name="viewCount" stored="true" type="long" />
 		<field indexed="true" name="visible" stored="true" type="string" />
 		<dynamicField docValues="true" indexed="true" name="*_coordinate" stored="false" type="double" />
 		<dynamicField docValues="true" indexed="true" multiValued="false" name="*Date_sortable" stored="true" type="long" />


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-173765)

The goal of these changes is to add the correct mapping for viewCount field into default mappings, also add it to Solr to keep it consistency.

## Change summary:

* Add field to **liferay-type-mappings.json** and **portal-search-solr8-impl/schema.xml**

## Test Scenario

1. Start Liferay
2. Go to Control Panel - Configuration - Search > Field Mappings
3. Copy the field mappings and inspect it, look for "viewCount" and "viewCount_sortable"

 Expected: "viewCount" is indexed as "keyword", "viewCount_sortable" is indexed as "long"
 Actual: "viewCount" is indexed as "text"