### PR TITLE
LPS-190910 Description localization incorrect with search suggestions

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/suggestions/spi/BasicSuggestionsContributor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/suggestions/spi/BasicSuggestionsContributor.java
@@ -272,7 +272,8 @@ public class BasicSuggestionsContributor implements SuggestionsContributor {
 			if (assetRenderer != null) {
 				suggestionBuilder.attribute(
 					"assetSearchSummary",
-					assetRenderer.getSearchSummary(locale));
+					assetRenderer.getSummary(
+						liferayPortletRequest, liferayPortletResponse));
 				suggestionBuilder.attribute(
 					"assetURL",
 					_getAssetURL(

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/suggestions/spi/BasicSuggestionsContributorTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/suggestions/spi/BasicSuggestionsContributorTest.java
@@ -223,8 +223,8 @@ public class BasicSuggestionsContributorTest {
 			summary
 		).when(
 			assetRenderer
-		).getSearchSummary(
-			Mockito.any()
+		).getSummary(
+			Mockito.any(), Mockito.any()
 		);
 
 		Mockito.doReturn(


### PR DESCRIPTION
### **LPS link:** [LPS-190910](https://liferay.atlassian.net/browse/LPS-190910)

# Context

The error occurs after performing a search for a web content (with translation) using a different locale than the default one. The suggestion is displayed correctly (with the translation compatible with the locale) but the SearchSummary is displayed without the translation (following the default locale). This happens because the [_getSuggestion](https://github.com/liferay/liferay-portal/blob/0f20ab121443b8c1e70c58285586d82ce48e7a8d/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/suggestions/spi/BasicSuggestionsContributor.java#L246C1-L306C3) function is filling the assetSearchSummary attribute through the [getSearchSummary](https://github.com/liferay/liferay-portal/blob/0f20ab121443b8c1e70c58285586d82ce48e7a8d/portal-kernel/src/com/liferay/asset/kernel/model/BaseAssetRenderer.java#L104C2-L107C3) function, as shown below. 

```
suggestionBuilder.attribute(
                   "assetSearchSummary",
		   assetRenderer.getSearchSummary(locale));
```

This function calls the [getSummary](https://github.com/liferay/liferay-portal/blob/0f20ab121443b8c1e70c58285586d82ce48e7a8d/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRenderer.java#L204C2-L214C3) function passing null values in the portletRequest and portletResponse parameters as shown below. 

```
public String getSearchSummary() {
		return getSummary(null, null);
	}
```

These null values cause the default locale to be used.

# Proposed solution 

The [_getSuggestion](https://github.com/liferay/liferay-portal/blob/0f20ab121443b8c1e70c58285586d82ce48e7a8d/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/suggestions/spi/BasicSuggestionsContributor.java#L246C1-L306C3) function was changed to fill the assetSearchSummary attribute directly by [getSummary](https://github.com/liferay/liferay-portal/blob/0f20ab121443b8c1e70c58285586d82ce48e7a8d/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRenderer.java#L204C2-L214C3)  function passing the correct parameters as shown below.

```
suggestionBuilder.attribute(
		"assetSearchSummary",
		assetRenderer.getSummary(
			liferayPortletRequest, liferayPortletResponse));
```