### PR TITLE
[TS] LPS 176791 Critical error in SortPortlet with wrong imported configuration

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/sort/portlet/shared/search/SortPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/sort/portlet/shared/search/SortPortletSharedSearchContributor.java
@@ -18,6 +18,8 @@ import com.liferay.dynamic.data.mapping.util.DDMIndexer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -74,7 +76,7 @@ public class SortPortletSharedSearchContributor
 	@Reference
 	protected DDMIndexer ddmIndexer;
 
-	private Sort _buildSort(String fieldValue, Locale locale) {
+	private Sort _buildSort(String fieldValue, long groupId, Locale locale) {
 		SortOrder sortOrder = SortOrder.ASC;
 
 		if (fieldValue.endsWith("+")) {
@@ -91,7 +93,9 @@ public class SortPortletSharedSearchContributor
 					fieldValue, locale, sortOrder);
 			}
 			catch (PortalException portalException) {
-				throw new RuntimeException(portalException);
+				if (_log.isWarnEnabled()) {
+					_log.warn(fieldValue + " is not a valid field name.");
+				}
 			}
 		}
 
@@ -122,7 +126,9 @@ public class SortPortletSharedSearchContributor
 		return stream.filter(
 			fieldValue -> !fieldValue.isEmpty()
 		).map(
-			fieldValue -> _buildSort(fieldValue, themeDisplay.getLocale())
+			fieldValue -> _buildSort(
+				fieldValue, themeDisplay.getScopeGroupId(),
+				themeDisplay.getLocale())
 		);
 	}
 
@@ -162,6 +168,9 @@ public class SortPortletSharedSearchContributor
 			throw new RuntimeException(portalException);
 		}
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SortPortletSharedSearchContributor.class);
 
 	@Reference
 	private SortBuilderFactory _sortBuilderFactory;


### PR DESCRIPTION
Currently if a ddm field with a wrong value is set in the SortPorlet all the portlets in the search page fail.

This value could also be set when a LAR is imported from other environment, so it's quite annoying for users.

With this code we'll warn admins that this value is wrong without break all the page with a simple LAR import.
