### PR TITLE
LPS-178546 search-experiences-web: Use new REST endpoint when loading element preview modal

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -102,6 +102,7 @@ function EditSXPBlueprintForm({
 	const controllerRef = useRef();
 
 	const [errors, setErrors] = useState([]);
+	const [isTitleEdited, setIsTitleEdited] = useState(false);
 	const [previewInfo, setPreviewInfo] = useState(() => ({
 		loading: false,
 		results: {},
@@ -603,6 +604,8 @@ function EditSXPBlueprintForm({
 	}) => {
 		formik.setFieldValue('description_i18n', description_i18n);
 		formik.setFieldValue('title_i18n', title_i18n);
+
+		setIsTitleEdited(true);
 	};
 
 	const _handleCloseSidebar = () => {
@@ -1027,6 +1030,7 @@ function EditSXPBlueprintForm({
 			<PageToolbar
 				description={initialDescription}
 				descriptionI18n={formik.values.description_i18n}
+				edited={isTitleEdited}
 				isSubmitting={formik.isSubmitting}
 				onCancel={redirectURL}
 				onChangeTab={_handleChangeTab}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -597,9 +597,12 @@ function EditSXPBlueprintForm({
 		setTab(tab);
 	};
 
-	const _handleChangeTitleAndDescription = ({description, title}) => {
-		formik.setFieldValue('description_i18n', description);
-		formik.setFieldValue('title_i18n', title);
+	const _handleChangeTitleAndDescription = ({
+		description_i18n,
+		title_i18n,
+	}) => {
+		formik.setFieldValue('description_i18n', description_i18n);
+		formik.setFieldValue('title_i18n', title_i18n);
 	};
 
 	const _handleCloseSidebar = () => {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -102,7 +102,10 @@ function EditSXPBlueprintForm({
 	const controllerRef = useRef();
 
 	const [errors, setErrors] = useState([]);
-	const [isTitleEdited, setIsTitleEdited] = useState(false);
+	const [
+		isTitleAndDescriptionEdited,
+		setIsTitleAndDescriptionEdited,
+	] = useState(false);
 	const [previewInfo, setPreviewInfo] = useState(() => ({
 		loading: false,
 		results: {},
@@ -605,7 +608,7 @@ function EditSXPBlueprintForm({
 		formik.setFieldValue('description_i18n', description_i18n);
 		formik.setFieldValue('title_i18n', title_i18n);
 
-		setIsTitleEdited(true);
+		setIsTitleAndDescriptionEdited(true);
 	};
 
 	const _handleCloseSidebar = () => {
@@ -1030,7 +1033,6 @@ function EditSXPBlueprintForm({
 			<PageToolbar
 				description={initialDescription}
 				descriptionI18n={formik.values.description_i18n}
-				edited={isTitleEdited}
 				isSubmitting={formik.isSubmitting}
 				onCancel={redirectURL}
 				onChangeTab={_handleChangeTab}
@@ -1039,6 +1041,7 @@ function EditSXPBlueprintForm({
 				tab={tab}
 				tabs={TABS}
 				title={initialTitle}
+				titleAndDescriptionEdited={isTitleAndDescriptionEdited}
 				titleI18n={formik.values.title_i18n}
 			>
 				<ClayToolbar.Item>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
@@ -30,16 +30,12 @@ import sxpElementSchema from '../../schemas/sxp-query-element.schema.json';
 import useDebounceCallback from '../hooks/useDebounceCallback';
 import useShouldConfirmBeforeNavigate from '../hooks/useShouldConfirmBeforeNavigate';
 import CodeMirrorEditor from '../shared/CodeMirrorEditor';
-import ErrorBoundary from '../shared/ErrorBoundary';
-import JSONSXPElement from '../shared/JSONSXPElement';
 import LearnMessage from '../shared/LearnMessage';
 import PageToolbar from '../shared/PageToolbar';
-import PreviewModal from '../shared/PreviewModal';
 import SearchInput from '../shared/SearchInput';
 import Sidebar from '../shared/Sidebar';
 import SubmitWarningModal from '../shared/SubmitWarningModal';
 import ThemeContext from '../shared/ThemeContext';
-import SXPElement from '../shared/sxp_element/index';
 import {CONFIG_PREFIX} from '../utils/constants';
 import {DEFAULT_ERROR} from '../utils/errorMessages';
 import {DEFAULT_HEADERS} from '../utils/fetch/fetch_data';
@@ -48,9 +44,8 @@ import formatLocaleWithDashes from '../utils/language/format_locale_with_dashes'
 import formatLocaleWithUnderscores from '../utils/language/format_locale_with_underscores';
 import renameKeys from '../utils/language/rename_keys';
 import sub from '../utils/language/sub';
-import getUIConfigurationValues from '../utils/sxp_element/get_ui_configuration_values';
-import isCustomJSONSXPElement from '../utils/sxp_element/is_custom_json_sxp_element';
 import {openErrorToast, setInitialSuccessToast} from '../utils/toasts';
+import PreviewSXPElement from './PreviewSXPElement';
 import SidebarPanel from './SidebarPanel';
 
 /**
@@ -495,51 +490,6 @@ function EditSXPElementForm({
 		doc.replaceRange(variable, cursor);
 	};
 
-	const _renderPreviewBody = () => {
-		if (!isSXPElementJSONInvalid) {
-			const previewSXPElementJSON = {
-				elementDefinition: {}, // Define elementDefinition to prevent error
-				...sxpElementJSONObject,
-			};
-
-			const uiConfigurationValues = getUIConfigurationValues(
-				previewSXPElementJSON
-			);
-
-			return (
-				<div className="portlet-sxp-blueprint-admin">
-					<ErrorBoundary>
-						{isCustomJSONSXPElement(uiConfigurationValues) ? (
-							<JSONSXPElement
-								collapseAll={false}
-								readOnly={true}
-								sxpElement={previewSXPElementJSON}
-								uiConfigurationValues={uiConfigurationValues}
-							/>
-						) : (
-							<SXPElement
-								collapseAll={false}
-								sxpElement={previewSXPElementJSON}
-								uiConfigurationValues={uiConfigurationValues}
-							/>
-						)}
-					</ErrorBoundary>
-				</div>
-			);
-		}
-		else {
-			return (
-				<ClayEmptyState
-					description={Liferay.Language.get(
-						'json-may-be-incorrect-and-we-were-unable-to-load-a-preview-of-the-configuration'
-					)}
-					imgSrc="/o/admin-theme/images/states/empty_state.gif"
-					title={Liferay.Language.get('unable-to-load-preview')}
-				/>
-			);
-		}
-	};
-
 	return (
 		<>
 			<form ref={formRef}>
@@ -586,21 +536,10 @@ function EditSXPElementForm({
 					)}
 
 					<ClayToolbar.Item>
-						<PreviewModal
-							body={_renderPreviewBody()}
-							size="lg"
-							title={Liferay.Language.get(
-								'preview-configuration'
-							)}
-						>
-							<ClayButton
-								borderless
-								displayType="secondary"
-								small
-							>
-								{Liferay.Language.get('preview')}
-							</ClayButton>
-						</PreviewModal>
+						<PreviewSXPElement
+							isSXPElementJSONInvalid={isSXPElementJSONInvalid}
+							sxpElementJSONObject={sxpElementJSONObject}
+						/>
 					</ClayToolbar.Item>
 				</PageToolbar>
 			</form>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
@@ -465,7 +465,10 @@ function EditSXPElementForm({
 	 * Updates `title_i18n`, `description_i18n` inside CodeMirror editor,
 	 * which triggers `_handleJSONEditorValueChange`.
 	 */
-	const _handleTitleAndDescriptionChange = ({description, title}) => {
+	const _handleTitleAndDescriptionChange = ({
+		description_i18n,
+		title_i18n,
+	}) => {
 		if (!isSXPElementJSONInvalid) {
 			const doc = elementJSONEditorRef.current.getDoc();
 
@@ -473,8 +476,8 @@ function EditSXPElementForm({
 				JSON.stringify(
 					reassignTitleAndDescription(
 						sxpElementJSONObject,
-						title,
-						description
+						title_i18n,
+						description_i18n
 					),
 					null,
 					'\t'

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
@@ -45,7 +45,7 @@ import formatLocaleWithUnderscores from '../utils/language/format_locale_with_un
 import renameKeys from '../utils/language/rename_keys';
 import sub from '../utils/language/sub';
 import {openErrorToast, setInitialSuccessToast} from '../utils/toasts';
-import PreviewSXPElement from './PreviewSXPElement';
+import PreviewSXPElementModal from './PreviewSXPElementModal';
 import SidebarPanel from './SidebarPanel';
 
 /**
@@ -200,11 +200,14 @@ function EditSXPElementForm({
 	const [expandAllVariables, setExpandAllVariables] = useState(false);
 	const [description, setDescription] = useState(initialDescription);
 	const [isSubmitting, setIsSubmitting] = useState(false);
-	const [isTitleEdited, setIsTitleEdited] = useState(false);
 	const [showInfoSidebar, setShowInfoSidebar] = useState(false);
 	const [showSubmitWarningModal, setShowSubmitWarningModal] = useState(false);
 	const [showVariablesSidebar, setShowVariablesSidebar] = useState(false);
 	const [title, setTitle] = useState(initialTitle);
+	const [
+		isTitleAndDescriptionEdited,
+		setIsTitleAndDescriptionEdited,
+	] = useState(false);
 	const [elementJSONEditorValue, setElementJSONEditorValue] = useState(
 		initialElementJSONEditorValueString
 	);
@@ -308,8 +311,8 @@ function EditSXPElementForm({
 	 * Parses CodeMirror text after user types into it or submits changes
 	 * on title and description modal. Validates `title_i18n` and
 	 * `description_i18n` and updates `sxpElementJSONObject` if parsing
-	 * succeeds. Also updates `isTitleEdited` if the `title_i18n` or
-	 * `description_i18n` changed.
+	 * succeeds. Also updates `isTitleAndDescriptionEdited` if the `title_i18n`
+	 * or `description_i18n` changed.
 	 */
 	const _handleJSONEditorValueChange = (value) => {
 		setElementJSONEditorValue(value);
@@ -326,7 +329,7 @@ function EditSXPElementForm({
 				['title_i18n', 'description_i18n']
 			)
 		) {
-			setIsTitleEdited(true);
+			setIsTitleAndDescriptionEdited(true);
 		}
 	};
 
@@ -499,8 +502,8 @@ function EditSXPElementForm({
 	/**
 	 * Called after clicking 'Done' in title and description edit modal.
 	 * Updates `title_i18n`, `description_i18n` inside CodeMirror editor,
-	 * which triggers `_handleJSONEditorValueChange`. Sets `isTitleEdited`
-	 * to true.
+	 * which triggers `_handleJSONEditorValueChange`. Sets
+	 * `isTitleAndDescriptionEdited` to true.
 	 */
 	const _handleTitleAndDescriptionChange = ({
 		description_i18n,
@@ -521,22 +524,22 @@ function EditSXPElementForm({
 				)
 			);
 
-			setIsTitleEdited(true);
+			setIsTitleAndDescriptionEdited(true);
 		}
 	};
 
 	/**
 	 * Called after clicking 'Preview' in the toolbar. Updates the
 	 * `title` and `description` with the new translations, as long as the
-	 * title is not empty. Also resets the `isTitleEdited` in order for
-	 * them to show on the toolbar.
+	 * title is not empty. Also resets the `isTitleAndDescriptionEdited`
+	 * in order for them to show on the toolbar.
 	 */
 	const _handleTitleAndDescriptionPreview = ({description, title}) => {
 		if (title) {
 			setDescription(description);
 			setTitle(title);
 
-			setIsTitleEdited(false);
+			setIsTitleAndDescriptionEdited(false);
 		}
 	};
 
@@ -568,7 +571,6 @@ function EditSXPElementForm({
 						formatLocaleWithDashes
 					)}
 					disableTitleAndDescriptionModal={isSXPElementJSONInvalid}
-					edited={isTitleEdited}
 					isSubmitting={isSubmitting}
 					onCancel={redirectURL}
 					onSubmit={_handleSubmit}
@@ -577,6 +579,7 @@ function EditSXPElementForm({
 					}
 					readOnly={readOnly}
 					title={title}
+					titleAndDescriptionEdited={isTitleAndDescriptionEdited}
 					titleI18n={renameKeys(
 						sxpElementJSONObject.title_i18n,
 						formatLocaleWithDashes
@@ -594,7 +597,7 @@ function EditSXPElementForm({
 					)}
 
 					<ClayToolbar.Item>
-						<PreviewSXPElement
+						<PreviewSXPElementModal
 							isSXPElementJSONInvalid={isSXPElementJSONInvalid}
 							onTitleAndDescriptionChange={
 								_handleTitleAndDescriptionPreview

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/PreviewSXPElement.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/PreviewSXPElement.js
@@ -25,6 +25,7 @@ import isCustomJSONSXPElement from '../utils/sxp_element/is_custom_json_sxp_elem
 
 export default function PreviewSXPElement({
 	isSXPElementJSONInvalid,
+	onTitleAndDescriptionChange,
 	sxpElementJSONObject,
 }) {
 	const [loading, setLoading] = useState(false);
@@ -59,10 +60,14 @@ export default function PreviewSXPElement({
 		})
 			.then((response) => response.json())
 			.then((jsonObject) => {
+				const {description, title} = jsonObject;
+
 				setPreview({
 					sxpElementJSONObject: jsonObject,
 					uiConfigurationValues: getUIConfigurationValues(jsonObject),
 				});
+
+				onTitleAndDescriptionChange({description, title});
 			})
 			.catch(() => {
 				setPreview({

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/PreviewSXPElement.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/PreviewSXPElement.js
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import ClayButton from '@clayui/button';
+import ClayEmptyState from '@clayui/empty-state';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
+import ClayModal, {useModal} from '@clayui/modal';
+import {fetch} from 'frontend-js-web';
+import React, {useState} from 'react';
+
+import ErrorBoundary from '../shared/ErrorBoundary';
+import JSONSXPElement from '../shared/JSONSXPElement';
+import SXPElement from '../shared/sxp_element/index';
+import {DEFAULT_HEADERS} from '../utils/fetch/fetch_data';
+import getUIConfigurationValues from '../utils/sxp_element/get_ui_configuration_values';
+import isCustomJSONSXPElement from '../utils/sxp_element/is_custom_json_sxp_element';
+
+export default function PreviewSXPElement({
+	isSXPElementJSONInvalid,
+	sxpElementJSONObject,
+}) {
+	const [loading, setLoading] = useState(false);
+	const [preview, setPreview] = useState({
+		sxpElementJSONObject: {},
+		uiConfigurationValues: {},
+	});
+	const [visible, setVisible] = useState(false);
+
+	const {observer} = useModal({
+		onClose: () => {
+			setVisible(false);
+
+			setPreview({
+				sxpElementJSONObject: {},
+				uiConfigurationValues: {},
+			});
+		},
+	});
+
+	const _fetchPreview = () => {
+		setLoading(true);
+
+		fetch('/o/search-experiences-rest/v1.0/sxp-elements/preview', {
+			body: JSON.stringify({
+				description_i18n: sxpElementJSONObject.description_i18n,
+				elementDefinition: sxpElementJSONObject.elementDefinition,
+				title_i18n: sxpElementJSONObject.title_i18n,
+			}),
+			headers: DEFAULT_HEADERS,
+			method: 'POST',
+		})
+			.then((response) => response.json())
+			.then((jsonObject) => {
+				setPreview({
+					sxpElementJSONObject: jsonObject,
+					uiConfigurationValues: getUIConfigurationValues(jsonObject),
+				});
+			})
+			.catch(() => {
+				setPreview({
+					sxpElementJSONObject,
+					uiConfigurationValues: getUIConfigurationValues(
+						sxpElementJSONObject
+					),
+				});
+			})
+			.finally(() => {
+				setLoading(false);
+			});
+	};
+
+	const _handleOpenModal = () => {
+		setVisible(true);
+
+		if (!isSXPElementJSONInvalid) {
+			_fetchPreview();
+		}
+	};
+
+	return (
+		<>
+			{visible && (
+				<ClayModal
+					className="sxp-preview-modal-root"
+					observer={observer}
+					size="lg"
+				>
+					<ClayModal.Header>
+						{Liferay.Language.get('preview-configuration')}
+					</ClayModal.Header>
+
+					<ClayModal.Body>
+						{!isSXPElementJSONInvalid ? (
+							<div className="portlet-sxp-blueprint-admin">
+								{loading ? (
+									<div
+										className="d-flex inline-item"
+										style={{
+											height: '400px',
+										}}
+									>
+										<ClayLoadingIndicator
+											displayType="secondary"
+											size="sm"
+										/>
+									</div>
+								) : (
+									<ErrorBoundary>
+										{isCustomJSONSXPElement(
+											preview.uiConfigurationValues
+										) ? (
+											<JSONSXPElement
+												collapseAll={false}
+												readOnly={true}
+												sxpElement={
+													preview.sxpElementJSONObject
+												}
+												uiConfigurationValues={
+													preview.uiConfigurationValues
+												}
+											/>
+										) : (
+											<SXPElement
+												collapseAll={false}
+												sxpElement={
+													preview.sxpElementJSONObject
+												}
+												uiConfigurationValues={
+													preview.uiConfigurationValues
+												}
+											/>
+										)}
+									</ErrorBoundary>
+								)}
+							</div>
+						) : (
+							<ClayEmptyState
+								description={Liferay.Language.get(
+									'json-may-be-incorrect-and-we-were-unable-to-load-a-preview-of-the-configuration'
+								)}
+								imgSrc="/o/admin-theme/images/states/empty_state.gif"
+								title={Liferay.Language.get(
+									'unable-to-load-preview'
+								)}
+							/>
+						)}
+					</ClayModal.Body>
+				</ClayModal>
+			)}
+
+			<ClayButton
+				borderless
+				displayType="secondary"
+				onClick={_handleOpenModal}
+				small
+			>
+				{Liferay.Language.get('preview')}
+			</ClayButton>
+		</>
+	);
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/PreviewSXPElementModal.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/PreviewSXPElementModal.js
@@ -14,12 +14,13 @@ import ClayEmptyState from '@clayui/empty-state';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal, {useModal} from '@clayui/modal';
 import {fetch} from 'frontend-js-web';
-import React, {useState} from 'react';
+import React, {useRef, useState} from 'react';
 
 import ErrorBoundary from '../shared/ErrorBoundary';
 import JSONSXPElement from '../shared/JSONSXPElement';
 import SXPElement from '../shared/sxp_element/index';
 import {DEFAULT_HEADERS} from '../utils/fetch/fetch_data';
+import isEmpty from '../utils/functions/is_empty';
 import getUIConfigurationValues from '../utils/sxp_element/get_ui_configuration_values';
 import isCustomJSONSXPElement from '../utils/sxp_element/is_custom_json_sxp_element';
 
@@ -28,6 +29,8 @@ export default function PreviewSXPElementModal({
 	onTitleAndDescriptionChange,
 	sxpElementJSONObject,
 }) {
+	const titleAndDescriptionRef = useRef({});
+
 	const [loading, setLoading] = useState(false);
 	const [preview, setPreview] = useState({
 		sxpElementJSONObject: {},
@@ -35,15 +38,23 @@ export default function PreviewSXPElementModal({
 	});
 	const [visible, setVisible] = useState(false);
 
-	const {observer} = useModal({
-		onClose: () => {
-			setVisible(false);
+	const _handleClose = () => {
+		setVisible(false);
 
-			setPreview({
-				sxpElementJSONObject: {},
-				uiConfigurationValues: {},
-			});
-		},
+		setPreview({
+			sxpElementJSONObject: {},
+			uiConfigurationValues: {},
+		});
+
+		if (!isEmpty(titleAndDescriptionRef.current)) {
+			onTitleAndDescriptionChange(titleAndDescriptionRef.current);
+
+			titleAndDescriptionRef.current = {};
+		}
+	};
+
+	const {observer} = useModal({
+		onClose: _handleClose,
 	});
 
 	const _fetchPreview = () => {
@@ -67,7 +78,7 @@ export default function PreviewSXPElementModal({
 					uiConfigurationValues: getUIConfigurationValues(jsonObject),
 				});
 
-				onTitleAndDescriptionChange({description, title});
+				titleAndDescriptionRef.current = {description, title};
 			})
 			.catch(() => {
 				setPreview({

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/PreviewSXPElementModal.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/PreviewSXPElementModal.js
@@ -23,7 +23,7 @@ import {DEFAULT_HEADERS} from '../utils/fetch/fetch_data';
 import getUIConfigurationValues from '../utils/sxp_element/get_ui_configuration_values';
 import isCustomJSONSXPElement from '../utils/sxp_element/is_custom_json_sxp_element';
 
-export default function PreviewSXPElement({
+export default function PreviewSXPElementModal({
 	isSXPElementJSONInvalid,
 	onTitleAndDescriptionChange,
 	sxpElementJSONObject,

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/EditTitleModal.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/EditTitleModal.js
@@ -61,11 +61,11 @@ export default function EditTitleModal({
 
 	const defaultLocaleBCP47 = formatLocaleWithDashes(defaultLocale);
 
-	const [description_i18n, setDescription_i18n] = useState(
+	const [descriptionI18n, setDescriptionI18n] = useState(
 		initialDescriptionI18n
 	);
 	const [hasError, setHasError] = useState(false);
-	const [title_i18n, setTitle_i18n] = useState(initialTitleI18n);
+	const [titleI18n, setTitleI18n] = useState(initialTitleI18n);
 
 	const descriptionInputRef = useRef();
 	const titleInputRef = useRef();
@@ -75,7 +75,7 @@ export default function EditTitleModal({
 			setHasError(!event.currentTarget.value);
 		}
 		else {
-			setHasError(!title_i18n[defaultLocaleBCP47]);
+			setHasError(!titleI18n[defaultLocaleBCP47]);
 		}
 	};
 
@@ -87,13 +87,16 @@ export default function EditTitleModal({
 	const _handleSubmit = (event) => {
 		event.preventDefault();
 
-		if (!title_i18n[defaultLocaleBCP47]) {
+		if (!titleI18n[defaultLocaleBCP47]) {
 			setHasError(true);
 
 			titleInputRef.current.focus();
 		}
 		else {
-			onSubmit({description_i18n, title_i18n});
+			onSubmit({
+				description_i18n: descriptionI18n,
+				title_i18n: titleI18n,
+			});
 
 			onClose();
 		}
@@ -149,11 +152,11 @@ export default function EditTitleModal({
 							onSelectedLocaleChange={_handleSelectedLocaleChange(
 								titleInputRef
 							)}
-							onTranslationsChange={setTitle_i18n}
+							onTranslationsChange={setTitleI18n}
 							placeholder=""
 							ref={titleInputRef}
 							selectedLocale={selectedLocale}
-							translations={disabled ? {} : title_i18n}
+							translations={disabled ? {} : titleI18n}
 						/>
 
 						{hasError && (
@@ -187,11 +190,11 @@ export default function EditTitleModal({
 							onSelectedLocaleChange={_handleSelectedLocaleChange(
 								descriptionInputRef
 							)}
-							onTranslationsChange={setDescription_i18n}
+							onTranslationsChange={setDescriptionI18n}
 							placeholder=""
 							ref={descriptionInputRef}
 							selectedLocale={selectedLocale}
-							translations={disabled ? {} : description_i18n}
+							translations={disabled ? {} : descriptionI18n}
 						/>
 					</div>
 				</ClayModal.Body>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/EditTitleModal.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/EditTitleModal.js
@@ -38,8 +38,8 @@ export default function EditTitleModal({
 	disabled,
 	displayLocale,
 	fieldFocus,
-	initialDescription,
-	initialTitle,
+	initialDescriptionI18n,
+	initialTitleI18n,
 	observer,
 	onClose,
 	onSubmit,
@@ -61,9 +61,11 @@ export default function EditTitleModal({
 
 	const defaultLocaleBCP47 = formatLocaleWithDashes(defaultLocale);
 
-	const [description, setDescription] = useState(initialDescription);
+	const [description_i18n, setDescription_i18n] = useState(
+		initialDescriptionI18n
+	);
 	const [hasError, setHasError] = useState(false);
-	const [title, setTitle] = useState(initialTitle);
+	const [title_i18n, setTitle_i18n] = useState(initialTitleI18n);
 
 	const descriptionInputRef = useRef();
 	const titleInputRef = useRef();
@@ -73,7 +75,7 @@ export default function EditTitleModal({
 			setHasError(!event.currentTarget.value);
 		}
 		else {
-			setHasError(!title[defaultLocaleBCP47]);
+			setHasError(!title_i18n[defaultLocaleBCP47]);
 		}
 	};
 
@@ -85,13 +87,13 @@ export default function EditTitleModal({
 	const _handleSubmit = (event) => {
 		event.preventDefault();
 
-		if (!title[defaultLocaleBCP47]) {
+		if (!title_i18n[defaultLocaleBCP47]) {
 			setHasError(true);
 
 			titleInputRef.current.focus();
 		}
 		else {
-			onSubmit({description, title});
+			onSubmit({description_i18n, title_i18n});
 
 			onClose();
 		}
@@ -147,11 +149,11 @@ export default function EditTitleModal({
 							onSelectedLocaleChange={_handleSelectedLocaleChange(
 								titleInputRef
 							)}
-							onTranslationsChange={setTitle}
+							onTranslationsChange={setTitle_i18n}
 							placeholder=""
 							ref={titleInputRef}
 							selectedLocale={selectedLocale}
-							translations={disabled ? {} : title}
+							translations={disabled ? {} : title_i18n}
 						/>
 
 						{hasError && (
@@ -185,11 +187,11 @@ export default function EditTitleModal({
 							onSelectedLocaleChange={_handleSelectedLocaleChange(
 								descriptionInputRef
 							)}
-							onTranslationsChange={setDescription}
+							onTranslationsChange={setDescription_i18n}
 							placeholder=""
 							ref={descriptionInputRef}
 							selectedLocale={selectedLocale}
-							translations={disabled ? {} : description}
+							translations={disabled ? {} : description_i18n}
 						/>
 					</div>
 				</ClayModal.Body>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PageToolbar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PageToolbar.js
@@ -124,8 +124,8 @@ export default function PageToolbar({
 									disabled={disableTitleAndDescriptionModal}
 									displayLocale={displayLocale}
 									fieldFocus={modalFieldFocus}
-									initialDescription={descriptionI18n}
-									initialTitle={titleI18n}
+									initialDescriptionI18n={descriptionI18n}
+									initialTitleI18n={titleI18n}
 									observer={observer}
 									onClose={onClose}
 									onSubmit={_handleSubmit}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PageToolbar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PageToolbar.js
@@ -68,6 +68,7 @@ export default function PageToolbar({
 	description,
 	descriptionI18n,
 	disableTitleAndDescriptionModal = false,
+	edited,
 	isSubmitting,
 	onCancel,
 	onChangeTab,
@@ -83,7 +84,6 @@ export default function PageToolbar({
 		ThemeContext
 	);
 
-	const [edited, setEdited] = useState(false);
 	const [modalFieldFocus, setModalFieldFocus] = useState('title');
 	const [modalVisible, setModalVisible] = useState(false);
 
@@ -104,12 +104,6 @@ export default function PageToolbar({
 		setModalVisible(true);
 	};
 
-	const _handleSubmit = (value) => {
-		setEdited(true);
-
-		onTitleAndDescriptionChange(value);
-	};
-
 	return (
 		<div className="page-toolbar-root">
 			<ClayToolbar
@@ -128,7 +122,7 @@ export default function PageToolbar({
 									initialTitleI18n={titleI18n}
 									observer={observer}
 									onClose={onClose}
-									onSubmit={_handleSubmit}
+									onSubmit={onTitleAndDescriptionChange}
 								/>
 							)}
 
@@ -306,6 +300,7 @@ PageToolbar.propTypes = {
 	description: PropTypes.string,
 	descriptionI18n: PropTypes.object,
 	disableTitleAndDescriptionModal: PropTypes.bool,
+	edited: PropTypes.bool,
 	isSubmitting: PropTypes.bool,
 	onCancel: PropTypes.string.isRequired,
 	onChangeTab: PropTypes.func,

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PageToolbar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PageToolbar.js
@@ -68,7 +68,6 @@ export default function PageToolbar({
 	description,
 	descriptionI18n,
 	disableTitleAndDescriptionModal = false,
-	edited,
 	isSubmitting,
 	onCancel,
 	onChangeTab,
@@ -78,6 +77,7 @@ export default function PageToolbar({
 	tab,
 	tabs,
 	title,
+	titleAndDescriptionEdited,
 	titleI18n,
 }) {
 	const {availableLanguages, defaultLocale, locale} = useContext(
@@ -166,7 +166,7 @@ export default function PageToolbar({
 										onClick={_handleClickEdit('title')}
 									>
 										<div className="entry-title text-truncate">
-											{(!edited
+											{(!titleAndDescriptionEdited
 												? title
 												: titleI18n[displayLocale]) || (
 												<span className="entry-title-blank">
@@ -199,14 +199,14 @@ export default function PageToolbar({
 												className="entry-description text-truncate"
 												data-tooltip-align="bottom"
 												title={
-													!edited
+													!titleAndDescriptionEdited
 														? description
 														: descriptionI18n[
 																displayLocale
 														  ]
 												}
 											>
-												{(!edited
+												{(!titleAndDescriptionEdited
 													? description
 													: descriptionI18n[
 															displayLocale
@@ -300,7 +300,6 @@ PageToolbar.propTypes = {
 	description: PropTypes.string,
 	descriptionI18n: PropTypes.object,
 	disableTitleAndDescriptionModal: PropTypes.bool,
-	edited: PropTypes.bool,
 	isSubmitting: PropTypes.bool,
 	onCancel: PropTypes.string.isRequired,
 	onChangeTab: PropTypes.func,
@@ -310,5 +309,6 @@ PageToolbar.propTypes = {
 	tab: PropTypes.string,
 	tabs: PropTypes.object,
 	title: PropTypes.string,
+	titleAndDescriptionEdited: PropTypes.bool,
 	titleI18n: PropTypes.object,
 };


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-178546 - [FE] Use new REST endpoint when loading element preview modal

These changes apply the new endpoint to preview the element, offering the updated translations for the title, description, field labels, and field helptexts. 

Some notes:
- A separate component called `PreviewSXPElement` was created in order to handle the new states of loading and the preview information. 
- Since the call is pretty fast, the loading indicator won't really be seen unless you choose a slow network. 
- Updated some of the naming of `title` and `description` to `title_i18n` and `description_i18n` for clarity.
- It looks like in the SXPElement editor, there are several places that title and description can be edited, so the state of `edited` that was originally in `PageToolbar` was lifted up to the forms as `isTitleEdited`. 
- There was a small bug happening where you make changes to the title/description on the editor, it won't update the toolbar's title/description unless you make some changes on the toolbar's edit title/description modal. So lifting the state and checking for when `title_i18n`/`description_i18n` gets changed on the editor did help fix that. 
- After you click on the preview button, the title and description will also be updated with the new translation. It seemed nice to have, and with the lifted state it was simple to do.
 
Hopefully that makes sense, let me know if that's okay and if any of the new things should be renamed! 😅 

Here's a short demo:

https://github.com/liferay-search/liferay-portal/assets/14063502/0834ee7b-e332-423e-893d-8997f55c4ab6
