### PR TITLE
7.4-blocker | LPS-179861 Duplicate entry 'SEARCH-BAR-LEFT-ALIGNED-ICON-FTL' during upgrade to GA/U67+ under specific circumstances 

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_3_0/DDMTemplateUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_3_0/DDMTemplateUpgradeProcess.java
@@ -38,53 +38,49 @@ public class DDMTemplateUpgradeProcess extends UpgradeProcess {
 		long resourceClassNameId = _classNameLocalService.getClassNameId(
 			"com.liferay.portlet.display.template.PortletDisplayTemplate");
 
-		_deleteOrphanedDefaultSearchBarPortletTemplate(
-			resourceClassNameId,
-			"com.liferay.portal.search.web.internal.search.bar.portlet." +
-				"display.context.SearchBarPortletDisplayContext");
-		_deleteOrphanedDefaultSearchBarPortletTemplate(
-			resourceClassNameId,
-			"com.liferay.portal.search.web.internal.search.bar.portlet." +
-				"SearchBarPortletDisplayContext");
+		for (String oldClassName : _OLD_CLASS_NAMES) {
+			long oldClassNameId = _classNameLocalService.getClassNameId(
+				oldClassName);
 
-		_updateDDMTemplate(
-			newClassNameId,
-			"com.liferay.portal.search.web.internal.search.bar.portlet." +
-				"display.context.SearchBarPortletDisplayContext",
-			resourceClassNameId);
-		_updateDDMTemplate(
-			newClassNameId,
-			"com.liferay.portal.search.web.internal.search.bar.portlet." +
-				"SearchBarPortletDisplayContext",
-			resourceClassNameId);
+			_deleteOrphanedDefaultSearchBarPortletTemplate(
+				oldClassNameId, resourceClassNameId);
+
+			_updateDDMTemplate(
+				newClassNameId, oldClassNameId, resourceClassNameId);
+		}
 	}
 
 	private void _deleteOrphanedDefaultSearchBarPortletTemplate(
-			long resourceClassNameId, String className)
+			long oldClassNameId, long resourceClassNameId)
 		throws Exception {
 
 		runSQL(
 			StringBundler.concat(
 				"delete from DDMTemplate where resourceClassNameId = ",
-				resourceClassNameId, " and classNameId = ",
-				_classNameLocalService.getClassNameId(className),
+				resourceClassNameId, " and classNameId = ", oldClassNameId,
 				" and templateKey = ", _DEFAULT_SEARCH_BAR_TEMPLATE_KEY));
 	}
 
 	private void _updateDDMTemplate(
-			long newClassNameId, String oldClassName, long resourceClassNameId)
+			long newClassNameId, long oldClassNameId, long resourceClassNameId)
 		throws Exception {
 
 		runSQL(
 			StringBundler.concat(
 				"update DDMTemplate set classNameId = ", newClassNameId,
-				" where classNameId = ",
-				_classNameLocalService.getClassNameId(oldClassName),
+				" where classNameId = ", oldClassNameId,
 				" and resourceClassNameId = ", resourceClassNameId));
 	}
 
 	private static final String _DEFAULT_SEARCH_BAR_TEMPLATE_KEY =
 		"'SEARCH-BAR-LEFT-ALIGNED-ICON-FTL'";
+
+	private static final String[] _OLD_CLASS_NAMES = {
+		"com.liferay.portal.search.web.internal.search.bar.portlet.display." +
+			"context.SearchBarPortletDisplayContext",
+		"com.liferay.portal.search.web.internal.search.bar.portlet." +
+			"SearchBarPortletDisplayContext"
+	};
 
 	private final ClassNameLocalService _classNameLocalService;
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_3_0/DDMTemplateUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_3_0/DDMTemplateUpgradeProcess.java
@@ -34,8 +34,18 @@ public class DDMTemplateUpgradeProcess extends UpgradeProcess {
 		long newClassNameId = _classNameLocalService.getClassNameId(
 			"com.liferay.portal.search.web.internal.search.bar.portlet." +
 				"SearchBarPortlet");
+
 		long resourceClassNameId = _classNameLocalService.getClassNameId(
 			"com.liferay.portlet.display.template.PortletDisplayTemplate");
+
+		_deleteOrphanedDefaultSearchBarPortletTemplate(
+			resourceClassNameId,
+			"com.liferay.portal.search.web.internal.search.bar.portlet." +
+				"display.context.SearchBarPortletDisplayContext");
+		_deleteOrphanedDefaultSearchBarPortletTemplate(
+			resourceClassNameId,
+			"com.liferay.portal.search.web.internal.search.bar.portlet." +
+				"SearchBarPortletDisplayContext");
 
 		_updateDDMTemplate(
 			newClassNameId,
@@ -49,6 +59,18 @@ public class DDMTemplateUpgradeProcess extends UpgradeProcess {
 			resourceClassNameId);
 	}
 
+	private void _deleteOrphanedDefaultSearchBarPortletTemplate(
+			long resourceClassNameId, String className)
+		throws Exception {
+
+		runSQL(
+			StringBundler.concat(
+				"delete from DDMTemplate where resourceClassNameId = ",
+				resourceClassNameId, " and classNameId = ",
+				_classNameLocalService.getClassNameId(className),
+				" and templateKey = ", _DEFAULT_SEARCH_BAR_TEMPLATE_KEY));
+	}
+
 	private void _updateDDMTemplate(
 			long newClassNameId, String oldClassName, long resourceClassNameId)
 		throws Exception {
@@ -60,6 +82,9 @@ public class DDMTemplateUpgradeProcess extends UpgradeProcess {
 				_classNameLocalService.getClassNameId(oldClassName),
 				" and resourceClassNameId = ", resourceClassNameId));
 	}
+
+	private static final String _DEFAULT_SEARCH_BAR_TEMPLATE_KEY =
+		"'SEARCH-BAR-LEFT-ALIGNED-ICON-FTL'";
 
 	private final ClassNameLocalService _classNameLocalService;
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-179861

Applying a pattern similar to https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_2_0/DDMFacetTemplateUpgradeProcess.java#L39

Note:


Besides fixing the logic in `v5_3_0` (which has already been released in GA/U67), we can skip adding a new upgrade process, because,
* If v5_3_0 fails in an env, they can't complete the upgrade to 67+, the schema version remains as before. They can complete the upgrade when U70 will be out, with this fix. :white_check_mark: 
* And for those who have already completed the upgrade to U67+ without duplicate errors, there is nothing to "delete" (as orphaned). :white_check_mark: 

Confirmed the above reasoning with Chaparro. ✅ 