### PR TITLE
LPS-182779 LPS-183982 portal-search-web: Update taglibs in search web portlet

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/low/level/search/options/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/low/level/search/options/view.jsp
@@ -14,12 +14,17 @@
  */
 --%>
 
-<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
-taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <liferay-theme:defineObjects />
 
+<%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %>
+
 <div class="alert alert-info text-center">
-	<aui:a href="javascript:void(0);" onClick="<%= portletDisplay.getURLConfigurationJS() %>"><liferay-ui:message key="low-level-search-options-help" /></aui:a>
+	<clay:link
+		href="javascript:void(0);"
+		label='<%= LanguageUtil.get(request, "low-level-search-options-help") %>'
+		onClick="<%= portletDisplay.getURLConfigurationJS() %>"
+	/>
 </div>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
@@ -54,7 +54,11 @@ SearchBarPortletDisplayContext searchBarPortletDisplayContext = (SearchBarPortle
 		<div class="alert alert-info c-mb-0 text-center">
 			<liferay-ui:message key="this-search-bar-is-not-visible-to-users-yet" />
 
-			<aui:a href="javascript:void(0);" onClick="<%= portletDisplay.getURLConfigurationJS() %>"><liferay-ui:message key="set-up-its-destination-to-make-it-visible" /></aui:a>
+			<clay:link
+				href="javascript:void(0);"
+				label='<%= LanguageUtil.get(request, "set-up-its-destination-to-make-it-visible") %>'
+				onClick="<%= portletDisplay.getURLConfigurationJS() %>"
+			/>
 		</div>
 	</c:when>
 	<c:otherwise>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/options/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/options/view.jsp
@@ -14,12 +14,17 @@
  */
 --%>
 
-<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
-taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <liferay-theme:defineObjects />
 
+<%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %>
+
 <div class="alert alert-info text-center">
-	<aui:a href="javascript:void(0);" onClick="<%= portletDisplay.getURLConfigurationJS() %>"><liferay-ui:message key="search-options-help" /></aui:a>
+	<clay:link
+		href="javascript:void(0);"
+		label='<%= LanguageUtil.get(request, "search-options-help") %>'
+		onClick="<%= portletDisplay.getURLConfigurationJS() %>"
+	/>
 </div>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/sort/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/sort/view.jsp
@@ -19,11 +19,13 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/ddm" prefix="liferay-ddm" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
+<%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
+page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.portal.search.web.internal.sort.configuration.SortPortletInstanceConfiguration" %><%@
@@ -47,7 +49,11 @@ SortPortletInstanceConfiguration sortPortletInstanceConfiguration = sortDisplayC
 		<div class="alert alert-info text-center">
 			<liferay-ui:message key="this-widget-is-not-visible-to-users-yet" />
 
-			<aui:a href="javascript:void(0);" onClick="<%= portletDisplay.getURLConfigurationJS() %>"><liferay-ui:message key="complete-its-configuration-to-make-it-visible" /></aui:a>
+			<clay:link
+				href="javascript:void(0);"
+				label='<%= LanguageUtil.get(request, "complete-its-configuration-to-make-it-visible") %>'
+				onClick="<%= portletDisplay.getURLConfigurationJS() %>"
+			/>
 		</div>
 	</c:when>
 	<c:otherwise>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/suggestions/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/suggestions/view.jsp
@@ -16,7 +16,7 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.portal.kernel.util.WebKeys" %><%@
@@ -39,9 +39,10 @@ SuggestionsPortletDisplayContext suggestionsPortletDisplayContext = (Suggestions
 				SuggestionDisplayContext suggestionDisplayContext = suggestionsPortletDisplayContext.getSpellCheckSuggestion();
 				%>
 
-				<aui:a href="<%= suggestionDisplayContext.getURL() %>">
-					<%= suggestionDisplayContext.getSuggestedKeywordsFormatted() %>
-				</aui:a>
+				<clay:link
+					href="<%= suggestionDisplayContext.getURL() %>"
+					label="<%= suggestionDisplayContext.getSuggestedKeywordsFormatted() %>"
+				/>
 			</li>
 		</ul>
 	</c:if>
@@ -57,9 +58,10 @@ SuggestionsPortletDisplayContext suggestionsPortletDisplayContext = (Suggestions
 			%>
 
 				<li>
-					<aui:a href="<%= suggestionDisplayContext.getURL() %>">
-						<%= suggestionDisplayContext.getSuggestedKeywordsFormatted() %>
-					</aui:a>
+					<clay:link
+						href="<%= suggestionDisplayContext.getURL() %>"
+						label="<%= suggestionDisplayContext.getSuggestedKeywordsFormatted() %>"
+					/>
 				</li>
 
 			<%

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_list.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_list.ftl
@@ -55,10 +55,9 @@
 									</#if>
 
 									<#if entry.isLocaleReminderVisible()>
-										<@liferay_ui["icon"]
-											icon="../language/${entry.getLocaleLanguageId()}"
-											message=entry.getLocaleReminder()
-										/>
+										<span class="lfr-portal-tooltip" title="${entry.getLocaleReminder()}">
+											<@clay["icon"] symbol="${entry.getLocaleLanguageId()?lower_case?replace('_', '-')}" />
+										</span>
 									</#if>
 
 									<#if entry.isCreatorVisible()>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-182779 - Update taglibs that are listed in new source formatting rule

This updates several of the outdated taglibs mentioned in LPS-179523 (SF rule). Some taglibs were left unchanged either because they were in legacy code or the recommended clay taglib does not work the same way as the "older" one (for example, `liferay-ui:icon` has a lot more attributes than `clay:icon` to introduce tooltips, links, etc). Since it looks like portal has many usages of the older taglibs and the source formatter is supposed to target new usages, it seems fine to leave some existing taglibs as is. 

Also I'm not sure if the icon for locale flags was working, but updated that too.

Thanks for taking a look!