### PR TITLE
[TS] LPS-161173 Search Bar Destination

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortlet.java
@@ -14,6 +14,9 @@
 
 package com.liferay.portal.search.web.internal.search.bar.portlet;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.Portal;
@@ -73,21 +76,31 @@ public class SearchBarPortlet extends MVCPortlet {
 		throws IOException, PortletException {
 
 		SearchBarPortletDisplayContextFactory
+			searchBarPortletDisplayContextFactory = null;
+
+		try {
 			searchBarPortletDisplayContextFactory =
 				new SearchBarPortletDisplayContextFactory(
 					layoutLocalService, portal, renderRequest);
 
-		SearchBarPortletDisplayContext searchBarPortletDisplayContext =
-			searchBarPortletDisplayContextFactory.create(
-				portletPreferencesLookup, portletSharedSearchRequest,
-				searchBarPrecedenceHelper, searchCapabilities);
+			SearchBarPortletDisplayContext searchBarPortletDisplayContext =
+				searchBarPortletDisplayContextFactory.create(
+					portletPreferencesLookup, portletSharedSearchRequest,
+					searchBarPrecedenceHelper, searchCapabilities);
 
-		renderRequest.setAttribute(
-			WebKeys.PORTLET_DISPLAY_CONTEXT, searchBarPortletDisplayContext);
-
-		if (searchBarPortletDisplayContext.isRenderNothing()) {
 			renderRequest.setAttribute(
-				WebKeys.PORTLET_CONFIGURATOR_VISIBILITY, Boolean.TRUE);
+				WebKeys.PORTLET_DISPLAY_CONTEXT,
+				searchBarPortletDisplayContext);
+
+			if (searchBarPortletDisplayContext.isRenderNothing()) {
+				renderRequest.setAttribute(
+					WebKeys.PORTLET_CONFIGURATOR_VISIBILITY, Boolean.TRUE);
+			}
+		}
+		catch (ConfigurationException configurationException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(configurationException);
+			}
 		}
 
 		super.render(renderRequest, renderResponse);
@@ -110,5 +123,8 @@ public class SearchBarPortlet extends MVCPortlet {
 
 	@Reference
 	protected SearchCapabilities searchCapabilities;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SearchBarPortlet.class);
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletPreferences.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletPreferences.java
@@ -54,9 +54,9 @@ public interface SearchBarPortletPreferences {
 	public static final String PREFERENCE_KEY_USE_ADVANCED_SEARCH_SYNTAX =
 		"useAdvancedSearchSyntax";
 
-	public Optional<String> getDestinationOptional();
+	public String getDestination();
 
-	public String getDestinationString();
+	public Optional<String> getDestinationOptional();
 
 	public String getFederatedSearchKey();
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletPreferencesImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletPreferencesImpl.java
@@ -36,16 +36,16 @@ public class SearchBarPortletPreferencesImpl
 	}
 
 	@Override
-	public Optional<String> getDestinationOptional() {
-		return _portletPreferencesHelper.getString(
-			SearchBarPortletPreferences.PREFERENCE_KEY_DESTINATION);
-	}
-
-	@Override
-	public String getDestinationString() {
+	public String getDestination() {
 		Optional<String> valueOptional = getDestinationOptional();
 
 		return valueOptional.orElse(StringPool.BLANK);
+	}
+
+	@Override
+	public Optional<String> getDestinationOptional() {
+		return _portletPreferencesHelper.getString(
+			SearchBarPortletPreferences.PREFERENCE_KEY_DESTINATION);
 	}
 
 	@Override

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/configuration/SearchBarPortletInstanceConfiguration.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/configuration/SearchBarPortletInstanceConfiguration.java
@@ -57,4 +57,7 @@ public interface SearchBarPortletInstanceConfiguration {
 	)
 	public int suggestionsDisplayThreshold();
 
+	@Meta.AD(deflt = "", name = "destination", required = false)
+	public String destination();
+
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
@@ -65,12 +65,22 @@ import javax.servlet.http.HttpServletRequest;
 public class SearchBarPortletDisplayContextFactory {
 
 	public SearchBarPortletDisplayContextFactory(
-		LayoutLocalService layoutLocalService, Portal portal,
-		RenderRequest renderRequest) {
+			LayoutLocalService layoutLocalService, Portal portal,
+			RenderRequest renderRequest)
+		throws ConfigurationException {
 
 		_layoutLocalService = layoutLocalService;
 		_portal = portal;
 		_renderRequest = renderRequest;
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		_searchBarPortletInstanceConfiguration =
+			portletDisplay.getPortletInstanceConfiguration(
+				SearchBarPortletInstanceConfiguration.class);
 	}
 
 	public SearchBarPortletDisplayContext create(
@@ -82,15 +92,11 @@ public class SearchBarPortletDisplayContextFactory {
 		SearchBarPortletDisplayContext searchBarPortletDisplayContext =
 			new SearchBarPortletDisplayContext();
 
-		SearchBarPortletPreferences searchBarPortletPreferences =
-			new SearchBarPortletPreferencesImpl(
-				Optional.ofNullable(_renderRequest.getPreferences()));
-
 		ThemeDisplay themeDisplay = (ThemeDisplay)_renderRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
 		String destinationString =
-			searchBarPortletPreferences.getDestinationString();
+			_searchBarPortletInstanceConfiguration.destination();
 
 		if (Validator.isBlank(destinationString)) {
 			searchBarPortletDisplayContext.setSearchURL(
@@ -109,6 +115,10 @@ public class SearchBarPortletDisplayContextFactory {
 
 			searchBarPortletDisplayContext.setSearchURL(destinationURL);
 		}
+
+		SearchBarPortletPreferences searchBarPortletPreferences =
+			new SearchBarPortletPreferencesImpl(
+				Optional.ofNullable(_renderRequest.getPreferences()));
 
 		PortletSharedSearchResponse portletSharedSearchResponse =
 			portletSharedSearchRequest.search(_renderRequest);
@@ -499,5 +509,7 @@ public class SearchBarPortletDisplayContextFactory {
 	private final LayoutLocalService _layoutLocalService;
 	private final Portal _portal;
 	private final RenderRequest _renderRequest;
+	private final SearchBarPortletInstanceConfiguration
+		_searchBarPortletInstanceConfiguration;
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
@@ -95,16 +95,16 @@ public class SearchBarPortletDisplayContextFactory {
 		ThemeDisplay themeDisplay = (ThemeDisplay)_renderRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		String destinationString =
+		String destination =
 			_searchBarPortletInstanceConfiguration.destination();
 
-		if (Validator.isBlank(destinationString)) {
+		if (Validator.isBlank(destination)) {
 			searchBarPortletDisplayContext.setSearchURL(
 				_getURLCurrentPath(themeDisplay));
 		}
 		else {
 			String destinationURL = _getDestinationURL(
-				destinationString, themeDisplay);
+				destination, themeDisplay);
 
 			if (destinationURL == null) {
 				searchBarPortletDisplayContext.setDestinationUnreachable(true);
@@ -132,8 +132,7 @@ public class SearchBarPortletDisplayContextFactory {
 			isAvailableEverythingSearchScope());
 		searchBarPortletDisplayContext.setCurrentSiteSearchScopeParameterString(
 			SearchScope.THIS_SITE.getParameterString());
-		searchBarPortletDisplayContext.setDestinationFriendlyURL(
-			destinationString);
+		searchBarPortletDisplayContext.setDestinationFriendlyURL(destination);
 		searchBarPortletDisplayContext.setDisplayStyleGroupId(
 			getDisplayStyleGroupId(
 				searchBarPortletInstanceConfiguration, themeDisplay));

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/configuration.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/configuration.jsp
@@ -95,7 +95,7 @@ String suggestionsContributorConfiguration = StringBundler.concat(StringPool.OPE
 
 			<aui:input disabled="<%= searchBarPortletDisplayContext.isDisplayWarningIgnoredConfiguration() %>" label="scope-parameter-name" name="<%= PortletPreferencesJspUtil.getInputName(SearchBarPortletPreferences.PREFERENCE_KEY_SCOPE_PARAMETER_NAME) %>" value="<%= searchBarPortletPreferences.getScopeParameterName() %>" />
 
-			<aui:input helpMessage="destination-page-help" label="destination-page" name="<%= PortletPreferencesJspUtil.getInputName(SearchBarPortletPreferences.PREFERENCE_KEY_DESTINATION) %>" value="<%= searchBarPortletPreferences.getDestinationString() %>" />
+			<aui:input helpMessage="destination-page-help" label="destination-page" name="<%= PortletPreferencesJspUtil.getInputName(SearchBarPortletPreferences.PREFERENCE_KEY_DESTINATION) %>" value="<%= searchBarPortletPreferences.getDestination() %>" />
 		</liferay-frontend:fieldset>
 
 		<c:if test="<%= searchBarPortletDisplayContext.isSuggestionsEndpointEnabled() %>">

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -80,7 +81,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testDestinationBlank() throws PortletException {
+	public void testDestinationBlank()
+		throws ConfigurationException, PortletException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(StringPool.BLANK);
@@ -95,7 +98,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testDestinationNull() throws PortletException {
+	public void testDestinationNull()
+		throws ConfigurationException, PortletException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(null);
@@ -110,7 +115,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testDestinationUnreachable() throws PortletException {
+	public void testDestinationUnreachable()
+		throws ConfigurationException, PortletException {
+
 		String destination = RandomTestUtil.randomString();
 
 		_whenLayoutLocalServiceFetchLayoutByFriendlyURL(destination, null);
@@ -186,7 +193,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testSamePageNoDestination() throws PortletException {
+	public void testSamePageNoDestination()
+		throws ConfigurationException, PortletException {
+
 		Mockito.doReturn(
 			"http://example.com/web/guest/home?param=arg"
 		).when(
@@ -210,7 +219,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testScopeParameterName() throws ReadOnlyException {
+	public void testScopeParameterName()
+		throws ConfigurationException, ReadOnlyException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(null, "sp", null);
@@ -225,7 +236,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testScopeParameterNameDefault() throws ReadOnlyException {
+	public void testScopeParameterNameDefault()
+		throws ConfigurationException, ReadOnlyException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(null, null, null);
@@ -241,7 +254,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testSearchScopePreferenceDefault() throws ReadOnlyException {
+	public void testSearchScopePreferenceDefault()
+		throws ConfigurationException, ReadOnlyException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(null, null, null);
@@ -250,7 +265,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testSearchScopePreferenceEverything() throws ReadOnlyException {
+	public void testSearchScopePreferenceEverything()
+		throws ConfigurationException, ReadOnlyException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(
@@ -261,7 +278,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 	@Test
 	public void testSearchScopePreferenceLetTheUserChooseEverything()
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
@@ -273,7 +290,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 	@Test
 	public void testSearchScopePreferenceLetTheUserChooseInvalidScopeParam()
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		expectedException.expect(IllegalArgumentException.class);
 		expectedException.expectMessage(
@@ -290,7 +307,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 	@Test
 	public void testSearchScopePreferenceLetTheUserChooseNoScopeParam()
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
@@ -302,7 +319,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 	@Test
 	public void testSearchScopePreferenceLetTheUserChooseThisSite()
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
@@ -313,7 +330,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 	}
 
 	@Test
-	public void testSearchScopePreferenceThisSite() throws ReadOnlyException {
+	public void testSearchScopePreferenceThisSite()
+		throws ConfigurationException, ReadOnlyException {
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				_createSearchBarPortletDisplayContextFactory(
@@ -396,7 +415,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 	private SearchBarPortletDisplayContextFactory
 			_createSearchBarPortletDisplayContextFactory(String destination)
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		return _createSearchBarPortletDisplayContextFactory(
 			destination, null, null, null);
@@ -406,7 +425,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 			_createSearchBarPortletDisplayContextFactory(
 				String scope, String scopeParameterName,
 				String scopeParameterValue)
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		return _createSearchBarPortletDisplayContextFactory(
 			null, scope, scopeParameterName, scopeParameterValue);
@@ -416,7 +435,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 			_createSearchBarPortletDisplayContextFactory(
 				String destination, String scope, String scopeParameterName,
 				String scopeParameterValue)
-		throws ReadOnlyException {
+		throws ConfigurationException, ReadOnlyException {
 
 		RenderRequest renderRequest = Mockito.mock(RenderRequest.class);
 

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
@@ -439,6 +439,12 @@ public class SearchBarPortletDisplayContextFactoryTest {
 
 		RenderRequest renderRequest = Mockito.mock(RenderRequest.class);
 
+		Mockito.when(
+			renderRequest.getAttribute(WebKeys.THEME_DISPLAY)
+		).thenReturn(
+			_themeDisplay
+		);
+
 		SearchBarPortletDisplayContextFactory
 			searchBarPortletDisplayContextFactory =
 				new SearchBarPortletDisplayContextFactory(
@@ -472,12 +478,6 @@ public class SearchBarPortletDisplayContextFactoryTest {
 			portletPreferences
 		);
 
-		Mockito.when(
-			renderRequest.getAttribute(WebKeys.THEME_DISPLAY)
-		).thenReturn(
-			_themeDisplay
-		);
-
 		PortletSharedSearchResponse portletSharedSearchResponse = Mockito.mock(
 			PortletSharedSearchResponse.class);
 
@@ -485,6 +485,12 @@ public class SearchBarPortletDisplayContextFactoryTest {
 			_portletSharedSearchRequest.search(renderRequest)
 		).thenReturn(
 			portletSharedSearchResponse
+		);
+
+		Mockito.when(
+			_searchBarPortletInstanceConfiguration.destination()
+		).thenReturn(
+			destination
 		);
 
 		Mockito.when(
@@ -562,7 +568,7 @@ public class SearchBarPortletDisplayContextFactoryTest {
 			Mockito.when(
 				_portletDisplay.getPortletInstanceConfiguration(Mockito.any())
 			).thenReturn(
-				Mockito.mock(SearchBarPortletInstanceConfiguration.class)
+				_searchBarPortletInstanceConfiguration
 			);
 		}
 		catch (Exception exception) {
@@ -616,6 +622,9 @@ public class SearchBarPortletDisplayContextFactoryTest {
 		Mockito.mock(PortletPreferencesLookup.class);
 	private final PortletSharedSearchRequest _portletSharedSearchRequest =
 		Mockito.mock(PortletSharedSearchRequest.class);
+	private final SearchBarPortletInstanceConfiguration
+		_searchBarPortletInstanceConfiguration = Mockito.mock(
+			SearchBarPortletInstanceConfiguration.class);
 	private final SearchBarPrecedenceHelper _searchBarPrecedenceHelper =
 		Mockito.mock(SearchBarPrecedenceHelper.class);
 	private final SearchCapabilities _searchCapabilities = Mockito.mock(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-161173

**Authors:** @bakayattila @joshuacords 
**Reviewers:** @joshuacords briandotchan

This originally was approved all the way to Brian Chan [here](https://github.com/brianchandotcom/liferay-portal/pull/124722), but he wanted to unify naming:

`			_searchBarPortletInstanceConfiguration.destination();`
"We had several names for destination.. can we sync on one? Thx."

I've unified the naming to "destination".