### PR TITLE
LPS-178234 search-experiences-web: Prevent automatically submitting values on Firefox

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/index.js
@@ -494,7 +494,12 @@ export default function ({
 	};
 
 	const _handleSubmit = () => {
-		formik.handleSubmit();
+		if (document[formName].checkValidity()) {
+			formik.handleSubmit();
+		}
+		else {
+			document[formName].reportValidity();
+		}
 	};
 
 	const _handleSubmitWarningModalClose = () => {
@@ -1207,7 +1212,6 @@ export default function ({
 				<ClayButton
 					disabled={formik.isSubmitting}
 					onClick={_handleSubmit}
-					type="submit"
 				>
 					{formik.isSubmitting && (
 						<span className="inline-item inline-item-before">


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-178234 - Warning modal does not appear when using Firefox

Having `type=submit` on the button seems to cause issues with Firefox, as it submits the form before expected, thus the warning modal is not appearing properly. While Formik is supposed to validate, the inputs that were marked `disabled` (like the Text Embeddings Enabled checkbox) get disregarded from submission.

In order to preserve the browser's form validation (they offer helpful tooltips if inputs are missing), the lines with `checkValidity` and `reportValidity` were added.

Hoping this helps fix some of the issues happening in https://liferay.slack.com/archives/C01BK21HCKD/p1679399396102749 🤞 