### PR TITLE
LPS-178234 LPS-179211 search-experiences-web: Prevent prematurely submitting values

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/index.js
@@ -180,7 +180,7 @@ export default function ({
 }) {
 	const [showSubmitWarningModal, setShowSubmitWarningModal] = useState(false);
 
-	const _handleFormikSubmit = async (values) => {
+	const _handleFormikSubmit = async (values, actions) => {
 		const {
 			attributes = {},
 			languageIds,
@@ -244,8 +244,14 @@ export default function ({
 				method: 'POST',
 			}
 		)
-			.then((response) => response.json())
+			.then((response) => {
+				actions.setSubmitting(false);
+
+				return response.json();
+			})
 			.catch((error) => {
+				actions.setSubmitting(false);
+
 				setShowSubmitWarningModal(true);
 
 				if (process.env.NODE_ENV === 'development') {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/index.js
@@ -29,6 +29,7 @@ const DEFAULT_TEXT_EMBEDDING_PROVIDER_CONFIGURATIONS = {
 		maxCharacterCount: 500,
 		model: '',
 		modelTimeout: 25,
+		textTruncationStrategy: 'beginning',
 	},
 	embeddingVectorDimensions: 768,
 	languageIds: ['en_US'],

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/semantic_search/js/configuration/index.js
@@ -494,7 +494,12 @@ export default function ({
 	};
 
 	const _handleSubmit = () => {
-		formik.handleSubmit();
+		if (document[formName].checkValidity()) {
+			formik.handleSubmit();
+		}
+		else {
+			document[formName].reportValidity();
+		}
 	};
 
 	const _handleSubmitWarningModalClose = () => {
@@ -1207,7 +1212,6 @@ export default function ({
 				<ClayButton
 					disabled={formik.isSubmitting}
 					onClick={_handleSubmit}
-					type="submit"
 				>
 					{formik.isSubmitting && (
 						<span className="inline-item inline-item-before">


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-178234 - Warning modal does not appear when using Firefox

- Having `type=submit` on the button seems to cause issues with Firefox, as it submits the form before expected, and the warning modal is not appearing properly. While Formik is supposed to validate, the inputs that were marked `disabled` (like the Text Embeddings Enabled checkbox) get disregarded from submission.
- In order to preserve the browser's form validation (they offer helpful tooltips if inputs are missing), the lines with `checkValidity` and `reportValidity` were added.

https://issues.liferay.com/browse/LPS-179211 - Text Embeddings Enabled sometimes cannot be saved on Semantic Search form

- Not 100% sure if this fixes the bug, but from Tibor's screencap it looked like the inputs were still marked `disabled` from `formik.isSubmitting` when it was getting submitted. When there was a modal, it had enough time to re-enable. I added `actions.setSubmitting` to see if this would help.

Reference: https://formik.org/docs/guides/form-submission

Also included the default value for `textTruncationStrategy`.

Hoping this helps fix some of the issues happening in https://liferay.slack.com/archives/C01BK21HCKD/p1679399396102749 🤞 