### PR TITLE
LPS-189127 FacetedSearcherTest failing with SearchException

### DIFF
--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/query/contributor/UserKeywordQueryContributor.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/query/contributor/UserKeywordQueryContributor.java
@@ -55,7 +55,7 @@ public class UserKeywordQueryContributor implements KeywordQueryContributor {
 		queryHelper.addSearchTerm(
 			booleanQuery, searchContext, "country", false);
 		queryHelper.addSearchTerm(
-			booleanQuery, searchContext, "emailAddress", false);
+			booleanQuery, searchContext, "emailAddress.text", false);
 		queryHelper.addSearchTerm(
 			booleanQuery, searchContext, "firstName", false);
 		queryHelper.addSearchTerm(


### PR DESCRIPTION
### **LPS Link:** [LPS-189127](https://liferay.atlassian.net/browse/LPS-189127)

# Context
The [testSearchByQuotedRegexKeywords](https://github.com/liferay/liferay-portal/blob/0f20ab121443b8c1e70c58285586d82ce48e7a8d/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FacetedSearcherTest.java#L93C1-L109C3) test is failing with an exception. This error is occurring because of the changes made in this [commit](https://github.com/liferay/liferay-portal/commit/8f65ba18f2c0b0d59a7e2b1f053b5c5aaee620d7). Basically the test is failing because it is not possible to use phrase prefix queries on keyword type fields, as shown in the below message:

```
Suppressed: org.elasticsearch.client.ResponseException: method [POST], host [http://172.31.0.3:9201], URI [/liferay-20096/_search?typed_keys=true&max_concurrent_shard_requests=5&search_type=query_then_fetch&batched_reduce_size=512], status line [HTTP/1.1 400 Bad Request]
	{"error":{"root_cause":[{"type":"query_shard_exception","reason":"failed to create query: Can only use phrase prefix queries on text fields - not on [emailAddress] which is of type [keyword]","index_uuid":"xoZGQOUcT8CNXuZbRZft9g","index":"liferay-20096"}],"type":"search_phase_execution_exception","reason":"all shards failed","phase":"query","grouped":true,"failed_shards":[{"shard":0,"index":"liferay-20096","node":"OH74nlVuT7ej5VbCMrmglA","reason":{"type":"query_shard_exception","reason":"failed to create query: Can only use phrase prefix queries on text fields - not on [emailAddress] which is of type [keyword]","index_uuid":"xoZGQOUcT8CNXuZbRZft9g","index":"liferay-20096","caused_by":{"type":"illegal_argument_exception","reason":"Can only use phrase prefix queries on text fields - not on [emailAddress] which is of type [keyword]"}}}]},"status":400}
			at org.elasticsearch.client.RestClient.convertResponse(RestClient.java:331)
```

# Proposed solution
The email address field name in [UserKeywordQueryContributor](https://github.com/liferay/liferay-portal/blob/0f20ab121443b8c1e70c58285586d82ce48e7a8d/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/query/contributor/UserKeywordQueryContributor.java#L58C33-L58C47) class was changed to `emailAddress.text ` as default field type is keyword as per its index mapping.

```
queryHelper.addSearchTerm(
			booleanQuery, searchContext, "emailAddress.text", false);
```