### PR TITLE
LPS-172161 Semantic Search Instance Settings always displays System Settings values

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-api/bnd.bnd
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Search Experiences API
 Bundle-SymbolicName: com.liferay.search.experiences.api
-Bundle-Version: 24.0.1
+Bundle-Version: 24.1.0
 Export-Package:\
 	com.liferay.search.experiences.blueprint.exception,\
 	com.liferay.search.experiences.blueprint.parameter,\

--- a/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/configuration/SemanticSearchConfigurationProvider.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/configuration/SemanticSearchConfigurationProvider.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.configuration;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * @author Drew Brokke
+ */
+@ProviderType
+public interface SemanticSearchConfigurationProvider {
+
+	public SemanticSearchConfiguration getCompanyConfiguration(long companyId);
+
+	public SemanticSearchConfiguration getSystemConfiguration();
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-api/src/main/resources/com/liferay/search/experiences/configuration/packageinfo
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/src/main/resources/com/liferay/search/experiences/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 8.1.0

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/SXPParameterDataCreator.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/SXPParameterDataCreator.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.search.experiences.blueprint.parameter.SXPParameter;
 import com.liferay.search.experiences.blueprint.parameter.contributor.SXPParameterContributorDefinition;
 import com.liferay.search.experiences.blueprint.parameter.contributor.SXPParameterContributorDefinitionProvider;
+import com.liferay.search.experiences.configuration.SemanticSearchConfigurationProvider;
 import com.liferay.search.experiences.internal.blueprint.parameter.contributor.ContextSXPParameterContributor;
 import com.liferay.search.experiences.internal.blueprint.parameter.contributor.IpstackSXPParameterContributor;
 import com.liferay.search.experiences.internal.blueprint.parameter.contributor.MLSXPParameterContributor;
@@ -140,7 +141,8 @@ public class SXPParameterDataCreator
 			new ContextSXPParameterContributor(_groupLocalService, _language),
 			new IpstackSXPParameterContributor(_configurationProvider),
 			new MLSXPParameterContributor(
-				_configurationProvider, _language, _textEmbeddingRetriever),
+				_language, _semanticSearchConfigurationProvider,
+				_textEmbeddingRetriever),
 			new OpenWeatherMapSXPParameterContributor(_configurationProvider),
 			new TimeSXPParameterContributor(),
 			new UserSXPParameterContributor(
@@ -733,6 +735,10 @@ public class SXPParameterDataCreator
 
 	@Reference
 	private SegmentsEntryRetriever _segmentsEntryRetriever;
+
+	@Reference
+	private SemanticSearchConfigurationProvider
+		_semanticSearchConfigurationProvider;
 
 	private SXPParameterContributor[] _sxpParameterContributors;
 

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/contributor/MLSXPParameterContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/contributor/MLSXPParameterContributor.java
@@ -18,13 +18,12 @@ import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.module.configuration.ConfigurationException;
-import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.search.experiences.blueprint.parameter.SXPParameter;
 import com.liferay.search.experiences.blueprint.parameter.contributor.SXPParameterContributorDefinition;
 import com.liferay.search.experiences.configuration.SemanticSearchConfiguration;
+import com.liferay.search.experiences.configuration.SemanticSearchConfigurationProvider;
 import com.liferay.search.experiences.internal.blueprint.parameter.DoubleArraySXPParameter;
 import com.liferay.search.experiences.internal.blueprint.parameter.IntegerSXPParameter;
 import com.liferay.search.experiences.internal.web.cache.TextEmbeddingProviderWebCacheItem;
@@ -46,11 +45,13 @@ import java.util.Set;
 public class MLSXPParameterContributor implements SXPParameterContributor {
 
 	public MLSXPParameterContributor(
-		ConfigurationProvider configurationProvider, Language language,
+		Language language,
+		SemanticSearchConfigurationProvider semanticSearchConfigurationProvider,
 		TextEmbeddingRetriever textEmbeddingRetriever) {
 
-		_configurationProvider = configurationProvider;
 		_language = language;
+		_semanticSearchConfigurationProvider =
+			semanticSearchConfigurationProvider;
 		_textEmbeddingRetriever = textEmbeddingRetriever;
 	}
 
@@ -150,13 +151,8 @@ public class MLSXPParameterContributor implements SXPParameterContributor {
 	private SemanticSearchConfiguration _getSemanticSearchConfiguration(
 		long companyId) {
 
-		try {
-			return _configurationProvider.getCompanyConfiguration(
-				SemanticSearchConfiguration.class, companyId);
-		}
-		catch (ConfigurationException configurationException) {
-			return ReflectionUtil.throwException(configurationException);
-		}
+		return _semanticSearchConfigurationProvider.getCompanyConfiguration(
+			companyId);
 	}
 
 	private List<SXPParameterContributorDefinition>
@@ -187,8 +183,9 @@ public class MLSXPParameterContributor implements SXPParameterContributor {
 				"ml.text_embeddings.keywords_embedding"));
 	}
 
-	private final ConfigurationProvider _configurationProvider;
 	private final Language _language;
+	private final SemanticSearchConfigurationProvider
+		_semanticSearchConfigurationProvider;
 	private final TextEmbeddingRetriever _textEmbeddingRetriever;
 
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/configuration/SemanticSearchConfigurationProviderImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/configuration/SemanticSearchConfigurationProviderImpl.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.internal.configuration;
+
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.module.configuration.ConfigurationException;
+import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
+import com.liferay.search.experiences.configuration.SemanticSearchConfiguration;
+import com.liferay.search.experiences.configuration.SemanticSearchConfigurationProvider;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Drew Brokke
+ */
+@Component(enabled = false, service = SemanticSearchConfigurationProvider.class)
+public class SemanticSearchConfigurationProviderImpl
+	implements SemanticSearchConfigurationProvider {
+
+	@Override
+	public SemanticSearchConfiguration getCompanyConfiguration(long companyId) {
+		return _getConfiguration(companyId);
+	}
+
+	@Override
+	public SemanticSearchConfiguration getSystemConfiguration() {
+		return _getConfiguration(CompanyConstants.SYSTEM);
+	}
+
+	private SemanticSearchConfiguration _getConfiguration(long companyId) {
+		try {
+			if (companyId > CompanyConstants.SYSTEM) {
+				return _configurationProvider.getCompanyConfiguration(
+					SemanticSearchConfiguration.class, companyId);
+			}
+
+			return _configurationProvider.getSystemConfiguration(
+				SemanticSearchConfiguration.class);
+		}
+		catch (ConfigurationException configurationException) {
+			return ReflectionUtil.throwException(configurationException);
+		}
+	}
+
+	@Reference
+	private ConfigurationProvider _configurationProvider;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/ml/embedding/text/TextEmbeddingRetrieverImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/ml/embedding/text/TextEmbeddingRetrieverImpl.java
@@ -16,15 +16,16 @@ package com.liferay.search.experiences.internal.ml.embedding.text;
 
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
-import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.ml.embedding.EmbeddingProviderInformation;
 import com.liferay.portal.search.ml.embedding.EmbeddingProviderStatus;
 import com.liferay.search.experiences.configuration.SemanticSearchConfiguration;
+import com.liferay.search.experiences.configuration.SemanticSearchConfigurationProvider;
 import com.liferay.search.experiences.ml.embedding.text.TextEmbeddingRetriever;
 import com.liferay.search.experiences.rest.dto.v1_0.EmbeddingProviderConfiguration;
 
@@ -36,12 +37,12 @@ import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Petteri Karttunen
  */
 @Component(
-	configurationPid = "com.liferay.search.experiences.configuration.SemanticSearchConfiguration",
 	enabled = false,
 	service = {EmbeddingProviderInformation.class, TextEmbeddingRetriever.class}
 )
@@ -122,8 +123,7 @@ public class TextEmbeddingRetrieverImpl implements TextEmbeddingRetriever {
 			new ArrayList<>();
 
 		for (String textEmbeddingProviderConfigurationJSON :
-				_semanticSearchConfiguration.
-					textEmbeddingProviderConfigurationJSONs()) {
+				_getTextEmbeddingProviderConfigurationJSONs()) {
 
 			embeddingProviderStatuses.add(
 				getEmbeddingProviderStatus(
@@ -168,9 +168,6 @@ public class TextEmbeddingRetrieverImpl implements TextEmbeddingRetriever {
 	protected void activate(
 		Map<String, Object> properties, BundleContext bundleContext) {
 
-		_semanticSearchConfiguration = ConfigurableUtil.createConfigurable(
-			SemanticSearchConfiguration.class, properties);
-
 		_textEmbeddingProviderServiceTrackerMap =
 			ServiceTrackerMapFactory.openSingleValueMap(
 				bundleContext, TextEmbeddingProvider.class,
@@ -186,8 +183,7 @@ public class TextEmbeddingRetrieverImpl implements TextEmbeddingRetriever {
 		String providerName) {
 
 		for (String textEmbeddingProviderConfigurationJSON :
-				_semanticSearchConfiguration.
-					textEmbeddingProviderConfigurationJSONs()) {
+				_getTextEmbeddingProviderConfigurationJSONs()) {
 
 			EmbeddingProviderConfiguration embeddingProviderConfiguration =
 				EmbeddingProviderConfiguration.toDTO(
@@ -203,10 +199,22 @@ public class TextEmbeddingRetrieverImpl implements TextEmbeddingRetriever {
 		return null;
 	}
 
+	private String[] _getTextEmbeddingProviderConfigurationJSONs() {
+		SemanticSearchConfiguration semanticSearchConfiguration =
+			_semanticSearchConfigurationProvider.getCompanyConfiguration(
+				CompanyThreadLocal.getCompanyId());
+
+		return semanticSearchConfiguration.
+			textEmbeddingProviderConfigurationJSONs();
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		TextEmbeddingRetrieverImpl.class);
 
-	private volatile SemanticSearchConfiguration _semanticSearchConfiguration;
+	@Reference
+	private SemanticSearchConfigurationProvider
+		_semanticSearchConfigurationProvider;
+
 	private ServiceTrackerMap<String, TextEmbeddingProvider>
 		_textEmbeddingProviderServiceTrackerMap;
 

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/search/spi/model/index/contributor/BaseTextEmbeddingModelDocumentContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/search/spi/model/index/contributor/BaseTextEmbeddingModelDocumentContributor.java
@@ -16,40 +16,35 @@ package com.liferay.search.experiences.internal.search.spi.model.index.contribut
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.CompanyModel;
 import com.liferay.portal.kernel.model.WorkflowedModel;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.search.experiences.configuration.SemanticSearchConfiguration;
+import com.liferay.search.experiences.configuration.SemanticSearchConfigurationProvider;
 import com.liferay.search.experiences.rest.dto.v1_0.EmbeddingProviderConfiguration;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.function.BiFunction;
 
-import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Petteri Karttunen
  */
 public abstract class BaseTextEmbeddingModelDocumentContributor
 	<T extends BaseModel<T>> {
-
-	@Activate
-	protected void activate(Map<String, Object> properties) {
-		semanticSearchConfiguration = ConfigurableUtil.createConfigurable(
-			SemanticSearchConfiguration.class, properties);
-	}
 
 	protected void addLocalizedTextEmbeddings(
 		T baseModel, BiFunction<String, String, Double[]> biFunction,
@@ -121,6 +116,16 @@ public abstract class BaseTextEmbeddingModelDocumentContributor
 		}
 	}
 
+	protected long getCompanyId(T baseModel) {
+		if (baseModel instanceof CompanyModel) {
+			CompanyModel companyModel = (CompanyModel)baseModel;
+
+			return companyModel.getCompanyId();
+		}
+
+		return CompanyThreadLocal.getCompanyId();
+	}
+
 	protected String getText(T baseModel) {
 		return StringPool.BLANK;
 	}
@@ -129,7 +134,9 @@ public abstract class BaseTextEmbeddingModelDocumentContributor
 		return StringPool.BLANK;
 	}
 
-	protected volatile SemanticSearchConfiguration semanticSearchConfiguration;
+	@Reference
+	protected SemanticSearchConfigurationProvider
+		semanticSearchConfigurationProvider;
 
 	private void _addTextEmbeddingField(
 		Document document, String languageId, Double[] textEmbedding) {
@@ -147,6 +154,10 @@ public abstract class BaseTextEmbeddingModelDocumentContributor
 
 	private EmbeddingProviderConfiguration _getEmbeddingProviderConfiguration(
 		T baseModel) {
+
+		SemanticSearchConfiguration semanticSearchConfiguration =
+			semanticSearchConfigurationProvider.getCompanyConfiguration(
+				getCompanyId(baseModel));
 
 		if (!FeatureFlagManagerUtil.isEnabled("LPS-163688") ||
 			!semanticSearchConfiguration.textEmbeddingsEnabled() ||

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/search/spi/model/index/contributor/BlogsEntryTextEmbeddingModelDocumentContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/search/spi/model/index/contributor/BlogsEntryTextEmbeddingModelDocumentContributor.java
@@ -31,7 +31,6 @@ import org.osgi.service.component.annotations.Reference;
  * @author Petteri Karttunen
  */
 @Component(
-	configurationPid = "com.liferay.search.experiences.configuration.SemanticSearchConfiguration",
 	enabled = false,
 	property = "indexer.class.name=com.liferay.blogs.model.BlogsEntry",
 	service = ModelDocumentContributor.class

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/search/spi/model/index/contributor/JournalArticleTextEmbeddingModelDocumentContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/search/spi/model/index/contributor/JournalArticleTextEmbeddingModelDocumentContributor.java
@@ -39,7 +39,6 @@ import org.osgi.service.component.annotations.Reference;
  * @author Petteri Karttunen
  */
 @Component(
-	configurationPid = "com.liferay.search.experiences.configuration.SemanticSearchConfiguration",
 	enabled = false,
 	property = "indexer.class.name=com.liferay.journal.model.JournalArticle",
 	service = ModelDocumentContributor.class

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/search/spi/model/index/contributor/KBArticleTextEmbeddingModelDocumentContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/search/spi/model/index/contributor/KBArticleTextEmbeddingModelDocumentContributor.java
@@ -31,7 +31,6 @@ import org.osgi.service.component.annotations.Reference;
  * @author Petteri Karttunen
  */
 @Component(
-	configurationPid = "com.liferay.search.experiences.configuration.SemanticSearchConfiguration",
 	enabled = false,
 	property = "indexer.class.name=com.liferay.knowledge.base.model.KBArticle",
 	service = ModelDocumentContributor.class

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/search/spi/model/index/contributor/MBMessageTextEmbeddingModelDocumentContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/search/spi/model/index/contributor/MBMessageTextEmbeddingModelDocumentContributor.java
@@ -31,7 +31,6 @@ import org.osgi.service.component.annotations.Reference;
  * @author Petteri Karttunen
  */
 @Component(
-	configurationPid = "com.liferay.search.experiences.configuration.SemanticSearchConfiguration",
 	enabled = false,
 	property = "indexer.class.name=com.liferay.message.boards.model.MBMessage",
 	service = ModelDocumentContributor.class

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/search/spi/model/index/contributor/WikiPageTextEmbeddingModelDocumentContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/search/spi/model/index/contributor/WikiPageTextEmbeddingModelDocumentContributor.java
@@ -31,7 +31,6 @@ import org.osgi.service.component.annotations.Reference;
  * @author Petteri Karttunen
  */
 @Component(
-	configurationPid = "com.liferay.search.experiences.configuration.SemanticSearchConfiguration",
 	enabled = false,
 	property = "indexer.class.name=com.liferay.wiki.model.WikiPage",
 	service = ModelDocumentContributor.class

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/configuration/admin/display/SemanticSearchConfigurationFormRenderer.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/configuration/admin/display/SemanticSearchConfigurationFormRenderer.java
@@ -14,13 +14,14 @@
 
 package com.liferay.search.experiences.web.internal.configuration.admin.display;
 
+import com.liferay.configuration.admin.constants.ConfigurationAdminPortletKeys;
 import com.liferay.configuration.admin.display.ConfigurationFormRenderer;
 import com.liferay.frontend.taglib.servlet.taglib.util.JSPRenderer;
 import com.liferay.petra.string.CharPool;
-import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.CamelCaseUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -29,9 +30,11 @@ import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.search.experiences.configuration.SemanticSearchConfiguration;
+import com.liferay.search.experiences.configuration.SemanticSearchConfigurationProvider;
 import com.liferay.search.experiences.ml.embedding.text.TextEmbeddingRetriever;
 import com.liferay.search.experiences.web.internal.display.context.SemanticSearchCompanyConfigurationDisplayContext;
 
@@ -44,6 +47,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -53,18 +57,13 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Petteri Karttunen
  */
-@Component(
-	configurationPid = "com.liferay.search.experiences.configuration.SemanticSearchConfiguration",
-	enabled = false, service = ConfigurationFormRenderer.class
-)
+@Component(enabled = false, service = ConfigurationFormRenderer.class)
 public class SemanticSearchConfigurationFormRenderer
 	implements ConfigurationFormRenderer {
 
@@ -129,15 +128,19 @@ public class SemanticSearchConfigurationFormRenderer
 		semanticSearchCompanyConfigurationDisplayContext.
 			setAvailableTextTruncationStrategies(
 				_getAvailableTextTruncationStrategies(httpServletRequest));
+
+		SemanticSearchConfiguration semanticSearchConfiguration =
+			_getSemanticSearchConfiguration(httpServletRequest);
+
 		semanticSearchCompanyConfigurationDisplayContext.
 			setTextEmbeddingCacheTimeout(
-				_semanticSearchConfiguration.textEmbeddingCacheTimeout());
+				semanticSearchConfiguration.textEmbeddingCacheTimeout());
 		semanticSearchCompanyConfigurationDisplayContext.
 			setTextEmbeddingsEnabled(
-				_semanticSearchConfiguration.textEmbeddingsEnabled());
+				semanticSearchConfiguration.textEmbeddingsEnabled());
 		semanticSearchCompanyConfigurationDisplayContext.
 			setTextEmbeddingProviderConfigurationJSONs(
-				_semanticSearchConfiguration.
+				semanticSearchConfiguration.
 					textEmbeddingProviderConfigurationJSONs());
 
 		httpServletRequest.setAttribute(
@@ -147,13 +150,6 @@ public class SemanticSearchConfigurationFormRenderer
 		_jspRenderer.renderJSP(
 			_servletContext, httpServletRequest, httpServletResponse,
 			"/semantic_search/configuration.jsp");
-	}
-
-	@Activate
-	@Modified
-	protected void activate(Map<String, Object> properties) {
-		_semanticSearchConfiguration = ConfigurableUtil.createConfigurable(
-			SemanticSearchConfiguration.class, properties);
 	}
 
 	private List<String> _getAvailableEmbeddingVectorDimensions() {
@@ -248,6 +244,20 @@ public class SemanticSearchConfigurationFormRenderer
 		).build();
 	}
 
+	private SemanticSearchConfiguration _getSemanticSearchConfiguration(
+		HttpServletRequest httpServletRequest) {
+
+		if (Objects.equals(
+				_portal.getPortletId(httpServletRequest),
+				ConfigurationAdminPortletKeys.INSTANCE_SETTINGS)) {
+
+			return _semanticSearchConfigurationProvider.getCompanyConfiguration(
+				_portal.getCompanyId(httpServletRequest));
+		}
+
+		return _semanticSearchConfigurationProvider.getSystemConfiguration();
+	}
+
 	private Map<String, String> _sortByValue(Map<String, String> map) {
 		Set<Map.Entry<String, String>> entrySet = map.entrySet();
 
@@ -263,6 +273,9 @@ public class SemanticSearchConfigurationFormRenderer
 	}
 
 	@Reference
+	private ConfigurationProvider _configurationProvider;
+
+	@Reference
 	private Http _http;
 
 	@Reference
@@ -274,7 +287,12 @@ public class SemanticSearchConfigurationFormRenderer
 	@Reference
 	private Language _language;
 
-	private volatile SemanticSearchConfiguration _semanticSearchConfiguration;
+	@Reference
+	private Portal _portal;
+
+	@Reference
+	private SemanticSearchConfigurationProvider
+		_semanticSearchConfigurationProvider;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.search.experiences.web)",


### PR DESCRIPTION
This is an update for [LPS-172161](https://issues.liferay.com/browse/LPS-172161).

I manually tested the bug as described in the ticket, and it seems to work well. 

However, since I also changed a number of other implementation classes, I think this needs to be tested more thoroughly to ensure I did not break anything else.

Please let me know if you have any questions or concerns. Thank you!

cc @peerkar @lipusz @felipelorenz @thektan 