### PR TITLE
LPS-176476 portal-search-web: Add redirect for back button usage in search results

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/util/SearchUtil.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/util/SearchUtil.java
@@ -156,6 +156,8 @@ public class SearchUtil {
 				renderResponse
 			).setMVCPath(
 				"/view_content.jsp"
+			).setRedirect(
+				currentURL
 			).setPortletMode(
 				PortletMode.VIEW
 			).setWindowState(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-176476 - The back button on the Documents & Media search results details page removes search results

Adding the `redirect` value helps in the case of when viewing a document from the search results. D&M determines its backURL using `redirect`.