### PR TITLE
[TS] LPS-161173 Search Bar Destination

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortlet.java
@@ -14,6 +14,9 @@
 
 package com.liferay.portal.search.web.internal.search.bar.portlet;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.Portal;
@@ -73,21 +76,31 @@ public class SearchBarPortlet extends MVCPortlet {
 		throws IOException, PortletException {
 
 		SearchBarPortletDisplayContextFactory
+			searchBarPortletDisplayContextFactory = null;
+
+		try {
 			searchBarPortletDisplayContextFactory =
 				new SearchBarPortletDisplayContextFactory(
 					layoutLocalService, portal, renderRequest);
 
-		SearchBarPortletDisplayContext searchBarPortletDisplayContext =
-			searchBarPortletDisplayContextFactory.create(
-				portletPreferencesLookup, portletSharedSearchRequest,
-				searchBarPrecedenceHelper, searchCapabilities);
+			SearchBarPortletDisplayContext searchBarPortletDisplayContext =
+				searchBarPortletDisplayContextFactory.create(
+					portletPreferencesLookup, portletSharedSearchRequest,
+					searchBarPrecedenceHelper, searchCapabilities);
 
-		renderRequest.setAttribute(
-			WebKeys.PORTLET_DISPLAY_CONTEXT, searchBarPortletDisplayContext);
-
-		if (searchBarPortletDisplayContext.isRenderNothing()) {
 			renderRequest.setAttribute(
-				WebKeys.PORTLET_CONFIGURATOR_VISIBILITY, Boolean.TRUE);
+				WebKeys.PORTLET_DISPLAY_CONTEXT,
+				searchBarPortletDisplayContext);
+
+			if (searchBarPortletDisplayContext.isRenderNothing()) {
+				renderRequest.setAttribute(
+					WebKeys.PORTLET_CONFIGURATOR_VISIBILITY, Boolean.TRUE);
+			}
+		}
+		catch (ConfigurationException configurationException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(configurationException);
+			}
 		}
 
 		super.render(renderRequest, renderResponse);
@@ -110,5 +123,8 @@ public class SearchBarPortlet extends MVCPortlet {
 
 	@Reference
 	protected SearchCapabilities searchCapabilities;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SearchBarPortlet.class);
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletPreferences.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletPreferences.java
@@ -54,9 +54,9 @@ public interface SearchBarPortletPreferences {
 	public static final String PREFERENCE_KEY_USE_ADVANCED_SEARCH_SYNTAX =
 		"useAdvancedSearchSyntax";
 
-	public Optional<String> getDestinationOptional();
+	public String getDestination();
 
-	public String getDestinationString();
+	public Optional<String> getDestinationOptional();
 
 	public Optional<String> getFederatedSearchKeyOptional();
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletPreferencesImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletPreferencesImpl.java
@@ -36,16 +36,16 @@ public class SearchBarPortletPreferencesImpl
 	}
 
 	@Override
-	public Optional<String> getDestinationOptional() {
-		return _portletPreferencesHelper.getString(
-			SearchBarPortletPreferences.PREFERENCE_KEY_DESTINATION);
-	}
-
-	@Override
-	public String getDestinationString() {
+	public String getDestination() {
 		Optional<String> valueOptional = getDestinationOptional();
 
 		return valueOptional.orElse(StringPool.BLANK);
+	}
+
+	@Override
+	public Optional<String> getDestinationOptional() {
+		return _portletPreferencesHelper.getString(
+			SearchBarPortletPreferences.PREFERENCE_KEY_DESTINATION);
 	}
 
 	@Override

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/configuration/SearchBarPortletInstanceConfiguration.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/configuration/SearchBarPortletInstanceConfiguration.java
@@ -57,4 +57,7 @@ public interface SearchBarPortletInstanceConfiguration {
 	)
 	public int suggestionsDisplayThreshold();
 
+	@Meta.AD(deflt = "", name = "destination", required = false)
+	public String destination();
+
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/configuration/SearchBarPortletInstanceConfiguration.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/configuration/SearchBarPortletInstanceConfiguration.java
@@ -58,6 +58,6 @@ public interface SearchBarPortletInstanceConfiguration {
 	public int suggestionsDisplayThreshold();
 
 	@Meta.AD(deflt = "", name = "destination", required = false)
-	public String destination();
+	public String destinationFriendlyURL();
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/SearchBarPortletDisplayContext.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/SearchBarPortletDisplayContext.java
@@ -29,6 +29,10 @@ public class SearchBarPortletDisplayContext {
 		return _destinationFriendlyURL;
 	}
 
+	public String getDestinationURL() {
+		return _destinationURL;
+	}
+
 	public long getDisplayStyleGroupId() {
 		return _displayStyleGroupId;
 	}
@@ -65,10 +69,6 @@ public class SearchBarPortletDisplayContext {
 		getSearchBarPortletInstanceConfiguration() {
 
 		return _searchBarPortletInstanceConfiguration;
-	}
-
-	public String getSearchURL() {
-		return _searchURL;
 	}
 
 	public String getSuggestionsContributorConfiguration() {
@@ -148,6 +148,10 @@ public class SearchBarPortletDisplayContext {
 		_destinationUnreachable = destinationUnreachable;
 	}
 
+	public void setDestinationURL(String destinationURL) {
+		_destinationURL = destinationURL;
+	}
+
 	public void setDisplayStyleGroupId(long displayStyleGroupId) {
 		_displayStyleGroupId = displayStyleGroupId;
 	}
@@ -220,10 +224,6 @@ public class SearchBarPortletDisplayContext {
 		_searchExperiencesSupported = searchExperiencesSupported;
 	}
 
-	public void setSearchURL(String searchURL) {
-		_searchURL = searchURL;
-	}
-
 	public void setSelectedCurrentSiteSearchScope(
 		boolean selectedCurrentSiteSearchScope) {
 
@@ -267,6 +267,7 @@ public class SearchBarPortletDisplayContext {
 	private String _currentSiteSearchScopeParameterString;
 	private String _destinationFriendlyURL;
 	private boolean _destinationUnreachable;
+	private String _destinationURL;
 	private long _displayStyleGroupId;
 	private boolean _displayWarningIgnoredConfiguration;
 	private boolean _emptySearchEnabled;
@@ -282,7 +283,6 @@ public class SearchBarPortletDisplayContext {
 	private SearchBarPortletInstanceConfiguration
 		_searchBarPortletInstanceConfiguration;
 	private boolean _searchExperiencesSupported;
-	private String _searchURL;
 	private boolean _selectedCurrentSiteSearchScope;
 	private boolean _selectedEverythingSearchScope;
 	private String _suggestionsContributorConfiguration;

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
@@ -94,16 +94,16 @@ public class SearchBarPortletDisplayContextFactory {
 		ThemeDisplay themeDisplay = (ThemeDisplay)_renderRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		String destinationString =
+		String destination =
 			_searchBarPortletInstanceConfiguration.destination();
 
-		if (Validator.isBlank(destinationString)) {
+		if (Validator.isBlank(destination)) {
 			searchBarPortletDisplayContext.setSearchURL(
 				_getURLCurrentPath(themeDisplay));
 		}
 		else {
 			String destinationURL = _getDestinationURL(
-				destinationString, themeDisplay);
+				destination, themeDisplay);
 
 			if (destinationURL == null) {
 				searchBarPortletDisplayContext.setDestinationUnreachable(true);
@@ -131,8 +131,7 @@ public class SearchBarPortletDisplayContextFactory {
 			isAvailableEverythingSearchScope());
 		searchBarPortletDisplayContext.setCurrentSiteSearchScopeParameterString(
 			SearchScope.THIS_SITE.getParameterString());
-		searchBarPortletDisplayContext.setDestinationFriendlyURL(
-			destinationString);
+		searchBarPortletDisplayContext.setDestinationFriendlyURL(destination);
 		searchBarPortletDisplayContext.setDisplayStyleGroupId(
 			getDisplayStyleGroupId(
 				searchBarPortletInstanceConfiguration, themeDisplay));

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
@@ -98,7 +98,7 @@ public class SearchBarPortletDisplayContextFactory {
 			_searchBarPortletInstanceConfiguration.destination();
 
 		if (Validator.isBlank(destination)) {
-			searchBarPortletDisplayContext.setSearchURL(
+			searchBarPortletDisplayContext.setDestinationURL(
 				_getURLCurrentPath(themeDisplay));
 		}
 		else {
@@ -112,7 +112,7 @@ public class SearchBarPortletDisplayContextFactory {
 				return searchBarPortletDisplayContext;
 			}
 
-			searchBarPortletDisplayContext.setSearchURL(destinationURL);
+			searchBarPortletDisplayContext.setDestinationURL(destinationURL);
 		}
 
 		SearchBarPortletPreferences searchBarPortletPreferences =

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
@@ -94,16 +94,16 @@ public class SearchBarPortletDisplayContextFactory {
 		ThemeDisplay themeDisplay = (ThemeDisplay)_renderRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		String destination =
-			_searchBarPortletInstanceConfiguration.destination();
+		String destinationFriendlyURL =
+			_searchBarPortletInstanceConfiguration.destinationFriendlyURL();
 
-		if (Validator.isBlank(destination)) {
+		if (Validator.isBlank(destinationFriendlyURL)) {
 			searchBarPortletDisplayContext.setDestinationURL(
 				_getURLCurrentPath(themeDisplay));
 		}
 		else {
 			String destinationURL = _getDestinationURL(
-				destination, themeDisplay);
+				destinationFriendlyURL, themeDisplay);
 
 			if (destinationURL == null) {
 				searchBarPortletDisplayContext.setDestinationUnreachable(true);
@@ -131,7 +131,8 @@ public class SearchBarPortletDisplayContextFactory {
 			isAvailableEverythingSearchScope());
 		searchBarPortletDisplayContext.setCurrentSiteSearchScopeParameterString(
 			SearchScope.THIS_SITE.getParameterString());
-		searchBarPortletDisplayContext.setDestinationFriendlyURL(destination);
+		searchBarPortletDisplayContext.setDestinationFriendlyURL(
+			destinationFriendlyURL);
 		searchBarPortletDisplayContext.setDisplayStyleGroupId(
 			getDisplayStyleGroupId(
 				searchBarPortletInstanceConfiguration, themeDisplay));

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
@@ -64,12 +64,22 @@ import javax.servlet.http.HttpServletRequest;
 public class SearchBarPortletDisplayContextFactory {
 
 	public SearchBarPortletDisplayContextFactory(
-		LayoutLocalService layoutLocalService, Portal portal,
-		RenderRequest renderRequest) {
+			LayoutLocalService layoutLocalService, Portal portal,
+			RenderRequest renderRequest)
+		throws ConfigurationException {
 
 		_layoutLocalService = layoutLocalService;
 		_portal = portal;
 		_renderRequest = renderRequest;
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		_searchBarPortletInstanceConfiguration =
+			portletDisplay.getPortletInstanceConfiguration(
+				SearchBarPortletInstanceConfiguration.class);
 	}
 
 	public SearchBarPortletDisplayContext create(
@@ -81,15 +91,11 @@ public class SearchBarPortletDisplayContextFactory {
 		SearchBarPortletDisplayContext searchBarPortletDisplayContext =
 			new SearchBarPortletDisplayContext();
 
-		SearchBarPortletPreferences searchBarPortletPreferences =
-			new SearchBarPortletPreferencesImpl(
-				Optional.ofNullable(_renderRequest.getPreferences()));
-
 		ThemeDisplay themeDisplay = (ThemeDisplay)_renderRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
 		String destinationString =
-			searchBarPortletPreferences.getDestinationString();
+			_searchBarPortletInstanceConfiguration.destination();
 
 		if (Validator.isBlank(destinationString)) {
 			searchBarPortletDisplayContext.setSearchURL(
@@ -108,6 +114,10 @@ public class SearchBarPortletDisplayContextFactory {
 
 			searchBarPortletDisplayContext.setSearchURL(destinationURL);
 		}
+
+		SearchBarPortletPreferences searchBarPortletPreferences =
+			new SearchBarPortletPreferencesImpl(
+				Optional.ofNullable(_renderRequest.getPreferences()));
 
 		PortletSharedSearchResponse portletSharedSearchResponse =
 			portletSharedSearchRequest.search(_renderRequest);
@@ -491,5 +501,7 @@ public class SearchBarPortletDisplayContextFactory {
 	private final LayoutLocalService _layoutLocalService;
 	private final Portal _portal;
 	private final RenderRequest _renderRequest;
+	private final SearchBarPortletInstanceConfiguration
+		_searchBarPortletInstanceConfiguration;
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
@@ -350,10 +350,10 @@ public class SearchBarPortletDisplayContextFactory {
 	}
 
 	private String _getDestinationURL(
-		String destinationString, ThemeDisplay themeDisplay) {
+		String destinationFriendlyURL, ThemeDisplay themeDisplay) {
 
 		Layout layout = fetchLayoutByFriendlyURL(
-			themeDisplay.getScopeGroupId(), _slashify(destinationString));
+			themeDisplay.getScopeGroupId(), _slashify(destinationFriendlyURL));
 
 		if (layout == null) {
 			return null;

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/upgrade/registry/SearchWebUpgradeStepRegistrator.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/upgrade/registry/SearchWebUpgradeStepRegistrator.java
@@ -17,9 +17,12 @@ package com.liferay.portal.search.web.internal.upgrade.registry;
 import com.liferay.portal.search.web.internal.upgrade.v1_0_0.UpgradePortletId;
 import com.liferay.portal.search.web.internal.upgrade.v1_0_0.UpgradePortletPreferences;
 import com.liferay.portal.search.web.internal.upgrade.v2_0_0.SearchPortletUpgradeProcess;
+import com.liferay.portal.search.web.internal.upgrade.v3_0_0.SearchBarPortletInstanceConfigurationUpgradeProcess;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
+import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eudaldo Alonso
@@ -36,6 +39,12 @@ public class SearchWebUpgradeStepRegistrator implements UpgradeStepRegistrator {
 			new UpgradePortletPreferences());
 
 		registry.register("1.0.0", "2.0.0", new SearchPortletUpgradeProcess());
+
+		registry.register("2.0.0", "3.0.0",
+			new SearchBarPortletInstanceConfigurationUpgradeProcess(
+				_configurationAdmin));
 	}
 
+	@Reference
+	private ConfigurationAdmin _configurationAdmin;
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/upgrade/v3_0_0/SearchBarPortletInstanceConfigurationUpgradeProcess.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/upgrade/v3_0_0/SearchBarPortletInstanceConfigurationUpgradeProcess.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.web.internal.upgrade.v3_0_0;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import com.liferay.portal.kernel.util.Props;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * @author Joshua Cords
+ */
+public class SearchBarPortletInstanceConfigurationUpgradeProcess extends
+	UpgradeProcess {
+
+	public SearchBarPortletInstanceConfigurationUpgradeProcess(
+		ConfigurationAdmin configurationAdmin) {
+
+		_configurationAdmin = configurationAdmin;
+	}
+
+	@Override
+	public void doUpgrade() throws Exception {
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			"(service.factoryPid=com.liferay.portal.search.web.internal." +
+			"search.bar.portlet.configuration." +
+			"SearchBarPortletInstanceConfiguration)");
+
+		if (configurations == null) {
+			return;
+		}
+
+		for (Configuration configuration : configurations) {
+			Dictionary<String, Object> properties =
+				configuration.getProperties();
+
+			if (properties == null) {
+				properties = new Hashtable<>();
+			}
+
+			String destinationFriendlyURL = (String)properties.get(
+				"destination");
+
+			properties.put(
+				"destinationFriendlyURL",
+				destinationFriendlyURL);
+
+			configuration.update(properties);
+		}
+	}
+
+	private final ConfigurationAdmin _configurationAdmin;
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/configuration.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/configuration.jsp
@@ -95,7 +95,7 @@ String suggestionsContributorConfiguration = StringBundler.concat(StringPool.OPE
 
 			<aui:input disabled="<%= searchBarPortletDisplayContext.isDisplayWarningIgnoredConfiguration() %>" label="scope-parameter-name" name="<%= PortletPreferencesJspUtil.getInputName(SearchBarPortletPreferences.PREFERENCE_KEY_SCOPE_PARAMETER_NAME) %>" value="<%= searchBarPortletPreferences.getScopeParameterName() %>" />
 
-			<aui:input helpMessage="destination-page-help" label="destination-page" name="<%= PortletPreferencesJspUtil.getInputName(SearchBarPortletPreferences.PREFERENCE_KEY_DESTINATION) %>" value="<%= searchBarPortletPreferences.getDestinationString() %>" />
+			<aui:input helpMessage="destination-page-help" label="destination-page" name="<%= PortletPreferencesJspUtil.getInputName(SearchBarPortletPreferences.PREFERENCE_KEY_DESTINATION) %>" value="<%= searchBarPortletPreferences.getDestination() %>" />
 		</liferay-frontend:fieldset>
 
 		<c:if test="<%= searchBarPortletDisplayContext.isSuggestionsEndpointEnabled() %>">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
@@ -56,7 +56,7 @@ SearchBarPortletDisplayContext searchBarPortletDisplayContext = (SearchBarPortle
 		</div>
 	</c:when>
 	<c:otherwise>
-		<aui:form action="<%= searchBarPortletDisplayContext.getSearchURL() %>" method="get" name="fm">
+		<aui:form action="<%= searchBarPortletDisplayContext.getDestinationURL() %>" method="get" name="fm">
 			<c:if test="<%= !Validator.isBlank(searchBarPortletDisplayContext.getPaginationStartParameterName()) %>">
 				<input class="search-bar-reset-start-page" name="<%= searchBarPortletDisplayContext.getPaginationStartParameterName() %>" type="hidden" value="0" />
 			</c:if>
@@ -105,7 +105,7 @@ SearchBarPortletDisplayContext searchBarPortletDisplayContext = (SearchBarPortle
 									).put(
 										"scopeParameterStringEverything", searchBarPortletDisplayContext.getEverythingSearchScopeParameterString()
 									).put(
-										"searchURL", searchBarPortletDisplayContext.getSearchURL()
+										"searchURL", searchBarPortletDisplayContext.getDestinationURL()
 									).put(
 										"selectedEverythingSearchScope", searchBarPortletDisplayContext.isSelectedEverythingSearchScope()
 									).put(

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -80,7 +81,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testDestinationBlank() throws PortletException {
+	public void testDestinationBlank()
+		throws ConfigurationException, PortletException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(StringPool.BLANK);
@@ -95,7 +98,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testDestinationNull() throws PortletException {
+	public void testDestinationNull()
+		throws ConfigurationException, PortletException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(null);
@@ -110,7 +115,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testDestinationUnreachable() throws PortletException {
+	public void testDestinationUnreachable()
+		throws ConfigurationException, PortletException {
+
 		String destination = RandomTestUtil.randomString();
 
 		_whenLayoutLocalServiceFetchLayoutByFriendlyURL(destination, null);
@@ -186,7 +193,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testSamePageNoDestination() throws PortletException {
+	public void testSamePageNoDestination()
+		throws ConfigurationException, PortletException {
+
 		Mockito.doReturn(
 			"http://example.com/web/guest/home?param=arg"
 		).when(
@@ -210,7 +219,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testScopeParameterName() throws ReadOnlyException {
+	public void testScopeParameterName()
+		throws ConfigurationException, ReadOnlyException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(null, "sp", null);
@@ -225,7 +236,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testScopeParameterNameDefault() throws ReadOnlyException {
+	public void testScopeParameterNameDefault()
+		throws ConfigurationException, ReadOnlyException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(null, null, null);
@@ -241,7 +254,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testSearchScopePreferenceDefault() throws ReadOnlyException {
+	public void testSearchScopePreferenceDefault()
+		throws ConfigurationException, ReadOnlyException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(null, null, null);
@@ -250,7 +265,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testSearchScopePreferenceEverything() throws ReadOnlyException {
+	public void testSearchScopePreferenceEverything()
+		throws ConfigurationException, ReadOnlyException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(
@@ -261,7 +278,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 	@Test
 	public void testSearchScopePreferenceLetTheUserChooseEverything()
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
@@ -273,7 +290,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 	@Test
 	public void testSearchScopePreferenceLetTheUserChooseInvalidScopeParam()
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		expectedException.expect(IllegalArgumentException.class);
 		expectedException.expectMessage(
@@ -290,7 +307,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 	@Test
 	public void testSearchScopePreferenceLetTheUserChooseNoScopeParam()
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
@@ -302,7 +319,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 	@Test
 	public void testSearchScopePreferenceLetTheUserChooseThisSite()
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
@@ -313,7 +330,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testSearchScopePreferenceThisSite() throws ReadOnlyException {
+	public void testSearchScopePreferenceThisSite()
+		throws ConfigurationException, ReadOnlyException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(
@@ -396,7 +415,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 	private SearchBarPortletDisplayContextFactory
 			_createSearchBarPortletDisplayContextFactory(String destination)
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		return _createSearchBarPortletDisplayContextFactory(
 			destination, null, null, null);
@@ -406,7 +425,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 			_createSearchBarPortletDisplayContextFactory(
 				String scope, String scopeParameterName,
 				String scopeParameterValue)
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		return _createSearchBarPortletDisplayContextFactory(
 			null, scope, scopeParameterName, scopeParameterValue);
@@ -416,7 +435,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 			_createSearchBarPortletDisplayContextFactory(
 				String destination, String scope, String scopeParameterName,
 				String scopeParameterValue)
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		RenderRequest renderRequest = Mockito.mock(RenderRequest.class);
 

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
@@ -439,6 +439,12 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 		RenderRequest renderRequest = Mockito.mock(RenderRequest.class);
 
+		Mockito.when(
+			renderRequest.getAttribute(WebKeys.THEME_DISPLAY)
+		).thenReturn(
+			_themeDisplay
+		);
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				new SearchBarPortletDisplayContextFactory(
@@ -472,12 +478,6 @@ public class SearchBarPortletDisplayContextFactoryTest {
 			portletPreferences
 		);
 
-		Mockito.when(
-			renderRequest.getAttribute(WebKeys.THEME_DISPLAY)
-		).thenReturn(
-			_themeDisplay
-		);
-
 		PortletSharedSearchResponse portletSharedSearchResponse = Mockito.mock(
 			PortletSharedSearchResponse.class);
 
@@ -485,6 +485,12 @@ public class SearchBarPortletDisplayContextFactoryTest {
 			_portletSharedSearchRequest.search(renderRequest)
 		).thenReturn(
 			portletSharedSearchResponse
+		);
+
+		Mockito.when(
+			_searchBarPortletInstanceConfiguration.destination()
+		).thenReturn(
+			destination
 		);
 
 		Mockito.when(
@@ -562,7 +568,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 			Mockito.when(
 				_portletDisplay.getPortletInstanceConfiguration(Mockito.any())
 			).thenReturn(
-				Mockito.mock(SearchBarPortletInstanceConfiguration.class)
+				_searchBarPortletInstanceConfiguration
 			);
 		}
 		catch (Exception exception) {
@@ -616,6 +622,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 		Mockito.mock(PortletPreferencesLookup.class);
 	private final PortletSharedSearchRequest _portletSharedSearchRequest =
 		Mockito.mock(PortletSharedSearchRequest.class);
+	private final SearchBarPortletInstanceConfiguration
+		_searchBarPortletInstanceConfiguration = Mockito.mock(
+			SearchBarPortletInstanceConfiguration.class);
 	private final SearchBarPrecedenceHelper _searchBarPrecedenceHelper =
 		Mockito.mock(SearchBarPrecedenceHelper.class);
 	private final SearchCapabilities _searchCapabilities = Mockito.mock(

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
@@ -158,7 +158,8 @@ public class SearchBarPortletDisplayContextFactoryTest {
 				_searchBarPrecedenceHelper, _searchCapabilities);
 
 		Assert.assertEquals(
-			layoutFriendlyURL, searchBarPortletDisplayContext.getSearchURL());
+			layoutFriendlyURL,
+			searchBarPortletDisplayContext.getDestinationURL());
 
 		Assert.assertFalse(
 			searchBarPortletDisplayContext.isDestinationUnreachable());
@@ -186,7 +187,8 @@ public class SearchBarPortletDisplayContextFactoryTest {
 				_searchBarPrecedenceHelper, _searchCapabilities);
 
 		Assert.assertEquals(
-			layoutFriendlyURL, searchBarPortletDisplayContext.getSearchURL());
+			layoutFriendlyURL,
+			searchBarPortletDisplayContext.getDestinationURL());
 
 		Assert.assertFalse(
 			searchBarPortletDisplayContext.isDestinationUnreachable());
@@ -215,7 +217,8 @@ public class SearchBarPortletDisplayContextFactoryTest {
 			searchBarPortletDisplayContext.isDestinationUnreachable());
 
 		Assert.assertEquals(
-			"/web/guest/home", searchBarPortletDisplayContext.getSearchURL());
+			"/web/guest/home",
+			searchBarPortletDisplayContext.getDestinationURL());
 	}
 
 	@Test

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
@@ -118,13 +118,15 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	public void testDestinationUnreachable()
 		throws ConfigurationException, PortletException {
 
-		String destination = RandomTestUtil.randomString();
+		String destinationFriendlyURL = RandomTestUtil.randomString();
 
-		_whenLayoutLocalServiceFetchLayoutByFriendlyURL(destination, null);
+		_whenLayoutLocalServiceFetchLayoutByFriendlyURL(
+			destinationFriendlyURL, null);
 
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
-				_createSearchBarPortletDisplayContextFactory(destination);
+				_createSearchBarPortletDisplayContextFactory(
+					destinationFriendlyURL);
 
 		SearchBarPortletDisplayContext searchBarPortletDisplayContext =
 			searchBarPortletDisplayContextFactory.create(
@@ -137,11 +139,12 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 	@Test
 	public void testDestinationWithLeadingSlash() throws Exception {
-		String destination = RandomTestUtil.randomString();
+		String destinationFriendlyURL = RandomTestUtil.randomString();
 
 		Layout layout = Mockito.mock(Layout.class);
 
-		_whenLayoutLocalServiceFetchLayoutByFriendlyURL(destination, layout);
+		_whenLayoutLocalServiceFetchLayoutByFriendlyURL(
+			destinationFriendlyURL, layout);
 
 		String layoutFriendlyURL = RandomTestUtil.randomString();
 
@@ -150,7 +153,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(
-					StringPool.SLASH.concat(destination));
+					StringPool.SLASH.concat(destinationFriendlyURL));
 
 		SearchBarPortletDisplayContext searchBarPortletDisplayContext =
 			searchBarPortletDisplayContextFactory.create(
@@ -167,11 +170,12 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 	@Test
 	public void testDestinationWithoutLeadingSlash() throws Exception {
-		String destination = RandomTestUtil.randomString();
+		String destinationFriendlyURL = RandomTestUtil.randomString();
 
 		Layout layout = Mockito.mock(Layout.class);
 
-		_whenLayoutLocalServiceFetchLayoutByFriendlyURL(destination, layout);
+		_whenLayoutLocalServiceFetchLayoutByFriendlyURL(
+			destinationFriendlyURL, layout);
 
 		String layoutFriendlyURL = RandomTestUtil.randomString();
 
@@ -179,7 +183,8 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
-				_createSearchBarPortletDisplayContextFactory(destination);
+				_createSearchBarPortletDisplayContextFactory(
+					destinationFriendlyURL);
 
 		SearchBarPortletDisplayContext searchBarPortletDisplayContext =
 			searchBarPortletDisplayContextFactory.create(
@@ -417,11 +422,12 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	private SearchBarPortletDisplayContextFactory
-			_createSearchBarPortletDisplayContextFactory(String destination)
+			_createSearchBarPortletDisplayContextFactory(
+				String destinationFriendlyURL)
 		throws ConfigurationException, ReadOnlyException {
 
 		return _createSearchBarPortletDisplayContextFactory(
-			destination, null, null, null);
+			destinationFriendlyURL, null, null, null);
 	}
 
 	private SearchBarPortletDisplayContextFactory
@@ -436,8 +442,8 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 	private SearchBarPortletDisplayContextFactory
 			_createSearchBarPortletDisplayContextFactory(
-				String destination, String scope, String scopeParameterName,
-				String scopeParameterValue)
+				String destinationFriendlyURL, String scope,
+				String scopeParameterName, String scopeParameterValue)
 		throws ConfigurationException, ReadOnlyException {
 
 		RenderRequest renderRequest = Mockito.mock(RenderRequest.class);
@@ -457,7 +463,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 		portletPreferences.setValue(
 			SearchBarPortletPreferences.PREFERENCE_KEY_DESTINATION,
-			destination);
+			destinationFriendlyURL);
 		portletPreferences.setValue(
 			SearchBarPortletPreferences.PREFERENCE_KEY_SEARCH_SCOPE, scope);
 
@@ -491,9 +497,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 		);
 
 		Mockito.when(
-			_searchBarPortletInstanceConfiguration.destination()
+			_searchBarPortletInstanceConfiguration.destinationFriendlyURL()
 		).thenReturn(
-			destination
+			destinationFriendlyURL
 		);
 
 		Mockito.when(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-161173

**Authors:** @bakayattila @joshuacords 
**Reviewers:** @joshuacords briandotchan

This originally was approved all the way to Brian Chan [here](https://github.com/brianchandotcom/liferay-portal/pull/124722), but he wanted to unify naming:

`			_searchBarPortletInstanceConfiguration.destination();`
"We had several names for destination.. can we sync on one? Thx."

I've unified naming to "destination", "destinationURL", and "destinationOptional". The last thing I considered was renaming the attribute "searchURL" set [here](https://github.com/liferay/liferay-portal/blob/4744faabfa955fd068ea478cfdc8fb671afeb09b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp#L108) but seemingly used across many components.

`.put("searchURL", searchBarPortletDisplayContext.getDestinationURL())`

In review we should consider whether we should change this as well.