### PR TITLE
[TS] LPS-190128 Upgrade fails for search experience blueprint with empty elementsIntancesJSON

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v1_3_0/SXPBlueprintUpgradeProcess.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v1_3_0/SXPBlueprintUpgradeProcess.java
@@ -84,7 +84,7 @@ public class SXPBlueprintUpgradeProcess extends UpgradeProcess {
 			ElementInstanceUtil.toElementInstances(elementInstancesJSON);
 
 		if (ArrayUtil.isEmpty(elementInstances)) {
-			return "{}";
+			return "[]";
 		}
 
 		for (ElementInstance elementInstance : elementInstances) {

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v1_3_2/SXPBlueprintUpgradeProcess.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v1_3_2/SXPBlueprintUpgradeProcess.java
@@ -95,6 +95,12 @@ public class SXPBlueprintUpgradeProcess extends UpgradeProcess {
 	private String _upgradeElementInstancesJSON(String elementInstancesJSON)
 		throws Exception {
 
+		if (elementInstancesJSON.equals("{}") ||
+			elementInstancesJSON.equals("[]")) {
+
+			return "[]";
+		}
+
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray(
 			elementInstancesJSON);
 


### PR DESCRIPTION
**LPS Link:**  [LPS-190128](https://liferay.atlassian.net/browse/LPS-190128)
**Previous PR:** #988 

# Context

This error occurs when an upgrade process is run and there is at least one SXPBlueprint with empty elementInstancesJSON column. The [_getElementInstancesJSON](https://github.com/liferay/liferay-portal-ee/blob/84a0af70bfbd2eee0f996fd143fa8af3e7c25438/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v1_3_0/SXPBlueprintUpgradeProcess.java#L80C2-L144C3) function returns "{}" when the elementInstances array is empty, as seen bellow:

```
if (ArrayUtil.isEmpty(elementInstances)) {
       return "{}";
}
```

This causes an error in the [constructor of the JSONArrayImpl](https://github.com/liferay/liferay-portal-ee/blob/84a0af70bfbd2eee0f996fd143fa8af3e7c25438/portal-impl/src/com/liferay/portal/json/JSONArrayImpl.java#L52C1-L64C1) class because a JSON array must contain "[]" instead of "{}". 

```
org.json.JSONException: A JSONArray text must start with '[' at 1 [character 2 line 1]
	at org.json.JSONTokener.syntaxError(JSONTokener.java:521) ~[json-java.jar:?]
	at org.json.JSONArray.<init>(JSONArray.java:109) ~[json-java.jar:?]
	at org.json.JSONArray.<init>(JSONArray.java:162) ~[json-java.jar:?]
	at com.liferay.portal.json.JSONArrayImpl.<init>(JSONArrayImpl.java:58) ~[portal-impl.jar:?]
	at com.liferay.portal.json.JSONFactoryImpl.createJSONArray(JSONFactoryImpl.java:154) ~[portal-impl.jar:?]
	at com.liferay.portal.kernel.json.JSONFactoryUtil.createJSONArray(JSONFactoryUtil.java:58) ~[portal-kernel.jar:?]
	at com.liferay.search.experiences.internal.upgrade.v1_3_2.SXPBlueprintUpgradeProcess._upgradeElementInstancesJSON(SXPBlueprintUpgradeProcess.java:98) ~[?:?]
	at com.liferay.search.experiences.internal.upgrade.v1_3_2.SXPBlueprintUpgradeProcess._upgradeSXPBlueprints(SXPBlueprintUpgradeProcess.java:154) ~[?:?]
	at com.liferay.search.experiences.internal.upgrade.v1_3_2.SXPBlueprintUpgradeProcess.doUpgrade(SXPBlueprintUpgradeProcess.java:55) ~[?:?]
	at com.liferay.portal.kernel.upgrade.UpgradeProcess.lambda$upgrade$0(UpgradeProcess.java:130) ~[portal-kernel.jar:?]
	at com.liferay.portal.db.partition.DBPartitionUtil.forEachCompanyId(DBPartitionUtil.java:126) ~[portal-impl.jar:?]
	at com.liferay.portal.dao.db.BaseDB.process(BaseDB.java:337) ~[portal-impl.jar:?]
	at com.liferay.portal.kernel.dao.db.BaseDBProcess.process(BaseDBProcess.java:394) ~[portal-kernel.jar:?]
	at com.liferay.portal.kernel.upgrade.UpgradeProcess.upgrade(UpgradeProcess.java:115) ~[portal-kernel.jar:?]
```

# Proposed solution 

The [_getElementInstancesJSON](https://github.com/liferay/liferay-portal-ee/blob/84a0af70bfbd2eee0f996fd143fa8af3e7c25438/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v1_3_0/SXPBlueprintUpgradeProcess.java#L80C2-L144C3) function was changed to return "[]" when elementInstancesJSON array is empty.

```
if (ArrayUtil.isEmpty(elementInstances)) {
       return "[]";
}
```

The [_upgradeElementInstancesJSON](https://github.com/liferay/liferay-portal/blob/607e862df7671e241e3e8cc7bd35bccbb89156cf/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v1_3_2/SXPBlueprintUpgradeProcess.java#L95C1-L138C1) function has been changed to return "[]" before calling `JSONFactoryUtil.createJSONArray(
elementInstancesJSON);` if elementInstancesJSON equals "[]" or "{}". This change prevents errors that would be caused by already corrupted databases.

```
private String _upgradeElementInstancesJSON(String elementInstancesJSON)
		throws Exception {

		if (elementInstancesJSON.equals("{}") ||
			elementInstancesJSON.equals("[]")) {

			return "[]";
		}

		JSONArray jsonArray = JSONFactoryUtil.createJSONArray(
			elementInstancesJSON);
...
```
