### PR TITLE
LPS-174196 LPS-174551 portal-search-elasticsearch7-impl: Inline private method that were unecessary

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterSearchRequestTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterSearchRequestTest.java
@@ -166,13 +166,9 @@ public class ElasticsearchSearchEngineAdapterSearchRequestTest {
 		_indexSuggestKeyword(RandomTestUtil.randomString());
 		_indexSuggestKeyword(RandomTestUtil.randomString());
 
-		SearchSearchRequest searchSearchRequest = new SearchSearchRequest();
+		SearchSearchRequest searchSearchRequest = _getSearchSearchRequest();
 
-		searchSearchRequest.setIndexNames(_INDEX_NAME);
 		searchSearchRequest.setScrollKeepAliveMinutes(1);
-		searchSearchRequest.setQuery(new MatchAllQuery());
-		searchSearchRequest.setStart(0);
-		searchSearchRequest.setSize(1);
 
 		SearchSearchResponse searchSearchResponse =
 			_searchEngineAdapter.execute(searchSearchRequest);
@@ -190,21 +186,15 @@ public class ElasticsearchSearchEngineAdapterSearchRequestTest {
 		_indexSuggestKeyword(RandomTestUtil.randomString());
 		_indexSuggestKeyword(RandomTestUtil.randomString());
 
-		SearchSearchRequest searchSearchRequest = new SearchSearchRequest();
+		SearchSearchRequest searchSearchRequest = _getSearchSearchRequest();
 
-		searchSearchRequest.setIndexNames(_INDEX_NAME);
 		searchSearchRequest.setPointInTime(_getPointInTime());
-		searchSearchRequest.setQuery(new MatchAllQuery());
-		searchSearchRequest.setSize(1);
 		searchSearchRequest.setSorts(new Sort[] {new Sort("_count", true)});
-		searchSearchRequest.setStart(0);
 
-		SearchSearchResponse searchSearchResponse = null;
+		SearchSearchResponse searchSearchResponse =
+			_searchEngineAdapter.execute(searchSearchRequest);
 
 		for (int i = 0; i < 3; i++) {
-			searchSearchResponse = _searchEngineAdapter.execute(
-				searchSearchRequest);
-
 			Assert.assertEquals(1, _getDocumentsLength(searchSearchResponse));
 
 			searchSearchResponse = _searchAfter(
@@ -464,6 +454,17 @@ public class ElasticsearchSearchEngineAdapterSearchRequestTest {
 			_searchEngineAdapter.execute(openPointInTimeRequest);
 
 		return new PointInTime(openPointInTimeResponse.pitId());
+	}
+
+	private SearchSearchRequest _getSearchSearchRequest() {
+		SearchSearchRequest searchSearchRequest = new SearchSearchRequest();
+
+		searchSearchRequest.setIndexNames(_INDEX_NAME);
+		searchSearchRequest.setQuery(new MatchAllQuery());
+		searchSearchRequest.setSize(1);
+		searchSearchRequest.setStart(0);
+
+		return searchSearchRequest;
 	}
 
 	private String _getUID(String value) {

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/search/SearchRequestExecutorFixture.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/search/SearchRequestExecutorFixture.java
@@ -267,6 +267,20 @@ public class SearchRequestExecutorFixture {
 		return multisearchSearchRequestExecutor;
 	}
 
+	private OpenPointInTimeRequestExecutor
+		_createOpenPointInTimeRequestExecutor(
+			ElasticsearchClientResolver elasticsearchClientResolver) {
+
+		OpenPointInTimeRequestExecutor openPointInTimeRequestExecutor =
+			new OpenPointInTimeRequestExecutorImpl();
+
+		ReflectionTestUtil.setFieldValue(
+			openPointInTimeRequestExecutor, "_elasticsearchClientResolver",
+			elasticsearchClientResolver);
+
+		return openPointInTimeRequestExecutor;
+	}
+
 	private SearchRequestExecutor _createSearchRequestExecutor(
 		ComplexQueryBuilderFactory complexQueryBuilderFactory,
 		ElasticsearchClientResolver elasticsearchClientResolver,
@@ -304,6 +318,9 @@ public class SearchRequestExecutorFixture {
 			_createMultisearchSearchRequestExecutor(
 				elasticsearchClientResolver, searchSearchRequestAssembler,
 				searchSearchResponseAssembler));
+		ReflectionTestUtil.setFieldValue(
+			searchRequestExecutor, "_openPointInTimeRequestExecutor",
+			_createOpenPointInTimeRequestExecutor(elasticsearchClientResolver));
 		ReflectionTestUtil.setFieldValue(
 			searchRequestExecutor, "_searchSearchRequestExecutor",
 			_createSearchSearchRequestExecutor(


### PR DESCRIPTION
Scrolls:

https://issues.liferay.com/browse/LPS-179382

What the test does:

1. Index 3 documents
2. Create SearchSearchRequest and set fields (need to set scroll to keep alive minutes to use scroll)
3. Execute the first search without scroll
4. Execute 3 more searches using scroll
5. The last search will return anything proving that the pagination is working

SearchAfter:

https://issues.liferay.com/browse/LPS-174551

What the test does:

1. Index 3 documents
2. Create SearchSearchRequest and set fields (need to set point in time and Sorts to use Search After)
3. Execute the first search without search after
4. Execute 3 more searches using search after
5. The last search will return anything, proving that the pagination is working.
 (one document per page until the last one without anything)
