### PR TITLE
LPS-183922 Remove 7.1 methods in PortletSharedSearchSettings

### DIFF
--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/java/com/liferay/commerce/product/content/search/web/internal/portlet/shared/search/CPOptionFacetsPortletSharedSearchContributor.java
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/java/com/liferay/commerce/product/content/search/web/internal/portlet/shared/search/CPOptionFacetsPortletSharedSearchContributor.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
 import com.liferay.portal.kernel.search.facet.collector.TermCollector;
 import com.liferay.portal.kernel.search.facet.config.FacetConfiguration;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -78,15 +79,15 @@ public class CPOptionFacetsPortletSharedSearchContributor
 			SerializableFacet serializableFacet = new SerializableFacet(
 				CPField.OPTION_NAMES, searchContext);
 
-			Optional<String[]> parameterValuesOptional =
-				portletSharedSearchSettings.getParameterValues71(
+			String[] parameterValues =
+				portletSharedSearchSettings.getParameterValues(
 					CPField.OPTION_NAMES);
 
-			if (parameterValuesOptional.isPresent()) {
-				serializableFacet.select(parameterValuesOptional.get());
+			if (ArrayUtil.isNotEmpty(parameterValues)) {
+				serializableFacet.select(parameterValues);
 
 				searchContext.setAttribute(
-					CPField.OPTION_NAMES, parameterValuesOptional.get());
+					CPField.OPTION_NAMES, parameterValues);
 			}
 
 			RenderRequest renderRequest =
@@ -123,9 +124,8 @@ public class CPOptionFacetsPortletSharedSearchContributor
 					CPOptionFacetsUtil.getCPOptionKeyFromIndexFieldName(
 						facet.getFieldName());
 
-				parameterValuesOptional =
-					portletSharedSearchSettings.getParameterValues71(
-						cpOptionKey);
+				parameterValues =
+					portletSharedSearchSettings.getParameterValues(cpOptionKey);
 
 				serializableFacet = new SerializableFacet(
 					facet.getFieldName(), searchContext);
@@ -134,11 +134,11 @@ public class CPOptionFacetsPortletSharedSearchContributor
 					buildFacetConfiguration(
 						frequencyThreshold, maxTerms, serializableFacet));
 
-				if (parameterValuesOptional.isPresent()) {
-					serializableFacet.select(parameterValuesOptional.get());
+				if (ArrayUtil.isNotEmpty(parameterValues)) {
+					serializableFacet.select(parameterValues);
 
 					searchContext.setAttribute(
-						facet.getFieldName(), parameterValuesOptional.get());
+						facet.getFieldName(), parameterValues);
 				}
 
 				portletSharedSearchSettings.addFacet(serializableFacet);

--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/java/com/liferay/commerce/product/content/search/web/internal/portlet/shared/search/CPPriceRangeFacetsPortletSharedSearchContributor.java
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/java/com/liferay/commerce/product/content/search/web/internal/portlet/shared/search/CPPriceRangeFacetsPortletSharedSearchContributor.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.search.facet.RangeFacet;
 import com.liferay.portal.kernel.search.facet.config.FacetConfiguration;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
@@ -68,18 +69,18 @@ public class CPPriceRangeFacetsPortletSharedSearchContributor
 			Facet facet = _getFacet(
 				portletSharedSearchSettings, renderRequest, searchContext);
 
-			Optional<String[]> parameterValuesOptional =
-				portletSharedSearchSettings.getParameterValues71(
+			String[] parameterValues =
+				portletSharedSearchSettings.getParameterValues(
 					facet.getFieldName());
 
 			SerializableFacet serializableFacet = new SerializableFacet(
 				facet.getFieldName(), searchContext);
 
-			if (parameterValuesOptional.isPresent()) {
-				serializableFacet.select(parameterValuesOptional.get());
+			if (ArrayUtil.isNotEmpty(parameterValues)) {
+				serializableFacet.select(parameterValues);
 
 				searchContext.setAttribute(
-					facet.getFieldName(), parameterValuesOptional.get());
+					facet.getFieldName(), parameterValues);
 			}
 
 			portletSharedSearchSettings.addFacet(facet);

--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/java/com/liferay/commerce/product/content/search/web/internal/portlet/shared/search/CPSearchResultsPortletSharedSearchContributor.java
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/java/com/liferay/commerce/product/content/search/web/internal/portlet/shared/search/CPSearchResultsPortletSharedSearchContributor.java
@@ -201,7 +201,7 @@ public class CPSearchResultsPortletSharedSearchContributor
 			cpSearchResultsPortletInstanceConfiguration.paginationDelta();
 
 		Optional<PortletPreferences> portletPreferencesOptional =
-			portletSharedSearchSettings.getPortletPreferences71();
+			portletSharedSearchSettings.getPortletPreferencesOptional();
 
 		if (portletPreferencesOptional.isPresent()) {
 			PortletPreferences portletPreferences =

--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/java/com/liferay/commerce/product/content/search/web/internal/portlet/shared/search/CPSearchResultsPortletSharedSearchContributor.java
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/java/com/liferay/commerce/product/content/search/web/internal/portlet/shared/search/CPSearchResultsPortletSharedSearchContributor.java
@@ -103,7 +103,7 @@ public class CPSearchResultsPortletSharedSearchContributor
 				themeDisplay.getScopeGroupId());
 
 		Optional<String> parameterValueOptional =
-			portletSharedSearchSettings.getParameter71("q");
+			portletSharedSearchSettings.getParameterOptional("q");
 
 		portletSharedSearchSettings.setKeywords(
 			parameterValueOptional.orElse(StringPool.BLANK));
@@ -179,7 +179,7 @@ public class CPSearchResultsPortletSharedSearchContributor
 			paginationStartParameterName);
 
 		Optional<String> paginationStartParameterValueOptional =
-			portletSharedSearchSettings.getParameter71(
+			portletSharedSearchSettings.getParameterOptional(
 				paginationStartParameterName);
 
 		Optional<Integer> paginationStartOptional =
@@ -191,7 +191,7 @@ public class CPSearchResultsPortletSharedSearchContributor
 		String paginationDeltaParameterName = "delta";
 
 		Optional<String> paginationDeltaParameterValueOptional =
-			portletSharedSearchSettings.getParameter71(
+			portletSharedSearchSettings.getParameterOptional(
 				paginationDeltaParameterName);
 
 		Optional<Integer> paginationDeltaOptional =

--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/java/com/liferay/commerce/product/content/search/web/internal/portlet/shared/search/CPSpecificationOptionFacetsPortletSharedSearchContributor.java
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/java/com/liferay/commerce/product/content/search/web/internal/portlet/shared/search/CPSpecificationOptionFacetsPortletSharedSearchContributor.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
 import com.liferay.portal.kernel.search.facet.collector.TermCollector;
 import com.liferay.portal.kernel.search.facet.config.FacetConfiguration;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -81,15 +82,15 @@ public class CPSpecificationOptionFacetsPortletSharedSearchContributor
 			SerializableFacet serializableFacet = new SerializableFacet(
 				CPField.SPECIFICATION_NAMES, searchContext);
 
-			Optional<String[]> parameterValuesOptional =
-				portletSharedSearchSettings.getParameterValues71(
+			String[] parameterValues =
+				portletSharedSearchSettings.getParameterValues(
 					CPField.SPECIFICATION_NAMES);
 
-			if (parameterValuesOptional.isPresent()) {
-				serializableFacet.select(parameterValuesOptional.get());
+			if (ArrayUtil.isNotEmpty(parameterValues)) {
+				serializableFacet.select(parameterValues);
 
 				searchContext.setAttribute(
-					CPField.SPECIFICATION_NAMES, parameterValuesOptional.get());
+					CPField.SPECIFICATION_NAMES, parameterValues);
 			}
 
 			portletSharedSearchSettings.addFacet(serializableFacet);
@@ -116,8 +117,8 @@ public class CPSpecificationOptionFacetsPortletSharedSearchContributor
 						getCPSpecificationOptionKeyFromIndexFieldName(
 							facet.getFieldName());
 
-				parameterValuesOptional =
-					portletSharedSearchSettings.getParameterValues71(
+				parameterValues =
+					portletSharedSearchSettings.getParameterValues(
 						cpSpecificationOptionKey);
 
 				serializableFacet = new SerializableFacet(
@@ -127,11 +128,11 @@ public class CPSpecificationOptionFacetsPortletSharedSearchContributor
 					_buildFacetConfiguration(
 						facet, frequencyThreshold, maxTerms));
 
-				if (parameterValuesOptional.isPresent()) {
-					serializableFacet.select(parameterValuesOptional.get());
+				if (ArrayUtil.isNotEmpty(parameterValues)) {
+					serializableFacet.select(parameterValues);
 
 					searchContext.setAttribute(
-						facet.getFieldName(), parameterValuesOptional.get());
+						facet.getFieldName(), parameterValues);
 				}
 
 				portletSharedSearchSettings.addFacet(serializableFacet);

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/search/bar/portlet/shared/search/test/DepotSearchBarPortletSharedSearchContributorTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/search/bar/portlet/shared/search/test/DepotSearchBarPortletSharedSearchContributorTest.java
@@ -319,11 +319,6 @@ public class DepotSearchBarPortletSharedSearchContributorTest {
 			}
 
 			@Override
-			public Optional<PortletPreferences> getPortletPreferences71() {
-				return Optional.empty();
-			}
-
-			@Override
 			public Optional<PortletPreferences>
 				getPortletPreferencesOptional() {
 

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/search/bar/portlet/shared/search/test/DepotSearchBarPortletSharedSearchContributorTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/search/bar/portlet/shared/search/test/DepotSearchBarPortletSharedSearchContributorTest.java
@@ -304,11 +304,6 @@ public class DepotSearchBarPortletSharedSearchContributorTest {
 			}
 
 			@Override
-			public Optional<String> getParameter71(String name) {
-				return Optional.empty();
-			}
-
-			@Override
 			public Optional<String> getParameterOptional(String name) {
 				return Optional.empty();
 			}

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/search/bar/portlet/shared/search/test/DepotSearchBarPortletSharedSearchContributorTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/search/bar/portlet/shared/search/test/DepotSearchBarPortletSharedSearchContributorTest.java
@@ -314,11 +314,6 @@ public class DepotSearchBarPortletSharedSearchContributorTest {
 			}
 
 			@Override
-			public Optional<String[]> getParameterValues71(String name) {
-				return Optional.empty();
-			}
-
-			@Override
 			public String getPortletId() {
 				return null;
 			}

--- a/modules/apps/portal-search/portal-search-web-api/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-web-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search Web API
 Bundle-SymbolicName: com.liferay.portal.search.web.api
-Bundle-Version: 8.0.1
+Bundle-Version: 9.0.0
 Export-Package:\
 	com.liferay.portal.search.web.application.list.constants,\
 	com.liferay.portal.search.web.constants,\

--- a/modules/apps/portal-search/portal-search-web-api/src/main/java/com/liferay/portal/search/web/portlet/shared/search/PortletSharedSearchSettings.java
+++ b/modules/apps/portal-search/portal-search-web-api/src/main/java/com/liferay/portal/search/web/portlet/shared/search/PortletSharedSearchSettings.java
@@ -34,8 +34,6 @@ public interface PortletSharedSearchSettings extends SearchSettings {
 
 	public String[] getParameterValues(String name);
 
-	public Optional<String[]> getParameterValues71(String name);
-
 	public String getPortletId();
 
 	public Optional<PortletPreferences> getPortletPreferences71();

--- a/modules/apps/portal-search/portal-search-web-api/src/main/java/com/liferay/portal/search/web/portlet/shared/search/PortletSharedSearchSettings.java
+++ b/modules/apps/portal-search/portal-search-web-api/src/main/java/com/liferay/portal/search/web/portlet/shared/search/PortletSharedSearchSettings.java
@@ -30,8 +30,6 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface PortletSharedSearchSettings extends SearchSettings {
 
-	public Optional<String> getParameter71(String name);
-
 	public Optional<String> getParameterOptional(String name);
 
 	public String[] getParameterValues(String name);

--- a/modules/apps/portal-search/portal-search-web-api/src/main/java/com/liferay/portal/search/web/portlet/shared/search/PortletSharedSearchSettings.java
+++ b/modules/apps/portal-search/portal-search-web-api/src/main/java/com/liferay/portal/search/web/portlet/shared/search/PortletSharedSearchSettings.java
@@ -36,8 +36,6 @@ public interface PortletSharedSearchSettings extends SearchSettings {
 
 	public String getPortletId();
 
-	public Optional<PortletPreferences> getPortletPreferences71();
-
 	public Optional<PortletPreferences> getPortletPreferencesOptional();
 
 	public RenderRequest getRenderRequest();

--- a/modules/apps/portal-search/portal-search-web-api/src/main/resources/com/liferay/portal/search/web/portlet/shared/search/packageinfo
+++ b/modules/apps/portal-search/portal-search-web-api/src/main/resources/com/liferay/portal/search/web/portlet/shared/search/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 6.0.0

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchSettingsImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchSettingsImpl.java
@@ -117,11 +117,6 @@ public class PortletSharedSearchSettingsImpl
 	}
 
 	@Override
-	public Optional<PortletPreferences> getPortletPreferences71() {
-		return _portletPreferencesOptional;
-	}
-
-	@Override
 	public Optional<PortletPreferences> getPortletPreferencesOptional() {
 		return _portletPreferencesOptional;
 	}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchSettingsImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchSettingsImpl.java
@@ -112,13 +112,6 @@ public class PortletSharedSearchSettingsImpl
 	}
 
 	@Override
-	public Optional<String[]> getParameterValues71(String name) {
-		return Optional.ofNullable(
-			_portletSharedRequestHelper.getParameterValues(
-				name, _renderRequest));
-	}
-
-	@Override
 	public String getPortletId() {
 		return _portletId;
 	}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchSettingsImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchSettingsImpl.java
@@ -98,12 +98,6 @@ public class PortletSharedSearchSettingsImpl
 	}
 
 	@Override
-	public Optional<String> getParameter71(String name) {
-		return Optional.ofNullable(
-			_portletSharedRequestHelper.getParameter(name, _renderRequest));
-	}
-
-	@Override
 	public Optional<String> getParameterOptional(String name) {
 		return Optional.ofNullable(
 			_portletSharedRequestHelper.getParameter(name, _renderRequest));

--- a/readme/BREAKING_CHANGES.markdown
+++ b/readme/BREAKING_CHANGES.markdown
@@ -1357,3 +1357,26 @@ Remove usage of `ServiceComponentLocalService.verifyDB()`
 ### Why was this change made?
 
 Upgrade framework manages all modules' tables and Release record creation. This verifyDB function does not do anything.
+
+---------------------------------------
+
+## Removed 7.1 methods in PortletSharedSearchSettings from portal-search-web-api module
+
+- **Date:** 2023-May-10
+- **JIRA Ticket:** [LPS-183921](https://issues.liferay.com/browse/LPS-183921)
+
+### What changed?
+
+ `PortalSharedSearchSettings` methods related to 7.1 compatibility are removed.
+
+### Who is affected?
+
+This affects anyone who is calling these methods from there code: `getParameter71()`, `getParameterValues71()`, and `getPortletPreferences71()`
+
+### How should I update my code?
+
+Replace `getParameter71()` with `getParameterOptional()`, `getParameterValues71()` with `getParameterValues()`, and `getPortletPreferences71()` with `getPortletPreferencesOptional()`.
+
+### Why was this change made?
+
+These methods were added back in 7.2 for forward compatibility: [LPS-101007](https://issues.liferay.com/browse/LPS-101007). Now in 7.4, they are only redundant methods to their Optional and String version.


### PR DESCRIPTION
@lipusz @peerkar 
Hi Petteri, Tibor, 
Per our discussion,
These methods were added back in 7.2 https://issues.liferay.com/browse/LPS-101007 to have two versions of the same methods for forward compatibility. Now in 7.4, there should be no need to do so anymore. We are removing these 71 methods here.

Thanks!