### PR TITLE
LPS-169035 portal-search-web: Allow customization of no-results display and pagination in a Search Results widget template

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/results/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/results/view.jsp
@@ -14,13 +14,9 @@
  */
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
-taglib uri="http://liferay.com/tld/ddm" prefix="liferay-ddm" %><%@
-taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+<%@ taglib uri="http://liferay.com/tld/ddm" prefix="liferay-ddm" %>
 
 <%@ page import="com.liferay.portal.kernel.dao.search.SearchContainer" %><%@
 page import="com.liferay.portal.kernel.model.User" %><%@
@@ -66,13 +62,3 @@ SearchContainer<Document> searchContainer = searchResultsPortletDisplayContext.g
 	displayStyleGroupId="<%= searchResultsPortletDisplayContext.getDisplayStyleGroupId() %>"
 	entries="<%= searchResultSummaryDisplayContexts %>"
 />
-
-<c:if test="<%= !searchResultSummaryDisplayContexts.isEmpty() %>">
-	<aui:form action="#" useNamespace="<%= false %>">
-		<liferay-ui:search-paginator
-			id='<%= liferayPortletResponse.getNamespace() + "searchContainerTag" %>'
-			markupView="lexicon"
-			searchContainer="<%= searchContainer %>"
-		/>
-	</aui:form>
-</c:if>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/results/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/results/view.jsp
@@ -20,15 +20,12 @@
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/ddm" prefix="liferay-ddm" %><%@
-taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.portal.kernel.dao.search.SearchContainer" %><%@
-page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.User" %><%@
 page import="com.liferay.portal.kernel.search.Document" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
-page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.portal.search.web.internal.result.display.context.SearchResultSummaryDisplayContext" %><%@
 page import="com.liferay.portal.search.web.internal.search.results.configuration.SearchResultsPortletInstanceConfiguration" %><%@
@@ -52,40 +49,30 @@ List<SearchResultSummaryDisplayContext> searchResultSummaryDisplayContexts = sea
 SearchContainer<Document> searchContainer = searchResultsPortletDisplayContext.getSearchContainer();
 %>
 
-<c:choose>
-	<c:when test="<%= searchResultSummaryDisplayContexts.isEmpty() %>">
-		<div class="sheet">
-			<liferay-frontend:empty-result-message
-				description='<%= LanguageUtil.format(request, "no-results-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>", false) %>'
-				title='<%= LanguageUtil.format(request, "no-results-were-found", false) %>'
-			/>
-		</div>
-	</c:when>
-	<c:otherwise>
-		<liferay-ddm:template-renderer
-			className="<%= SearchResultSummaryDisplayContext.class.getName() %>"
-			contextObjects='<%=
-				HashMapBuilder.<String, Object>put(
-					"namespace", liferayPortletResponse.getNamespace()
-				).put(
-					"searchContainer", searchContainer
-				).put(
-					"searchResultsPortletDisplayContext", searchResultsPortletDisplayContext
-				).put(
-					"userClassName", User.class.getName()
-				).build()
-			%>'
-			displayStyle="<%= searchResultsPortletInstanceConfiguration.displayStyle() %>"
-			displayStyleGroupId="<%= searchResultsPortletDisplayContext.getDisplayStyleGroupId() %>"
-			entries="<%= searchResultSummaryDisplayContexts %>"
-		/>
+<liferay-ddm:template-renderer
+	className="<%= SearchResultSummaryDisplayContext.class.getName() %>"
+	contextObjects='<%=
+		HashMapBuilder.<String, Object>put(
+			"namespace", liferayPortletResponse.getNamespace()
+		).put(
+			"searchContainer", searchContainer
+		).put(
+			"searchResultsPortletDisplayContext", searchResultsPortletDisplayContext
+		).put(
+			"userClassName", User.class.getName()
+		).build()
+	%>'
+	displayStyle="<%= searchResultsPortletInstanceConfiguration.displayStyle() %>"
+	displayStyleGroupId="<%= searchResultsPortletDisplayContext.getDisplayStyleGroupId() %>"
+	entries="<%= searchResultSummaryDisplayContexts %>"
+/>
 
-		<aui:form action="#" useNamespace="<%= false %>">
-			<liferay-ui:search-paginator
-				id='<%= liferayPortletResponse.getNamespace() + "searchContainerTag" %>'
-				markupView="lexicon"
-				searchContainer="<%= searchContainer %>"
-			/>
-		</aui:form>
-	</c:otherwise>
-</c:choose>
+<c:if test="<%= !searchResultSummaryDisplayContexts.isEmpty() %>">
+	<aui:form action="#" useNamespace="<%= false %>">
+		<liferay-ui:search-paginator
+			id='<%= liferayPortletResponse.getNamespace() + "searchContainerTag" %>'
+			markupView="lexicon"
+			searchContainer="<%= searchContainer %>"
+		/>
+	</aui:form>
+</c:if>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_card.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_card.ftl
@@ -94,4 +94,15 @@
 			</#list>
 		</ul>
 	</div>
+
+	<@liferay_aui.form
+		action="#"
+		useNamespace=false
+	>
+		<@liferay_ui["search-paginator"]
+			id="${namespace + 'searchContainerTag'}"
+			markupView="lexicon"
+			searchContainer=searchContainer
+		/>
+	</@liferay_aui.form>
 </#if>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_card.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_card.ftl
@@ -1,14 +1,22 @@
-<div class="c-mb-4 c-mt-4 search-total-label">
-	<#if searchContainer.getTotal() == 1>
-		${languageUtil.format(locale, "x-result-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
-	<#else>
-		${languageUtil.format(locale, "x-results-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
-	</#if>
-</div>
+<#if !entries?has_content>
+	<div class="sheet">
+		<@liferay_frontend["empty-result-message"]
+			description='${languageUtil.format(locale, "no-results-were-found-that-matched-the-keywords-x",	"<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>", false)}'
+			title='${languageUtil.format(request, "no-results-were-found", false)}'
+		/>
+	</div>
 
-<div class="display-card">
-	<ul class="card-page">
-		<#if entries?has_content>
+<#else>
+	<div class="c-mb-4 c-mt-4 search-total-label">
+		<#if searchContainer.getTotal() == 1>
+			${languageUtil.format(locale, "x-result-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
+		<#else>
+			${languageUtil.format(locale, "x-results-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
+		</#if>
+	</div>
+
+	<div class="display-card">
+		<ul class="card-page">
 			<#list entries as entry>
 				<li class="card-page-item card-page-item-asset">
 					<div class="card card-type-asset file-card">
@@ -84,6 +92,6 @@
 					</div>
 				</li>
 			</#list>
-		</#if>
-	</ul>
-</div>
+		</ul>
+	</div>
+</#if>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_compact.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_compact.ftl
@@ -26,4 +26,15 @@
 			</#list>
 		</ul>
 	</div>
+
+	<@liferay_aui.form
+		action="#"
+		useNamespace=false
+	>
+		<@liferay_ui["search-paginator"]
+			id="${namespace + 'searchContainerTag'}"
+			markupView="lexicon"
+			searchContainer=searchContainer
+		/>
+	</@liferay_aui.form>
 </#if>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_compact.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_compact.ftl
@@ -1,14 +1,22 @@
-<div class="c-mb-4 c-mt-4 search-total-label">
-	<#if searchContainer.getTotal() == 1>
-		${languageUtil.format(locale, "x-result-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
-	<#else>
-		${languageUtil.format(locale, "x-results-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
-	</#if>
-</div>
+<#if !entries?has_content>
+	<div class="sheet">
+		<@liferay_frontend["empty-result-message"]
+			description='${languageUtil.format(locale, "no-results-were-found-that-matched-the-keywords-x", "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>", false)}'
+			title='${languageUtil.format(request, "no-results-were-found", false)}'
+		/>
+	</div>
 
-<div class="display-compact">
-	<ul class="list-unstyled">
-		<#if entries?has_content>
+<#else>
+	<div class="c-mb-4 c-mt-4 search-total-label">
+		<#if searchContainer.getTotal() == 1>
+			${languageUtil.format(locale, "x-result-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
+		<#else>
+			${languageUtil.format(locale, "x-results-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
+		</#if>
+	</div>
+
+	<div class="display-compact">
+		<ul class="list-unstyled">
 			<#list entries as entry>
 				<li class="c-mb-3 c-mt-3">
 					<a class="link-primary single-link" href="${entry.getViewURL()}">
@@ -16,6 +24,6 @@
 					</a>
 				</li>
 			</#list>
-		</#if>
-	</ul>
-</div>
+		</ul>
+	</div>
+</#if>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_list.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_list.ftl
@@ -1,14 +1,22 @@
-<div class="c-mb-4 c-mt-4 search-total-label">
-	<#if searchContainer.getTotal() == 1>
-		${languageUtil.format(locale, "x-result-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
-	<#else>
-		${languageUtil.format(locale, "x-results-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
-	</#if>
-</div>
+<#if !entries?has_content>
+	<div class="sheet">
+		<@liferay_frontend["empty-result-message"]
+			description='${languageUtil.format(locale, "no-results-were-found-that-matched-the-keywords-x", "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>", false)}'
+			title='${languageUtil.format(request, "no-results-were-found", false)}'
+		/>
+	</div>
 
-<div class="display-list">
-	<ul class="list-group" id="search-results-display-list">
-		<#if entries?has_content>
+<#else>
+	<div class="c-mb-4 c-mt-4 search-total-label">
+		<#if searchContainer.getTotal() == 1>
+			${languageUtil.format(locale, "x-result-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
+		<#else>
+			${languageUtil.format(locale, "x-results-for-x", [searchContainer.getTotal(), "<strong>" + htmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"], false)}
+		</#if>
+	</div>
+
+	<div class="display-list">
+		<ul class="list-group" id="search-results-display-list">
 			<#list entries as entry>
 				<li class="list-group-item list-group-item-flex">
 					<div class="autofit-col">
@@ -161,18 +169,18 @@
 					</div>
 				</li>
 			</#list>
-		</#if>
-	</ul>
-</div>
+		</ul>
+	</div>
 
-<@liferay_aui.script use="aui-base">
-	A.one('#search-results-display-list').delegate(
-		'click',
-		function(event) {
-			var currentTarget = event.currentTarget;
+	<@liferay_aui.script use="aui-base">
+		A.one('#search-results-display-list').delegate(
+			'click',
+			function(event) {
+				var currentTarget = event.currentTarget;
 
-			currentTarget.siblings('.search-results-list').toggleClass('hide');
-		},
-		'.expand-details'
-	);
-</@liferay_aui.script>
+				currentTarget.siblings('.search-results-list').toggleClass('hide');
+			},
+			'.expand-details'
+		);
+	</@liferay_aui.script>
+</#if>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_list.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_list.ftl
@@ -172,6 +172,17 @@
 		</ul>
 	</div>
 
+	<@liferay_aui.form
+		action="#"
+		useNamespace=false
+	>
+		<@liferay_ui["search-paginator"]
+			id="${namespace + 'searchContainerTag'}"
+			markupView="lexicon"
+			searchContainer=searchContainer
+		/>
+	</@liferay_aui.form>
+
 	<@liferay_aui.script use="aui-base">
 		A.one('#search-results-display-list').delegate(
 			'click',


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-181641 - [FE] Move "no results" display into template renderer
https://issues.liferay.com/browse/LPS-181642 - [FE] Move pagination into template renderer

Changes offer more flexibility for users by letting the current search results templates have control over pagination and default empty view (moves the `search-paginator` from `liferay-ui` and `empty-results-message` from `liferay-frontend` into the .ftl). There shouldn't be any visual changes to the results view!

@thektan 