### PR TITLE
LPS-149968 Adapt API search to be able to implement JournalArticleIndexer as Contributors

### DIFF
--- a/modules/apps/portal-search/portal-search-api/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search API
 Bundle-SymbolicName: com.liferay.portal.search.api
-Bundle-Version: 11.2.1
+Bundle-Version: 11.3.0
 Export-Package:\
 	com.liferay.portal.search.aggregation,\
 	com.liferay.portal.search.aggregation.bucket,\

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/indexer/IndexerWriter.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/indexer/IndexerWriter.java
@@ -43,6 +43,10 @@ public interface IndexerWriter<T extends BaseModel<?>> {
 
 	public void reindex(T baseModel);
 
+	public default void reindex(T baseModel, boolean notify) {
+		reindex(baseModel);
+	}
+
 	public void setEnabled(boolean enabled);
 
 	public void updatePermissionFields(T baseModel);

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/indexer/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/indexer/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/portal-search/portal-search-spi/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-spi/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search SPI
 Bundle-SymbolicName: com.liferay.portal.search.spi
-Bundle-Version: 7.0.1
+Bundle-Version: 7.1.0
 Export-Package:\
 	com.liferay.portal.search.spi.index,\
 	com.liferay.portal.search.spi.model.index.contributor,\

--- a/modules/apps/portal-search/portal-search-spi/src/main/java/com/liferay/portal/search/spi/model/index/contributor/ModelIndexerWriterContributor.java
+++ b/modules/apps/portal-search/portal-search-spi/src/main/java/com/liferay/portal/search/spi/model/index/contributor/ModelIndexerWriterContributor.java
@@ -36,6 +36,9 @@ public interface ModelIndexerWriterContributor<T extends BaseModel<?>> {
 		return null;
 	}
 
+	public default void modelDeleted(T baseModel) {
+	}
+
 	public default void modelIndexed(T baseModel) {
 	}
 

--- a/modules/apps/portal-search/portal-search-spi/src/main/resources/com/liferay/portal/search/spi/model/index/contributor/packageinfo
+++ b/modules/apps/portal-search/portal-search-spi/src/main/resources/com/liferay/portal/search/spi/model/index/contributor/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/DefaultIndexer.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/DefaultIndexer.java
@@ -264,6 +264,11 @@ public class DefaultIndexer<T extends BaseModel<?>> implements Indexer<T> {
 	}
 
 	@Override
+	public void reindex(T baseModel, boolean notify) throws SearchException {
+		_indexerWriter.reindex(baseModel, notify);
+	}
+
+	@Override
 	public Hits search(SearchContext searchContext) throws SearchException {
 		return _indexerSearcher.search(searchContext);
 	}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerWriterImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerWriterImpl.java
@@ -210,6 +210,11 @@ public class IndexerWriterImpl<T extends BaseModel<?>>
 
 	@Override
 	public void reindex(T baseModel) {
+		reindex(baseModel, true);
+	}
+
+	@Override
+	public void reindex(T baseModel, boolean notify) {
 		if (!isEnabled() || (baseModel == null)) {
 			return;
 		}
@@ -234,7 +239,9 @@ public class IndexerWriterImpl<T extends BaseModel<?>>
 			}
 		}
 
-		_modelIndexerWriterContributor.modelIndexed(baseModel);
+		if (notify) {
+			_modelIndexerWriterContributor.modelIndexed(baseModel);
+		}
 	}
 
 	@Override

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerWriterImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerWriterImpl.java
@@ -233,7 +233,12 @@ public class IndexerWriterImpl<T extends BaseModel<?>>
 				document);
 		}
 		else if (indexerWriterMode == IndexerWriterMode.DELETE) {
-			delete(baseModel);
+			long companyId = _modelIndexerWriterContributor.getCompanyId(
+				baseModel);
+
+			String uid = _indexerDocumentBuilder.getDocumentUID(baseModel);
+
+			delete(companyId, uid);
 		}
 		else if (indexerWriterMode == IndexerWriterMode.SKIP) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerWriterImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerWriterImpl.java
@@ -99,6 +99,8 @@ public class IndexerWriterImpl<T extends BaseModel<?>>
 		String uid = _indexerDocumentBuilder.getDocumentUID(baseModel);
 
 		delete(companyId, uid);
+
+		_modelIndexerWriterContributor.modelDeleted(baseModel);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/search/Indexer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/Indexer.java
@@ -137,6 +137,12 @@ public interface Indexer<T> {
 	@Bufferable
 	public void reindex(T object) throws SearchException;
 
+	public default void reindex(T object, boolean notify)
+		throws SearchException {
+
+		reindex(object);
+	}
+
 	public Hits search(SearchContext searchContext) throws SearchException;
 
 	public Hits search(

--- a/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
@@ -1,1 +1,1 @@
-version 20.0.0
+version 20.1.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-149968

Hi Team 👋 

From the Echo Team,  we are trying to migrate the indexing of JournalArticles to the new paradigm. Due to the characteristics of JournalArticles, we have found a series of limitations in the API that prevent us from completing this migration.

The main problem is that all the versions of a JournalArticle are in the same table and, furthermore, the version indexing is configurable by the user.
There are two possible ways to configure version indexing:
1. All versions are indexed.
2. Only the latest published version is indexed.

The fact that everything is modeled by JournalArticle complicates indexing because indexing an article, depending on its status and the configuration, can trigger different actions.

When configured to index all versions, indexing of an article should trigger indexing of all its versions. This with the current API cannot be done without falling into an infinite loop. This is because we are not able to tell when one version is being indexed because another has been indexed.

In the case that it is configured to index only the last published version, we also find that sometimes it must trigger the indexing of other versions because the update implies that the last published version has changed.

After analyzing all this we concluded that we need to add mechanisms to the API that allow us to:

1. From ModelIndexerWriterContributor.modelIndexed to be able to launch the indexing of other objects of that same model without that method being called again to avoid the infinite loop
2. To receive a notification when an object has been deleted as a result of the @Indexable(type = IndexableType.DELETE) annotation.

This PR is my proposal to solve these points, with these changes JournalArticle can be migrated to the new paradigm.

Could you please review this proposal?

Thanks in advance ❤️ 