### PR TITLE
[TS] LPS-176871 Considering context path when searching for suggestions

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -42,6 +42,11 @@ export default function SearchBar({
 	suggestionsDisplayThreshold = '2',
 	suggestionsURL = '/o/portal-search-rest/v1.0/suggestions',
 }) {
+	const fetchURL = new URL(
+		`${Liferay.ThemeDisplay.getPathContext()}${suggestionsURL}`,
+		Liferay.ThemeDisplay.getPortalURL()
+	);
+
 	const [active, setActive] = useState(false);
 	const [autocompleteSearchValue, setAutocompleteSearchValue] = useState('');
 	const [inputValue, setInputValue] = useState(keywords);
@@ -109,7 +114,7 @@ export default function SearchBar({
 					scope: scopeValue,
 					search: searchValue,
 				},
-				Liferay.ThemeDisplay.getPathContext() + suggestionsURL
+				fetchURL.href
 			),
 			{
 				body: _getSuggestionsContributorConfiguration(),

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -109,7 +109,7 @@ export default function SearchBar({
 					scope: scopeValue,
 					search: searchValue,
 				},
-				suggestionsURL
+				Liferay.ThemeDisplay.getPathContext() + suggestionsURL
 			),
 			{
 				body: _getSuggestionsContributorConfiguration(),


### PR DESCRIPTION
Continued from https://github.com/liferay-search/liferay-portal/pull/809

> https://issues.liferay.com/browse/LPS-176871
> 
> Hi guys,
> 
> Can you review this pull request, please?
> 
> This is a regression bug from [this commit](https://github.com/liferay/liferay-portal/commit/778d476814176c7e427607a7523cd2cf242cd2c8#diff-9a251bfad674e84ebf27c67d0afd76a68233753cd93fe47bc929c080d1ba6a0cL42) where we stopped considering context path.
> 
> Thanks.
> 
> Regards.



Dev notes:
It looks like using `addParams` creates a full URL without context path, so `fetch` does not add it on. We just reapplied use of the `fetchURL` from the commit above.

Thanks @antonio-ortega for working on this!