### PR TITLE
LPS-179782 search-experiences-web: Rerender asset types modal to get most current list

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/SearchableTypesModal.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/SearchableTypesModal.js
@@ -20,18 +20,14 @@ import React, {useState} from 'react';
 import sub from '../../utils/language/sub';
 
 function SearchableTypesModal({
-	children,
+	observer,
+	onClose,
 	onFetchSearchableTypes,
 	onFrameworkConfigChange,
 	searchableTypes,
 	selectedTypes,
 }) {
-	const [visible, setVisible] = useState(false);
 	const [modalSelectedTypes, setModalSelectedTypes] = useState(selectedTypes);
-
-	const {observer, onClose} = useModal({
-		onClose: () => setVisible(false),
-	});
 
 	const searchableTypesClassNames = searchableTypes.map(
 		({className}) => className
@@ -56,177 +52,189 @@ function SearchableTypesModal({
 	};
 
 	return (
-		<>
-			{visible && (
-				<ClayModal
-					className="modal-height-xl sxp-searchable-types-modal-root"
-					observer={observer}
-					size="lg"
-				>
-					<ClayModal.Header>
-						{Liferay.Language.get('select-types')}
-					</ClayModal.Header>
+		<ClayModal
+			className="modal-height-xl sxp-searchable-types-modal-root"
+			observer={observer}
+			size="lg"
+		>
+			<ClayModal.Header>
+				{Liferay.Language.get('select-types')}
+			</ClayModal.Header>
 
-					{searchableTypes.length ? (
-						<>
-							<ManagementToolbar.Container
-								className={
-									!!modalSelectedTypes.length &&
-									'management-bar-primary'
-								}
-							>
-								<div className="navbar-form navbar-form-autofit navbar-overlay">
-									<ManagementToolbar.ItemList>
-										<ManagementToolbar.Item>
-											<ClayCheckbox
-												checked={
-													!!modalSelectedTypes.length
-												}
-												indeterminate={
-													!!modalSelectedTypes.length &&
-													modalSelectedTypes.length !==
-														searchableTypes.length
-												}
-												onChange={() =>
-													setModalSelectedTypes(
-														!modalSelectedTypes.length
-															? searchableTypesClassNames
-															: []
-													)
-												}
-											/>
-										</ManagementToolbar.Item>
+			{searchableTypes.length ? (
+				<>
+					<ManagementToolbar.Container
+						className={
+							!!modalSelectedTypes.length &&
+							'management-bar-primary'
+						}
+					>
+						<div className="navbar-form navbar-form-autofit navbar-overlay">
+							<ManagementToolbar.ItemList>
+								<ManagementToolbar.Item>
+									<ClayCheckbox
+										checked={!!modalSelectedTypes.length}
+										indeterminate={
+											!!modalSelectedTypes.length &&
+											modalSelectedTypes.length !==
+												searchableTypes.length
+										}
+										onChange={() =>
+											setModalSelectedTypes(
+												!modalSelectedTypes.length
+													? searchableTypesClassNames
+													: []
+											)
+										}
+									/>
+								</ManagementToolbar.Item>
 
-										<ManagementToolbar.Item>
-											{modalSelectedTypes.length ? (
-												<>
-													<span className="component-text">
-														{sub(
-															Liferay.Language.get(
-																'x-of-x-selected'
-															),
-															[
-																modalSelectedTypes.length,
-																searchableTypes.length,
-															],
-															false
-														)}
-													</span>
+								<ManagementToolbar.Item>
+									{modalSelectedTypes.length ? (
+										<>
+											<span className="component-text">
+												{sub(
+													Liferay.Language.get(
+														'x-of-x-selected'
+													),
+													[
+														modalSelectedTypes.length,
+														searchableTypes.length,
+													],
+													false
+												)}
+											</span>
 
-													{modalSelectedTypes.length <
-														searchableTypes.length && (
-														<ClayButton
-															displayType="link"
-															onClick={() => {
-																setModalSelectedTypes(
-																	searchableTypesClassNames
-																);
-															}}
-															small
-														>
-															{Liferay.Language.get(
-																'select-all'
-															)}
-														</ClayButton>
-													)}
-												</>
-											) : (
-												<span className="component-text">
+											{modalSelectedTypes.length <
+												searchableTypes.length && (
+												<ClayButton
+													displayType="link"
+													onClick={() => {
+														setModalSelectedTypes(
+															searchableTypesClassNames
+														);
+													}}
+													small
+												>
 													{Liferay.Language.get(
 														'select-all'
 													)}
-												</span>
+												</ClayButton>
 											)}
-										</ManagementToolbar.Item>
-									</ManagementToolbar.ItemList>
-								</div>
-							</ManagementToolbar.Container>
+										</>
+									) : (
+										<span className="component-text">
+											{Liferay.Language.get('select-all')}
+										</span>
+									)}
+								</ManagementToolbar.Item>
+							</ManagementToolbar.ItemList>
+						</div>
+					</ManagementToolbar.Container>
 
-							<ClayModal.Body scrollable>
-								<ClayTable>
-									<ClayTable.Body>
-										{searchableTypes.map(
-											({className, displayName}) => {
-												const isSelected = modalSelectedTypes.includes(
+					<ClayModal.Body scrollable>
+						<ClayTable>
+							<ClayTable.Body>
+								{searchableTypes.map(
+									({className, displayName}) => {
+										const isSelected = modalSelectedTypes.includes(
+											className
+										);
+
+										return (
+											<ClayTable.Row
+												active={isSelected}
+												key={className}
+												onClick={_handleRowCheck(
 													className
-												);
-
-												return (
-													<ClayTable.Row
-														active={isSelected}
-														key={className}
-														onClick={_handleRowCheck(
+												)}
+											>
+												<ClayTable.Cell>
+													<ClayCheckbox
+														checked={isSelected}
+														onChange={_handleRowCheck(
 															className
 														)}
-													>
-														<ClayTable.Cell>
-															<ClayCheckbox
-																checked={
-																	isSelected
-																}
-																onChange={_handleRowCheck(
-																	className
-																)}
-															/>
-														</ClayTable.Cell>
+													/>
+												</ClayTable.Cell>
 
-														<ClayTable.Cell
-															expanded
-															headingTitle
-														>
-															{displayName}
-														</ClayTable.Cell>
-													</ClayTable.Row>
-												);
-											}
-										)}
-									</ClayTable.Body>
-								</ClayTable>
-							</ClayModal.Body>
-						</>
-					) : (
-						<ClayModal.Body>
-							<ClayEmptyState
-								description={Liferay.Language.get(
-									'an-error-has-occurred-and-we-were-unable-to-load-the-results'
+												<ClayTable.Cell
+													expanded
+													headingTitle
+												>
+													{displayName}
+												</ClayTable.Cell>
+											</ClayTable.Row>
+										);
+									}
 								)}
-								imgSrc="/o/admin-theme/images/states/empty_state.gif"
-								title={Liferay.Language.get(
-									'no-items-were-found'
-								)}
-							>
-								<ClayButton
-									displayType="secondary"
-									onClick={onFetchSearchableTypes}
-								>
-									{Liferay.Language.get('refresh')}
-								</ClayButton>
-							</ClayEmptyState>
-						</ClayModal.Body>
-					)}
+							</ClayTable.Body>
+						</ClayTable>
+					</ClayModal.Body>
+				</>
+			) : (
+				<ClayModal.Body>
+					<ClayEmptyState
+						description={Liferay.Language.get(
+							'an-error-has-occurred-and-we-were-unable-to-load-the-results'
+						)}
+						imgSrc="/o/admin-theme/images/states/empty_state.gif"
+						title={Liferay.Language.get('no-items-were-found')}
+					>
+						<ClayButton
+							displayType="secondary"
+							onClick={onFetchSearchableTypes}
+						>
+							{Liferay.Language.get('refresh')}
+						</ClayButton>
+					</ClayEmptyState>
+				</ClayModal.Body>
+			)}
 
-					<ClayModal.Footer
-						last={
-							<ClayButton.Group spaced>
-								<ClayButton
-									displayType="secondary"
-									onClick={onClose}
-								>
-									{Liferay.Language.get('cancel')}
-								</ClayButton>
+			<ClayModal.Footer
+				last={
+					<ClayButton.Group spaced>
+						<ClayButton displayType="secondary" onClick={onClose}>
+							{Liferay.Language.get('cancel')}
+						</ClayButton>
 
-								<ClayButton onClick={_handleModalDone}>
-									{Liferay.Language.get('done')}
-								</ClayButton>
-							</ClayButton.Group>
-						}
-					/>
-				</ClayModal>
+						<ClayButton onClick={_handleModalDone}>
+							{Liferay.Language.get('done')}
+						</ClayButton>
+					</ClayButton.Group>
+				}
+			/>
+		</ClayModal>
+	);
+}
+
+export default function ({
+	children,
+	onFetchSearchableTypes,
+	onFrameworkConfigChange,
+	searchableTypes,
+	selectedTypes,
+}) {
+	const [visible, setVisible] = useState(false);
+
+	const {observer, onClose} = useModal({
+		onClose: () => setVisible(false),
+	});
+
+	return (
+		<>
+			{visible && (
+				<SearchableTypesModal
+					observer={observer}
+					onClose={onClose}
+					onFetchSearchableTypes={onFetchSearchableTypes}
+					onFrameworkConfigChange={onFrameworkConfigChange}
+					searchableTypes={searchableTypes}
+					selectedTypes={selectedTypes}
+				/>
 			)}
 
 			<span onClick={() => setVisible(!visible)}>{children}</span>
 		</>
 	);
 }
-
-export default React.memo(SearchableTypesModal);

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/SearchableTypesModal.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/SearchableTypesModal.js
@@ -20,14 +20,16 @@ import React, {useState} from 'react';
 import sub from '../../utils/language/sub';
 
 function SearchableTypesModal({
+	initialSelectedTypes,
 	observer,
 	onClose,
 	onFetchSearchableTypes,
 	onFrameworkConfigChange,
 	searchableTypes,
-	selectedTypes,
 }) {
-	const [modalSelectedTypes, setModalSelectedTypes] = useState(selectedTypes);
+	const [modalSelectedTypes, setModalSelectedTypes] = useState(
+		initialSelectedTypes
+	);
 
 	const searchableTypesClassNames = searchableTypes.map(
 		({className}) => className
@@ -210,31 +212,31 @@ function SearchableTypesModal({
 
 export default function ({
 	children,
+	initialSelectedTypes,
 	onFetchSearchableTypes,
 	onFrameworkConfigChange,
 	searchableTypes,
-	selectedTypes,
 }) {
-	const [visible, setVisible] = useState(false);
+	const {observer, onOpenChange, open} = useModal();
 
-	const {observer, onClose} = useModal({
-		onClose: () => setVisible(false),
-	});
+	const _handleClose = () => {
+		onOpenChange(false);
+	};
 
 	return (
 		<>
-			{visible && (
+			{open && (
 				<SearchableTypesModal
+					initialSelectedTypes={initialSelectedTypes}
 					observer={observer}
-					onClose={onClose}
+					onClose={_handleClose}
 					onFetchSearchableTypes={onFetchSearchableTypes}
 					onFrameworkConfigChange={onFrameworkConfigChange}
 					searchableTypes={searchableTypes}
-					selectedTypes={selectedTypes}
 				/>
 			)}
 
-			<span onClick={() => setVisible(!visible)}>{children}</span>
+			<span onClick={() => onOpenChange(!open)}>{children}</span>
 		</>
 	);
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/SelectTypes.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/SelectTypes.js
@@ -40,10 +40,10 @@ function SelectTypes({
 	return (
 		<>
 			<SearchableTypesModal
+				initialSelectedTypes={selectedTypes}
 				onFetchSearchableTypes={onFetchSearchableTypes}
 				onFrameworkConfigChange={onFrameworkConfigChange}
 				searchableTypes={searchableTypesSorted}
-				selectedTypes={selectedTypes}
 			>
 				<ClayButton
 					className="select-types-button"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-179782 - Blueprints deselect asset type doesn't remove from pop-up

It seemed like the issue was that the `modalSelectedTypes` state inside `SearchableTypesModal` wouldn't be the most up-to-date since the user is able to delete asset types on the main page, but the modal doesn't update for that. Luckily, the outdated list doesn't get saved with the blueprint. To address the bug, the component `SearchableTypesModal` just gets rendered again with the most current `selectedTypes`.

Let me know what you think, several other search experiences modals get rendered again when visibility is set to true (like `EditTitleModal`). I don't think I noticed other cases of this bug happening, but if you do, lmk!