### PR TITLE
LPS-165348 LPS-165349 [FE] Apply JS Local/Session Storage Management API in Search experiences components

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -40,7 +40,10 @@ import getResultsError from '../utils/functions/get_results_error';
 import isDefined from '../utils/functions/is_defined';
 import formatLocaleWithUnderscores from '../utils/language/format_locale_with_underscores';
 import renameKeys from '../utils/language/rename_keys';
-import {setStorageAddSXPElementSidebar} from '../utils/sessionStorage';
+import {
+	SIDEBAR_STATE,
+	setStorageAddSXPElementSidebar,
+} from '../utils/sessionStorage';
 import cleanUIConfiguration from '../utils/sxp_element/clean_ui_configuration';
 import getUIConfigurationValues from '../utils/sxp_element/get_ui_configuration_values';
 import isCustomJSONSXPElement from '../utils/sxp_element/is_custom_json_sxp_element';
@@ -448,7 +451,7 @@ function EditSXPBlueprintForm({
 			setSearchIndexes([]);
 		}
 
-		setStorageAddSXPElementSidebar('open');
+		setStorageAddSXPElementSidebar(SIDEBAR_STATE.OPEN);
 	}, []); //eslint-disable-line
 
 	/**
@@ -850,7 +853,7 @@ function EditSXPBlueprintForm({
 
 	const _handleToggleSidebar = (type) => () => {
 		if (type === SIDEBAR_TYPES.PREVIEW) {
-			setStorageAddSXPElementSidebar('closed');
+			setStorageAddSXPElementSidebar(SIDEBAR_STATE.CLOSED);
 		}
 
 		setOpenSidebar(openSidebar === type ? '' : type);

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/add_sxp_element_sidebar/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/add_sxp_element_sidebar/index.js
@@ -37,7 +37,10 @@ import {
 } from '../../utils/data';
 import addParams from '../../utils/fetch/add_params';
 import fetchData from '../../utils/fetch/fetch_data';
-import {setStorageAddSXPElementSidebar} from '../../utils/sessionStorage';
+import {
+	SIDEBAR_STATE,
+	setStorageAddSXPElementSidebar,
+} from '../../utils/sessionStorage';
 import getSXPElementTitleAndDescription from '../../utils/sxp_element/get_sxp_element_title_and_description';
 import isElementInactiveFromNonCompanyIndex from '../../utils/sxp_element/is_element_inactive_from_noncompany_index';
 
@@ -343,7 +346,7 @@ function AddSXPElementSidebar({
 	}
 
 	const _handleClose = () => {
-		setStorageAddSXPElementSidebar('closed');
+		setStorageAddSXPElementSidebar(SIDEBAR_STATE.CLOSED);
 
 		onClose();
 	};

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/index.js
@@ -14,7 +14,10 @@ import {ClayVerticalNav} from '@clayui/nav';
 import {PropTypes} from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
-import {SESSION_IDS} from '../../utils/sessionStorage';
+import {
+	SIDEBAR_STATE,
+	getStorageAddSXPElementSidebar,
+} from '../../utils/sessionStorage';
 import {SIDEBAR_TYPES} from '../../utils/types/sidebarTypes';
 import QuerySXPElements from './QuerySXPElements';
 import QuerySettings from './QuerySettings';
@@ -58,8 +61,7 @@ function QueryBuilderTab({
 		if (
 			activeVerticalNavKey === VERTICAL_NAV_KEYS.QUERY_SXP_ELEMENTS &&
 			!openSidebar &&
-			sessionStorage.getItem(SESSION_IDS.ADD_SXP_ELEMENT_SIDEBAR) ===
-				'open'
+			getStorageAddSXPElementSidebar() === SIDEBAR_STATE.OPEN
 		) {
 			setOpenSidebar(SIDEBAR_TYPES.ADD_SXP_ELEMENT);
 		}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/sessionStorage.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/sessionStorage.js
@@ -9,6 +9,8 @@
  * distribution rights of the Software.
  */
 
+import {sessionStorage} from 'frontend-js-web';
+
 import isDefined from './functions/is_defined';
 
 const NAMESPACE = 'com.liferay.search.experiences.web_';
@@ -21,6 +23,22 @@ export const SESSION_IDS = {
 	SUCCESS_MESSAGE: `${NAMESPACE}successMessage`,
 };
 
+export const SIDEBAR_STATE = {
+	CLOSED: 'closed',
+	OPEN: 'open',
+};
+
+/**
+ * Gets the current state of the Add Elements Sidebar.
+ * @return {string}
+ */
+export function getStorageAddSXPElementSidebar() {
+	return sessionStorage.getItem(
+		SESSION_IDS.ADD_SXP_ELEMENT_SIDEBAR,
+		sessionStorage.TYPES.FUNCTIONAL
+	);
+}
+
 /**
  * Helper function to set the session storage value of
  * SESSION_IDS.ADD_SXP_ELEMENT_SIDEBAR.
@@ -32,20 +50,30 @@ export function setStorageAddSXPElementSidebar(state) {
 		sessionStorage.setItem(
 			SESSION_IDS.ADD_SXP_ELEMENT_SIDEBAR,
 			sessionStorage.getItem(SESSION_IDS.ADD_SXP_ELEMENT_SIDEBAR) ===
-				'open'
-				? 'closed'
-				: 'open'
+				SIDEBAR_STATE.OPEN
+				? SIDEBAR_STATE.CLOSED
+				: SIDEBAR_STATE.OPEN,
+			sessionStorage.TYPES.FUNCTIONAL
 		);
 	}
 	else {
-		sessionStorage.setItem(SESSION_IDS.ADD_SXP_ELEMENT_SIDEBAR, state);
+		sessionStorage.setItem(
+			SESSION_IDS.ADD_SXP_ELEMENT_SIDEBAR,
+			state,
+			sessionStorage.TYPES.FUNCTIONAL
+		);
 	}
 
 	if (process.env.NODE_ENV === 'development') {
-		if (isDefined(state) && state !== 'open' && state !== 'closed') {
+		if (
+			isDefined(state) &&
+			state !== SIDEBAR_STATE.OPEN &&
+			state !== SIDEBAR_STATE.CLOSED
+		) {
 			console.warn(
 				`Session ID: ${SESSION_IDS.ADD_SXP_ELEMENT_SIDEBAR}`,
-				`Parameter value must be 'open' or 'closed'.`,
+				`Parameter value must be ${SIDEBAR_STATE.OPEN} or ${SIDEBAR_STATE.CLOSED}'.`,
+				`Use SIDEBAR_STATE.OPEN or SIDEBAR_STATE.CLOSE from utils/sessionStorage`,
 				`'${state}' was passed in instead.`
 			);
 		}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/toasts.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/toasts.js
@@ -9,7 +9,7 @@
  * distribution rights of the Software.
  */
 
-import {openToast} from 'frontend-js-web';
+import {openToast, sessionStorage} from 'frontend-js-web';
 
 import {SESSION_IDS} from './sessionStorage';
 
@@ -36,7 +36,10 @@ export function openSuccessToast(config) {
  * when a new blueprint is created and redirected to the edit page.
  */
 export function openInitialSuccessToast() {
-	const successMessage = sessionStorage.getItem(SESSION_IDS.SUCCESS_MESSAGE);
+	const successMessage = sessionStorage.getItem(
+		SESSION_IDS.SUCCESS_MESSAGE,
+		sessionStorage.TYPES.NECESSARY
+	);
 
 	if (successMessage) {
 		openSuccessToast({message: successMessage});
@@ -51,5 +54,9 @@ export function openInitialSuccessToast() {
  * @param {String} message The success message to display in the toast.
  */
 export function setInitialSuccessToast(message) {
-	return sessionStorage.setItem(SESSION_IDS.SUCCESS_MESSAGE, message);
+	return sessionStorage.setItem(
+		SESSION_IDS.SUCCESS_MESSAGE,
+		message,
+		sessionStorage.TYPES.NECESSARY
+	);
 }


### PR DESCRIPTION
Task: https://issues.liferay.com/browse/LPS-165348
Subtask: https://issues.liferay.com/browse/LPS-165349

**Dev Notes:**
- `sessionStorage`'s `getItem` and `setItem` takes in an extra parameter for `CONTENT_TYPES`. See the new util method here: https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/storage.js
- The success toast is marked as `NECESSARY` since it provides a success message when a blueprint or element is saved or created.
- The Add Element sidebar open state is marked as `FUNCTIONAL` since it's a preference for the sidebar state should be remembered as opened or closed. If this cookie is disabled, the sidebar will always start as closed when switching between tabs in the Edit Blueprint page.