### PR TITLE
[Remove Stream/Optional usage] LPS-172262 Remove Stream<> in portal-search-tuning-rankings-web PART2

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/display/context/RankingPortletDisplayBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/display/context/RankingPortletDisplayBuilder.java
@@ -345,12 +345,6 @@ public class RankingPortletDisplayBuilder {
 		).buildPortletURL();
 	}
 
-	private List<RankingEntryDisplayContext> _getRankingEntryDisplayContexts(
-		List<SearchHit> searchHits) {
-
-		return TransformUtil.transform(searchHits, this::_buildDisplayContext);
-	}
-
 	private boolean _hasResults(
 		SearchContainer<RankingEntryDisplayContext> searchContainer) {
 
@@ -383,7 +377,8 @@ public class RankingPortletDisplayBuilder {
 		SearchHits searchHits = searchRankingResponse.getSearchHits();
 
 		searchContainer.setResultsAndTotal(
-			() -> _getRankingEntryDisplayContexts(searchHits.getSearchHits()),
+			() -> TransformUtil.transform(
+				searchHits.getSearchHits(), this::_buildDisplayContext),
 			searchRankingResponse.getTotalHits());
 
 		searchContainer.setSearch(true);

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/display/context/RankingPortletDisplayBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/display/context/RankingPortletDisplayBuilder.java
@@ -18,6 +18,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenuBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
@@ -48,8 +49,6 @@ import com.liferay.portal.search.tuning.rankings.web.internal.request.SearchRank
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.portlet.PortletURL;
 import javax.portlet.RenderRequest;
@@ -349,13 +348,7 @@ public class RankingPortletDisplayBuilder {
 	private List<RankingEntryDisplayContext> _getRankingEntryDisplayContexts(
 		List<SearchHit> searchHits) {
 
-		Stream<SearchHit> stream = searchHits.stream();
-
-		return stream.map(
-			this::_buildDisplayContext
-		).collect(
-			Collectors.toList()
-		);
+		return TransformUtil.transform(searchHits, this::_buildDisplayContext);
 	}
 
 	private boolean _hasResults(

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/DocumentToRankingTranslatorImpl.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/DocumentToRankingTranslatorImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.search.tuning.rankings.web.internal.index;
 
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -22,8 +23,6 @@ import com.liferay.portal.search.document.Document;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -92,13 +91,8 @@ public class DocumentToRankingTranslatorImpl
 			return Collections.emptyList();
 		}
 
-		List<Map<String, String>> maps = (List<Map<String, String>>)values;
-
-		Stream<Map<String, String>> stream = maps.stream();
-
-		Stream<Ranking.Pin> pinStream = stream.map(this::_toPin);
-
-		return pinStream.collect(Collectors.toList());
+		return TransformUtil.transform(
+			(List<Map<String, String>>)values, this::_toPin);
 	}
 
 	private String _getQueryString(Document document) {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/DuplicateQueryStringsDetectorImpl.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/DuplicateQueryStringsDetectorImpl.java
@@ -185,7 +185,7 @@ public class DuplicateQueryStringsDetectorImpl
 	}
 
 	private void _addQueryClauses(Consumer<Query> consumer, Query... queries) {
-		List<Query> queriesList = new ArrayList<>(Arrays.asList(queries));
+		List<Query> queriesList = Arrays.asList(queries);
 
 		List<Query> isNotNullQueriesList = ListUtil.filter(
 			queriesList, Objects::nonNull);

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/DuplicateQueryStringsDetectorImpl.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/DuplicateQueryStringsDetectorImpl.java
@@ -80,10 +80,10 @@ public class DuplicateQueryStringsDetectorImpl
 
 		List<String> duplicateQueryStrings = new ArrayList<>();
 
-		TransformUtil.transform(
-			searchHits.getSearchHits(),
-			searchHit -> duplicateQueryStrings.addAll(
-				_getDuplicateQueryStrings(searchHit, queryStrings)));
+		for (SearchHit searchHit : searchHits.getSearchHits()) {
+			duplicateQueryStrings.addAll(
+				_getDuplicateQueryStrings(searchHit, queryStrings));
+		}
 
 		return duplicateQueryStrings;
 	}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/DuplicateQueryStringsDetectorImpl.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/DuplicateQueryStringsDetectorImpl.java
@@ -14,8 +14,6 @@
 
 package com.liferay.portal.search.tuning.rankings.web.internal.index;
 
-import com.liferay.petra.function.transform.TransformUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.document.Document;
 import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
@@ -32,12 +30,10 @@ import com.liferay.portal.search.tuning.rankings.web.internal.index.name.Ranking
 import com.liferay.portal.search.tuning.rankings.web.internal.index.name.RankingIndexNameBuilder;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Consumer;
 
 import org.osgi.service.component.annotations.Component;
@@ -185,12 +181,11 @@ public class DuplicateQueryStringsDetectorImpl
 	}
 
 	private void _addQueryClauses(Consumer<Query> consumer, Query... queries) {
-		List<Query> queriesList = Arrays.asList(queries);
-
-		List<Query> isNotNullQueriesList = ListUtil.filter(
-			queriesList, Objects::nonNull);
-
-		isNotNullQueriesList.forEach(consumer);
+		for (Query query : queries) {
+			if (query != null) {
+				consumer.accept(query);
+			}
+		}
 	}
 
 	private BooleanQuery _getCriteriaQuery(Criteria criteria) {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/Ranking.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/Ranking.java
@@ -86,7 +86,7 @@ public class Ranking {
 
 	public Collection<String> getQueryStrings() {
 		List<String> querySrtings = ListUtil.concat(
-			ListUtil.fromString(_queryString), _aliases);
+			Collections.singletonList(_queryString), _aliases);
 
 		querySrtings = ListUtil.filter(
 			querySrtings, querySring -> !Validator.isBlank(querySring));

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/Ranking.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/Ranking.java
@@ -16,8 +16,7 @@ package com.liferay.portal.search.tuning.rankings.web.internal.index;
 
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.tuning.rankings.web.internal.util.RankingUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -84,15 +83,7 @@ public class Ranking {
 	}
 
 	public Collection<String> getQueryStrings() {
-		List<String> querySrtings = ListUtil.concat(
-			Collections.singletonList(_queryString), _aliases);
-
-		querySrtings = ListUtil.filter(
-			querySrtings, querySring -> !Validator.isBlank(querySring));
-
-		ListUtil.distinct(querySrtings);
-
-		return ListUtil.sort(querySrtings);
+		return RankingUtil.getQueryStrings(_queryString, _aliases);
 	}
 
 	public String getRankingDocumentId() {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/Ranking.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/Ranking.java
@@ -14,8 +14,10 @@
 
 package com.liferay.portal.search.tuning.rankings.web.internal.index;
 
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
@@ -26,8 +28,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Bryan Engler
@@ -85,15 +85,15 @@ public class Ranking {
 	}
 
 	public Collection<String> getQueryStrings() {
-		return Stream.concat(
-			Stream.of(_queryString), _aliases.stream()
-		).filter(
-			string -> !Validator.isBlank(string)
-		).distinct(
-		).sorted(
-		).collect(
-			Collectors.toList()
-		);
+		List<String> querySrtings = ListUtil.concat(
+			ListUtil.fromString(_queryString), _aliases);
+
+		querySrtings = ListUtil.filter(
+			querySrtings, querySring -> !Validator.isBlank(querySring));
+
+		ListUtil.distinct(querySrtings);
+
+		return ListUtil.sort(querySrtings);
 	}
 
 	public String getRankingDocumentId() {
@@ -177,14 +177,12 @@ public class Ranking {
 
 		public RankingBuilder pins(List<Pin> pins) {
 			if (pins != null) {
-				Stream<Pin> stream = pins.stream();
+				Set<String> documentIds = new LinkedHashSet<>();
 
-				_ranking._pinnedDocumentIds = new LinkedHashSet<>(
-					stream.map(
-						Pin::getDocumentId
-					).collect(
-						Collectors.toSet()
-					));
+				TransformUtil.transform(
+					pins, pin -> documentIds.add(pin.getDocumentId()));
+
+				_ranking._pinnedDocumentIds = new LinkedHashSet<>(documentIds);
 
 				_ranking._pins = pins;
 			}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/Ranking.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/Ranking.java
@@ -14,7 +14,6 @@
 
 package com.liferay.portal.search.tuning.rankings.web.internal.index;
 
-import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -179,10 +178,9 @@ public class Ranking {
 			if (pins != null) {
 				Set<String> documentIds = new LinkedHashSet<>();
 
-				TransformUtil.transform(
-					pins, pin -> documentIds.add(pin.getDocumentId()));
+				pins.forEach(pin -> documentIds.add(pin.getDocumentId()));
 
-				_ranking._pinnedDocumentIds = new LinkedHashSet<>(documentIds);
+				_ranking._pinnedDocumentIds = documentIds;
 
 				_ranking._pins = pins;
 			}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingToDocumentTranslatorImpl.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingToDocumentTranslatorImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.search.tuning.rankings.web.internal.index;
 
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.search.document.Document;
@@ -21,8 +22,6 @@ import com.liferay.portal.search.document.DocumentBuilderFactory;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -61,17 +60,13 @@ public class RankingToDocumentTranslatorImpl
 	}
 
 	private Collection<Object> _toMaps(List<Ranking.Pin> pins) {
-		Stream<Ranking.Pin> stream = pins.stream();
-
-		return stream.map(
+		return TransformUtil.transform(
+			pins,
 			pin -> LinkedHashMapBuilder.put(
 				RankingFields.POSITION, String.valueOf(pin.getPosition())
 			).put(
 				RankingFields.UID, pin.getDocumentId()
-			).build()
-		).collect(
-			Collectors.toList()
-		);
+			).build());
 	}
 
 	@Reference

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/importer/SingleIndexToMultipleIndexImporterImpl.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/importer/SingleIndexToMultipleIndexImporterImpl.java
@@ -35,6 +35,7 @@ import com.liferay.portal.search.tuning.rankings.web.internal.index.RankingIndex
 import com.liferay.portal.search.tuning.rankings.web.internal.index.name.RankingIndexName;
 import com.liferay.portal.search.tuning.rankings.web.internal.index.name.RankingIndexNameBuilder;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -150,7 +151,10 @@ public class SingleIndexToMultipleIndexImporterImpl
 		Map<String, List<Document>> documentsMap = new HashMap<>();
 
 		for (Document document : documents) {
-			documentsMap.put(document.getString("index"), documents);
+			List<Document> documentList = documentsMap.computeIfAbsent(
+				document.getString("index"), key -> new ArrayList<>());
+
+			documentList.add(document);
 		}
 
 		return documentsMap;

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/EditRankingMVCActionCommand.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/EditRankingMVCActionCommand.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.search.tuning.rankings.web.internal.portlet.action;
 
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.LiferayPortletURL;
@@ -53,9 +54,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -323,15 +321,7 @@ public class EditRankingMVCActionCommand extends BaseMVCActionCommand {
 		List<String> strings = new ArrayList<>(
 			editRankingMVCActionRequest.getAliases());
 
-		Stream<String> stream = strings.stream();
-
-		Predicate<String> predicate = this::_isUpdateSpecial;
-
-		return stream.filter(
-			predicate.negate()
-		).collect(
-			Collectors.toList()
-		);
+		return ListUtil.filter(strings, string -> !_isUpdateSpecial(string));
 	}
 
 	private String _getCompanyIndexName() {
@@ -342,18 +332,19 @@ public class EditRankingMVCActionCommand extends BaseMVCActionCommand {
 		String oldName,
 		EditRankingMVCActionRequest editRankingMVCActionRequest) {
 
-		List<String> strings = editRankingMVCActionRequest.getAliases();
+		List<String> stripUpdateSpecialStrings = TransformUtil.transform(
+			ListUtil.filter(
+				editRankingMVCActionRequest.getAliases(),
+				this::_isUpdateSpecial),
+			this::_stripUpdateSpecial);
 
-		Stream<String> stream = strings.stream();
+		for (String string : stripUpdateSpecialStrings) {
+			if (string != null) {
+				return _stripUpdateSpecial(string);
+			}
+		}
 
-		return stream.filter(
-			this::_isUpdateSpecial
-		).map(
-			this::_stripUpdateSpecial
-		).findAny(
-		).orElse(
-			oldName
-		);
+		return oldName;
 	}
 
 	private String[] _getRankingDocumentIds(
@@ -465,17 +456,16 @@ public class EditRankingMVCActionCommand extends BaseMVCActionCommand {
 		Collection<String> queryStrings = ranking.getQueryStrings();
 
 		if (editRankingMVCActionRequest.isCmd(Constants.UPDATE)) {
-			List<String> aliases = _getAliases(editRankingMVCActionRequest);
+			List<String> strings = ListUtil.concat(
+				ListUtil.fromString(ranking.getQueryString()),
+				_getAliases(editRankingMVCActionRequest));
 
-			queryStrings = Stream.concat(
-				Stream.of(ranking.getQueryString()), aliases.stream()
-			).filter(
-				string -> !Validator.isBlank(string)
-			).distinct(
-			).sorted(
-			).collect(
-				Collectors.toList()
-			);
+			strings = ListUtil.filter(
+				strings, concatString -> !Validator.isBlank(concatString));
+
+			ListUtil.distinct(strings);
+
+			queryStrings = ListUtil.sort(strings);
 		}
 
 		if (_detectedDuplicateQueryStrings(ranking, queryStrings)) {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/EditRankingMVCActionCommand.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/EditRankingMVCActionCommand.java
@@ -332,18 +332,20 @@ public class EditRankingMVCActionCommand extends BaseMVCActionCommand {
 		EditRankingMVCActionRequest editRankingMVCActionRequest) {
 
 		List<String> stripUpdateSpecialStrings = TransformUtil.transform(
-			ListUtil.filter(
-				editRankingMVCActionRequest.getAliases(),
-				this::_isUpdateSpecial),
-			this::_stripUpdateSpecial);
+			editRankingMVCActionRequest.getAliases(),
+			alias -> {
+				if (_isUpdateSpecial(alias)) {
+					return _stripUpdateSpecial(alias);
+				}
 
-		for (String string : stripUpdateSpecialStrings) {
-			if (string != null) {
-				return string;
-			}
+				return null;
+			});
+
+		if (stripUpdateSpecialStrings.isEmpty()) {
+			return oldName;
 		}
 
-		return oldName;
+		return stripUpdateSpecialStrings.get(0);
 	}
 
 	private String[] _getRankingDocumentIds(

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/EditRankingMVCActionCommand.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/EditRankingMVCActionCommand.java
@@ -318,10 +318,9 @@ public class EditRankingMVCActionCommand extends BaseMVCActionCommand {
 	private List<String> _getAliases(
 		EditRankingMVCActionRequest editRankingMVCActionRequest) {
 
-		List<String> strings = new ArrayList<>(
-			editRankingMVCActionRequest.getAliases());
-
-		return ListUtil.filter(strings, string -> !_isUpdateSpecial(string));
+		return ListUtil.filter(
+			editRankingMVCActionRequest.getAliases(),
+			string -> !_isUpdateSpecial(string));
 	}
 
 	private String _getCompanyIndexName() {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/EditRankingMVCActionCommand.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/EditRankingMVCActionCommand.java
@@ -44,6 +44,7 @@ import com.liferay.portal.search.tuning.rankings.web.internal.index.RankingIndex
 import com.liferay.portal.search.tuning.rankings.web.internal.index.name.RankingIndexName;
 import com.liferay.portal.search.tuning.rankings.web.internal.index.name.RankingIndexNameBuilder;
 import com.liferay.portal.search.tuning.rankings.web.internal.storage.RankingStorageAdapter;
+import com.liferay.portal.search.tuning.rankings.web.internal.util.RankingUtil;
 
 import java.io.IOException;
 
@@ -457,16 +458,9 @@ public class EditRankingMVCActionCommand extends BaseMVCActionCommand {
 		Collection<String> queryStrings = ranking.getQueryStrings();
 
 		if (editRankingMVCActionRequest.isCmd(Constants.UPDATE)) {
-			List<String> strings = ListUtil.concat(
-				Collections.singletonList(ranking.getQueryString()),
+			queryStrings = RankingUtil.getQueryStrings(
+				ranking.getQueryString(),
 				_getAliases(editRankingMVCActionRequest));
-
-			strings = ListUtil.filter(
-				strings, concatString -> !Validator.isBlank(concatString));
-
-			ListUtil.distinct(strings);
-
-			queryStrings = ListUtil.sort(strings);
 		}
 
 		if (_detectedDuplicateQueryStrings(ranking, queryStrings)) {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/EditRankingMVCActionCommand.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/EditRankingMVCActionCommand.java
@@ -339,7 +339,7 @@ public class EditRankingMVCActionCommand extends BaseMVCActionCommand {
 
 		for (String string : stripUpdateSpecialStrings) {
 			if (string != null) {
-				return _stripUpdateSpecial(string);
+				return string;
 			}
 		}
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/EditRankingMVCActionCommand.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/EditRankingMVCActionCommand.java
@@ -458,7 +458,7 @@ public class EditRankingMVCActionCommand extends BaseMVCActionCommand {
 
 		if (editRankingMVCActionRequest.isCmd(Constants.UPDATE)) {
 			List<String> strings = ListUtil.concat(
-				ListUtil.fromString(ranking.getQueryString()),
+				Collections.singletonList(ranking.getQueryString()),
 				_getAliases(editRankingMVCActionRequest));
 
 			strings = ListUtil.filter(

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/ValidateRankingMVCResourceCommand.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/ValidateRankingMVCResourceCommand.java
@@ -43,9 +43,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
@@ -146,15 +143,7 @@ public class ValidateRankingMVCResourceCommand implements MVCResourceCommand {
 		List<String> strings = new ArrayList<>(
 			validateRankingMVCResourceRequest.getAliases());
 
-		Stream<String> stream = strings.stream();
-
-		Predicate<String> predicate = this::_isUpdateSpecial;
-
-		return stream.filter(
-			predicate.negate()
-		).collect(
-			Collectors.toList()
-		);
+		return ListUtil.filter(strings, string -> !_isUpdateSpecial(string));
 	}
 
 	private long _getCompanyId(ResourceRequest resourceRequest) {
@@ -165,18 +154,17 @@ public class ValidateRankingMVCResourceCommand implements MVCResourceCommand {
 		ResourceRequest resourceRequest,
 		ValidateRankingMVCResourceRequest validateRankingMVCResourceRequest) {
 
-		List<String> aliases = _getAliases(validateRankingMVCResourceRequest);
+		List<String> strings = ListUtil.concat(
+			ListUtil.fromString(
+				validateRankingMVCResourceRequest.getQueryString()),
+			_getAliases(validateRankingMVCResourceRequest));
 
-		Collection<String> queryStrings = Stream.concat(
-			Stream.of(validateRankingMVCResourceRequest.getQueryString()),
-			aliases.stream()
-		).filter(
-			string -> !Validator.isBlank(string)
-		).distinct(
-		).sorted(
-		).collect(
-			Collectors.toList()
-		);
+		strings = ListUtil.filter(
+			strings, string -> !Validator.isBlank(string));
+
+		ListUtil.distinct(strings);
+
+		Collection<String> queryStrings = ListUtil.sort(strings);
 
 		return duplicateQueryStringsDetector.detect(
 			duplicateQueryStringsDetector.builder(

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/ValidateRankingMVCResourceCommand.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/ValidateRankingMVCResourceCommand.java
@@ -153,7 +153,7 @@ public class ValidateRankingMVCResourceCommand implements MVCResourceCommand {
 		ValidateRankingMVCResourceRequest validateRankingMVCResourceRequest) {
 
 		List<String> strings = ListUtil.concat(
-			ListUtil.fromString(
+			Collections.singletonList(
 				validateRankingMVCResourceRequest.getQueryString()),
 			_getAliases(validateRankingMVCResourceRequest));
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/ValidateRankingMVCResourceCommand.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/ValidateRankingMVCResourceCommand.java
@@ -28,18 +28,17 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.index.IndexNameBuilder;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.tuning.rankings.web.internal.constants.ResultRankingsPortletKeys;
 import com.liferay.portal.search.tuning.rankings.web.internal.index.DuplicateQueryStringsDetector;
 import com.liferay.portal.search.tuning.rankings.web.internal.index.name.RankingIndexName;
 import com.liferay.portal.search.tuning.rankings.web.internal.index.name.RankingIndexNameBuilder;
+import com.liferay.portal.search.tuning.rankings.web.internal.util.RankingUtil;
 
 import java.io.IOException;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -152,24 +151,14 @@ public class ValidateRankingMVCResourceCommand implements MVCResourceCommand {
 		ResourceRequest resourceRequest,
 		ValidateRankingMVCResourceRequest validateRankingMVCResourceRequest) {
 
-		List<String> strings = ListUtil.concat(
-			Collections.singletonList(
-				validateRankingMVCResourceRequest.getQueryString()),
-			_getAliases(validateRankingMVCResourceRequest));
-
-		strings = ListUtil.filter(
-			strings, string -> !Validator.isBlank(string));
-
-		ListUtil.distinct(strings);
-
-		Collection<String> queryStrings = ListUtil.sort(strings);
-
 		return duplicateQueryStringsDetector.detect(
 			duplicateQueryStringsDetector.builder(
 			).index(
 				_getIndexName(resourceRequest)
 			).queryStrings(
-				queryStrings
+				RankingUtil.getQueryStrings(
+					validateRankingMVCResourceRequest.getQueryString(),
+					_getAliases(validateRankingMVCResourceRequest))
 			).rankingIndexName(
 				_getRankingIndexName(resourceRequest)
 			).unlessRankingDocumentId(

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/ValidateRankingMVCResourceCommand.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/ValidateRankingMVCResourceCommand.java
@@ -38,7 +38,6 @@ import com.liferay.portal.search.tuning.rankings.web.internal.index.name.Ranking
 
 import java.io.IOException;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -140,10 +139,9 @@ public class ValidateRankingMVCResourceCommand implements MVCResourceCommand {
 	private List<String> _getAliases(
 		ValidateRankingMVCResourceRequest validateRankingMVCResourceRequest) {
 
-		List<String> strings = new ArrayList<>(
-			validateRankingMVCResourceRequest.getAliases());
-
-		return ListUtil.filter(strings, string -> !_isUpdateSpecial(string));
+		return ListUtil.filter(
+			validateRankingMVCResourceRequest.getAliases(),
+			alias -> !_isUpdateSpecial(alias));
 	}
 
 	private long _getCompanyId(ResourceRequest resourceRequest) {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetHiddenResultsBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetHiddenResultsBuilder.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.search.tuning.rankings.web.internal.results.builder;
 
 import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -36,8 +37,8 @@ import com.liferay.portal.search.tuning.rankings.web.internal.index.name.Ranking
 import com.liferay.portal.search.tuning.rankings.web.internal.util.RankingResultUtil;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
@@ -111,20 +112,19 @@ public class RankingGetHiddenResultsBuilder {
 	}
 
 	protected JSONArray buildDocuments(List<String> ids, Ranking ranking) {
-		Stream<String> stringStream = ids.stream();
-
-		Stream<JSONObject> jsonObjectStream = stringStream.map(
-			id -> _getDocument(
-				ranking.getIndexName(), id, LIFERAY_DOCUMENT_TYPE)
-		).filter(
-			document -> document != null
-		).map(
-			this::translate
-		);
-
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
-		jsonObjectStream.forEach(jsonArray::put);
+		List<Document> documents = TransformUtil.transform(
+			ids,
+			id -> _getDocument(
+				ranking.getIndexName(), id, LIFERAY_DOCUMENT_TYPE));
+
+		List<Document> isNotNullDocuments = ListUtil.filter(
+			documents, Objects::nonNull);
+
+		for (Document document : isNotNullDocuments) {
+			jsonArray.put(translate(document));
+		}
 
 		return jsonArray;
 	}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetHiddenResultsBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetHiddenResultsBuilder.java
@@ -20,6 +20,8 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactory;
@@ -112,21 +114,14 @@ public class RankingGetHiddenResultsBuilder {
 	}
 
 	protected JSONArray buildDocuments(List<String> ids, Ranking ranking) {
-		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+		List<Document> documents = ListUtil.filter(
+			TransformUtil.transform(
+				ids,
+				id -> _getDocument(
+					ranking.getIndexName(), id, LIFERAY_DOCUMENT_TYPE)),
+			Objects::nonNull);
 
-		List<Document> documents = TransformUtil.transform(
-			ids,
-			id -> _getDocument(
-				ranking.getIndexName(), id, LIFERAY_DOCUMENT_TYPE));
-
-		List<Document> isNotNullDocuments = ListUtil.filter(
-			documents, Objects::nonNull);
-
-		for (Document document : isNotNullDocuments) {
-			jsonArray.put(translate(document));
-		}
-
-		return jsonArray;
+		return JSONUtil.toJSONArray(documents, this::translate, _log);
 	}
 
 	protected Query getIdsQuery(List<String> ids) {
@@ -187,6 +182,9 @@ public class RankingGetHiddenResultsBuilder {
 
 		return ListUtil.subList(ids, _from, end);
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		RankingGetHiddenResultsBuilder.class.getName());
 
 	private final DLAppLocalService _dlAppLocalService;
 	private final FastDateFormatFactory _fastDateFormatFactory;

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetHiddenResultsBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetHiddenResultsBuilder.java
@@ -39,7 +39,6 @@ import com.liferay.portal.search.tuning.rankings.web.internal.index.name.Ranking
 import com.liferay.portal.search.tuning.rankings.web.internal.util.RankingResultUtil;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 import javax.portlet.ResourceRequest;
@@ -114,14 +113,12 @@ public class RankingGetHiddenResultsBuilder {
 	}
 
 	protected JSONArray buildDocuments(List<String> ids, Ranking ranking) {
-		List<Document> documents = ListUtil.filter(
+		return JSONUtil.toJSONArray(
 			TransformUtil.transform(
 				ids,
 				id -> _getDocument(
 					ranking.getIndexName(), id, LIFERAY_DOCUMENT_TYPE)),
-			Objects::nonNull);
-
-		return JSONUtil.toJSONArray(documents, this::translate, _log);
+			this::translate, _log);
 	}
 
 	protected Query getIdsQuery(List<String> ids) {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/searcher/helper/RankingSearchRequestHelper.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/searcher/helper/RankingSearchRequestHelper.java
@@ -42,7 +42,12 @@ public class RankingSearchRequestHelper {
 		List<ComplexQueryPart> complexQueryParts =
 			_getPinnedDocumentIdsQueryParts(ranking);
 
-		complexQueryParts.add(_getHiddenDocumentIdsQueryPart(ranking));
+		ComplexQueryPart complexQueryPart = _getHiddenDocumentIdsQueryPart(
+			ranking);
+
+		if (complexQueryPart != null) {
+			complexQueryParts.add(complexQueryPart);
+		}
 
 		complexQueryParts.forEach(searchRequestBuilder::addComplexQueryPart);
 	}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/searcher/helper/RankingSearchRequestHelper.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/searcher/helper/RankingSearchRequestHelper.java
@@ -16,7 +16,6 @@ package com.liferay.portal.search.tuning.rankings.web.internal.searcher.helper;
 
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.search.filter.ComplexQueryPart;
 import com.liferay.portal.search.filter.ComplexQueryPartBuilderFactory;
 import com.liferay.portal.search.query.IdsQuery;
@@ -40,9 +39,10 @@ public class RankingSearchRequestHelper {
 	public void contribute(
 		SearchRequestBuilder searchRequestBuilder, Ranking ranking) {
 
-		List<ComplexQueryPart> complexQueryParts = ListUtil.concat(
-			_getPinnedDocumentIdsQueryParts(ranking),
-			ListUtil.fromArray(_getHiddenDocumentIdsQueryPart(ranking)));
+		List<ComplexQueryPart> complexQueryParts =
+			_getPinnedDocumentIdsQueryParts(ranking);
+
+		complexQueryParts.add(_getHiddenDocumentIdsQueryPart(ranking));
 
 		complexQueryParts.forEach(searchRequestBuilder::addComplexQueryPart);
 	}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/searcher/helper/RankingSearchRequestHelper.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/searcher/helper/RankingSearchRequestHelper.java
@@ -14,7 +14,9 @@
 
 package com.liferay.portal.search.tuning.rankings.web.internal.searcher.helper;
 
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.search.filter.ComplexQueryPart;
 import com.liferay.portal.search.filter.ComplexQueryPartBuilderFactory;
 import com.liferay.portal.search.query.IdsQuery;
@@ -25,7 +27,6 @@ import com.liferay.portal.search.tuning.rankings.web.internal.index.Ranking;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Stream;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -39,12 +40,11 @@ public class RankingSearchRequestHelper {
 	public void contribute(
 		SearchRequestBuilder searchRequestBuilder, Ranking ranking) {
 
-		Stream.concat(
+		List<ComplexQueryPart> complexQueryParts = ListUtil.concat(
 			_getPinnedDocumentIdsQueryParts(ranking),
-			Stream.of(_getHiddenDocumentIdsQueryPart(ranking))
-		).forEach(
-			searchRequestBuilder::addComplexQueryPart
-		);
+			ListUtil.fromArray(_getHiddenDocumentIdsQueryPart(ranking)));
+
+		complexQueryParts.forEach(searchRequestBuilder::addComplexQueryPart);
 	}
 
 	@Reference
@@ -103,18 +103,13 @@ public class RankingSearchRequestHelper {
 		).build();
 	}
 
-	private Stream<ComplexQueryPart> _getPinnedDocumentIdsQueryParts(
+	private List<ComplexQueryPart> _getPinnedDocumentIdsQueryParts(
 		Ranking ranking) {
 
 		List<Ranking.Pin> pins = ranking.getPins();
 
-		Stream<Ranking.Pin> stream = pins.stream();
-
-		return stream.map(
-			pin -> _getIdsQuery(pin, pins.size())
-		).map(
-			this::_getPinIdsQueryPart
-		);
+		return TransformUtil.transform(
+			pins, pin -> _getPinIdsQueryPart(_getIdsQuery(pin, pins.size())));
 	}
 
 }

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/util/RankingUtil.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/util/RankingUtil.java
@@ -17,9 +17,11 @@ package com.liferay.portal.search.tuning.rankings.web.internal.util;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Dante Wang
@@ -29,15 +31,19 @@ public class RankingUtil {
 	public static Collection<String> getQueryStrings(
 		String queryString, List<String> aliases) {
 
-		List<String> strings = ListUtil.concat(
-			Collections.singletonList(queryString), aliases);
+		Set<String> queryStrings = new LinkedHashSet<>();
 
-		strings = ListUtil.filter(
-			strings, string -> !Validator.isBlank(string));
+		if (!Validator.isBlank(queryString)) {
+			queryStrings.add(queryString);
+		}
 
-		ListUtil.distinct(strings);
+		for (String alias : aliases) {
+			if (!Validator.isBlank(alias)) {
+				queryStrings.add(alias);
+			}
+		}
 
-		return ListUtil.sort(strings);
+		return ListUtil.sort(new ArrayList<>(queryStrings));
 	}
 
 }

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/util/RankingUtil.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/util/RankingUtil.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.portal.search.tuning.rankings.web.internal.util;
+
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Dante Wang
+ */
+public class RankingUtil {
+
+	public static Collection<String> getQueryStrings(
+		String queryString, List<String> aliases) {
+
+		List<String> strings = ListUtil.concat(
+			Collections.singletonList(queryString), aliases);
+
+		strings = ListUtil.filter(
+			strings, string -> !Validator.isBlank(string));
+
+		ListUtil.distinct(strings);
+
+		return ListUtil.sort(strings);
+	}
+
+}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/test/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingToDocumentTranslatorTest.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/test/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingToDocumentTranslatorTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.search.tuning.rankings.web.internal.index;
 
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.search.document.Document;
 import com.liferay.portal.search.document.Field;
@@ -24,8 +25,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -156,14 +155,9 @@ public class RankingToDocumentTranslatorTest {
 	}
 
 	private String _toString(List<Ranking.Pin> pins) {
-		Stream<Ranking.Pin> stream = pins.stream();
-
 		return String.valueOf(
-			stream.map(
-				pin -> pin.getPosition() + "=" + pin.getDocumentId()
-			).collect(
-				Collectors.toList()
-			));
+			TransformUtil.transform(
+				pins, pin -> pin.getPosition() + "=" + pin.getDocumentId()));
 	}
 
 	private DocumentToRankingTranslator _documentToRankingTranslator;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-172262

Hi Team,

We did some changes about Stream.concat() usages, it will change the original logic. Before the fix, some places used Stream.concat(a,b). In this method, a and b requireNonNull. The previous logic missed the null check and it will throw NPE if a or b is null. Please refer to the last three commits files log history of the fix and you can see the Stream.concat() usages.

Could you please check if the fix is good to you?

cc @dantewang, @LisztLiszt

Thanks,
Hai  
