### PR TITLE
[TS] LPS-157425 (Initial Review)

### DIFF
--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BaseBatchEngineTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BaseBatchEngineTaskExecutorTest.java
@@ -147,7 +147,8 @@ public class BaseBatchEngineTaskExecutorTest {
 				new IntegerEntityField("creatorId", locale -> Field.USER_ID),
 				new StringEntityField(
 					"headline",
-					locale -> Field.getSortableFieldName(Field.TITLE)));
+					locale -> Field.getSortableFieldName(Field.TITLE),
+					locale -> Field.TITLE + ".keyword"));
 		}
 
 		@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/odata/entity/v1_0/AccountEntityModel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/odata/entity/v1_0/AccountEntityModel.java
@@ -38,7 +38,8 @@ public class AccountEntityModel implements EntityModel {
 				locale -> Field.getSortableFieldName(Field.MODIFIED_DATE),
 				locale -> Field.MODIFIED_DATE),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName(Field.NAME)),
+				"name", locale -> Field.getSortableFieldName(Field.NAME),
+				locale -> Field.NAME + ".keyword"),
 			new StringEntityField("type", locale -> Field.TYPE));
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/odata/entity/v1_0/AccountGroupEntityModel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/odata/entity/v1_0/AccountGroupEntityModel.java
@@ -29,7 +29,8 @@ public class AccountGroupEntityModel implements EntityModel {
 	public AccountGroupEntityModel() {
 		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName(Field.NAME)));
+				"name", locale -> Field.getSortableFieldName(Field.NAME),
+				locale -> Field.NAME + ".keyword"));
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/odata/entity/v1_0/CatalogEntityModel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/odata/entity/v1_0/CatalogEntityModel.java
@@ -29,7 +29,8 @@ public class CatalogEntityModel implements EntityModel {
 	public CatalogEntityModel() {
 		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName("name")));
+				"name", locale -> Field.getSortableFieldName("name"),
+				locale -> "name.keyword"));
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/odata/entity/v1_0/OptionEntityModel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/odata/entity/v1_0/OptionEntityModel.java
@@ -31,7 +31,8 @@ public class OptionEntityModel implements EntityModel {
 		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new StringEntityField("key", locale -> "key"),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName(Field.NAME)),
+				"name", locale -> Field.getSortableFieldName(Field.NAME),
+				locale -> Field.NAME + ".keyword"),
 			new StringEntityField(
 				"fieldType", locale -> CPField.DDM_FORM_FIELD_TYPE_NAME));
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/odata/entity/v1_0/ProductEntityModel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/odata/entity/v1_0/ProductEntityModel.java
@@ -62,7 +62,8 @@ public class ProductEntityModel implements EntityModel {
 				locale -> Field.MODIFIED_DATE),
 			new IntegerEntityField("catalogId", locale -> "commerceCatalogId"),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName("name")),
+				"name", locale -> Field.getSortableFieldName("name"),
+				locale -> "name.keyword"),
 			new StringEntityField("productType", locale -> "productTypeName"));
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/odata/entity/v1_0/ChannelEntityModel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/odata/entity/v1_0/ChannelEntityModel.java
@@ -32,7 +32,8 @@ public class ChannelEntityModel implements EntityModel {
 			new IdEntityField(
 				"siteGroupId", locale -> Field.SCOPE_GROUP_ID, String::valueOf),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName("name")));
+				"name", locale -> Field.getSortableFieldName("name"),
+				locale -> "name.keyword"));
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/odata/entity/v1_0/PriceListEntityModel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/odata/entity/v1_0/PriceListEntityModel.java
@@ -29,7 +29,8 @@ public class PriceListEntityModel implements EntityModel {
 	public PriceListEntityModel() {
 		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName("name")));
+				"name", locale -> Field.getSortableFieldName("name"),
+				locale -> "name.keyword"));
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/odata/entity/v2_0/PriceListEntityModel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/odata/entity/v2_0/PriceListEntityModel.java
@@ -47,7 +47,8 @@ public class PriceListEntityModel implements EntityModel {
 				new IntegerEntityField(
 					"orderTypeId", locale -> "commerceOrderTypeId")),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName("name")),
+				"name", locale -> Field.getSortableFieldName("name"),
+				locale -> "name.keyword"),
 			new BooleanEntityField(
 				"catalogBasePriceList", locale -> "catalogBasePriceList"),
 			new StringEntityField("type", locale -> "type"),

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/odata/entity/v1_0/ChannelEntityModel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/odata/entity/v1_0/ChannelEntityModel.java
@@ -32,7 +32,8 @@ public class ChannelEntityModel implements EntityModel {
 			new IdEntityField(
 				"siteGroupId", locale -> Field.SCOPE_GROUP_ID, String::valueOf),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName("name")));
+				"name", locale -> Field.getSortableFieldName("name"),
+				locale -> "name.keyword"));
 	}
 
 	@Override

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/odata/entity/v1_0/ProductEntityModel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/odata/entity/v1_0/ProductEntityModel.java
@@ -46,7 +46,8 @@ public class ProductEntityModel implements EntityModel {
 				locale -> Field.getSortableFieldName(Field.MODIFIED_DATE),
 				locale -> Field.MODIFIED_DATE),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName("name")),
+				"name", locale -> Field.getSortableFieldName("name"),
+				locale -> "name.keyword"),
 			new StringEntityField("productType", locale -> "productTypeName"),
 			new IntegerEntityField("statusCode", locale -> Field.STATUS));
 	}

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v2_0/DataDefinitionEntityModel.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v2_0/DataDefinitionEntityModel.java
@@ -14,6 +14,7 @@
 
 package com.liferay.data.engine.rest.internal.odata.entity.v2_0;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
@@ -41,8 +42,10 @@ public class DataDefinitionEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_name_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_name_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> StringBundler.concat(
+					"localized_name_", LocaleUtil.toLanguageId(locale),
+					".keyword")));
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v2_0/DataLayoutEntityModel.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v2_0/DataLayoutEntityModel.java
@@ -14,6 +14,7 @@
 
 package com.liferay.data.engine.rest.internal.odata.entity.v2_0;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
@@ -41,8 +42,10 @@ public class DataLayoutEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_name_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_name_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> StringBundler.concat(
+					"localized_name_", LocaleUtil.toLanguageId(locale),
+					".keyword")));
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v2_0/DataListViewEntityModel.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v2_0/DataListViewEntityModel.java
@@ -14,6 +14,7 @@
 
 package com.liferay.data.engine.rest.internal.odata.entity.v2_0;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
@@ -41,8 +42,10 @@ public class DataListViewEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_name_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_name_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> StringBundler.concat(
+					"localized_name_", LocaleUtil.toLanguageId(locale),
+					".keyword")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/odata/entity/v1_0/StructuredContentEntityModel.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/odata/entity/v1_0/StructuredContentEntityModel.java
@@ -64,12 +64,16 @@ public class StructuredContentEntityModel implements EntityModel {
 				locale -> Field.getSortableFieldName(
 					StringBundler.concat(
 						"urlTitle_", LocaleUtil.toLanguageId(locale),
-						"_String"))),
+						"_String")),
+				locale -> StringBundler.concat(
+					"urlTitle_", LocaleUtil.toLanguageId(locale), ".keyword")),
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> StringBundler.concat(
+					"localized_title_", LocaleUtil.toLanguageId(locale),
+					".keyword")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/odata/entity/v1_0/ListTypeDefinitionEntityModel.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/odata/entity/v1_0/ListTypeDefinitionEntityModel.java
@@ -40,7 +40,8 @@ public class ListTypeDefinitionEntityModel implements EntityModel {
 				locale -> Field.MODIFIED_DATE),
 			new IntegerEntityField("userId", locale -> Field.USER_ID),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName(Field.NAME)));
+				"name", locale -> Field.getSortableFieldName(Field.NAME),
+				locale -> Field.NAME + ".keyword"));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/odata/entity/v1_0/ListTypeEntryEntityModel.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/odata/entity/v1_0/ListTypeEntryEntityModel.java
@@ -43,7 +43,13 @@ public class ListTypeEntryEntityModel implements EntityModel {
 			new StringEntityField(
 				Field.NAME,
 				locale -> Field.getSortableFieldName(
-					Field.getLocalizedName(locale, "localized_name"))));
+					Field.getLocalizedName(locale, "localized_name")),
+				locale -> {
+					String localizedName = Field.getLocalizedName(
+						locale, "localized_name");
+
+					return localizedName + ".keyword";
+				}));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/CategoryEntityModel.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/CategoryEntityModel.java
@@ -15,6 +15,7 @@
 package com.liferay.headless.admin.taxonomy.internal.odata.entity.v1_0;
 
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
@@ -42,7 +43,10 @@ public class CategoryEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_title_" + LocaleUtil.toLanguageId(locale))));
+					"localized_title_" + LocaleUtil.toLanguageId(locale)),
+				locale -> StringBundler.concat(
+					"localized_title_", LocaleUtil.toLanguageId(locale),
+					".keyword")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/KeywordEntityModel.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/KeywordEntityModel.java
@@ -42,7 +42,8 @@ public class KeywordEntityModel implements EntityModel {
 				locale -> Field.MODIFIED_DATE),
 			new StringEntityField(
 				Field.NAME,
-				locale -> Field.getSortableFieldName(Field.NAME + "_String")));
+				locale -> Field.getSortableFieldName(Field.NAME + "_String"),
+				locale -> Field.NAME + ".keyword"));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/VocabularyEntityModel.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/VocabularyEntityModel.java
@@ -15,6 +15,7 @@
 package com.liferay.headless.admin.taxonomy.internal.odata.entity.v1_0;
 
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
@@ -42,7 +43,10 @@ public class VocabularyEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_title_" + LocaleUtil.toLanguageId(locale))));
+					"localized_title_" + LocaleUtil.toLanguageId(locale)),
+				locale -> StringBundler.concat(
+					"localized_title_", LocaleUtil.toLanguageId(locale),
+					".keyword")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/odata/entity/v1_0/AccountEntityModel.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/odata/entity/v1_0/AccountEntityModel.java
@@ -30,7 +30,8 @@ public class AccountEntityModel implements EntityModel {
 	public AccountEntityModel() {
 		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName(Field.NAME)),
+				"name", locale -> Field.getSortableFieldName(Field.NAME),
+				locale -> Field.NAME + ".keyword"),
 			new IdEntityField(
 				"organizationIds", locale -> "organizationIds",
 				String::valueOf));

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/odata/entity/v1_0/AccountRoleEntityModel.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/odata/entity/v1_0/AccountRoleEntityModel.java
@@ -29,7 +29,8 @@ public class AccountRoleEntityModel implements EntityModel {
 	public AccountRoleEntityModel() {
 		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName(Field.NAME)));
+				"name", locale -> Field.getSortableFieldName(Field.NAME),
+				locale -> Field.NAME + ".keyword"));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/odata/entity/v1_0/OrganizationEntityModel.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/odata/entity/v1_0/OrganizationEntityModel.java
@@ -43,7 +43,8 @@ public class OrganizationEntityModel implements EntityModel {
 				"parentOrganizationId", locale -> "parentOrganizationId",
 				String::valueOf),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName(Field.NAME)));
+				"name", locale -> Field.getSortableFieldName(Field.NAME),
+				locale -> Field.NAME + ".keyword"));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/odata/entity/v1_0/UserAccountEntityModel.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/odata/entity/v1_0/UserAccountEntityModel.java
@@ -59,11 +59,14 @@ public class UserAccountEntityModel implements EntityModel {
 				locale -> Field.getSortableFieldName("screenName")),
 			new StringEntityField("emailAddress", locale -> "emailAddress"),
 			new StringEntityField(
-				"familyName", locale -> Field.getSortableFieldName("lastName")),
+				"familyName", locale -> Field.getSortableFieldName("lastName"),
+				locale -> "lastName.keyword"),
 			new StringEntityField(
-				"givenName", locale -> Field.getSortableFieldName("firstName")),
+				"givenName", locale -> Field.getSortableFieldName("firstName"),
+				locale -> "firstName.keyword"),
 			new StringEntityField(
-				"jobTitle", locale -> Field.getSortableFieldName("jobTitle")),
+				"jobTitle", locale -> Field.getSortableFieldName("jobTitle"),
+				locale -> "jobTitle.keyword"),
 			new StringEntityField("name", locale -> Field.USER_NAME));
 	}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/odata/entity/v1_0/UserAccountEntityModel.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/odata/entity/v1_0/UserAccountEntityModel.java
@@ -56,7 +56,8 @@ public class UserAccountEntityModel implements EntityModel {
 				"userGroupIds", locale -> "userGroupIds", String::valueOf),
 			new StringEntityField(
 				"alternateName",
-				locale -> Field.getSortableFieldName("screenName")),
+				locale -> Field.getSortableFieldName("screenName"),
+				locale -> "screenName"),
 			new StringEntityField("emailAddress", locale -> "emailAddress"),
 			new StringEntityField(
 				"familyName", locale -> Field.getSortableFieldName("lastName"),

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/odata/entity/v1_0/UserGroupEntityModel.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/odata/entity/v1_0/UserGroupEntityModel.java
@@ -33,7 +33,8 @@ public class UserGroupEntityModel implements EntityModel {
 				"companyId", locale -> Field.COMPANY_ID, String::valueOf),
 			new StringEntityField("description", locale -> Field.DESCRIPTION),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName(Field.NAME)),
+				"name", locale -> Field.getSortableFieldName(Field.NAME),
+				locale -> Field.NAME + ".keyword"),
 			new IdEntityField(
 				"userGroupId", locale -> Field.USER_GROUP_ID, String::valueOf));
 	}

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/odata/entity/v1_0/WorkflowDefinitionEntityModel.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/odata/entity/v1_0/WorkflowDefinitionEntityModel.java
@@ -34,7 +34,8 @@ public class WorkflowDefinitionEntityModel implements EntityModel {
 				locale -> Field.getSortableFieldName(Field.MODIFIED_DATE),
 				locale -> Field.MODIFIED_DATE),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName(Field.NAME)));
+				"name", locale -> Field.getSortableFieldName(Field.NAME),
+				locale -> Field.NAME + ".keyword"));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/BlogPostingEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/BlogPostingEntityModel.java
@@ -54,7 +54,8 @@ public class BlogPostingEntityModel implements EntityModel {
 				"friendlyUrlPath",
 				locale -> Field.getSortableFieldName("urlTitle_String")),
 			new StringEntityField(
-				"headline", locale -> Field.getSortableFieldName(Field.TITLE)));
+				"headline", locale -> Field.getSortableFieldName(Field.TITLE),
+				locale -> Field.TITLE + ".keyword"));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/BlogPostingEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/BlogPostingEntityModel.java
@@ -52,7 +52,8 @@ public class BlogPostingEntityModel implements EntityModel {
 			new IntegerEntityField("creatorId", locale -> Field.USER_ID),
 			new StringEntityField(
 				"friendlyUrlPath",
-				locale -> Field.getSortableFieldName("urlTitle_String")),
+				locale -> Field.getSortableFieldName("urlTitle_String"),
+				locale -> "urlTitle.keyword"),
 			new StringEntityField(
 				"headline", locale -> Field.getSortableFieldName(Field.TITLE),
 				locale -> Field.TITLE + ".keyword"));

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/BlogPostingImageEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/BlogPostingImageEntityModel.java
@@ -16,6 +16,7 @@ package com.liferay.headless.delivery.internal.odata.entity.v1_0;
 
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -51,8 +52,10 @@ public class BlogPostingImageEntityModel implements EntityModel {
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> StringBundler.concat(
+					"localized_title_", LocaleUtil.toLanguageId(locale),
+					".keyword")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/BlogPostingImageEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/BlogPostingImageEntityModel.java
@@ -48,7 +48,8 @@ public class BlogPostingImageEntityModel implements EntityModel {
 				"sizeInBytes", locale -> Field.getSortableFieldName("size")),
 			new StringEntityField(
 				"fileExtension",
-				locale -> Field.getSortableFieldName("extension_String")),
+				locale -> Field.getSortableFieldName("extension_String"),
+				locale -> "extension"),
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/ContentElementEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/ContentElementEntityModel.java
@@ -15,6 +15,7 @@
 package com.liferay.headless.delivery.internal.odata.entity.v1_0;
 
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.CollectionEntityField;
@@ -65,8 +66,10 @@ public class ContentElementEntityModel implements EntityModel {
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> StringBundler.concat(
+					"localized_title_", LocaleUtil.toLanguageId(locale),
+					".keyword")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/ContentStructureEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/ContentStructureEntityModel.java
@@ -15,6 +15,7 @@
 package com.liferay.headless.delivery.internal.odata.entity.v1_0;
 
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
@@ -42,8 +43,10 @@ public class ContentStructureEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_name_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_name_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> StringBundler.concat(
+					"localized_name_", LocaleUtil.toLanguageId(locale),
+					".keyword")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/DocumentEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/DocumentEntityModel.java
@@ -68,7 +68,8 @@ public class DocumentEntityModel implements EntityModel {
 				"sizeInBytes", locale -> Field.getSortableFieldName("size")),
 			new StringEntityField(
 				"fileExtension",
-				locale -> Field.getSortableFieldName("extension_String")),
+				locale -> Field.getSortableFieldName("extension_String"),
+				locale -> "extension"),
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/DocumentEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/DocumentEntityModel.java
@@ -16,6 +16,7 @@ package com.liferay.headless.delivery.internal.odata.entity.v1_0;
 
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -71,8 +72,10 @@ public class DocumentEntityModel implements EntityModel {
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> StringBundler.concat(
+					"localized_title_", LocaleUtil.toLanguageId(locale),
+					".keyword")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/DocumentFolderEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/DocumentFolderEntityModel.java
@@ -44,7 +44,8 @@ public class DocumentFolderEntityModel implements EntityModel {
 				locale -> Field.MODIFIED_DATE),
 			new IntegerEntityField("creatorId", locale -> Field.USER_ID),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName(Field.TITLE)));
+				"name", locale -> Field.getSortableFieldName(Field.TITLE),
+				locale -> Field.TITLE + ".keyword"));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/KnowledgeBaseArticleEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/KnowledgeBaseArticleEntityModel.java
@@ -53,7 +53,8 @@ public class KnowledgeBaseArticleEntityModel implements EntityModel {
 				locale -> Field.MODIFIED_DATE),
 			new StringEntityField(
 				"friendlyUrlPath",
-				locale -> Field.getSortableFieldName("urlTitle_String")),
+				locale -> Field.getSortableFieldName("urlTitle_String"),
+				locale -> "urlTitle.keyword"),
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/KnowledgeBaseArticleEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/KnowledgeBaseArticleEntityModel.java
@@ -15,6 +15,7 @@
 package com.liferay.headless.delivery.internal.odata.entity.v1_0;
 
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.CollectionEntityField;
@@ -56,8 +57,10 @@ public class KnowledgeBaseArticleEntityModel implements EntityModel {
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> StringBundler.concat(
+					"localized_title_", LocaleUtil.toLanguageId(locale),
+					".keyword")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/MessageBoardMessageEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/MessageBoardMessageEntityModel.java
@@ -83,7 +83,8 @@ public class MessageBoardMessageEntityModel implements EntityModel {
 				"viewCount", locale -> Field.getSortableFieldName("viewCount")),
 			new StringEntityField(
 				"friendlyUrlPath",
-				locale -> Field.getSortableFieldName("urlSubject_String")),
+				locale -> Field.getSortableFieldName("urlSubject_String"),
+				locale -> "urlSubject.keyword"),
 			new StringEntityField(
 				"headline",
 				locale -> Field.getSortableFieldName(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/MessageBoardMessageEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/MessageBoardMessageEntityModel.java
@@ -15,6 +15,7 @@
 package com.liferay.headless.delivery.internal.odata.entity.v1_0;
 
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.BooleanEntityField;
@@ -86,8 +87,10 @@ public class MessageBoardMessageEntityModel implements EntityModel {
 			new StringEntityField(
 				"headline",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> StringBundler.concat(
+					"localized_title_", LocaleUtil.toLanguageId(locale),
+					".keyword")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/MessageBoardSectionEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/MessageBoardSectionEntityModel.java
@@ -44,7 +44,8 @@ public class MessageBoardSectionEntityModel implements EntityModel {
 				locale -> Field.MODIFIED_DATE),
 			new IntegerEntityField("creatorId", locale -> Field.USER_ID),
 			new StringEntityField(
-				"title", locale -> Field.getSortableFieldName(Field.NAME)));
+				"title", locale -> Field.getSortableFieldName(Field.NAME),
+				locale -> Field.NAME + ".keyword"));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/StructuredContentEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/StructuredContentEntityModel.java
@@ -74,12 +74,16 @@ public class StructuredContentEntityModel implements EntityModel {
 				locale -> Field.getSortableFieldName(
 					StringBundler.concat(
 						"urlTitle_", LocaleUtil.toLanguageId(locale),
-						"_String"))),
+						"_String")),
+				locale -> StringBundler.concat(
+					"urlTitle_", LocaleUtil.toLanguageId(locale), ".keyword")),
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> StringBundler.concat(
+					"localized_title_", LocaleUtil.toLanguageId(locale),
+					".keyword")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/StructuredContentFolderEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/StructuredContentFolderEntityModel.java
@@ -15,6 +15,7 @@
 package com.liferay.headless.delivery.internal.odata.entity.v1_0;
 
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.ComplexEntityField;
@@ -47,8 +48,10 @@ public class StructuredContentFolderEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> StringBundler.concat(
+					"localized_title_", LocaleUtil.toLanguageId(locale),
+					".keyword")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/WikiNodeEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/WikiNodeEntityModel.java
@@ -41,7 +41,8 @@ public class WikiNodeEntityModel implements EntityModel {
 				locale -> Field.MODIFIED_DATE),
 			new IntegerEntityField("creatorId", locale -> Field.USER_ID),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName(Field.TITLE)));
+				"name", locale -> Field.getSortableFieldName(Field.TITLE),
+				locale -> Field.TITLE + ".keyword"));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/WikiPageEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/WikiPageEntityModel.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.delivery.internal.odata.entity.v1_0;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.ComplexEntityField;
@@ -44,8 +45,10 @@ public class WikiPageEntityModel implements EntityModel {
 			new StringEntityField(
 				"headline",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> StringBundler.concat(
+					"localized_title_", LocaleUtil.toLanguageId(locale),
+					".keyword")));
 	}
 
 	@Override

--- a/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/odata/entity/v1_0/NotificationTemplateEntityModel.java
+++ b/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/odata/entity/v1_0/NotificationTemplateEntityModel.java
@@ -40,7 +40,8 @@ public class NotificationTemplateEntityModel implements EntityModel {
 				locale -> Field.MODIFIED_DATE),
 			new IntegerEntityField("userId", locale -> Field.USER_ID),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName(Field.NAME)));
+				"name", locale -> Field.getSortableFieldName(Field.NAME),
+				locale -> Field.NAME + ".keyword"));
 	}
 
 	@Override

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/odata/entity/v1_0/ObjectDefinitionEntityModel.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/odata/entity/v1_0/ObjectDefinitionEntityModel.java
@@ -40,7 +40,8 @@ public class ObjectDefinitionEntityModel implements EntityModel {
 				locale -> Field.MODIFIED_DATE),
 			new IntegerEntityField("userId", locale -> Field.USER_ID),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName("name")));
+				"name", locale -> Field.getSortableFieldName("name"),
+				locale -> "name.keyword"));
 	}
 
 	@Override

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/odata/entity/v1_0/ObjectRelationshipEntityModel.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/odata/entity/v1_0/ObjectRelationshipEntityModel.java
@@ -40,7 +40,8 @@ public class ObjectRelationshipEntityModel implements EntityModel {
 				locale -> Field.MODIFIED_DATE),
 			new IntegerEntityField("userId", locale -> Field.USER_ID),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName("name")));
+				"name", locale -> Field.getSortableFieldName("name"),
+				locale -> "name.keyword"));
 	}
 
 	@Override

--- a/modules/apps/portal-odata/portal-odata-api/bnd.bnd
+++ b/modules/apps/portal-odata/portal-odata-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal OData API
 Bundle-SymbolicName: com.liferay.portal.odata.api
-Bundle-Version: 4.2.2
+Bundle-Version: 4.3.0
 Export-Package:\
 	com.liferay.portal.odata.entity,\
 	com.liferay.portal.odata.filter,\

--- a/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/entity/StringEntityField.java
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/entity/StringEntityField.java
@@ -44,4 +44,25 @@ public class StringEntityField extends EntityField {
 			filterableAndSortableFieldNameFunction, String::valueOf);
 	}
 
+	/**
+	 * Creates a new {@code StringEntityField} with a {@code Function} to
+	 * convert the entity field's name to a filterable/sortable field name for a
+	 * locale.
+	 *
+	 * @param  name the entity field's name
+	 * @param  sortableFieldNameFunction the sortable field name {@code
+	 *         Function}
+	 * @param  filterableFieldNameFunction the filterable field name {@code
+	 *         Function}
+	 * @review
+	 */
+	public StringEntityField(
+		String name, Function<Locale, String> sortableFieldNameFunction,
+		Function<Locale, String> filterableFieldNameFunction) {
+
+		super(
+			name, Type.STRING, sortableFieldNameFunction,
+			filterableFieldNameFunction, String::valueOf);
+	}
+
 }

--- a/modules/apps/portal-odata/portal-odata-api/src/main/resources/com/liferay/portal/odata/entity/packageinfo
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/resources/com/liferay/portal/odata/entity/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -1901,6 +1901,16 @@
 				"store": true,
 				"type": "keyword"
 			},
+			"urlSubject": {
+				"fields": {
+					"keyword": {
+						"store": true,
+						"type": "keyword"
+					}
+				},
+				"store": true,
+				"type": "text"
+			},
 			"urlTitle": {
 				"fields": {
 					"keyword": {

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -1605,6 +1605,16 @@
 				"store": true,
 				"type": "text"
 			},
+			"firstName": {
+				"fields": {
+					"keyword": {
+						"store": true,
+						"type": "keyword"
+					}
+				},
+				"store": true,
+				"type": "text"
+			},
 			"folderId": {
 				"store": true,
 				"type": "keyword"
@@ -1643,6 +1653,16 @@
 				"store": true,
 				"type": "keyword"
 			},
+			"jobTitle": {
+				"fields": {
+					"keyword": {
+						"store": true,
+						"type": "keyword"
+					}
+				},
+				"store": true,
+				"type": "text"
+			},
 			"languageId": {
 				"store": true,
 				"type": "keyword"
@@ -1651,6 +1671,16 @@
 				"format": "yyyyMMddHHmmss",
 				"store": true,
 				"type": "date"
+			},
+			"lastName": {
+				"fields": {
+					"keyword": {
+						"store": true,
+						"type": "keyword"
+					}
+				},
+				"store": true,
+				"type": "text"
 			},
 			"lastPostDate": {
 				"format": "yyyyMMddHHmmss",

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -1714,6 +1714,16 @@
 				"store": true,
 				"type": "text"
 			},
+			"nameTreePath": {
+				"fields": {
+					"keyword": {
+						"store": true,
+						"type": "keyword"
+					}
+				},
+				"store": true,
+				"type": "text"
+			},
 			"nestedFieldArray": {
 				"properties": {
 					"fieldName": {
@@ -1802,6 +1812,16 @@
 			"recordSetId": {
 				"store": true,
 				"type": "keyword"
+			},
+			"region": {
+				"fields": {
+					"keyword": {
+						"store": true,
+						"type": "keyword"
+					}
+				},
+				"store": true,
+				"type": "text"
 			},
 			"removedByUser": {
 				"type": "keyword"

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -1871,6 +1871,16 @@
 				"store": true,
 				"type": "keyword"
 			},
+			"urlTitle": {
+				"fields": {
+					"keyword": {
+						"store": true,
+						"type": "keyword"
+					}
+				},
+				"store": true,
+				"type": "text"
+			},
 			"userGroupId": {
 				"store": true,
 				"type": "keyword"

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -641,6 +641,12 @@
 				"template_ar": {
 					"mapping": {
 						"analyzer": "arabic",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -654,6 +660,12 @@
 				"template_bg": {
 					"mapping": {
 						"analyzer": "bulgarian",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -667,6 +679,12 @@
 				"template_ca": {
 					"mapping": {
 						"analyzer": "catalan",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -680,6 +698,12 @@
 				"template_cs": {
 					"mapping": {
 						"analyzer": "czech",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -693,6 +717,12 @@
 				"template_da": {
 					"mapping": {
 						"analyzer": "danish",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -706,6 +736,12 @@
 				"template_de": {
 					"mapping": {
 						"analyzer": "german",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -719,6 +755,12 @@
 				"template_el": {
 					"mapping": {
 						"analyzer": "greek",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -732,6 +774,12 @@
 				"template_en": {
 					"mapping": {
 						"analyzer": "english",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"search_analyzer": "liferay_analyzer_en",
 						"store": true,
 						"term_vector": "with_positions_offsets",
@@ -746,6 +794,12 @@
 				"template_es": {
 					"mapping": {
 						"analyzer": "spanish",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"search_analyzer": "liferay_analyzer_es",
 						"store": true,
 						"term_vector": "with_positions_offsets",
@@ -760,6 +814,12 @@
 				"template_et": {
 					"mapping": {
 						"analyzer": "estonian",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -773,6 +833,12 @@
 				"template_eu": {
 					"mapping": {
 						"analyzer": "basque",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -786,6 +852,12 @@
 				"template_fa": {
 					"mapping": {
 						"analyzer": "persian",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -799,6 +871,12 @@
 				"template_fi": {
 					"mapping": {
 						"analyzer": "finnish",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -812,6 +890,12 @@
 				"template_fr": {
 					"mapping": {
 						"analyzer": "french",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -825,6 +909,12 @@
 				"template_gl": {
 					"mapping": {
 						"analyzer": "galician",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -838,6 +928,12 @@
 				"template_hi": {
 					"mapping": {
 						"analyzer": "hindi",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -851,6 +947,12 @@
 				"template_hu": {
 					"mapping": {
 						"analyzer": "hungarian",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -864,6 +966,12 @@
 				"template_hy": {
 					"mapping": {
 						"analyzer": "armenian",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -877,6 +985,12 @@
 				"template_in": {
 					"mapping": {
 						"analyzer": "indonesian",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -890,6 +1004,12 @@
 				"template_it": {
 					"mapping": {
 						"analyzer": "italian",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -903,6 +1023,12 @@
 				"template_ja": {
 					"mapping": {
 						"analyzer": "kuromoji",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -916,6 +1042,12 @@
 				"template_ko": {
 					"mapping": {
 						"analyzer": "cjk",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -929,6 +1061,12 @@
 				"template_lt": {
 					"mapping": {
 						"analyzer": "lithuanian",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -942,6 +1080,12 @@
 				"template_nl": {
 					"mapping": {
 						"analyzer": "dutch",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -955,6 +1099,12 @@
 				"template_no": {
 					"mapping": {
 						"analyzer": "norwegian",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -968,6 +1118,12 @@
 				"template_pl": {
 					"mapping": {
 						"analyzer": "polish",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -981,6 +1137,12 @@
 				"template_pt": {
 					"mapping": {
 						"analyzer": "portuguese",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -994,6 +1156,12 @@
 				"template_pt_br": {
 					"mapping": {
 						"analyzer": "brazilian",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -1006,6 +1174,12 @@
 				"template_ro": {
 					"mapping": {
 						"analyzer": "romanian",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -1019,6 +1193,12 @@
 				"template_ru": {
 					"mapping": {
 						"analyzer": "russian",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -1032,6 +1212,12 @@
 				"template_sv": {
 					"mapping": {
 						"analyzer": "swedish",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -1045,6 +1231,12 @@
 				"template_th": {
 					"mapping": {
 						"analyzer": "thai",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -1058,6 +1250,12 @@
 				"template_tr": {
 					"mapping": {
 						"analyzer": "turkish",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"
@@ -1071,6 +1269,12 @@
 				"template_zh": {
 					"mapping": {
 						"analyzer": "smartcn",
+						"fields": {
+							"keyword": {
+								"store": true,
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"term_vector": "with_positions_offsets",
 						"type": "text"

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -643,6 +643,7 @@
 						"analyzer": "arabic",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -662,6 +663,7 @@
 						"analyzer": "bulgarian",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -681,6 +683,7 @@
 						"analyzer": "catalan",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -700,6 +703,7 @@
 						"analyzer": "czech",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -719,6 +723,7 @@
 						"analyzer": "danish",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -738,6 +743,7 @@
 						"analyzer": "german",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -757,6 +763,7 @@
 						"analyzer": "greek",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -776,6 +783,7 @@
 						"analyzer": "english",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -796,6 +804,7 @@
 						"analyzer": "spanish",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -816,6 +825,7 @@
 						"analyzer": "estonian",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -835,6 +845,7 @@
 						"analyzer": "basque",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -854,6 +865,7 @@
 						"analyzer": "persian",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -873,6 +885,7 @@
 						"analyzer": "finnish",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -892,6 +905,7 @@
 						"analyzer": "french",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -911,6 +925,7 @@
 						"analyzer": "galician",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -930,6 +945,7 @@
 						"analyzer": "hindi",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -949,6 +965,7 @@
 						"analyzer": "hungarian",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -968,6 +985,7 @@
 						"analyzer": "armenian",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -987,6 +1005,7 @@
 						"analyzer": "indonesian",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -1006,6 +1025,7 @@
 						"analyzer": "italian",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -1025,6 +1045,7 @@
 						"analyzer": "kuromoji",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -1044,6 +1065,7 @@
 						"analyzer": "cjk",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -1063,6 +1085,7 @@
 						"analyzer": "lithuanian",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -1082,6 +1105,7 @@
 						"analyzer": "dutch",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -1101,6 +1125,7 @@
 						"analyzer": "norwegian",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -1120,6 +1145,7 @@
 						"analyzer": "polish",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -1139,6 +1165,7 @@
 						"analyzer": "portuguese",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -1158,6 +1185,7 @@
 						"analyzer": "brazilian",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -1176,6 +1204,7 @@
 						"analyzer": "romanian",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -1195,6 +1224,7 @@
 						"analyzer": "russian",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -1214,6 +1244,7 @@
 						"analyzer": "swedish",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -1233,6 +1264,7 @@
 						"analyzer": "thai",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -1252,6 +1284,7 @@
 						"analyzer": "turkish",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -1271,6 +1304,7 @@
 						"analyzer": "smartcn",
 						"fields": {
 							"keyword": {
+								"normalizer": "lowercase",
 								"store": true,
 								"type": "keyword"
 							}
@@ -1608,6 +1642,7 @@
 			"firstName": {
 				"fields": {
 					"keyword": {
+						"normalizer": "lowercase",
 						"store": true,
 						"type": "keyword"
 					}
@@ -1656,6 +1691,7 @@
 			"jobTitle": {
 				"fields": {
 					"keyword": {
+						"normalizer": "lowercase",
 						"store": true,
 						"type": "keyword"
 					}
@@ -1675,6 +1711,7 @@
 			"lastName": {
 				"fields": {
 					"keyword": {
+						"normalizer": "lowercase",
 						"store": true,
 						"type": "keyword"
 					}
@@ -1707,6 +1744,7 @@
 			"name": {
 				"fields": {
 					"keyword": {
+						"normalizer": "lowercase",
 						"store": true,
 						"type": "keyword"
 					}
@@ -1717,6 +1755,7 @@
 			"nameTreePath": {
 				"fields": {
 					"keyword": {
+						"normalizer": "lowercase",
 						"store": true,
 						"type": "keyword"
 					}
@@ -1816,6 +1855,7 @@
 			"region": {
 				"fields": {
 					"keyword": {
+						"normalizer": "lowercase",
 						"store": true,
 						"type": "keyword"
 					}
@@ -1901,6 +1941,7 @@
 			"title": {
 				"fields": {
 					"keyword": {
+						"normalizer": "lowercase",
 						"store": true,
 						"type": "keyword"
 					}
@@ -1924,6 +1965,7 @@
 			"urlSubject": {
 				"fields": {
 					"keyword": {
+						"normalizer": "lowercase",
 						"store": true,
 						"type": "keyword"
 					}
@@ -1934,6 +1976,7 @@
 			"urlTitle": {
 				"fields": {
 					"keyword": {
+						"normalizer": "lowercase",
 						"store": true,
 						"type": "keyword"
 					}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -1674,6 +1674,16 @@
 				"store": true,
 				"type": "date"
 			},
+			"name": {
+				"fields": {
+					"keyword": {
+						"store": true,
+						"type": "keyword"
+					}
+				},
+				"store": true,
+				"type": "text"
+			},
 			"nestedFieldArray": {
 				"properties": {
 					"fieldName": {

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -1849,6 +1849,12 @@
 				"type": "keyword"
 			},
 			"title": {
+				"fields": {
+					"keyword": {
+						"store": true,
+						"type": "keyword"
+					}
+				},
 				"store": true,
 				"term_vector": "with_positions_offsets",
 				"type": "text"

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/OrganizationEntityModel.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/OrganizationEntityModel.java
@@ -63,7 +63,8 @@ public class OrganizationEntityModel extends BaseExpandoEntityModel {
 				String::valueOf),
 			new StringEntityField("country", locale -> "country"),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName(Field.NAME)),
+				"name", locale -> Field.getSortableFieldName(Field.NAME),
+				locale -> Field.NAME + ".keyword"),
 			new StringEntityField(
 				"nameTreePath",
 				locale -> Field.getSortableFieldName("nameTreePath_String")),

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/OrganizationEntityModel.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/OrganizationEntityModel.java
@@ -67,9 +67,11 @@ public class OrganizationEntityModel extends BaseExpandoEntityModel {
 				locale -> Field.NAME + ".keyword"),
 			new StringEntityField(
 				"nameTreePath",
-				locale -> Field.getSortableFieldName("nameTreePath_String")),
+				locale -> Field.getSortableFieldName("nameTreePath_String"),
+				locale -> "nameTreePath.keyword"),
 			new StringEntityField(
-				"region", locale -> Field.getSortableFieldName("region")),
+				"region", locale -> Field.getSortableFieldName("region"),
+				locale -> "region.keyword"),
 			new StringEntityField("type", locale -> Field.TYPE)
 		};
 	}

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/UserEntityModel.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/UserEntityModel.java
@@ -85,11 +85,14 @@ public class UserEntityModel extends BaseExpandoEntityModel {
 				"userId", locale -> Field.USER_ID, String::valueOf),
 			new StringEntityField("emailAddress", locale -> "emailAddress"),
 			new StringEntityField(
-				"firstName", locale -> Field.getSortableFieldName("firstName")),
+				"firstName", locale -> Field.getSortableFieldName("firstName"),
+				locale -> "firstName.keyword"),
 			new StringEntityField(
-				"jobTitle", locale -> Field.getSortableFieldName("jobTitle")),
+				"jobTitle", locale -> Field.getSortableFieldName("jobTitle"),
+				locale -> "jobTitle.keyword"),
 			new StringEntityField(
-				"lastName", locale -> Field.getSortableFieldName("lastName")),
+				"lastName", locale -> Field.getSortableFieldName("lastName"),
+				locale -> "lastName.keyword"),
 			new StringEntityField(
 				"screenName",
 				locale -> Field.getSortableFieldName("screenName")),

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/UserEntityModel.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/UserEntityModel.java
@@ -95,7 +95,8 @@ public class UserEntityModel extends BaseExpandoEntityModel {
 				locale -> "lastName.keyword"),
 			new StringEntityField(
 				"screenName",
-				locale -> Field.getSortableFieldName("screenName")),
+				locale -> Field.getSortableFieldName("screenName"),
+				locale -> "screenName"),
 			new StringEntityField("userName", locale -> Field.USER_NAME)
 		};
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/odata/entity/v1_0/InstanceEntityModel.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/odata/entity/v1_0/InstanceEntityModel.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.workflow.metrics.rest.internal.odata.entity.v1_0;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
@@ -33,7 +34,9 @@ public class InstanceEntityModel implements EntityModel {
 			new StringEntityField(
 				"assetType",
 				locale -> Field.getSortableFieldName(
-					"assetType_".concat(LocaleUtil.toLanguageId(locale)))),
+					"assetType_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> StringBundler.concat(
+					"assetType_", LocaleUtil.toLanguageId(locale), ".keyword")),
 			new StringEntityField("assigneeName", locale -> "assigneeName"),
 			new DateTimeEntityField(
 				"dateCreated", locale -> "createDate", locale -> "createDate"),

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/resources/META-INF/search/mappings.json
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/resources/META-INF/search/mappings.json
@@ -1731,6 +1731,12 @@
 				"type": "text"
 			},
 			"assetType": {
+				"fields": {
+					"keyword": {
+						"store": true,
+						"type": "keyword"
+					}
+				},
 				"store": true,
 				"term_vector": "with_positions_offsets",
 				"type": "text"

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/resources/META-INF/search/mappings.json
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/resources/META-INF/search/mappings.json
@@ -1733,6 +1733,7 @@
 			"assetType": {
 				"fields": {
 					"keyword": {
+						"normalizer": "lowercase",
 						"store": true,
 						"type": "keyword"
 					}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/odata/entity/v1_0/SXPBlueprintEntityModel.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/odata/entity/v1_0/SXPBlueprintEntityModel.java
@@ -45,12 +45,24 @@ public class SXPBlueprintEntityModel implements EntityModel {
 				"description",
 				locale -> Field.getSortableFieldName(
 					LocalizationUtil.getLocalizedName(
-						Field.DESCRIPTION, LocaleUtil.toLanguageId(locale)))),
+						Field.DESCRIPTION, LocaleUtil.toLanguageId(locale))),
+				locale -> {
+					String localizedName = LocalizationUtil.getLocalizedName(
+						Field.DESCRIPTION, LocaleUtil.toLanguageId(locale));
+
+					return localizedName + ".keyword";
+				}),
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
 					LocalizationUtil.getLocalizedName(
-						Field.TITLE, LocaleUtil.toLanguageId(locale)))));
+						Field.TITLE, LocaleUtil.toLanguageId(locale))),
+				locale -> {
+					String localizedName = LocalizationUtil.getLocalizedName(
+						Field.TITLE, LocaleUtil.toLanguageId(locale));
+
+					return localizedName + ".keyword";
+				}));
 	}
 
 	@Override

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/odata/entity/v1_0/SXPElementEntityModel.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/odata/entity/v1_0/SXPElementEntityModel.java
@@ -46,12 +46,24 @@ public class SXPElementEntityModel implements EntityModel {
 				"description",
 				locale -> Field.getSortableFieldName(
 					LocalizationUtil.getLocalizedName(
-						Field.DESCRIPTION, LocaleUtil.toLanguageId(locale)))),
+						Field.DESCRIPTION, LocaleUtil.toLanguageId(locale))),
+				locale -> {
+					String localizedName = LocalizationUtil.getLocalizedName(
+						Field.DESCRIPTION, LocaleUtil.toLanguageId(locale));
+
+					return localizedName + ".keyword";
+				}),
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
 					LocalizationUtil.getLocalizedName(
-						Field.TITLE, LocaleUtil.toLanguageId(locale)))));
+						Field.TITLE, LocaleUtil.toLanguageId(locale))),
+				locale -> {
+					String localizedName = LocalizationUtil.getLocalizedName(
+						Field.TITLE, LocaleUtil.toLanguageId(locale));
+
+					return localizedName + ".keyword";
+				}));
 	}
 
 	@Override


### PR DESCRIPTION
Hi Team,

**Context**
This PR was created with guidance from [PTR-3915](https://issues.liferay.com/browse/PTR-3915) and will serve as the initial PR for the Search Team and Headless Team to review.

**Goal**
The goal of this PR is to restore the filtering functionality of Headless API, which was partially broken after the Breaking Change that was introduced by [LPS-152937](https://issues.liferay.com/browse/LPS-152937)

**PR**
This PR basically introduces 2 types of changes:
- Headless: To no longer utilize *_sortable fields for filtering String fields
- Search: Update mapping to introduce multi-field keyword fields to replace the previous *_sortable fields

Note: For the multi-field keyword fields, I ended up setting the normalizer to lowercase. 
- See commit (https://github.com/liferay-search/liferay-portal/commit/205dabdd6496036ef394c0cb158e95b3e84d1de6) for details

Please let me know if you have any questions.
Thanks!

/cc @lipusz @peerkar @4lejandrito