### PR TITLE
[TS] LPS-177249 Include context path for fetching in search experiences

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/fetch/add_params.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/fetch/add_params.js
@@ -16,7 +16,11 @@
  * @returns {string} The modified url.
  */
 export default function addParams(url, params) {
-	const fetchURL = new URL(url, Liferay.ThemeDisplay.getPortalURL());
+	const contextURL = url.startsWith(Liferay.ThemeDisplay.getPathContext())
+		? url
+		: `${Liferay.ThemeDisplay.getPathContext()}${url}`;
+
+	const fetchURL = new URL(contextURL, Liferay.ThemeDisplay.getPortalURL());
 
 	Object.keys(params).forEach((key) => {
 		if (params[key] !== null) {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -58,6 +58,7 @@ afterAll(() => {
 });
 
 Liferay.ThemeDisplay.getDefaultLanguageId = () => 'en_US';
+Liferay.ThemeDisplay.getPathContext = () => '';
 
 function renderEditSXPBlueprintForm(props) {
 	return render(

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/edit_sxp_blueprint/add_sxp_element_sidebar/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/edit_sxp_blueprint/add_sxp_element_sidebar/index.js
@@ -23,6 +23,8 @@ import '@testing-library/jest-dom/extend-expect';
 
 const originalError = console.error;
 
+Liferay.ThemeDisplay.getPathContext = () => '';
+
 beforeAll(() => {
 	console.error = (...args) => {
 		if (/Warning.*not wrapped in act/.test(args[0])) {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/edit_sxp_blueprint/preview_sidebar/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/edit_sxp_blueprint/preview_sidebar/index.js
@@ -26,6 +26,7 @@ jest.mock(
 );
 
 Liferay.ThemeDisplay.getDefaultLanguageId = () => 'en_US';
+Liferay.ThemeDisplay.getPathContext = () => '';
 
 const SEARCH_RESULTS = mockSearchResults();
 const SEARCH_HITS = transformToSearchPreviewHits(SEARCH_RESULTS);

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/utils/fetch/add_params.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/utils/fetch/add_params.js
@@ -11,6 +11,8 @@
 
 import addParams from '../../../../src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/fetch/add_params';
 
+Liferay.ThemeDisplay.getPathContext = () => '';
+
 describe('addParams', () => {
 	it('adds a parameter to a url', () => {
 		expect(


### PR DESCRIPTION
Continued from https://github.com/liferay-search/liferay-portal/pull/819 
https://issues.liferay.com/browse/LPS-177249 - Search Experiences preview does not work and Query Elements missing within custom Portal context

On taking a closer look at each use of the fetch call, it seemed like the common issue was that the contextPath is not added whenever the `addParams` is paired with `fetch`. In order to simplify needing to add contextPath to each affected URL, I just added to the `addParams` function. Also, related frontend tests were updated.

Thanks @antonio-ortega for bringing this to our attention and working on the PR!