### PR TITLE
LPS-186376 Fix SearchResultEntity filter fields after LPS-157425

### DIFF
--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
@@ -42,11 +42,6 @@ public class SearchResultEntityModel implements EntityModel {
 				locale -> Field.MODIFIED_DATE),
 			new IntegerEntityField("creatorId", locale -> Field.USER_ID),
 			new StringEntityField(
-				"description",
-				locale -> Field.getSortableFieldName(
-					LocalizationUtil.getLocalizedName(
-						Field.DESCRIPTION, LocaleUtil.toLanguageId(locale)))),
-			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
 					LocalizationUtil.getLocalizedName(

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
@@ -7,7 +7,6 @@ package com.liferay.portal.search.rest.internal.odata.entity.v1_0;
 
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.odata.entity.CollectionEntityField;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
@@ -44,8 +43,14 @@ public class SearchResultEntityModel implements EntityModel {
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					LocalizationUtil.getLocalizedName(
-						"localized_title", LocaleUtil.toLanguageId(locale)))));
+					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> {
+					String sortableFieldName = Field.getSortableFieldName(
+						"localized_title_".concat(
+							LocaleUtil.toLanguageId(locale)));
+
+					return sortableFieldName.concat(".keyword_lowercase");
+				}));
 	}
 
 	@Override


### PR DESCRIPTION
### **LPS link:** [LPS-186376](https://liferay.atlassian.net/browse/LPS-186376)

# Context 
A new constructor was added in the [StringEntityField](https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/entity/StringEntityField.java) class by [LPS-157425](https://liferay.atlassian.net/browse/LPS-157425). This PR aims to change the title field in the [SearchResultEntityModel](https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java) to use the new [StringEntityField](https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/entity/StringEntityField.java) constructor. 

The Description field has been removed following the conversation in this [PR](https://github.com/AlmirFe/liferay-portal/pull/8).