### PR TITLE
[TS] LPS-177889 - incorrect search results can be returned with certain combinations of delta and results

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java
@@ -49,6 +49,7 @@ import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.configuration.DefaultSearchResultPermissionFilterConfiguration;
+import com.liferay.portal.search.searcher.SearchRequest;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -400,7 +401,19 @@ public class DefaultSearchResultPermissionFilter
 					(oldDocs.length < amplifiedCount) ||
 					(amplifiedEnd >= hitsSize)) {
 
-					updateDocuments(filteredDocsCount, start, end);
+					SearchRequest searchRequest =
+						(SearchRequest)searchContext.getAttribute(
+							"search.request");
+
+					if ((searchRequest != null) &&
+						(searchRequest.getFrom() != null)) {
+
+						documents.addAll(0, standbyDocuments);
+						scores.addAll(0, standbyScores);
+					}
+					else {
+						updateDocuments(filteredDocsCount, start, end);
+					}
 
 					updateHits(hits, hitsSize - excludedDocsSize, startTime);
 


### PR DESCRIPTION
Hi Search team!

https://issues.liferay.com/browse/LPS-177889

This is to fix an issue that arises in specific conditions. The following must be true:
- Search results returned must exceed one page (so there should be at least two pages of results).
- The 'leftover' result count should be *over half* of the delta value.

So for example, in the test case presented by the client we have 31 results and a delta of 20. Since 11 results is over 10, this error occurs. Essentially, the error boils down to the fact that:

1. Using the 'from' clause in our query, we already return what is essentially the 'filtered' results for a page.
2. When calling updateDocuments, we attempt to calculate the 'start and end' of the documents we need. However, since we're already filtering it before, we essentially can end up removing results we want to keep. For example, in our test case we're technically looking for results 20-40 (so our start-end) and our 'total/accumulatedCount' returned results is 11. The docs are calculated to therefore start at 20 - 11 or 9 and end at 29. 9 is not greater than our total of '11' so the recalculation that occurs in SearchPaginationUtil never occurs like it would for other values (which is why the leftover result count must be over half of the delta value for this error to occur). 

In fixing this, I made a specific assumption which may be incorrect. I've assumed the start/end calculation are calculations that were based on previously grabbing all results and therefore needing to filter them by refining the start/end values. My solution essentially entails checking if we refined the results using a 'from' clause previously and, if so, skipping the update documents step. I did it in this manner to try to avoid adding any new steps requiring an API but please let me know if there's anything I'm missing or if there's anything you guys would like me to investigate further. Thanks!