### PR TITLE
[TS] LPS-122230 "Reindex all search indexes" progress bar shows 100% completion when reindex is still in progress

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexBackgroundTaskStatusMessageTranslator.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexBackgroundTaskStatusMessageTranslator.java
@@ -20,7 +20,9 @@ import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.background.task.ReindexBackgroundTaskConstants;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Set;
@@ -84,18 +86,22 @@ public class ReindexBackgroundTaskStatusMessageTranslator
 		int percentage = 100;
 
 		if (phase.equals(ReindexBackgroundTaskConstants.PORTAL_START)) {
-			String lastIndexer = GetterUtil.getString(
-				backgroundTaskStatus.getAttribute("lastIndexer"));
+			String[] pastIndexers = GetterUtil.getStringValues(
+				backgroundTaskStatus.getAttribute("pastIndexers"));
 			int indexerCount = GetterUtil.getInteger(
 				backgroundTaskStatus.getAttribute("indexerCount"));
 
-			if (Validator.isNull(lastIndexer)) {
-				backgroundTaskStatus.setAttribute("lastIndexer", className);
+			Set<String> pastIndexersSet = SetUtil.fromArray(pastIndexers);
+
+			if (pastIndexersSet.isEmpty()) {
+				backgroundTaskStatus.setAttribute(
+					"pastIndexers", new String[] {className});
 			}
-			else if (!lastIndexer.equals(className)) {
+			else if (pastIndexersSet.add(className)) {
 				backgroundTaskStatus.setAttribute(
 					"indexerCount", ++indexerCount);
-				backgroundTaskStatus.setAttribute("lastIndexer", className);
+				backgroundTaskStatus.setAttribute(
+					"pastIndexers", ArrayUtil.toStringArray(pastIndexersSet));
 			}
 
 			Set<Indexer<?>> indexers = IndexerRegistryUtil.getIndexers();

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexBackgroundTaskStatusMessageTranslator.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexBackgroundTaskStatusMessageTranslator.java
@@ -71,11 +71,11 @@ public class ReindexBackgroundTaskStatusMessageTranslator
 			backgroundTaskStatus.getAttribute(
 				ReindexBackgroundTaskConstants.COMPANY_IDS));
 
-		for (long companyId : companyIds) {
-			long currentCompanyId = GetterUtil.getLong(
-				backgroundTaskStatus.getAttribute(
-					ReindexBackgroundTaskConstants.COMPANY_ID));
+		long currentCompanyId = GetterUtil.getLong(
+			backgroundTaskStatus.getAttribute(
+				ReindexBackgroundTaskConstants.COMPANY_ID));
 
+		for (long companyId : companyIds) {
 			if (companyId == currentCompanyId) {
 				break;
 			}
@@ -87,21 +87,25 @@ public class ReindexBackgroundTaskStatusMessageTranslator
 
 		if (phase.equals(ReindexBackgroundTaskConstants.PORTAL_START)) {
 			String[] pastIndexers = GetterUtil.getStringValues(
-				backgroundTaskStatus.getAttribute("pastIndexers"));
+				backgroundTaskStatus.getAttribute(
+					"pastIndexers" + currentCompanyId));
 			int indexerCount = GetterUtil.getInteger(
-				backgroundTaskStatus.getAttribute("indexerCount"));
+				backgroundTaskStatus.getAttribute(
+					"indexerCount" + currentCompanyId));
 
 			Set<String> pastIndexersSet = SetUtil.fromArray(pastIndexers);
 
 			if (pastIndexersSet.isEmpty()) {
 				backgroundTaskStatus.setAttribute(
-					"pastIndexers", new String[] {className});
+					"pastIndexers" + currentCompanyId,
+					new String[] {className});
 			}
 			else if (pastIndexersSet.add(className)) {
 				backgroundTaskStatus.setAttribute(
-					"indexerCount", ++indexerCount);
+					"indexerCount" + currentCompanyId, ++indexerCount);
 				backgroundTaskStatus.setAttribute(
-					"pastIndexers", ArrayUtil.toStringArray(pastIndexersSet));
+					"pastIndexers" + currentCompanyId,
+					ArrayUtil.toStringArray(pastIndexersSet));
 			}
 
 			Set<Indexer<?>> indexers = IndexerRegistryUtil.getIndexers();


### PR DESCRIPTION
Hello @liferay-search,

This is a solution for [LPS-122230](https://issues.liferay.com/browse/LPS-122230) about the progress bar for the reindex button not being in sync with the actual reindex process. 

The solution is based on two underlying problems:
1. Keeping track of the `lastIndexer` is not enough to avoid overcounting if indexers for the same `className` don't come in a row. To fix this we keep track of all processed `className`'s instead of just the last one. (Commit cb1f42bb26b13429bd2a5eeb8a245596380755a9.)
2. If we index more than one company we need to keep the index counters separate by `companyId`: the progress by company is already taken care of separately with `companyCount` and `companyTotal`, so we need `indexCounter` to always be less than or equal to `indexers.size()`. (Commit 920b91b25e754b63533958059843981310f510da.)

Please let me know if you have any questions.

Thanks!