### PR TITLE
LPS-163888 LPS-179376 [FE] Add improvements to the Clear button in ootb templates for search facet widgets

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/category/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/category/facet/view.jsp
@@ -84,49 +84,47 @@ CategoryFacetPortletInstanceConfiguration categoryFacetPortletInstanceConfigurat
 							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
 						</c:if>
 
-						<aui:fieldset>
-							<ul class="list-unstyled">
+						<ul class="list-unstyled">
 
-								<%
-								int i = 0;
+							<%
+							int i = 0;
 
-								for (BucketDisplayContext bucketDisplayContext : assetCategoriesSearchFacetDisplayContext.getBucketDisplayContexts()) {
-									i++;
-								%>
+							for (BucketDisplayContext bucketDisplayContext : assetCategoriesSearchFacetDisplayContext.getBucketDisplayContexts()) {
+								i++;
+							%>
 
-									<li class="facet-value">
-										<div class="custom-checkbox custom-control">
-											<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
-												<input
-													<%= bucketDisplayContext.isSelected() ? "checked" : StringPool.BLANK %>
-													class="custom-control-input facet-term"
-													data-term-id="<%= bucketDisplayContext.getFilterValue() %>"
-													disabled
-													id="<portlet:namespace />term_<%= i %>"
-													name="<portlet:namespace />term_<%= i %>"
-													onChange="Liferay.Search.FacetUtil.changeSelection(event);"
-													type="checkbox"
-												/>
+								<li class="facet-value">
+									<div class="custom-checkbox custom-control">
+										<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
+											<input
+												<%= bucketDisplayContext.isSelected() ? "checked" : StringPool.BLANK %>
+												class="custom-control-input facet-term"
+												data-term-id="<%= bucketDisplayContext.getFilterValue() %>"
+												disabled
+												id="<portlet:namespace />term_<%= i %>"
+												name="<portlet:namespace />term_<%= i %>"
+												onChange="Liferay.Search.FacetUtil.changeSelection(event);"
+												type="checkbox"
+											/>
 
-												<span class="custom-control-label term-name <%= bucketDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
-													<span class="custom-control-label-text"><%= HtmlUtil.escape(bucketDisplayContext.getBucketText()) %></span>
-												</span>
+											<span class="custom-control-label term-name <%= bucketDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
+												<span class="custom-control-label-text"><%= HtmlUtil.escape(bucketDisplayContext.getBucketText()) %></span>
+											</span>
 
-												<c:if test="<%= bucketDisplayContext.isFrequencyVisible() %>">
-													<small class="term-count">
-														(<%= bucketDisplayContext.getFrequency() %>)
-													</small>
-												</c:if>
-											</label>
-										</div>
-									</li>
+											<c:if test="<%= bucketDisplayContext.isFrequencyVisible() %>">
+												<small class="term-count">
+													(<%= bucketDisplayContext.getFrequency() %>)
+												</small>
+											</c:if>
+										</label>
+									</div>
+								</li>
 
-								<%
-								}
-								%>
+							<%
+							}
+							%>
 
-							</ul>
-						</aui:fieldset>
+						</ul>
 					</liferay-ui:panel>
 				</liferay-ui:panel-container>
 			</liferay-ddm:template-renderer>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/category/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/category/facet/view.jsp
@@ -81,7 +81,7 @@ CategoryFacetPortletInstanceConfiguration categoryFacetPortletInstanceConfigurat
 						title="category"
 					>
 						<c:if test="<%= !assetCategoriesSearchFacetDisplayContext.isNothingSelected() %>">
-							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
+							<aui:button cssClass="btn-link btn-unstyled c-mb-4 facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
 						</c:if>
 
 						<ul class="list-unstyled">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/category/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/category/facet/view.jsp
@@ -80,6 +80,10 @@ CategoryFacetPortletInstanceConfiguration categoryFacetPortletInstanceConfigurat
 						persistState="<%= true %>"
 						title="category"
 					>
+						<c:if test="<%= !assetCategoriesSearchFacetDisplayContext.isNothingSelected() %>">
+							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
+						</c:if>
+
 						<aui:fieldset>
 							<ul class="list-unstyled">
 
@@ -123,10 +127,6 @@ CategoryFacetPortletInstanceConfiguration categoryFacetPortletInstanceConfigurat
 
 							</ul>
 						</aui:fieldset>
-
-						<c:if test="<%= !assetCategoriesSearchFacetDisplayContext.isNothingSelected() %>">
-							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
-						</c:if>
 					</liferay-ui:panel>
 				</liferay-ui:panel-container>
 			</liferay-ddm:template-renderer>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/facet/view.jsp
@@ -76,6 +76,10 @@ CustomFacetPortletInstanceConfiguration customFacetPortletInstanceConfiguration 
 						persistState="<%= true %>"
 						title="<%= customFacetDisplayContext.getDisplayCaption() %>"
 					>
+						<c:if test="<%= !customFacetDisplayContext.isNothingSelected() %>">
+							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
+						</c:if>
+
 						<aui:fieldset>
 							<ul class="list-unstyled">
 
@@ -110,10 +114,6 @@ CustomFacetPortletInstanceConfiguration customFacetPortletInstanceConfiguration 
 
 							</ul>
 						</aui:fieldset>
-
-						<c:if test="<%= !customFacetDisplayContext.isNothingSelected() %>">
-							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
-						</c:if>
 					</liferay-ui:panel>
 				</liferay-ui:panel-container>
 			</liferay-ddm:template-renderer>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/folder/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/folder/facet/view.jsp
@@ -81,7 +81,7 @@ FolderFacetPortletInstanceConfiguration folderFacetPortletInstanceConfiguration 
 						title="folder"
 					>
 						<c:if test="<%= !folderSearchFacetDisplayContext.isNothingSelected() %>">
-							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
+							<aui:button cssClass="btn-link btn-unstyled c-mb-4 facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
 						</c:if>
 
 						<ul class="list-unstyled">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/folder/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/folder/facet/view.jsp
@@ -80,6 +80,10 @@ FolderFacetPortletInstanceConfiguration folderFacetPortletInstanceConfiguration 
 						persistState="<%= true %>"
 						title="folder"
 					>
+						<c:if test="<%= !folderSearchFacetDisplayContext.isNothingSelected() %>">
+							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
+						</c:if>
+
 						<aui:fieldset>
 							<ul class="list-unstyled">
 
@@ -125,10 +129,6 @@ FolderFacetPortletInstanceConfiguration folderFacetPortletInstanceConfiguration 
 
 							</ul>
 						</aui:fieldset>
-
-						<c:if test="<%= !folderSearchFacetDisplayContext.isNothingSelected() %>">
-							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
-						</c:if>
 					</liferay-ui:panel>
 				</liferay-ui:panel-container>
 			</liferay-ddm:template-renderer>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/folder/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/folder/facet/view.jsp
@@ -84,51 +84,49 @@ FolderFacetPortletInstanceConfiguration folderFacetPortletInstanceConfiguration 
 							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
 						</c:if>
 
-						<aui:fieldset>
-							<ul class="list-unstyled">
+						<ul class="list-unstyled">
 
-								<%
-								int i = 0;
+							<%
+							int i = 0;
 
-								for (BucketDisplayContext bucketDisplayContext : folderSearchFacetDisplayContext.getBucketDisplayContexts()) {
-									i++;
-								%>
+							for (BucketDisplayContext bucketDisplayContext : folderSearchFacetDisplayContext.getBucketDisplayContexts()) {
+								i++;
+							%>
 
-									<li class="facet-value">
-										<div class="custom-checkbox custom-control">
-											<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
-												<input
-													autocomplete="off"
-													class="custom-control-input facet-term"
-													data-term-id="<%= bucketDisplayContext.getFilterValue() %>"
-													disabled
-													id="<portlet:namespace />term_<%= i %>"
-													name="<portlet:namespace />term_<%= i %>"
-													onChange="Liferay.Search.FacetUtil.changeSelection(event);"
-													type="checkbox" <%= bucketDisplayContext.isSelected() ? "checked" : StringPool.BLANK %>
-												/>
+								<li class="facet-value">
+									<div class="custom-checkbox custom-control">
+										<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
+											<input
+												autocomplete="off"
+												class="custom-control-input facet-term"
+												data-term-id="<%= bucketDisplayContext.getFilterValue() %>"
+												disabled
+												id="<portlet:namespace />term_<%= i %>"
+												name="<portlet:namespace />term_<%= i %>"
+												onChange="Liferay.Search.FacetUtil.changeSelection(event);"
+												type="checkbox" <%= bucketDisplayContext.isSelected() ? "checked" : StringPool.BLANK %>
+											/>
 
-												<span class="custom-control-label term-name <%= bucketDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
-													<span class="custom-control-label-text">
-														<%= HtmlUtil.escape(bucketDisplayContext.getBucketText()) %>
-													</span>
+											<span class="custom-control-label term-name <%= bucketDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
+												<span class="custom-control-label-text">
+													<%= HtmlUtil.escape(bucketDisplayContext.getBucketText()) %>
 												</span>
+											</span>
 
-												<c:if test="<%= bucketDisplayContext.isFrequencyVisible() %>">
-													<small class="term-count">
-														(<%= bucketDisplayContext.getFrequency() %>)
-													</small>
-												</c:if>
-											</label>
-										</div>
-									</li>
+											<c:if test="<%= bucketDisplayContext.isFrequencyVisible() %>">
+												<small class="term-count">
+													(<%= bucketDisplayContext.getFrequency() %>)
+												</small>
+											</c:if>
+										</label>
+									</div>
+								</li>
 
-								<%
-								}
-								%>
+							<%
+							}
+							%>
 
-							</ul>
-						</aui:fieldset>
+						</ul>
 					</liferay-ui:panel>
 				</liferay-ui:panel-container>
 			</liferay-ddm:template-renderer>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/modified/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/modified/facet/view.jsp
@@ -87,7 +87,7 @@ ModifiedFacetPortletInstanceConfiguration modifiedFacetPortletInstanceConfigurat
 					title="last-modified"
 				>
 					<c:if test="<%= !modifiedFacetDisplayContext.isNothingSelected() %>">
-						<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
+						<aui:button cssClass="btn-link btn-unstyled c-mb-4 facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
 					</c:if>
 
 					<ul class="list-unstyled modified">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/modified/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/modified/facet/view.jsp
@@ -86,6 +86,10 @@ ModifiedFacetPortletInstanceConfiguration modifiedFacetPortletInstanceConfigurat
 					persistState="<%= true %>"
 					title="last-modified"
 				>
+					<c:if test="<%= !modifiedFacetDisplayContext.isNothingSelected() %>">
+						<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
+					</c:if>
+
 					<ul class="list-unstyled modified">
 
 						<%
@@ -165,10 +169,6 @@ ModifiedFacetPortletInstanceConfiguration modifiedFacetPortletInstanceConfigurat
 							<aui:button cssClass="modified-facet-custom-range-filter-button" disabled="<%= modifiedFacetCalendarDisplayContext.isRangeBackwards() %>" name="searchCustomRangeButton" value="search" />
 						</li>
 					</ul>
-
-					<c:if test="<%= !modifiedFacetDisplayContext.isNothingSelected() %>">
-						<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
-					</c:if>
 				</liferay-ui:panel>
 			</liferay-ui:panel-container>
 		</liferay-ddm:template-renderer>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/site/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/site/facet/view.jsp
@@ -80,6 +80,10 @@ SiteFacetPortletInstanceConfiguration siteFacetPortletInstanceConfiguration = sc
 						persistState="<%= true %>"
 						title="site"
 					>
+						<c:if test="<%= !scopeSearchFacetDisplayContext.isNothingSelected() %>">
+							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
+						</c:if>
+
 						<aui:fieldset>
 							<ul class="list-unstyled">
 
@@ -124,10 +128,6 @@ SiteFacetPortletInstanceConfiguration siteFacetPortletInstanceConfiguration = sc
 
 							</ul>
 						</aui:fieldset>
-
-						<c:if test="<%= !scopeSearchFacetDisplayContext.isNothingSelected() %>">
-							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
-						</c:if>
 					</liferay-ui:panel>
 				</liferay-ui:panel-container>
 			</liferay-ddm:template-renderer>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/tag/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/tag/facet/view.jsp
@@ -81,7 +81,7 @@ TagFacetPortletInstanceConfiguration tagFacetPortletInstanceConfiguration = asse
 						title="tag"
 					>
 						<c:if test="<%= !assetTagsSearchFacetDisplayContext.isNothingSelected() %>">
-							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
+							<aui:button cssClass="btn-link btn-unstyled c-mb-4 facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
 						</c:if>
 
 						<ul class="list-unstyled">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/tag/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/tag/facet/view.jsp
@@ -80,6 +80,10 @@ TagFacetPortletInstanceConfiguration tagFacetPortletInstanceConfiguration = asse
 						persistState="<%= true %>"
 						title="tag"
 					>
+						<c:if test="<%= !assetTagsSearchFacetDisplayContext.isNothingSelected() %>">
+							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
+						</c:if>
+
 						<aui:fieldset>
 							<ul class="list-unstyled">
 
@@ -124,10 +128,6 @@ TagFacetPortletInstanceConfiguration tagFacetPortletInstanceConfiguration = asse
 
 							</ul>
 						</aui:fieldset>
-
-						<c:if test="<%= !assetTagsSearchFacetDisplayContext.isNothingSelected() %>">
-							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
-						</c:if>
 					</liferay-ui:panel>
 				</liferay-ui:panel-container>
 			</liferay-ddm:template-renderer>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/tag/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/tag/facet/view.jsp
@@ -84,50 +84,48 @@ TagFacetPortletInstanceConfiguration tagFacetPortletInstanceConfiguration = asse
 							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
 						</c:if>
 
-						<aui:fieldset>
-							<ul class="list-unstyled">
+						<ul class="list-unstyled">
 
-								<%
-								int i = 0;
+							<%
+							int i = 0;
 
-								for (BucketDisplayContext bucketDisplayContext : assetTagsSearchFacetDisplayContext.getBucketDisplayContexts()) {
-									i++;
-								%>
+							for (BucketDisplayContext bucketDisplayContext : assetTagsSearchFacetDisplayContext.getBucketDisplayContexts()) {
+								i++;
+							%>
 
-									<li class="facet-value">
-										<div class="custom-checkbox custom-control">
-											<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
-												<input
-													autocomplete="off"
-													<%= bucketDisplayContext.isSelected() ? "checked" : StringPool.BLANK %>
-													class="custom-control-input facet-term"
-													data-term-id="<%= HtmlUtil.escapeAttribute(bucketDisplayContext.getFilterValue()) %>"
-													disabled
-													id="<portlet:namespace />term_<%= i %>"
-													name="<portlet:namespace />term_<%= i %>"
-													onChange="Liferay.Search.FacetUtil.changeSelection(event);"
-													type="checkbox"
-												/>
+								<li class="facet-value">
+									<div class="custom-checkbox custom-control">
+										<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
+											<input
+												autocomplete="off"
+												<%= bucketDisplayContext.isSelected() ? "checked" : StringPool.BLANK %>
+												class="custom-control-input facet-term"
+												data-term-id="<%= HtmlUtil.escapeAttribute(bucketDisplayContext.getFilterValue()) %>"
+												disabled
+												id="<portlet:namespace />term_<%= i %>"
+												name="<portlet:namespace />term_<%= i %>"
+												onChange="Liferay.Search.FacetUtil.changeSelection(event);"
+												type="checkbox"
+											/>
 
-												<span class="custom-control-label term-name <%= bucketDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
-													<span class="custom-control-label-text"><%= HtmlUtil.escape(bucketDisplayContext.getBucketText()) %></span>
-												</span>
+											<span class="custom-control-label term-name <%= bucketDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
+												<span class="custom-control-label-text"><%= HtmlUtil.escape(bucketDisplayContext.getBucketText()) %></span>
+											</span>
 
-												<c:if test="<%= bucketDisplayContext.isFrequencyVisible() %>">
-													<small class="term-count">
-														(<%= bucketDisplayContext.getFrequency() %>)
-													</small>
-												</c:if>
-											</label>
-										</div>
-									</li>
+											<c:if test="<%= bucketDisplayContext.isFrequencyVisible() %>">
+												<small class="term-count">
+													(<%= bucketDisplayContext.getFrequency() %>)
+												</small>
+											</c:if>
+										</label>
+									</div>
+								</li>
 
-								<%
-								}
-								%>
+							<%
+							}
+							%>
 
-							</ul>
-						</aui:fieldset>
+						</ul>
 					</liferay-ui:panel>
 				</liferay-ui:panel-container>
 			</liferay-ddm:template-renderer>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/view.jsp
@@ -80,6 +80,10 @@ TypeFacetPortletInstanceConfiguration typeFacetPortletInstanceConfiguration = as
 						persistState="<%= true %>"
 						title="type"
 					>
+						<c:if test="<%= !assetEntriesSearchFacetDisplayContext.isNothingSelected() %>">
+							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
+						</c:if>
+
 						<aui:fieldset>
 							<ul class="asset-type list-unstyled">
 
@@ -124,10 +128,6 @@ TypeFacetPortletInstanceConfiguration typeFacetPortletInstanceConfiguration = as
 
 							</ul>
 						</aui:fieldset>
-
-						<c:if test="<%= !assetEntriesSearchFacetDisplayContext.isNothingSelected() %>">
-							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
-						</c:if>
 					</liferay-ui:panel>
 				</liferay-ui:panel-container>
 			</liferay-ddm:template-renderer>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/view.jsp
@@ -81,7 +81,7 @@ TypeFacetPortletInstanceConfiguration typeFacetPortletInstanceConfiguration = as
 						title="type"
 					>
 						<c:if test="<%= !assetEntriesSearchFacetDisplayContext.isNothingSelected() %>">
-							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
+							<aui:button cssClass="btn-link btn-unstyled c-mb-4 facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
 						</c:if>
 
 						<ul class="asset-type list-unstyled">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/view.jsp
@@ -84,50 +84,48 @@ TypeFacetPortletInstanceConfiguration typeFacetPortletInstanceConfiguration = as
 							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
 						</c:if>
 
-						<aui:fieldset>
-							<ul class="asset-type list-unstyled">
+						<ul class="asset-type list-unstyled">
 
-								<%
-								int i = 0;
+							<%
+							int i = 0;
 
-								for (BucketDisplayContext bucketDisplayContext : assetEntriesSearchFacetDisplayContext.getBucketDisplayContexts()) {
-									i++;
-								%>
+							for (BucketDisplayContext bucketDisplayContext : assetEntriesSearchFacetDisplayContext.getBucketDisplayContexts()) {
+								i++;
+							%>
 
-									<li class="facet-value">
-										<div class="custom-checkbox custom-control">
-											<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
-												<input
-													autocomplete="off"
-													class="custom-control-input facet-term"
-													data-term-id="<%= bucketDisplayContext.getFilterValue() %>"
-													disabled
-													id="<portlet:namespace />term_<%= i %>"
-													name="<portlet:namespace />term_<%= i %>"
-													onChange="Liferay.Search.FacetUtil.changeSelection(event);"
-													type="checkbox"
-													<%= bucketDisplayContext.isSelected() ? "checked" : StringPool.BLANK %>
-												/>
+								<li class="facet-value">
+									<div class="custom-checkbox custom-control">
+										<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
+											<input
+												autocomplete="off"
+												class="custom-control-input facet-term"
+												data-term-id="<%= bucketDisplayContext.getFilterValue() %>"
+												disabled
+												id="<portlet:namespace />term_<%= i %>"
+												name="<portlet:namespace />term_<%= i %>"
+												onChange="Liferay.Search.FacetUtil.changeSelection(event);"
+												type="checkbox"
+												<%= bucketDisplayContext.isSelected() ? "checked" : StringPool.BLANK %>
+											/>
 
-												<span class="custom-control-label term-name <%= bucketDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
-													<span class="custom-control-label-text"><%= HtmlUtil.escape(bucketDisplayContext.getBucketText()) %></span>
-												</span>
+											<span class="custom-control-label term-name <%= bucketDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
+												<span class="custom-control-label-text"><%= HtmlUtil.escape(bucketDisplayContext.getBucketText()) %></span>
+											</span>
 
-												<c:if test="<%= bucketDisplayContext.isFrequencyVisible() %>">
-													<small class="term-count">
-														(<%= bucketDisplayContext.getFrequency() %>)
-													</small>
-												</c:if>
-											</label>
-										</div>
-									</li>
+											<c:if test="<%= bucketDisplayContext.isFrequencyVisible() %>">
+												<small class="term-count">
+													(<%= bucketDisplayContext.getFrequency() %>)
+												</small>
+											</c:if>
+										</label>
+									</div>
+								</li>
 
-								<%
-								}
-								%>
+							<%
+							}
+							%>
 
-							</ul>
-						</aui:fieldset>
+						</ul>
 					</liferay-ui:panel>
 				</liferay-ui:panel-container>
 			</liferay-ddm:template-renderer>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/user/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/user/facet/view.jsp
@@ -80,6 +80,10 @@ UserFacetPortletInstanceConfiguration userFacetPortletInstanceConfiguration = us
 						persistState="<%= true %>"
 						title="user"
 					>
+						<c:if test="<%= !userSearchFacetDisplayContext.isNothingSelected() %>">
+							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
+						</c:if>
+
 						<aui:fieldset>
 							<ul class="list-unstyled">
 
@@ -125,10 +129,6 @@ UserFacetPortletInstanceConfiguration userFacetPortletInstanceConfiguration = us
 
 							</ul>
 						</aui:fieldset>
-
-						<c:if test="<%= !userSearchFacetDisplayContext.isNothingSelected() %>">
-							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
-						</c:if>
 					</liferay-ui:panel>
 				</liferay-ui:panel-container>
 			</liferay-ddm:template-renderer>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/user/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/user/facet/view.jsp
@@ -84,51 +84,49 @@ UserFacetPortletInstanceConfiguration userFacetPortletInstanceConfiguration = us
 							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
 						</c:if>
 
-						<aui:fieldset>
-							<ul class="list-unstyled">
+						<ul class="list-unstyled">
 
-								<%
-								int i = 0;
+							<%
+							int i = 0;
 
-								for (BucketDisplayContext bucketDisplayContext : userSearchFacetDisplayContext.getBucketDisplayContexts()) {
-									i++;
-								%>
+							for (BucketDisplayContext bucketDisplayContext : userSearchFacetDisplayContext.getBucketDisplayContexts()) {
+								i++;
+							%>
 
-									<li class="facet-value">
-										<div class="custom-checkbox custom-control">
-											<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
-												<input
-													autocomplete="off"
-													<%= bucketDisplayContext.isSelected() ? "checked" : StringPool.BLANK %>
-													class="custom-control-input facet-term"
-													data-term-id="<%= HtmlUtil.escapeAttribute(bucketDisplayContext.getBucketText()) %>"
-													disabled
-													id="<portlet:namespace />term_<%= i %>"name="<portlet:namespace />term_<%= i %>"
-													onChange="Liferay.Search.FacetUtil.changeSelection(event);"
-													type="checkbox"
-												/>
+								<li class="facet-value">
+									<div class="custom-checkbox custom-control">
+										<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
+											<input
+												autocomplete="off"
+												<%= bucketDisplayContext.isSelected() ? "checked" : StringPool.BLANK %>
+												class="custom-control-input facet-term"
+												data-term-id="<%= HtmlUtil.escapeAttribute(bucketDisplayContext.getBucketText()) %>"
+												disabled
+												id="<portlet:namespace />term_<%= i %>"name="<portlet:namespace />term_<%= i %>"
+												onChange="Liferay.Search.FacetUtil.changeSelection(event);"
+												type="checkbox"
+											/>
 
-												<span class="custom-control-label term-name <%= bucketDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
-													<span class="custom-control-label-text">
-														<%= HtmlUtil.escape(bucketDisplayContext.getBucketText()) %>
-													</span>
+											<span class="custom-control-label term-name <%= bucketDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
+												<span class="custom-control-label-text">
+													<%= HtmlUtil.escape(bucketDisplayContext.getBucketText()) %>
 												</span>
+											</span>
 
-												<c:if test="<%= bucketDisplayContext.isFrequencyVisible() %>">
-													<small class="term-count">
-														(<%= bucketDisplayContext.getFrequency() %>)
-													</small>
-												</c:if>
-											</label>
-										</div>
-									</li>
+											<c:if test="<%= bucketDisplayContext.isFrequencyVisible() %>">
+												<small class="term-count">
+													(<%= bucketDisplayContext.getFrequency() %>)
+												</small>
+											</c:if>
+										</label>
+									</div>
+								</li>
 
-								<%
-								}
-								%>
+							<%
+							}
+							%>
 
-							</ul>
-						</aui:fieldset>
+						</ul>
 					</liferay-ui:panel>
 				</liferay-ui:panel-container>
 			</liferay-ddm:template-renderer>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/user/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/user/facet/view.jsp
@@ -81,7 +81,7 @@ UserFacetPortletInstanceConfiguration userFacetPortletInstanceConfiguration = us
 						title="user"
 					>
 						<c:if test="<%= !userSearchFacetDisplayContext.isNothingSelected() %>">
-							<aui:button cssClass="btn-link btn-unstyled facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
+							<aui:button cssClass="btn-link btn-unstyled c-mb-4 facet-clear-btn" onClick="Liferay.Search.FacetUtil.clearSelections(event);" value="clear" />
 						</c:if>
 
 						<ul class="list-unstyled">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/category/facet/portlet/display/template/dependencies/portlet_display_template_cloud.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/category/facet/portlet/display/template/dependencies/portlet_display_template_cloud.ftl
@@ -12,6 +12,14 @@
 		persistState=true
 		title="category"
 	>
+		<#if !assetCategoriesSearchFacetDisplayContext.isNothingSelected()>
+			<@liferay_aui.button
+				cssClass="btn-link btn-unstyled facet-clear-btn"
+				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
+				value="clear"
+			/>
+		</#if>
+
 		<ul class="list-unstyled tag-cloud">
 			<#if entries?has_content>
 				<#list entries as entry>
@@ -28,13 +36,5 @@
 				</#list>
 			</#if>
 		</ul>
-
-		<#if !assetCategoriesSearchFacetDisplayContext.isNothingSelected()>
-			<@liferay_aui.button
-				cssClass="btn-link btn-unstyled facet-clear-btn"
-				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
-				value="clear"
-			/>
-		</#if>
 	</@>
 </@>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/category/facet/portlet/display/template/dependencies/portlet_display_template_compact.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/category/facet/portlet/display/template/dependencies/portlet_display_template_compact.ftl
@@ -12,6 +12,14 @@
 		persistState=true
 		title="category"
 	>
+		<#if !assetCategoriesSearchFacetDisplayContext.isNothingSelected()>
+			<@liferay_aui.button
+				cssClass="btn-link btn-unstyled facet-clear-btn"
+				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
+				value="clear"
+			/>
+		</#if>
+
 		<ul class="list-unstyled">
 			<#if entries?has_content>
 				<#list entries as entry>
@@ -34,13 +42,5 @@
 				</#list>
 			</#if>
 		</ul>
-
-		<#if !assetCategoriesSearchFacetDisplayContext.isNothingSelected()>
-			<@liferay_aui.button
-				cssClass="btn-link btn-unstyled facet-clear-btn"
-				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
-				value="clear"
-			/>
-		</#if>
 	</@>
 </@>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/category/facet/portlet/display/template/dependencies/portlet_display_template_label.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/category/facet/portlet/display/template/dependencies/portlet_display_template_label.ftl
@@ -12,6 +12,14 @@
 		persistState=true
 		title="category"
 	>
+		<#if !assetCategoriesSearchFacetDisplayContext.isNothingSelected()>
+			<@liferay_aui.button
+				cssClass="btn-link btn-unstyled facet-clear-btn"
+				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
+				value="clear"
+			/>
+		</#if>
+
 		<#if entries?has_content>
 			<div class="label-container">
 				<#list entries as entry>
@@ -32,14 +40,6 @@
 					</button>
 				</#list>
 			</div>
-		</#if>
-
-		<#if !assetCategoriesSearchFacetDisplayContext.isNothingSelected()>
-			<@liferay_aui.button
-				cssClass="btn-link btn-unstyled facet-clear-btn"
-				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
-				value="clear"
-			/>
 		</#if>
 	</@>
 </@>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/category/facet/portlet/display/template/dependencies/portlet_display_template_vocabulary.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/category/facet/portlet/display/template/dependencies/portlet_display_template_vocabulary.ftl
@@ -130,6 +130,14 @@
 		persistState=true
 		title="${(vocabularyNames?size == 1)?then(vocabularyNames[0]!'', 'category')}"
 	>
+		<#if !assetCategoriesSearchFacetDisplayContext.isNothingSelected()>
+			<@liferay_aui.button
+				cssClass="btn-link btn-unstyled facet-clear-btn"
+				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
+				value="clear"
+			/>
+		</#if>
+
 		<#if vocabularyNames?has_content>
 			<ul class="treeview treeview-light treeview-nested treeview-vocabulary-display" role="tree">
 				<#list vocabularyNames as vocabularyName>
@@ -142,14 +150,6 @@
 					/>
 				</#list>
 			</ul>
-		</#if>
-
-		<#if !assetCategoriesSearchFacetDisplayContext.isNothingSelected()>
-			<@liferay_aui.button
-				cssClass="btn-link btn-unstyled facet-clear-btn"
-				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
-				value="clear"
-			/>
 		</#if>
 	</@>
 </@>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/custom/facet/portlet/display/template/dependencies/portlet_display_template_compact.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/custom/facet/portlet/display/template/dependencies/portlet_display_template_compact.ftl
@@ -12,6 +12,14 @@
 		persistState=true
 		title="${customFacetDisplayContext.getDisplayCaption()}"
 	>
+		<#if !customFacetDisplayContext.isNothingSelected()>
+			<@liferay_aui.button
+				cssClass="btn-link btn-unstyled facet-clear-btn"
+				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
+				value="clear"
+			/>
+		</#if>
+
 		<ul class="list-unstyled">
 			<#if entries?has_content>
 				<#list entries as entry>
@@ -35,13 +43,5 @@
 				</#list>
 			</#if>
 		</ul>
-
-		<#if !customFacetDisplayContext.isNothingSelected()>
-			<@liferay_aui.button
-				cssClass="btn-link btn-unstyled facet-clear-btn"
-				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
-				value="clear"
-			/>
-		</#if>
 	</@>
 </@>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/custom/facet/portlet/display/template/dependencies/portlet_display_template_label.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/custom/facet/portlet/display/template/dependencies/portlet_display_template_label.ftl
@@ -12,6 +12,14 @@
 		persistState=true
 		title="${customFacetDisplayContext.getDisplayCaption()}"
 	>
+		<#if !customFacetDisplayContext.isNothingSelected()>
+			<@liferay_aui.button
+				cssClass="btn-link btn-unstyled facet-clear-btn"
+				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
+				value="clear"
+			/>
+		</#if>
+
 		<#if entries?has_content>
 			<div class="label-container">
 				<#list entries as entry>
@@ -30,14 +38,6 @@
 					</button>
 				</#list>
 			</div>
-		</#if>
-
-		<#if !customFacetDisplayContext.isNothingSelected()>
-			<@liferay_aui.button
-				cssClass="btn-link btn-unstyled facet-clear-btn"
-				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
-				value="clear"
-			/>
 		</#if>
 	</@>
 </@>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/folder/facet/portlet/display/template/dependencies/portlet_display_template_compact.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/folder/facet/portlet/display/template/dependencies/portlet_display_template_compact.ftl
@@ -12,6 +12,14 @@
 		persistState=true
 		title="folder"
 	>
+		<#if !folderSearchFacetDisplayContext.isNothingSelected()>
+			<@liferay_aui.button
+				cssClass="btn-link btn-unstyled facet-clear-btn"
+				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
+				value="clear"
+			/>
+		</#if>
+
 		<ul class="list-unstyled">
 			<#if entries?has_content>
 				<#list entries as entry>
@@ -34,13 +42,5 @@
 				</#list>
 			</#if>
 		</ul>
-
-		<#if !folderSearchFacetDisplayContext.isNothingSelected()>
-			<@liferay_aui.button
-				cssClass="btn-link btn-unstyled facet-clear-btn"
-				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
-				value="clear"
-			/>
-		</#if>
 	</@>
 </@>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/folder/facet/portlet/display/template/dependencies/portlet_display_template_label.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/folder/facet/portlet/display/template/dependencies/portlet_display_template_label.ftl
@@ -12,6 +12,14 @@
 		persistState=true
 		title="folder"
 	>
+		<#if !folderSearchFacetDisplayContext.isNothingSelected()>
+			<@liferay_aui.button
+				cssClass="btn-link btn-unstyled facet-clear-btn"
+				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
+				value="clear"
+			/>
+		</#if>
+
 		<#if entries?has_content>
 			<div class="label-container">
 				<#list entries as entry>
@@ -32,14 +40,6 @@
 					</button>
 				</#list>
 			</div>
-		</#if>
-
-		<#if !folderSearchFacetDisplayContext.isNothingSelected()>
-			<@liferay_aui.button
-				cssClass="btn-link btn-unstyled facet-clear-btn"
-				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
-				value="clear"
-			/>
 		</#if>
 	</@>
 </@>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/modified/facet/portlet/display/template/dependencies/portlet_display_template_radio.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/modified/facet/portlet/display/template/dependencies/portlet_display_template_radio.ftl
@@ -12,6 +12,14 @@
 		persistState=true
 		title="last-modified"
 	>
+		<#if !modifiedFacetDisplayContext.isNothingSelected()>
+			<@liferay_aui.button
+				cssClass="btn-link btn-unstyled facet-clear-btn"
+				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
+				value="clear"
+			/>
+		</#if>
+
 		<ul class="list-unstyled modified">
 			<#if entries?has_content>
 				<#list entries as entry>
@@ -118,13 +126,5 @@
 				/>
 			</div>
 		</ul>
-
-		<#if !modifiedFacetDisplayContext.isNothingSelected()>
-			<@liferay_aui.button
-				cssClass="btn-link btn-unstyled facet-clear-btn"
-				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
-				value="clear"
-			/>
-		</#if>
 	</@>
 </@>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/site/facet/portlet/display/template/dependencies/portlet_display_template_compact.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/site/facet/portlet/display/template/dependencies/portlet_display_template_compact.ftl
@@ -12,6 +12,14 @@
 		persistState=true
 		title="site"
 	>
+		<#if !scopeSearchFacetDisplayContext.isNothingSelected()>
+			<@liferay_aui.button
+				cssClass="btn-link btn-unstyled facet-clear-btn"
+				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
+				value="clear"
+			/>
+		</#if>
+
 		<ul class="list-unstyled">
 			<#if entries?has_content>
 				<#list entries as entry>
@@ -34,13 +42,5 @@
 				</#list>
 			</#if>
 		</ul>
-
-		<#if !scopeSearchFacetDisplayContext.isNothingSelected()>
-			<@liferay_aui.button
-				cssClass="btn-link btn-unstyled facet-clear-btn"
-				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
-				value="clear"
-			/>
-		</#if>
 	</@>
 </@>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/site/facet/portlet/display/template/dependencies/portlet_display_template_label.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/site/facet/portlet/display/template/dependencies/portlet_display_template_label.ftl
@@ -12,6 +12,14 @@
 		persistState=true
 		title="site"
 	>
+		<#if !scopeSearchFacetDisplayContext.isNothingSelected()>
+			<@liferay_aui.button
+				cssClass="btn-link btn-unstyled facet-clear-btn"
+				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
+				value="clear"
+			/>
+		</#if>
+
 		<#if entries?has_content>
 			<div class="label-container">
 				<#list entries as entry>
@@ -30,14 +38,6 @@
 					</button>
 				</#list>
 			</div>
-		</#if>
-
-		<#if !scopeSearchFacetDisplayContext.isNothingSelected()>
-			<@liferay_aui.button
-				cssClass="btn-link btn-unstyled facet-clear-btn"
-				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
-				value="clear"
-			/>
 		</#if>
 	</@>
 </@>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/tag/facet/portlet/display/template/dependencies/portlet_display_template_cloud.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/tag/facet/portlet/display/template/dependencies/portlet_display_template_cloud.ftl
@@ -12,6 +12,14 @@
 		persistState=true
 		title="tag"
 	>
+		<#if !assetTagsSearchFacetDisplayContext.isNothingSelected()>
+			<@liferay_aui.button
+				cssClass="btn-link btn-unstyled facet-clear-btn"
+				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
+				value="clear"
+			/>
+		</#if>
+
 		<ul class="list-unstyled tag-cloud">
 			<#if entries?has_content>
 				<#list entries as entry>
@@ -28,13 +36,5 @@
 				</#list>
 			</#if>
 		</ul>
-
-		<#if !assetTagsSearchFacetDisplayContext.isNothingSelected()>
-			<@liferay_aui.button
-				cssClass="btn-link btn-unstyled facet-clear-btn"
-				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
-				value="clear"
-			/>
-		</#if>
 	</@>
 </@>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/tag/facet/portlet/display/template/dependencies/portlet_display_template_compact.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/tag/facet/portlet/display/template/dependencies/portlet_display_template_compact.ftl
@@ -12,6 +12,14 @@
 		persistState=true
 		title="tag"
 	>
+		<#if !assetTagsSearchFacetDisplayContext.isNothingSelected()>
+			<@liferay_aui.button
+				cssClass="btn-link btn-unstyled facet-clear-btn"
+				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
+				value="clear"
+			/>
+		</#if>
+
 		<ul class="list-unstyled">
 			<#if entries?has_content>
 				<#list entries as entry>
@@ -34,13 +42,5 @@
 				</#list>
 			</#if>
 		</ul>
-
-		<#if !assetTagsSearchFacetDisplayContext.isNothingSelected()>
-			<@liferay_aui.button
-				cssClass="btn-link btn-unstyled facet-clear-btn"
-				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
-				value="clear"
-			/>
-		</#if>
 	</@>
 </@>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/tag/facet/portlet/display/template/dependencies/portlet_display_template_label.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/tag/facet/portlet/display/template/dependencies/portlet_display_template_label.ftl
@@ -12,6 +12,14 @@
 		persistState=true
 		title="tag"
 	>
+		<#if !assetTagsSearchFacetDisplayContext.isNothingSelected()>
+			<@liferay_aui.button
+				cssClass="btn-link btn-unstyled facet-clear-btn"
+				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
+				value="clear"
+			/>
+		</#if>
+
 		<#if entries?has_content>
 			<div class="label-container">
 				<#list entries as entry>
@@ -32,14 +40,6 @@
 					</button>
 				</#list>
 			</div>
-		</#if>
-
-		<#if !assetTagsSearchFacetDisplayContext.isNothingSelected()>
-			<@liferay_aui.button
-				cssClass="btn-link btn-unstyled facet-clear-btn"
-				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
-				value="clear"
-			/>
 		</#if>
 	</@>
 </@>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/type/facet/portlet/display/template/dependencies/portlet_display_template_compact.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/type/facet/portlet/display/template/dependencies/portlet_display_template_compact.ftl
@@ -12,6 +12,14 @@
 		persistState=true
 		title="type"
 	>
+		<#if !assetEntriesSearchFacetDisplayContext.isNothingSelected()>
+			<@liferay_aui.button
+				cssClass="btn-link btn-unstyled facet-clear-btn"
+				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
+				value="clear"
+			/>
+		</#if>
+
 		<ul class="list-unstyled">
 			<#if entries?has_content>
 				<#list entries as entry>
@@ -34,13 +42,5 @@
 				</#list>
 			</#if>
 		</ul>
-
-		<#if !assetEntriesSearchFacetDisplayContext.isNothingSelected()>
-			<@liferay_aui.button
-				cssClass="btn-link btn-unstyled facet-clear-btn"
-				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
-				value="clear"
-			/>
-		</#if>
 	</@>
 </@>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/type/facet/portlet/display/template/dependencies/portlet_display_template_label.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/type/facet/portlet/display/template/dependencies/portlet_display_template_label.ftl
@@ -12,6 +12,14 @@
 		persistState=true
 		title="type"
 	>
+		<#if !assetEntriesSearchFacetDisplayContext.isNothingSelected()>
+			<@liferay_aui.button
+				cssClass="btn-link btn-unstyled facet-clear-btn"
+				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
+				value="clear"
+			/>
+		</#if>
+
 		<#if entries?has_content>
 			<div class="label-container">
 				<#list entries as entry>
@@ -32,14 +40,6 @@
 					</button>
 				</#list>
 			</div>
-		</#if>
-
-		<#if !assetEntriesSearchFacetDisplayContext.isNothingSelected()>
-			<@liferay_aui.button
-				cssClass="btn-link btn-unstyled facet-clear-btn"
-				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
-				value="clear"
-			/>
 		</#if>
 	</@>
 </@>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/user/facet/portlet/display/template/dependencies/portlet_display_template_compact.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/user/facet/portlet/display/template/dependencies/portlet_display_template_compact.ftl
@@ -12,6 +12,14 @@
 		persistState=true
 		title="user"
 	>
+		<#if !userSearchFacetDisplayContext.isNothingSelected()>
+			<@liferay_aui.button
+				cssClass="btn-link btn-unstyled facet-clear-btn"
+				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
+				value="clear"
+			/>
+		</#if>
+
 		<ul class="list-unstyled">
 			<#if entries?has_content>
 				<#list entries as entry>
@@ -34,13 +42,5 @@
 				</#list>
 			</#if>
 		</ul>
-
-		<#if !userSearchFacetDisplayContext.isNothingSelected()>
-			<@liferay_aui.button
-				cssClass="btn-link btn-unstyled facet-clear-btn"
-				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
-				value="clear"
-			/>
-		</#if>
 	</@>
 </@>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/user/facet/portlet/display/template/dependencies/portlet_display_template_label.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/user/facet/portlet/display/template/dependencies/portlet_display_template_label.ftl
@@ -12,6 +12,14 @@
 		persistState=true
 		title="user"
 	>
+		<#if !userSearchFacetDisplayContext.isNothingSelected()>
+			<@liferay_aui.button
+				cssClass="btn-link btn-unstyled facet-clear-btn"
+				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
+				value="clear"
+			/>
+		</#if>
+
 		<#if entries?has_content>
 			<div class="label-container">
 				<#list entries as entry>
@@ -32,14 +40,6 @@
 					</button>
 				</#list>
 			</div>
-		</#if>
-
-		<#if !userSearchFacetDisplayContext.isNothingSelected()>
-			<@liferay_aui.button
-				cssClass="btn-link btn-unstyled facet-clear-btn"
-				onClick="Liferay.Search.FacetUtil.clearSelections(event);"
-				value="clear"
-			/>
 		</#if>
 	</@>
 </@>


### PR DESCRIPTION
**Story:** https://issues.liferay.com/browse/LPS-163888
**Subtask:** https://issues.liferay.com/browse/LPS-179376

Follow up to https://github.com/liferay-search/liferay-portal/pull/857

**New Changes:**
- Added adjustments to the styling

**Original comment:**
> Pretty straightforward, this moves the 'Clear' button to above the facets, for better ux.(https://issues.liferay.com/browse/COMMERCE-9253)

**Screenshots:**
![Screenshot 2023-03-27 at 7 17 32 PM](https://user-images.githubusercontent.com/4496722/228112664-f4f804d8-334c-402a-9288-8b02ad8b5c79.png)
