### PR TITLE
LPS-191707 Allow SearchRegistrars to configure/override permissionAware

### DIFF
--- a/modules/apps/portal-search/portal-search-spi/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-spi/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search SPI
 Bundle-SymbolicName: com.liferay.portal.search.spi
-Bundle-Version: 9.0.1
+Bundle-Version: 9.1.0
 Export-Package:\
 	com.liferay.portal.search.spi.model.index.contributor,\
 	com.liferay.portal.search.spi.model.index.contributor.helper,\

--- a/modules/apps/portal-search/portal-search-spi/src/main/java/com/liferay/portal/search/spi/model/registrar/ModelSearchDefinition.java
+++ b/modules/apps/portal-search/portal-search-spi/src/main/java/com/liferay/portal/search/spi/model/registrar/ModelSearchDefinition.java
@@ -41,6 +41,15 @@ public interface ModelSearchDefinition {
 	public void setModelVisibilityContributor(
 		ModelVisibilityContributor modelVisibilityContributor);
 
+	/**
+	 * Allows backwards compatibility to disable permission filtering in search
+	 * queries. By default, permission awareness is controlled by the presence
+	 * of a ModelResourcePermission implementation for the class. It is
+	 * generally not suggested to set this value to false.
+	 *
+	 * @param permissionAware false if the indexer should not add permission
+	 *        clauses to the pre-filter of the search query
+	 */
 	public void setPermissionAware(boolean permissionAware);
 
 	public void setSearchResultPermissionFilterSuppressed(

--- a/modules/apps/portal-search/portal-search-spi/src/main/java/com/liferay/portal/search/spi/model/registrar/ModelSearchDefinition.java
+++ b/modules/apps/portal-search/portal-search-spi/src/main/java/com/liferay/portal/search/spi/model/registrar/ModelSearchDefinition.java
@@ -41,6 +41,8 @@ public interface ModelSearchDefinition {
 	public void setModelVisibilityContributor(
 		ModelVisibilityContributor modelVisibilityContributor);
 
+	public void setPermissionAware(boolean permissionAware);
+
 	public void setSearchResultPermissionFilterSuppressed(
 		boolean searchResultPermissionFilterSuppressed);
 

--- a/modules/apps/portal-search/portal-search-spi/src/main/java/com/liferay/portal/search/spi/model/registrar/ModelSearchSettings.java
+++ b/modules/apps/portal-search/portal-search-spi/src/main/java/com/liferay/portal/search/spi/model/registrar/ModelSearchSettings.java
@@ -32,6 +32,8 @@ public interface ModelSearchSettings {
 
 	public boolean isCommitImmediately();
 
+	public boolean isPermissionAware();
+
 	public boolean isSearchResultPermissionFilterSuppressed();
 
 	public boolean isSelectAllLocales();

--- a/modules/apps/portal-search/portal-search-spi/src/main/resources/com/liferay/portal/search/spi/model/registrar/packageinfo
+++ b/modules/apps/portal-search/portal-search-spi/src/main/resources/com/liferay/portal/search/spi/model/registrar/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/DefaultIndexer.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/DefaultIndexer.java
@@ -199,7 +199,13 @@ public class DefaultIndexer<T extends BaseModel<?>> implements Indexer<T> {
 
 	@Override
 	public boolean isPermissionAware() {
-		return _indexerPermissionPostFilter.isPermissionAware();
+		if (_modelSearchSettings.isPermissionAware() &&
+			_indexerPermissionPostFilter.isPermissionAware()) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/ModelSearchRegistrarHelperImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/ModelSearchRegistrarHelperImpl.java
@@ -112,6 +112,11 @@ public class ModelSearchRegistrarHelperImpl
 		}
 
 		@Override
+		public void setPermissionAware(boolean permissionAware) {
+			_modelSearchSettingsImpl.setPermissionAware(permissionAware);
+		}
+
+		@Override
 		public void setSearchResultPermissionFilterSuppressed(
 			boolean searchResultPermissionFilterSuppressed) {
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/ModelSearchSettingsImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/ModelSearchSettingsImpl.java
@@ -53,6 +53,11 @@ public class ModelSearchSettingsImpl implements ModelSearchSettings {
 	}
 
 	@Override
+	public boolean isPermissionAware() {
+		return _permissionAware;
+	}
+
+	@Override
 	public boolean isSearchResultPermissionFilterSuppressed() {
 		return _searchResultPermissionFilterSuppressed;
 	}
@@ -84,6 +89,10 @@ public class ModelSearchSettingsImpl implements ModelSearchSettings {
 			defaultSelectedLocalizedFieldNames;
 	}
 
+	public void setPermissionAware(boolean permissionAware) {
+		_permissionAware = permissionAware;
+	}
+
 	public void setSearchClassNames(String... searchClassNames) {
 		_searchClassNames = searchClassNames;
 	}
@@ -107,6 +116,7 @@ public class ModelSearchSettingsImpl implements ModelSearchSettings {
 	private boolean _commitImmediately;
 	private String[] _defaultSelectedFieldNames;
 	private String[] _defaultSelectedLocalizedFieldNames;
+	private boolean _permissionAware = true;
 	private String[] _searchClassNames;
 	private boolean _searchResultPermissionFilterSuppressed;
 	private boolean _selectAllLocales;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-191707

This addition allows for backwards compatibility for omitting permission clauses in the search query. This provides a solution to https://liferay.atlassian.net/browse/PTR-4138 

**Authors:** @joshuacords @BryanEngler 

cc: @brianikim