### PR TITLE
LPS-151999 Post 7.3 -> 7.4 Upgrade, custom Search Bar widget templates are no longer visible in the UI

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
@@ -36,6 +36,6 @@ Import-Package:\
 	org.tukaani.*;resolution:=optional,\
 	\
 	*
-Liferay-Require-SchemaVersion: 5.2.0
+Liferay-Require-SchemaVersion: 5.3.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java
@@ -56,6 +56,7 @@ import com.liferay.dynamic.data.mapping.internal.upgrade.v4_3_4.DDMStructureLink
 import com.liferay.dynamic.data.mapping.internal.upgrade.v4_3_4.DLFileEntryTypeDDMFieldAttributeUpgradeProcess;
 import com.liferay.dynamic.data.mapping.internal.upgrade.v4_3_5.DDMTemplateVersionUpgradeProcess;
 import com.liferay.dynamic.data.mapping.internal.upgrade.v5_2_0.DDMFacetTemplateUpgradeProcess;
+import com.liferay.dynamic.data.mapping.internal.upgrade.v5_3_0.DDMSearchBarTemplateUpgradeProcess;
 import com.liferay.dynamic.data.mapping.io.DDMFormDeserializer;
 import com.liferay.dynamic.data.mapping.io.DDMFormLayoutDeserializer;
 import com.liferay.dynamic.data.mapping.io.DDMFormLayoutSerializer;
@@ -504,6 +505,10 @@ public class DDMServiceUpgradeStepRegistrator
 		registry.register(
 			"5.1.5", "5.2.0",
 			new DDMFacetTemplateUpgradeProcess(_classNameLocalService));
+
+		registry.register(
+			"5.2.0", "5.3.0",
+			new DDMSearchBarTemplateUpgradeProcess(_classNameLocalService));
 	}
 
 	@Activate

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_3_0/DDMSearchBarTemplateUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_3_0/DDMSearchBarTemplateUpgradeProcess.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.internal.upgrade.v5_3_0;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+
+import java.util.Map;
+
+/**
+ * @author Tibor Lipusz
+ */
+public class DDMSearchBarTemplateUpgradeProcess extends UpgradeProcess {
+
+	public DDMSearchBarTemplateUpgradeProcess(
+		ClassNameLocalService classNameLocalService) {
+
+		_classNameLocalService = classNameLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		_updateSearchBarTemplates();
+	}
+
+	private void _updateSearchBarTemplates() throws Exception {
+		long resourceClassNameId = _classNameLocalService.getClassNameId(
+			"com.liferay.portlet.display.template.PortletDisplayTemplate");
+
+		for (Map.Entry<String, String> entry :
+				_searchBarTemplateClassNames.entrySet()) {
+
+			long newClassNameId = _classNameLocalService.getClassNameId(
+				entry.getValue());
+			long oldClassNameId = _classNameLocalService.getClassNameId(
+				entry.getKey());
+
+			runSQL(
+				StringBundler.concat(
+					"update DDMTemplate set classNameId = ", newClassNameId,
+					" where classNameId = ", oldClassNameId,
+					" and resourceClassNameId = ", resourceClassNameId));
+		}
+	}
+
+	private final ClassNameLocalService _classNameLocalService;
+	private final Map<String, String> _searchBarTemplateClassNames =
+		HashMapBuilder.put(
+			"com.liferay.portal.search.web.internal.search.bar.portlet." +
+				"display.context.SearchBarPortletDisplayContext",
+			"com.liferay.portal.search.web.internal.search.bar.portlet." +
+				"SearchBarPortlet"
+		).put(
+			"com.liferay.portal.search.web.internal.search.bar.portlet." +
+				"SearchBarPortletDisplayContext",
+			"com.liferay.portal.search.web.internal.search.bar.portlet." +
+				"SearchBarPortlet"
+		).build();
+
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/template/SearchBarPortletDisplayTemplateHandler.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/template/SearchBarPortletDisplayTemplateHandler.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.template.TemplateVariableGroup;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.search.web.constants.SearchBarPortletKeys;
+import com.liferay.portal.search.web.internal.search.bar.portlet.SearchBarPortlet;
 import com.liferay.portal.search.web.internal.search.bar.portlet.display.context.SearchBarPortletDisplayContext;
 
 import java.util.Locale;
@@ -42,7 +43,7 @@ public class SearchBarPortletDisplayTemplateHandler
 
 	@Override
 	public String getClassName() {
-		return SearchBarPortletDisplayContext.class.getName();
+		return SearchBarPortlet.class.getName();
 	}
 
 	@Override

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/configuration.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/configuration.jsp
@@ -34,6 +34,7 @@ page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.ReleaseInfo" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
+page import="com.liferay.portal.search.web.internal.search.bar.portlet.SearchBarPortlet" %><%@
 page import="com.liferay.portal.search.web.internal.search.bar.portlet.SearchBarPortletPreferences" %><%@
 page import="com.liferay.portal.search.web.internal.search.bar.portlet.SearchBarPortletPreferencesImpl" %><%@
 page import="com.liferay.portal.search.web.internal.search.bar.portlet.configuration.SearchBarPortletInstanceConfiguration" %><%@
@@ -70,7 +71,7 @@ String suggestionsContributorConfiguration = StringBundler.concat(StringPool.OPE
 			label="display-settings"
 		>
 			<liferay-template:template-selector
-				className="<%= SearchBarPortletDisplayContext.class.getName() %>"
+				className="<%= SearchBarPortlet.class.getName() %>"
 				displayStyle="<%= searchBarPortletInstanceConfiguration.displayStyle() %>"
 				displayStyleGroupId="<%= searchBarPortletDisplayContext.getDisplayStyleGroupId() %>"
 				refreshURL="<%= configurationRenderURL %>"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
@@ -32,6 +32,7 @@ page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
+page import="com.liferay.portal.search.web.internal.search.bar.portlet.SearchBarPortlet" %><%@
 page import="com.liferay.portal.search.web.internal.search.bar.portlet.configuration.SearchBarPortletInstanceConfiguration" %><%@
 page import="com.liferay.portal.search.web.internal.search.bar.portlet.display.context.SearchBarPortletDisplayContext" %>
 
@@ -66,7 +67,7 @@ SearchBarPortletDisplayContext searchBarPortletDisplayContext = (SearchBarPortle
 			%>
 
 			<liferay-ddm:template-renderer
-				className="<%= SearchBarPortletDisplayContext.class.getName() %>"
+				className="<%= SearchBarPortlet.class.getName() %>"
 				contextObjects='<%=
 					HashMapBuilder.<String, Object>put(
 						"namespace", liferayPortletResponse.getNamespace()


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-151999

### Fix Notes

Followed pattern from https://github.com/brianchandotcom/liferay-portal/pull/127638 without the removal part, as there are no template we should delete at this point imo.

:heavy_check_mark: The facet widgets have been addressed in [LPS-170694](https://issues.liferay.com/browse/LPS-170694)

### Analysis 

Caused by , [LPS-147369](https://issues.liferay.com/browse/LPS-147369): https://github.com/liferay/liferay-portal/commit/2efe7c97b8cd716ce597c1feb7f460b59d942fd4#diff-e08850f3cf8da693387e962e3906b41c92c86d93a6f8beb5b791e083fc60f719
* 7.4 U9+/GA13+: `com.liferay.portal.search.web.internal.search.bar.portlet.display.context`
* 7.3.x, 7.4 U8/GA12 and prior: `com.liferay.portal.search.web.internal.search.bar.portlet`

More about the root cause [here](https://issues.liferay.com/browse/LPS-170694?focusedCommentId=2816937&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2816937).

### QA Results

Search QA has tested the upgrade scenarios from the ticket already. :white_check_mark: 