### PR TITLE
LPS-183021 portal-search-web: Use of stringified action value causes errors on websphere

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_card.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_card.ftl
@@ -94,10 +94,7 @@
 		</ul>
 	</div>
 
-	<@liferay_aui.form
-		action="#"
-		useNamespace=false
-	>
+	<@liferay_aui.form useNamespace=false>
 		<@liferay_ui["search-paginator"]
 			id="${namespace + 'searchContainerTag'}"
 			markupView="lexicon"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_compact.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_compact.ftl
@@ -26,10 +26,7 @@
 		</ul>
 	</div>
 
-	<@liferay_aui.form
-		action="#"
-		useNamespace=false
-	>
+	<@liferay_aui.form useNamespace=false>
 		<@liferay_ui["search-paginator"]
 			id="${namespace + 'searchContainerTag'}"
 			markupView="lexicon"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_list.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_list.ftl
@@ -171,10 +171,7 @@
 		</ul>
 	</div>
 
-	<@liferay_aui.form
-		action="#"
-		useNamespace=false
-	>
+	<@liferay_aui.form useNamespace=false>
 		<@liferay_ui["search-paginator"]
 			id="${namespace + 'searchContainerTag'}"
 			markupView="lexicon"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-183021 - No search results when using websphere

It looks like when `action` is set to a string `#`, it causes syntax errors on websphere. Since `#` is actually omitted in several cases (vocabulary, commerce, fragments) when the page is not supposed to redirect, it should be fine to just avoid setting that value to avoid that websphere error altogether. Search paginator is functional without that value.

https://stackoverflow.com/questions/1131781/is-it-a-good-practice-to-use-an-empty-url-for-a-html-forms-action-attribute-a

```
2023-04-26 15:57:35.380 ERROR [default-16][runtime:59] Error executing FreeMarker template
freemarker.core._TemplateModelException: Failed to set JSP tag parameter "action" (declared type: javax.portlet.PortletURL, actual value's type: String). See cause exception for the more specific cause...

----
Tip: This problem is often caused by unnecessary parameter quotation. Paramters aren't quoted in FTL, similarly as they aren't quoted in most languages. For example, these parameter assignments are wrong: <@my.tag p1="true" p2="10" p3="${someVariable}" p4="${x+1}" />. The correct form is: <@my.tag p1=true p2=10 p3=someVariable p4=x+1 />. Only string literals are quoted (regardless of where they occur): <@my.box style="info" message="Hello ${name}!" width=200 />.
```