### PR TITLE
LPS-187225 search-experiences-web: Translate blueprint title inside options widget

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_options/configuration.jsp
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_options/configuration.jsp
@@ -47,7 +47,7 @@
 						).put(
 							"initialSXPBlueprintId", SXPBlueprintOptionsPortletPreferencesUtil.getValue(portletPreferences, "sxpBlueprintId")
 						).put(
-							"initialSXPBlueprintTitle", (sxpBlueprint != null) ? HtmlUtil.escape(sxpBlueprint.getTitle(locale)) : StringPool.BLANK
+							"initialSXPBlueprintTitle", (sxpBlueprint != null) ? LanguageUtil.get(request, HtmlUtil.escape(sxpBlueprint.getTitle(locale))) : StringPool.BLANK
 						).put(
 							"learnMessages", LearnMessageUtil.getJSONObject("search-experiences-web")
 						).put(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-187225 - On Blueprint Options widget, title is not translated on initial load

Just need to add a translate step when passing in the `initialSXPBlueprintTitle` 👍 