### PR TITLE
LPS-183360 portal-search: Hide execution mode in search admin when using Solr

### DIFF
--- a/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/display/context/builder/IndexActionsDisplayContextBuilder.java
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/display/context/builder/IndexActionsDisplayContextBuilder.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.admin.web.internal.display.context.IndexActionsDisplayContext;
+import com.liferay.portal.search.capabilities.SearchCapabilities;
 
 import java.util.Map;
 
@@ -45,12 +46,13 @@ public class IndexActionsDisplayContextBuilder {
 
 	public IndexActionsDisplayContextBuilder(
 		Language language, Portal portal, RenderRequest renderRequest,
-		RenderResponse renderResponse) {
+		RenderResponse renderResponse, SearchCapabilities searchCapabilities) {
 
 		_language = language;
 		_portal = portal;
 		_renderRequest = renderRequest;
 		_renderResponse = renderResponse;
+		_searchCapabilities = searchCapabilities;
 
 		_httpServletRequest = portal.getHttpServletRequest(renderRequest);
 	}
@@ -71,6 +73,8 @@ public class IndexActionsDisplayContextBuilder {
 			"initialExecutionMode", _getInitialExecutionMode()
 		).put(
 			"initialScope", _getInitialScope()
+		).put(
+			"isConcurrentModeSupported", _isConcurrentModeSupported()
 		).put(
 			"virtualInstances", _getVirtualInstancesJSONArray()
 		).build();
@@ -126,6 +130,10 @@ public class IndexActionsDisplayContextBuilder {
 		return jsonArray;
 	}
 
+	private boolean _isConcurrentModeSupported() {
+		return _searchCapabilities.isConcurrentModeSupported();
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		IndexActionsDisplayContextBuilder.class);
 
@@ -134,5 +142,6 @@ public class IndexActionsDisplayContextBuilder {
 	private final Portal _portal;
 	private final RenderRequest _renderRequest;
 	private final RenderResponse _renderResponse;
+	private final SearchCapabilities _searchCapabilities;
 
 }

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/display/context/builder/IndexActionsDisplayContextBuilder.java
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/display/context/builder/IndexActionsDisplayContextBuilder.java
@@ -74,7 +74,8 @@ public class IndexActionsDisplayContextBuilder {
 		).put(
 			"initialScope", _getInitialScope()
 		).put(
-			"isConcurrentModeSupported", _isConcurrentModeSupported()
+			"isConcurrentModeSupported",
+			_searchCapabilities.isConcurrentModeSupported()
 		).put(
 			"virtualInstances", _getVirtualInstancesJSONArray()
 		).build();
@@ -128,10 +129,6 @@ public class IndexActionsDisplayContextBuilder {
 		}
 
 		return jsonArray;
-	}
-
-	private boolean _isConcurrentModeSupported() {
-		return _searchCapabilities.isConcurrentModeSupported();
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/portlet/SearchAdminPortlet.java
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/portlet/SearchAdminPortlet.java
@@ -28,6 +28,7 @@ import com.liferay.portal.search.admin.web.internal.display.context.builder.Inde
 import com.liferay.portal.search.admin.web.internal.display.context.builder.SearchAdminDisplayContextBuilder;
 import com.liferay.portal.search.admin.web.internal.display.context.builder.SearchEngineDisplayContextBuilder;
 import com.liferay.portal.search.admin.web.internal.reindexer.IndexReindexerRegistry;
+import com.liferay.portal.search.capabilities.SearchCapabilities;
 import com.liferay.portal.search.engine.SearchEngineInformation;
 import com.liferay.portal.search.index.IndexInformation;
 
@@ -138,7 +139,8 @@ public class SearchAdminPortlet extends MVCPortlet {
 			IndexActionsDisplayContextBuilder
 				indexActionsDisplayContextBuilder =
 					new IndexActionsDisplayContextBuilder(
-						_language, _portal, renderRequest, renderResponse);
+						_language, _portal, renderRequest, renderResponse,
+						_searchCapabilities);
 
 			renderRequest.setAttribute(
 				SearchAdminWebKeys.INDEX_ACTIONS_DISPLAY_CONTEXT,
@@ -170,5 +172,8 @@ public class SearchAdminPortlet extends MVCPortlet {
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private SearchCapabilities _searchCapabilities;
 
 }

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/js/execution_options/index.js
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/js/execution_options/index.js
@@ -44,6 +44,7 @@ function ExecutionOptions({
 	initialCompanyIds = [],
 	initialExecutionMode,
 	initialScope,
+	isConcurrentModeSupported,
 	portletNamespace,
 	virtualInstances = [],
 }) {
@@ -85,7 +86,7 @@ function ExecutionOptions({
 
 	return (
 		<div className="execution-scope-sheet sheet sheet-lg">
-			{Liferay.FeatureFlags['LPS-177664'] && (
+			{Liferay.FeatureFlags['LPS-177664'] && isConcurrentModeSupported && (
 				<div className="sheet-section">
 					<h2 className="sheet-title">
 						{Liferay.Language.get('execution-mode')}

--- a/modules/apps/portal-search/portal-search-api/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search API
 Bundle-SymbolicName: com.liferay.portal.search.api
-Bundle-Version: 11.5.1
+Bundle-Version: 11.6.0
 Export-Package:\
 	com.liferay.portal.search.aggregation,\
 	com.liferay.portal.search.aggregation.bucket,\

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/capabilities/SearchCapabilities.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/capabilities/SearchCapabilities.java
@@ -24,6 +24,8 @@ public interface SearchCapabilities {
 
 	public boolean isCommerceSupported();
 
+	public boolean isConcurrentModeSupported();
+
 	public boolean isResultRankingsSupported();
 
 	public boolean isSearchExperiencesSupported();

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/capabilities/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/capabilities/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/capabilities/SearchCapabilitiesImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/capabilities/SearchCapabilitiesImpl.java
@@ -38,6 +38,15 @@ public class SearchCapabilitiesImpl implements SearchCapabilities {
 	}
 
 	@Override
+	public boolean isConcurrentModeSupported() {
+		if (_isSearchEngineSolr()) {
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
 	public boolean isResultRankingsSupported() {
 		if (_isSearchEngineSolr()) {
 			return false;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-183360 - Concurrent (aka. Blue/Green) reindex execution mode is not available when using Solr

In order to keep track of whether concurrent mode is allowed, there was another boolean added to SearchCapabilities that would know when Solr was being used (I was following examples of the other properties inside SearchCapabilities), which gets passed into the execution options JS component. Hopefully that makes sense, let me know if it should be updated, thanks!