### PR TITLE
LPS-191707 Allow SearchRegistrars to configure/override permissionAware

### DIFF
--- a/modules/apps/portal-search/portal-search-spi/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-spi/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search SPI
 Bundle-SymbolicName: com.liferay.portal.search.spi
-Bundle-Version: 9.0.2
+Bundle-Version: 9.1.0
 Export-Package:\
 	com.liferay.portal.search.spi.model.index.contributor,\
 	com.liferay.portal.search.spi.model.index.contributor.helper,\

--- a/modules/apps/portal-search/portal-search-spi/src/main/java/com/liferay/portal/search/spi/model/registrar/ModelSearchDefinition.java
+++ b/modules/apps/portal-search/portal-search-spi/src/main/java/com/liferay/portal/search/spi/model/registrar/ModelSearchDefinition.java
@@ -32,6 +32,15 @@ public interface ModelSearchDefinition {
 	public void setModelVisibilityContributor(
 		ModelVisibilityContributor modelVisibilityContributor);
 
+	/**
+	 * Allows backwards compatibility to disable permission filtering in search
+	 * queries. By default, permission awareness is controlled by the presence
+	 * of a ModelResourcePermission implementation for the class. It is
+	 * generally not suggested to set this value to false.
+	 *
+	 * @param permissionAware false if the indexer should not add permission
+	 *        clauses to the pre-filter of the search query
+	 */
 	public void setPermissionAware(boolean permissionAware);
 
 	public void setSearchResultPermissionFilterSuppressed(

--- a/modules/apps/portal-search/portal-search-spi/src/main/java/com/liferay/portal/search/spi/model/registrar/ModelSearchDefinition.java
+++ b/modules/apps/portal-search/portal-search-spi/src/main/java/com/liferay/portal/search/spi/model/registrar/ModelSearchDefinition.java
@@ -32,6 +32,8 @@ public interface ModelSearchDefinition {
 	public void setModelVisibilityContributor(
 		ModelVisibilityContributor modelVisibilityContributor);
 
+	public void setPermissionAware(boolean permissionAware);
+
 	public void setSearchResultPermissionFilterSuppressed(
 		boolean searchResultPermissionFilterSuppressed);
 

--- a/modules/apps/portal-search/portal-search-spi/src/main/java/com/liferay/portal/search/spi/model/registrar/ModelSearchSettings.java
+++ b/modules/apps/portal-search/portal-search-spi/src/main/java/com/liferay/portal/search/spi/model/registrar/ModelSearchSettings.java
@@ -23,6 +23,8 @@ public interface ModelSearchSettings {
 
 	public boolean isCommitImmediately();
 
+	public boolean isPermissionAware();
+
 	public boolean isSearchResultPermissionFilterSuppressed();
 
 	public boolean isSelectAllLocales();

--- a/modules/apps/portal-search/portal-search-spi/src/main/resources/com/liferay/portal/search/spi/model/registrar/packageinfo
+++ b/modules/apps/portal-search/portal-search-spi/src/main/resources/com/liferay/portal/search/spi/model/registrar/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/DefaultIndexer.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/DefaultIndexer.java
@@ -190,7 +190,13 @@ public class DefaultIndexer<T extends BaseModel<?>> implements Indexer<T> {
 
 	@Override
 	public boolean isPermissionAware() {
-		return _indexerPermissionPostFilter.isPermissionAware();
+		if (_modelSearchSettings.isPermissionAware() &&
+			_indexerPermissionPostFilter.isPermissionAware()) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/ModelSearchRegistrarHelperImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/ModelSearchRegistrarHelperImpl.java
@@ -103,6 +103,11 @@ public class ModelSearchRegistrarHelperImpl
 		}
 
 		@Override
+		public void setPermissionAware(boolean permissionAware) {
+			_modelSearchSettingsImpl.setPermissionAware(permissionAware);
+		}
+
+		@Override
 		public void setSearchResultPermissionFilterSuppressed(
 			boolean searchResultPermissionFilterSuppressed) {
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/ModelSearchSettingsImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/ModelSearchSettingsImpl.java
@@ -44,6 +44,11 @@ public class ModelSearchSettingsImpl implements ModelSearchSettings {
 	}
 
 	@Override
+	public boolean isPermissionAware() {
+		return _permissionAware;
+	}
+
+	@Override
 	public boolean isSearchResultPermissionFilterSuppressed() {
 		return _searchResultPermissionFilterSuppressed;
 	}
@@ -75,6 +80,10 @@ public class ModelSearchSettingsImpl implements ModelSearchSettings {
 			defaultSelectedLocalizedFieldNames;
 	}
 
+	public void setPermissionAware(boolean permissionAware) {
+		_permissionAware = permissionAware;
+	}
+
 	public void setSearchClassNames(String... searchClassNames) {
 		_searchClassNames = searchClassNames;
 	}
@@ -98,6 +107,7 @@ public class ModelSearchSettingsImpl implements ModelSearchSettings {
 	private boolean _commitImmediately;
 	private String[] _defaultSelectedFieldNames;
 	private String[] _defaultSelectedLocalizedFieldNames;
+	private boolean _permissionAware = true;
 	private String[] _searchClassNames;
 	private boolean _searchResultPermissionFilterSuppressed;
 	private boolean _selectAllLocales;


### PR DESCRIPTION
**Rebased** see: https://github.com/brianchandotcom/liferay-portal/pull/138422

https://liferay.atlassian.net/browse/LPS-191707

This addition allows for backwards compatibility for omitting permission clauses in the search query. This provides a solution to https://liferay.atlassian.net/browse/PTR-4138 

**Authors:** @joshuacords @BryanEngler 

cc: @brianikim