### PR TITLE
LPS-177107 screenName changes

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -1597,6 +1597,11 @@
 				"type": "keyword"
 			},
 			"screenName": {
+				"fields": {
+					"text": {
+						"type": "text"
+					}
+				},
 				"store": true,
 				"type": "keyword"
 			},

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
@@ -1608,6 +1608,11 @@
 					"type": "keyword"
 				},
 				"screenName": {
+					"fields": {
+						"text": {
+							"type": "text"
+						}
+					},
 					"store": true,
 					"type": "keyword"
 				},

--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/query/contributor/UserKeywordQueryContributor.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/query/contributor/UserKeywordQueryContributor.java
@@ -66,6 +66,8 @@ public class UserKeywordQueryContributor implements KeywordQueryContributor {
 			booleanQuery, searchContext, "middleName", false);
 		queryHelper.addSearchTerm(booleanQuery, searchContext, "region", false);
 		queryHelper.addSearchTerm(
+			booleanQuery, searchContext, "screenName", false);
+		queryHelper.addSearchTerm(
 			booleanQuery, searchContext, "screenName.text", false);
 		queryHelper.addSearchTerm(booleanQuery, searchContext, "street", false);
 		queryHelper.addSearchTerm(booleanQuery, searchContext, "zip", false);

--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/query/contributor/UserKeywordQueryContributor.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/query/contributor/UserKeywordQueryContributor.java
@@ -66,7 +66,7 @@ public class UserKeywordQueryContributor implements KeywordQueryContributor {
 			booleanQuery, searchContext, "middleName", false);
 		queryHelper.addSearchTerm(booleanQuery, searchContext, "region", false);
 		queryHelper.addSearchTerm(
-			booleanQuery, searchContext, "screenName", false);
+			booleanQuery, searchContext, "screenName.text", false);
 		queryHelper.addSearchTerm(booleanQuery, searchContext, "street", false);
 		queryHelper.addSearchTerm(booleanQuery, searchContext, "zip", false);
 
@@ -81,7 +81,7 @@ public class UserKeywordQueryContributor implements KeywordQueryContributor {
 					_getTrailingWildcardQuery("emailAddressDomain", keywords),
 					BooleanClauseOccur.SHOULD);
 				booleanQuery.add(
-					_getTrailingWildcardQuery("screenName", keywords),
+					_getTrailingWildcardQuery("screenName.text", keywords),
 					BooleanClauseOccur.SHOULD);
 			}
 			catch (ParseException parseException) {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web-test/src/testIntegration/resources/com/liferay/portal/search/tuning/synonyms/web/test/dependencies/SynonymSearchTest-overrideTypeMappings.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web-test/src/testIntegration/resources/com/liferay/portal/search/tuning/synonyms/web/test/dependencies/SynonymSearchTest-overrideTypeMappings.json
@@ -811,6 +811,11 @@
 				"type": "keyword"
 			},
 			"screenName": {
+				"fields": {
+					"text": {
+						"type": "text"
+					}
+				},
 				"store": true,
 				"type": "keyword"
 			},


### PR DESCRIPTION
Redone from https://github.com/drewbrokke/liferay-portal/pull/1424 based on [slack](https://liferay.slack.com/archives/CKY6F59A6/p1682437469029719).
https://issues.liferay.com/browse/LPS-177107

**Author:** @joshuacords 

I'm leaving the keyword field as is and introducing a text field under it that the UserKeywordContributor can use to retain it's old searchability. (username does this too) No change to the type mean no configuration change, no test change, no upgrade.