### PR TITLE
[TS] LPS-187515 Authenticated requests fail with [HTTP/1.1 403 Forbidden]

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/RestHighLevelClientFactory.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/RestHighLevelClientFactory.java
@@ -253,7 +253,6 @@ public class RestHighLevelClientFactory {
 					_proxyConfig.getHost(), _proxyConfig.getPort(), "http"));
 		}
 
-		httpClientBuilder.disableAuthCaching();
 		httpClientBuilder.disableAutomaticRetries();
 		httpClientBuilder.disableConnectionState();
 		httpClientBuilder.disableContentCompression();


### PR DESCRIPTION
[LPS-187515](https://issues.liferay.com/browse/LPS-187515)
Hi Search Team,

Please review my change that removes a call which breaks authenticated requests. I haven't found much information about _disableAuthCaching()_, but as written [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/7.17/_basic_authentication.html), it disables adding authentication headers to the request.

Please let me know if you have any questions or concerns.

Thank you,
Istvan