### PR TITLE
LPS-190495 Copy to Keyboard for the Search Insights portlet copies URL encoded text

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/insights/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/insights/view.jsp
@@ -77,7 +77,7 @@ String insightsResponseId = liferayPortletResponse.getNamespace() + "insightsRes
 				>
 					<clay:button
 						cssClass="search-insights-copy-to-clipboard"
-						data-clipboard-text="<%= HtmlUtil.escape(searchInsightsDisplayContext.getRequestString()) %>"
+						data-clipboard-text="<%= searchInsightsDisplayContext.getRequestString() %>"
 						displayType="secondary"
 						icon="copy"
 						label="copy-to-clipboard"
@@ -107,7 +107,7 @@ String insightsResponseId = liferayPortletResponse.getNamespace() + "insightsRes
 				>
 					<clay:button
 						cssClass="search-insights-copy-to-clipboard"
-						data-clipboard-text="<%= HtmlUtil.escape(searchInsightsDisplayContext.getResponseString()) %>"
+						data-clipboard-text="<%= searchInsightsDisplayContext.getResponseString() %>"
 						displayType="secondary"
 						icon="copy"
 						label="copy-to-clipboard"


### PR DESCRIPTION
### **LPS link:** [LPS-190495](https://liferay.atlassian.net/browse/LPS-190495)

# Context

The "Copy to Keyboard" button in Insights portlet copy the encoded text when the user presses it. The [data-clipboard-text](https://github.com/liferay/liferay-portal/blob/379d5d45bc941efe624948991865b40fe63e5c14/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/insights/view.jsp#L80C7-L80C100) parameter of the "Copy to clipboard" button was being populated through `HtmlUtil.escape(searchInsightsDisplayContext.getRequestString())`. The "HtmlUtil.escape()" is responsible for encoding the text. So this makes the copied text to be the encoded text.

## Expected copied text

```
{
    "explain": true,
    "highlight": {
        "pre_tags": ["<liferay-hl>"],
        "post_tags": ["<\/liferay-hl>"],
        "require_field_match": true,
        "fields": {
...
```

## Currently copied text

```
{
    &#34;explain&#34;: true,
    &#34;highlight&#34;: {
        &#34;pre_tags&#34;: [&#34;&lt;liferay-hl&gt;&#34;],
        &#34;post_tags&#34;: [&#34;&lt;\/liferay-hl&gt;&#34;],
        &#34;require_field_match&#34;: true,
        &#34;fields&#34;: {
...
```

# Proposed solution

The code was modified so that the data-clipboard-text parameter is filled directly by "searchInsightsDisplayContext.getRequestString()" without using "HtmlUtil.escape()".

```
data-clipboard-text="<%= searchInsightsDisplayContext.getResponseString() %>"
```