### PR TITLE
LPS-189258 For category facet configuration, add Global Site into list of sites to display vocabularies

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/components/_select_vocabularies.scss
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/components/_select_vocabularies.scss
@@ -1,10 +1,14 @@
-.select-vocabularies {
-	.treeview-group {
-		.treeview-link {
-			padding-left: 36px !important;
+html#{$cadmin-selector} {
+	.portlet-category-facet .cadmin {
+		.select-vocabularies {
+			.treeview-group {
+				.treeview-link {
+					padding-left: 36px !important;
 
-			.c-inner {
-				margin-right: -36px !important;
+					.c-inner {
+						margin-right: -36px !important;
+					}
+				}
 			}
 		}
 	}

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/components/_select_vocabularies.scss
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/components/_select_vocabularies.scss
@@ -10,6 +10,12 @@ html#{$cadmin-selector} {
 					}
 				}
 			}
+
+			.treeview-link-site-row {
+				.lexicon-icon {
+					font-size: 10px;
+				}
+			}
 		}
 	}
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SelectVocabularies.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SelectVocabularies.js
@@ -55,7 +55,10 @@ function SiteRow({disabled, name, onSelect, vocabularies}) {
 	};
 
 	return (
-		<div className="autofit-row">
+		<div
+			className="autofit-row"
+			style={{marginLeft: vocabularies.length ? '0' : '-24px'}}
+		>
 			<div className="autofit-col">
 				<ClayButton
 					className="component-expander"
@@ -404,6 +407,7 @@ function SelectVocabularies({
 						)}
 
 						<LearnMessage
+							className="c-ml-1"
 							learnMessages={learnMessages}
 							resourceKey="tag-and-category-facet"
 						/>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SelectVocabularies.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SelectVocabularies.js
@@ -39,24 +39,13 @@ const SELECT_OPTIONS = {
 };
 
 /**
- * Converts a stringified list of IDs into an array of numbers. This separates
- * values by commas, filters out empty values, and parses the string into a
- * number, if possible.
+ * Converts a stringified list of IDs into an array of IDs. This separates
+ * values by commas and filters out empty values.
  * @param {string} idsString The list of IDs as a string
- * @return {Array} Array of ID numbers
+ * @return {Array} Array of IDs as strings
  */
 const convertToIDArray = (idsString) =>
-	idsString
-		.split(',')
-		.filter((id) => id !== '')
-		.map((id) => {
-			try {
-				return JSON.parse(id);
-			}
-			catch {
-				return id;
-			}
-		});
+	idsString.split(',').filter((id) => id !== '');
 
 function SiteRow({disabled, name, onSelect, vocabularies}) {
 	const _handleSelect = (select = true) => (event) => {
@@ -149,7 +138,7 @@ function VocabularyTree({
 		setSelectedKeys(newList);
 	};
 
-	const _handleToggle = (id) => () => {
+	const _handleToggle = (id) => {
 		_handleSelect([{id}], !selectedKeys.has(id));
 	};
 
@@ -323,10 +312,10 @@ function SelectVocabularies({
 								...itemsWithGlobalSite[index],
 								children: (vocabularies?.items || []).map(
 									({id, name}) => {
-										ids.push(id); // Collect IDs for _isDisplayInfoSelectedVocabulariesHidden
+										ids.push(id.toString()); // Collect IDs for _isDisplayInfoSelectedVocabulariesHidden
 
 										return {
-											id,
+											id: id.toString(),
 											name,
 										};
 									}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-189258 - When Category Facet Field is set to assetVocabularyCategoryIds, global vocabularies don't show up in Category Facet configuration 

It looks like the API to get a user account's sites has changed and no longer includes what was the "Global Site" (asked about it [here](https://liferay.slack.com/archives/CNUCYF7EW/p1688066456304889)), so these are a few changes to add it back in, in order to see those default "Topic - Audience - Stage" vocabularies. 

Additional things:
- It looks like there is now an endpoint to specifically get sites, so it's using `/o/headless-admin-user/v1.0/my-user-account/sites` instead of `/o/headless-admin-user/v1.0/my-user-account` now
- I had issues with the vocabularies persisting after being saved, and it looked like it had to do with the values being numbers when using the Clay Treeview object (not sure when this started, but made the update to be strings instead)
- Style updates like adding some margin to learn message, making the lexicon arrows more petite, fixing the indent for tree items with no vocabularies

How it looks:
<img width="973" alt="Screenshot 2023-07-06 at 4 40 49 PM" src="https://github.com/liferay-search/liferay-portal/assets/14063502/95e4d292-5608-40c1-9b0f-cae92430e8da">

Thanks for taking a look, let me know if I should add anything else!