### PR TITLE
LPS-185839: Fix CTEntrySearcherTest

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTCollectionModelDocumentContributor.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTCollectionModelDocumentContributor.java
@@ -46,6 +46,7 @@ public class CTCollectionModelDocumentContributor
 
 	@Override
 	public void contribute(Document document, CTCollection ctCollection) {
+		document.addKeyword(Field.COMPANY_ID, ctCollection.getCompanyId());
 		document.addDate(Field.CREATE_DATE, ctCollection.getCreateDate());
 		document.addText(Field.DESCRIPTION, ctCollection.getDescription());
 		document.addDate(Field.MODIFIED_DATE, ctCollection.getModifiedDate());

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTEntryModelDocumentContributor.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTEntryModelDocumentContributor.java
@@ -148,9 +148,9 @@ public class CTEntryModelDocumentContributor
 			_ctDisplayRendererRegistry.getCTDisplayRenderer(
 				ctEntry.getModelClassNameId()));
 
-		document.addLocalizedKeyword(
-			"typeName",
-			_getTypeNameMap(locales, ctEntry.getModelClassNameId()));
+		document.addLocalizedText(
+			"typeName", _getTypeNameMap(locales, ctEntry.getModelClassNameId()),
+			true);
 
 		if (model == null) {
 			return;
@@ -173,7 +173,7 @@ public class CTEntryModelDocumentContributor
 			_getTitleMap(locales, model, ctEntry.getModelClassNameId()));
 		document.addLocalizedText(
 			Field.TITLE,
-			_getTitleMap(locales, model, ctEntry.getModelClassNameId()));
+			_getTitleMap(locales, model, ctEntry.getModelClassNameId()), true);
 
 		document.addKeyword(
 			"hideable",

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTEntryModelDocumentContributor.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTEntryModelDocumentContributor.java
@@ -56,6 +56,7 @@ public class CTEntryModelDocumentContributor
 
 	@Override
 	public void contribute(Document document, CTEntry ctEntry) {
+		document.addKeyword(Field.COMPANY_ID, ctEntry.getCompanyId());
 		document.addDate(Field.CREATE_DATE, ctEntry.getCreateDate());
 		document.addDate(Field.MODIFIED_DATE, ctEntry.getModifiedDate());
 

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTProcessModelDocumentContributor.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTProcessModelDocumentContributor.java
@@ -38,6 +38,7 @@ public class CTProcessModelDocumentContributor
 
 	@Override
 	public void contribute(Document document, CTProcess ctProcess) {
+		document.addKeyword(Field.COMPANY_ID, ctProcess.getCompanyId());
 		document.addDate(Field.CREATE_DATE, ctProcess.getCreateDate());
 		document.addKeyword(Field.TYPE, ctProcess.getType());
 		document.addKeyword(Field.USER_ID, ctProcess.getUserId());

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/search/test/CTEntrySearcherTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/search/test/CTEntrySearcherTest.java
@@ -270,12 +270,18 @@ public class CTEntrySearcherTest {
 
 		_assertHits(
 			_getUIDs(_getCTEntries(journalFolder1, journalFolder2)),
-			_getSort(Field.TITLE, SortOrder.ASC),
+			_getSort(
+				Field.getSortableFieldName(
+					Field.getLocalizedName(LocaleUtil.US, Field.TITLE)),
+				SortOrder.ASC),
 			_byAttribute(
 				"modelClassNameId", new long[] {_journalFolderClassNameId}));
 		_assertHits(
 			_getUIDs(_getCTEntries(journalFolder2, journalFolder1)),
-			_getSort(Field.TITLE, SortOrder.DESC),
+			_getSort(
+				Field.getSortableFieldName(
+					Field.getLocalizedName(LocaleUtil.US, Field.TITLE)),
+				SortOrder.DESC),
 			_byAttribute(
 				"modelClassNameId", new long[] {_journalFolderClassNameId}));
 	}
@@ -308,7 +314,10 @@ public class CTEntrySearcherTest {
 
 		_assertHits(
 			_getUIDs(journalArticleCTEntry, journalFolderCTEntry),
-			_getSort("typeName", SortOrder.ASC),
+			_getSort(
+				Field.getSortableFieldName(
+					Field.getLocalizedName(LocaleUtil.US, "typeName")),
+				SortOrder.ASC),
 			_byAttribute(
 				"modelClassNameId",
 				new long[] {
@@ -316,7 +325,10 @@ public class CTEntrySearcherTest {
 				}));
 		_assertHits(
 			_getUIDs(journalFolderCTEntry, journalArticleCTEntry),
-			_getSort("typeName", SortOrder.DESC),
+			_getSort(
+				Field.getSortableFieldName(
+					Field.getLocalizedName(LocaleUtil.US, "typeName")),
+				SortOrder.DESC),
 			_byAttribute(
 				"modelClassNameId",
 				new long[] {

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/search/test/CTEntrySearcherTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/search/test/CTEntrySearcherTest.java
@@ -419,9 +419,11 @@ public class CTEntrySearcherTest {
 		SearchResponse searchResponse = _searcher.search(
 			searchRequestBuilder.build());
 
-		DocumentsAssert.assertValuesIgnoreRelevance(
+		DocumentsAssert.assertValues(
 			searchResponse.getResponseString(), searchResponse.getDocuments(),
-			Field.UID, expectedValues);
+			Field.UID,
+			StringBundler.concat(
+				"[", StringUtils.join(expectedValues, ", "), "]"));
 	}
 
 	private Consumer<SearchRequestBuilder> _byAttribute(

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/search/test/CTEntrySearcherTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/search/test/CTEntrySearcherTest.java
@@ -50,7 +50,6 @@ import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.portal.search.sort.Sort;
-import com.liferay.portal.search.sort.SortFieldBuilder;
 import com.liferay.portal.search.sort.SortOrder;
 import com.liferay.portal.search.sort.Sorts;
 import com.liferay.portal.search.test.util.DocumentsAssert;
@@ -434,10 +433,8 @@ public class CTEntrySearcherTest {
 			CTEntry.class);
 	}
 
-	private Sort _getSort(String orderByCol, SortOrder sortOrder) {
-		return _sorts.field(
-			_sortFieldBuilder.getSortField(CTEntry.class, orderByCol),
-			sortOrder);
+	private Sort _getSort(String field, SortOrder sortOrder) {
+		return _sorts.field(field, sortOrder);
 	}
 
 	private List<String> _getUIDs(BaseModel<?>... baseModels) {
@@ -476,9 +473,6 @@ public class CTEntrySearcherTest {
 
 	@Inject
 	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
-
-	@Inject
-	private SortFieldBuilder _sortFieldBuilder;
 
 	@Inject
 	private Sorts _sorts;

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/search/test/CTEntrySearcherTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/search/test/CTEntrySearcherTest.java
@@ -29,6 +29,7 @@ import com.liferay.journal.test.util.JournalFolderFixture;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.model.BaseModel;
@@ -41,6 +42,7 @@ import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -61,6 +63,8 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
+
+import org.apache.commons.lang3.StringUtils;
 
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -340,30 +344,41 @@ public class CTEntrySearcherTest {
 	public void testSortByUserName() throws Exception {
 		JournalFolder journalFolder1 = null;
 
-		try (SafeCloseable safeCloseable =
-				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
-					_ctCollection.getCtCollectionId())) {
-
-			journalFolder1 = _journalFolderFixture.addFolder(
-				_group.getGroupId(), RandomTestUtil.randomString());
-		}
-
-		User user = UserTestUtil.addUser(
-			"ZZ", LocaleUtil.getDefault(), "ZZ", "ZZ", null);
-
 		JournalFolder journalFolder2 = null;
 
 		String originalName = PrincipalThreadLocal.getName();
 
+		User user1 = UserTestUtil.addUser(
+			"AA", LocaleUtil.getDefault(), "AA", "AA", null);
+
+		User user2 = UserTestUtil.addUser(
+			"BB", LocaleUtil.getDefault(), "BB", "BB", null);
+
 		try {
-			PrincipalThreadLocal.setName(user.getUserId());
+			PrincipalThreadLocal.setName(user1.getUserId());
+
+			try (SafeCloseable safeCloseable =
+					CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+						_ctCollection.getCtCollectionId())) {
+
+				journalFolder1 = _journalFolderFixture.addFolder(
+					JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+					RandomTestUtil.randomString(),
+					ServiceContextTestUtil.getServiceContext(
+						_group.getGroupId(), user1.getUserId()));
+			}
+
+			PrincipalThreadLocal.setName(user2.getUserId());
 
 			try (SafeCloseable safeCloseable =
 					CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
 						_ctCollection.getCtCollectionId())) {
 
 				journalFolder2 = _journalFolderFixture.addFolder(
-					_group.getGroupId(), RandomTestUtil.randomString());
+					JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+					RandomTestUtil.randomString(),
+					ServiceContextTestUtil.getServiceContext(
+						_group.getGroupId(), user2.getUserId()));
 			}
 		}
 		finally {

--- a/portal-kernel/src/com/liferay/portal/kernel/search/Document.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/Document.java
@@ -137,6 +137,9 @@ public interface Document extends Cloneable, Serializable {
 
 	public void addLocalizedText(String name, Map<Locale, String> values);
 
+	public void addLocalizedText(
+		String name, Map<Locale, String> values, boolean sortable);
+
 	public void addNumber(String name, BigDecimal value);
 
 	public void addNumber(String name, BigDecimal[] values);

--- a/portal-kernel/src/com/liferay/portal/kernel/search/DocumentImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/DocumentImpl.java
@@ -477,6 +477,19 @@ public class DocumentImpl implements Document {
 	}
 
 	@Override
+	public void addLocalizedText(
+		String name, Map<Locale, String> values, boolean sortable) {
+
+		if ((values == null) || values.isEmpty()) {
+			return;
+		}
+
+		Field field = createField(name, values, sortable);
+
+		field.setTokenized(true);
+	}
+
+	@Override
 	public void addNumber(String name, BigDecimal value) {
 		createNumberField(name, value);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
@@ -1,1 +1,1 @@
-version 20.1.0
+version 20.2.0


### PR DESCRIPTION
Covers:

- https://issues.liferay.com/browse/LPS-185839
  - https://issues.liferay.com/browse/LPS-187614

Fixes the following issues in CTEntrySearcherTest:
- companyId not indexed for CT entities (causes SOLR tests to failI)
- sort tests failing, because of:
  -  ignoring the order
  - getting a blank field to sort on
  - no sortable fields available
