### PR TITLE
[TS] LPS-178336 Add a parameter to avoid missing pagination (see com.liferay.portal.vulcan.internal.jaxrs.context.provider.PaginationContextProvider.createContext method for more details).

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SelectVocabularies.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SelectVocabularies.js
@@ -280,7 +280,7 @@ function SelectVocabularies({
 				Promise.all(
 					siteBriefs.map((site) =>
 						fetch(
-							`/o/headless-admin-taxonomy/v1.0/sites/${site.id}/taxonomy-vocabularies`,
+							`/o/headless-admin-taxonomy/v1.0/sites/${site.id}/taxonomy-vocabularies?page=0&pageSize=0`,
 							CONFIGURATION
 						).then((response) => response.json())
 					)


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-178336

If an admin creates more than 20 vocabularies it is not possible to select all of them (only the first 20 elements)

Current portal logic, by default limits the headless api calls to 20 when there's no pagination. (see https://github.com/liferay/liferay-portal/blob/43b763b02f23e3ac3c1c8f25ba5c505ec157d0e4/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/PaginationContextProvider.java#L35,L49)

I've added this parameters to the url in order to avoid the pagination and do not limit it to 20.