### PR TITLE
LPS-189331 Remove search.experiences.blueprint.json attribute

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/SXPBlueprintSearchRequestContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/SXPBlueprintSearchRequestContributor.java
@@ -73,15 +73,14 @@ public class SXPBlueprintSearchRequestContributor
 						continue;
 					}
 
-					SXPBlueprint sxpBlueprint =
+					_enhance(
+						searchRequestBuilder,
 						_sxpBlueprintLocalService.
 							fetchSXPBlueprintByExternalReferenceCode(
 								sxpBlueprintExternalReferenceCode,
 								GetterUtil.getLong(
 									searchRequestBuilder.withSearchContextGet(
-										SearchContext::getCompanyId)));
-
-					_enhance(searchRequestBuilder, sxpBlueprint);
+										SearchContext::getCompanyId))));
 				}
 			}
 		}
@@ -127,10 +126,10 @@ public class SXPBlueprintSearchRequestContributor
 					continue;
 				}
 
-				SXPBlueprint sxpBlueprint =
-					_sxpBlueprintLocalService.fetchSXPBlueprint(sxpBlueprintId);
-
-				_enhance(searchRequestBuilder, sxpBlueprint);
+				_enhance(
+					searchRequestBuilder,
+					_sxpBlueprintLocalService.fetchSXPBlueprint(
+						sxpBlueprintId));
 			}
 		}
 	}
@@ -142,26 +141,28 @@ public class SXPBlueprintSearchRequestContributor
 			_log.debug("Search experiences blueprint " + sxpBlueprint);
 		}
 
-		if (sxpBlueprint != null) {
-			RuntimeException runtimeException = new RuntimeException();
+		if (sxpBlueprint == null) {
+			return;
+		}
 
-			try {
-				_sxpBlueprintSearchRequestEnhancer.enhance(
-					searchRequestBuilder, sxpBlueprint);
-			}
-			catch (Exception exception) {
-				runtimeException.addSuppressed(exception);
-			}
+		RuntimeException runtimeException = new RuntimeException();
 
-			if (ArrayUtil.isNotEmpty(runtimeException.getSuppressed())) {
-				if (_log.isWarnEnabled()) {
-					_log.warn(runtimeException);
-				}
-			}
+		try {
+			_sxpBlueprintSearchRequestEnhancer.enhance(
+				searchRequestBuilder, sxpBlueprint);
+		}
+		catch (Exception exception) {
+			runtimeException.addSuppressed(exception);
+		}
 
-			if (SXPExceptionUtil.hasErrors(runtimeException)) {
-				throw runtimeException;
+		if (ArrayUtil.isNotEmpty(runtimeException.getSuppressed())) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(runtimeException);
 			}
+		}
+
+		if (SXPExceptionUtil.hasErrors(runtimeException)) {
+			throw runtimeException;
 		}
 	}
 

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/SXPBlueprintSearchRequestContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/SXPBlueprintSearchRequestContributor.java
@@ -42,7 +42,6 @@ public class SXPBlueprintSearchRequestContributor
 
 		_contributeSXPBlueprintExternalReferenceCode(searchRequestBuilder);
 		_contributeSXPBlueprintId(searchRequestBuilder);
-		_contributeSXPBlueprintJSON(searchRequestBuilder);
 
 		return searchRequestBuilder.build();
 	}
@@ -101,41 +100,6 @@ public class SXPBlueprintSearchRequestContributor
 		else if (object != null) {
 			throw new IllegalArgumentException(
 				"Invalid search experiences blueprint ID " + object);
-		}
-	}
-
-	private void _contributeSXPBlueprintJSON(
-		SearchRequestBuilder searchRequestBuilder) {
-
-		String sxpBlueprintJSON = searchRequestBuilder.withSearchContextGet(
-			searchContext -> GetterUtil.getString(
-				searchContext.getAttribute(
-					"search.experiences.blueprint.json")));
-
-		if (_log.isDebugEnabled()) {
-			_log.debug("Search experiences blueprint JSON " + sxpBlueprintJSON);
-		}
-
-		RuntimeException runtimeException = new RuntimeException();
-
-		try {
-			if (Validator.isNotNull(sxpBlueprintJSON)) {
-				_sxpBlueprintSearchRequestEnhancer.enhance(
-					searchRequestBuilder, sxpBlueprintJSON);
-			}
-		}
-		catch (Exception exception) {
-			runtimeException.addSuppressed(exception);
-		}
-
-		if (ArrayUtil.isNotEmpty(runtimeException.getSuppressed())) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(runtimeException);
-			}
-		}
-
-		if (SXPExceptionUtil.hasErrors(runtimeException)) {
-			throw runtimeException;
 		}
 	}
 

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/SXPBlueprintSearchRequestContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/SXPBlueprintSearchRequestContributor.java
@@ -40,8 +40,8 @@ public class SXPBlueprintSearchRequestContributor
 		SearchRequestBuilder searchRequestBuilder =
 			_searchRequestBuilderFactory.builder(searchRequest);
 
-		_contributeSXPBlueprintExternalReferenceCode(searchRequestBuilder);
 		_contributeSXPBlueprintId(searchRequestBuilder);
+		_contributeSXPBlueprintExternalReferenceCode(searchRequestBuilder);
 
 		return searchRequestBuilder.build();
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/SXPBlueprintSearchRequestContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/SXPBlueprintSearchRequestContributor.java
@@ -62,26 +62,28 @@ public class SXPBlueprintSearchRequestContributor
 		if (object instanceof String) {
 			String string = (String)object;
 
-			if (!Validator.isBlank(string)) {
-				String[] sxpBlueprintExternalReferenceCodes = StringUtil.split(
-					string);
+			if (Validator.isBlank(string)) {
+				return;
+			}
 
-				for (String sxpBlueprintExternalReferenceCode :
-						sxpBlueprintExternalReferenceCodes) {
+			String[] sxpBlueprintExternalReferenceCodes = StringUtil.split(
+				string);
 
-					if (Validator.isBlank(sxpBlueprintExternalReferenceCode)) {
-						continue;
-					}
+			for (String sxpBlueprintExternalReferenceCode :
+					sxpBlueprintExternalReferenceCodes) {
 
-					_enhance(
-						searchRequestBuilder,
-						_sxpBlueprintLocalService.
-							fetchSXPBlueprintByExternalReferenceCode(
-								sxpBlueprintExternalReferenceCode,
-								GetterUtil.getLong(
-									searchRequestBuilder.withSearchContextGet(
-										SearchContext::getCompanyId))));
+				if (Validator.isBlank(sxpBlueprintExternalReferenceCode)) {
+					continue;
 				}
+
+				_enhance(
+					searchRequestBuilder,
+					_sxpBlueprintLocalService.
+						fetchSXPBlueprintByExternalReferenceCode(
+							sxpBlueprintExternalReferenceCode,
+							GetterUtil.getLong(
+								searchRequestBuilder.withSearchContextGet(
+									SearchContext::getCompanyId))));
 			}
 		}
 		else if (object != null) {
@@ -120,17 +122,18 @@ public class SXPBlueprintSearchRequestContributor
 				"Invalid search experiences blueprint ID " + object);
 		}
 
-		if (sxpBlueprintIds != null) {
-			for (long sxpBlueprintId : sxpBlueprintIds) {
-				if (sxpBlueprintId == 0) {
-					continue;
-				}
+		if (sxpBlueprintIds == null) {
+			return;
+		}
 
-				_enhance(
-					searchRequestBuilder,
-					_sxpBlueprintLocalService.fetchSXPBlueprint(
-						sxpBlueprintId));
+		for (long sxpBlueprintId : sxpBlueprintIds) {
+			if (sxpBlueprintId == 0) {
+				continue;
 			}
+
+			_enhance(
+				searchRequestBuilder,
+				_sxpBlueprintLocalService.fetchSXPBlueprint(sxpBlueprintId));
 		}
 	}
 

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/parameter/test/SXPParameterDataCreatorTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/parameter/test/SXPParameterDataCreatorTest.java
@@ -158,8 +158,8 @@ public class SXPParameterDataCreatorTest {
 			).withSearchContext(
 				_searchContext -> {
 					_searchContext.setAttribute(
-						"search.experiences.blueprint.id",
-						String.valueOf(_sxpBlueprint.getSXPBlueprintId()));
+						"search.experiences.blueprint.external.reference.code",
+						_sxpBlueprint.getExternalReferenceCode());
 					_searchContext.setAttribute(
 						"search.experiences.scope.group.id",
 						_group.getGroupId());

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/SXPBlueprintSearchRequestContributorFederatedTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/SXPBlueprintSearchRequestContributorFederatedTest.java
@@ -85,8 +85,10 @@ public class SXPBlueprintSearchRequestContributorFederatedTest {
 		String query = "jedi";
 
 		_assert(searchResponse, query);
-		_assert(searchResponse.getFederatedSearchResponse("federatedKey1"), query);
-		_assert(searchResponse.getFederatedSearchResponse("federatedKey2"), query);
+		_assert(
+			searchResponse.getFederatedSearchResponse("federatedKey1"), query);
+		_assert(
+			searchResponse.getFederatedSearchResponse("federatedKey2"), query);
 	}
 
 	@Rule

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/SXPBlueprintSearchRequestContributorFederatedTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/SXPBlueprintSearchRequestContributorFederatedTest.java
@@ -66,7 +66,7 @@ public class SXPBlueprintSearchRequestContributorFederatedTest {
 					_sxpBlueprint.getExternalReferenceCode())
 			).addFederatedSearchRequest(
 				searchRequestBuilder2.federatedSearchKey(
-					"federatedKey1"
+					"federatedSearchKey1"
 				).withSearchContext(
 					searchContext -> searchContext.setAttribute(
 						"search.experiences.blueprint.external.reference.code",
@@ -74,7 +74,7 @@ public class SXPBlueprintSearchRequestContributorFederatedTest {
 				).build()
 			).addFederatedSearchRequest(
 				searchRequestBuilder3.federatedSearchKey(
-					"federatedKey2"
+					"federatedSearchKey2"
 				).withSearchContext(
 					searchContext -> searchContext.setAttribute(
 						"search.experiences.blueprint.external.reference.code",
@@ -86,9 +86,11 @@ public class SXPBlueprintSearchRequestContributorFederatedTest {
 
 		_assert(searchResponse, query);
 		_assert(
-			searchResponse.getFederatedSearchResponse("federatedKey1"), query);
+			searchResponse.getFederatedSearchResponse("federatedSearchKey1"),
+			query);
 		_assert(
-			searchResponse.getFederatedSearchResponse("federatedKey2"), query);
+			searchResponse.getFederatedSearchResponse("federatedSearchKey2"),
+			query);
 	}
 
 	@Rule

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/SXPBlueprintSearchRequestContributorFederatedTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/SXPBlueprintSearchRequestContributorFederatedTest.java
@@ -6,8 +6,17 @@
 package com.liferay.search.experiences.internal.blueprint.search.spi.searcher.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.searcher.SearchRequestBuilder;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.SearchResponse;
@@ -15,11 +24,10 @@ import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.search.experiences.rest.dto.v1_0.Clause;
-import com.liferay.search.experiences.rest.dto.v1_0.Configuration;
-import com.liferay.search.experiences.rest.dto.v1_0.QueryConfiguration;
-import com.liferay.search.experiences.rest.dto.v1_0.QueryEntry;
-import com.liferay.search.experiences.rest.dto.v1_0.SXPBlueprint;
+import com.liferay.search.experiences.model.SXPBlueprint;
+import com.liferay.search.experiences.service.SXPBlueprintLocalService;
+
+import java.util.Collections;
 
 import org.hamcrest.CoreMatchers;
 
@@ -27,6 +35,7 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 /**
@@ -44,6 +53,8 @@ public class SXPBlueprintSearchRequestContributorFederatedTest {
 
 	@Test
 	public void test() throws Exception {
+		_addSXPBlueprint();
+
 		SearchRequestBuilder searchRequestBuilder1 = _getSearchRequestBuilder();
 		SearchRequestBuilder searchRequestBuilder2 = _getSearchRequestBuilder();
 		SearchRequestBuilder searchRequestBuilder3 = _getSearchRequestBuilder();
@@ -51,29 +62,55 @@ public class SXPBlueprintSearchRequestContributorFederatedTest {
 		SearchResponse searchResponse = _searcher.search(
 			searchRequestBuilder1.withSearchContext(
 				searchContext -> searchContext.setAttribute(
-					"search.experiences.blueprint.json",
-					_getSXPBlueprintJSON("R2D2"))
+					"search.experiences.blueprint.external.reference.code",
+					_sxpBlueprint.getExternalReferenceCode())
 			).addFederatedSearchRequest(
 				searchRequestBuilder2.federatedSearchKey(
-					"jedi"
+					"federatedKey1"
 				).withSearchContext(
 					searchContext -> searchContext.setAttribute(
-						"search.experiences.blueprint.json",
-						_getSXPBlueprintJSON("Yoda"))
+						"search.experiences.blueprint.external.reference.code",
+						_sxpBlueprint.getExternalReferenceCode())
 				).build()
 			).addFederatedSearchRequest(
 				searchRequestBuilder3.federatedSearchKey(
-					"sith"
+					"federatedKey2"
 				).withSearchContext(
 					searchContext -> searchContext.setAttribute(
-						"search.experiences.blueprint.json",
-						_getSXPBlueprintJSON("Vader"))
+						"search.experiences.blueprint.external.reference.code",
+						_sxpBlueprint.getExternalReferenceCode())
 				).build()
 			).build());
 
-		_assert(searchResponse, "R2D2");
-		_assert(searchResponse.getFederatedSearchResponse("jedi"), "Yoda");
-		_assert(searchResponse.getFederatedSearchResponse("sith"), "Vader");
+		String query = "jedi";
+
+		_assert(searchResponse, query);
+		_assert(searchResponse.getFederatedSearchResponse("federatedKey1"), query);
+		_assert(searchResponse.getFederatedSearchResponse("federatedKey2"), query);
+	}
+
+	@Rule
+	public TestName testName = new TestName();
+
+	private void _addSXPBlueprint() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		Class<?> clazz = getClass();
+
+		_sxpBlueprint = _sxpBlueprintLocalService.addSXPBlueprint(
+			null, TestPropsValues.getUserId(),
+			StringUtil.read(
+				clazz,
+				StringBundler.concat(
+					"dependencies/", clazz.getSimpleName(), StringPool.PERIOD,
+					testName.getMethodName(), ".json")),
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			"", "",
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			ServiceContextTestUtil.getServiceContext(
+				_group, TestPropsValues.getUserId()));
 	}
 
 	private void _assert(SearchResponse searchResponse, String value) {
@@ -91,43 +128,19 @@ public class SXPBlueprintSearchRequestContributorFederatedTest {
 		);
 	}
 
-	private String _getSXPBlueprintJSON(String value) {
-		Clause clause = new Clause() {
-			{
-				field = "friend";
-				type = "match";
-			}
-		};
-
-		clause.setValue(value);
-
-		SXPBlueprint sxpBlueprint = new SXPBlueprint() {
-			{
-				configuration = new Configuration() {
-					{
-						queryConfiguration = new QueryConfiguration() {
-							{
-								queryEntries = new QueryEntry[] {
-									new QueryEntry() {
-										{
-											clauses = new Clause[] {clause};
-										}
-									}
-								};
-							}
-						};
-					}
-				};
-			}
-		};
-
-		return sxpBlueprint.toString();
-	}
+	@DeleteAfterTestRun
+	private Group _group;
 
 	@Inject
 	private Searcher _searcher;
 
 	@Inject
 	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+
+	@DeleteAfterTestRun
+	private SXPBlueprint _sxpBlueprint;
+
+	@Inject
+	private SXPBlueprintLocalService _sxpBlueprintLocalService;
 
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/SXPBlueprintSearchRequestContributorTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/SXPBlueprintSearchRequestContributorTest.java
@@ -162,11 +162,27 @@ public class SXPBlueprintSearchRequestContributorTest {
 				"[charlie delta, beta delta, alpha delta]", "", "delta"));
 	}
 
+	@Test
+	public void testSXPBlueprintIdAttribute() throws Exception {
+		_test(
+			new String[] {"alpha", "beta", "charlie"},
+			() -> _assertSearch(
+				"[beta]", "", "beta", _sxpBlueprint.getSXPBlueprintId()));
+	}
+
 	@Rule
 	public TestName testName = new TestName();
 
 	private void _assertSearch(
 			String expected, String ipAddress, String keywords)
+		throws Exception {
+
+		_assertSearch(expected, ipAddress, keywords, 0);
+	}
+
+	private void _assertSearch(
+			String expected, String ipAddress, String keywords,
+			long sxpBlueprintId)
 		throws Exception {
 
 		SearchResponse searchResponse = _searcher.search(
@@ -178,10 +194,18 @@ public class SXPBlueprintSearchRequestContributorTest {
 					keywords
 				).withSearchContext(
 					_searchContext -> {
-						_searchContext.setAttribute(
-							"search.experiences.blueprint.external.reference." +
-								"code",
-							_sxpBlueprint.getExternalReferenceCode());
+						if (sxpBlueprintId > 0) {
+							_searchContext.setAttribute(
+								"search.experiences.blueprint.id",
+								sxpBlueprintId);
+						}
+						else {
+							_searchContext.setAttribute(
+								"search.experiences.blueprint.external." +
+									"reference.code",
+								_sxpBlueprint.getExternalReferenceCode());
+						}
+
 						_searchContext.setAttribute(
 							"search.experiences.ip.address", ipAddress);
 						_searchContext.setAttribute(

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/SXPBlueprintSearchRequestContributorTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/SXPBlueprintSearchRequestContributorTest.java
@@ -179,8 +179,9 @@ public class SXPBlueprintSearchRequestContributorTest {
 				).withSearchContext(
 					_searchContext -> {
 						_searchContext.setAttribute(
-							"search.experiences.blueprint.id",
-							_sxpBlueprint.getSXPBlueprintId());
+							"search.experiences.blueprint.external.reference." +
+								"code",
+							_sxpBlueprint.getExternalReferenceCode());
 						_searchContext.setAttribute(
 							"search.experiences.ip.address", ipAddress);
 						_searchContext.setAttribute(

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
@@ -2361,8 +2361,8 @@ public class SXPBlueprintSearchResultTest {
 			).withSearchContext(
 				_searchContext -> {
 					_searchContext.setAttribute(
-						"search.experiences.blueprint.id",
-						String.valueOf(_sxpBlueprint.getSXPBlueprintId()));
+						"search.experiences.blueprint.external.reference.code",
+						_sxpBlueprint.getExternalReferenceCode());
 					_searchContext.setAttribute(
 						"search.experiences.scope.group.id",
 						_group.getGroupId());

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/resources/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/dependencies/SXPBlueprintSearchRequestContributorFederatedTest.test.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/resources/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/dependencies/SXPBlueprintSearchRequestContributorFederatedTest.test.json
@@ -1,0 +1,15 @@
+{
+	"queryConfiguration": {
+		"queryEntries": [
+			{
+				"clauses": [
+					{
+						"field": "friend",
+						"type": "match",
+						"value": "jedi"
+					}
+				]
+			}
+		]
+	}
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/resources/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/dependencies/SXPBlueprintSearchRequestContributorTest.testSXPBlueprintIdAttribute.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/resources/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/dependencies/SXPBlueprintSearchRequestContributorTest.testSXPBlueprintIdAttribute.json
@@ -1,0 +1,25 @@
+{
+	"queryConfiguration": {
+		"applyIndexerClauses": false,
+		"queryEntries": [
+			{
+				"clauses": [
+					{
+						"context": "query",
+						"occur": "must",
+						"query": {
+							"match": {
+								"localized_title_${context.language_id}": {
+									"boost": 2,
+									"operator": "or",
+									"query": "${keywords}"
+								}
+							}
+						}
+					}
+				],
+				"enabled": true
+			}
+		]
+	}
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
@@ -144,26 +144,6 @@ definition {
 			searchAssetType = "Web Content Article");
 	}
 
-	test ApplyBlueprintJSONToSearchViaLLSO {
-		property test.liferay.virtual.instance = "false";
-
-		SearchPortlets.addWidgets(searchPortletList = "Search Insights,Low Level Search Options");
-
-		Search.openSearchPage();
-
-		var blueprintJson = '''{"configuration":{"generalConfiguration":{"includeResponseString":false}}}''';
-
-		SearchPortlets.configureLowLevelSearchOptions(
-			attributesKey = "search.experiences.blueprint.json",
-			attributesValue = ${blueprintJson});
-
-		SearchPortlets.searchEmbedded(searchTerm = "test");
-
-		AssertElementNotPresent(
-			key_text = "hits",
-			locator1 = "SearchResults#SEARCH_INSIGHTS_WIDGET_RESPONSE_QUERY");
-	}
-
 	test ApplyBlueprintToContentPageViaBlueprintsOptions {
 		JSONBlog.addEntry(
 			entryContent = "",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-189331

### **Note:**
I needed to refactor one test class to remove totally `search.experiences.blueprint.json` so I added a JSON file based on the JSON that was created in the old test class.

I took the opportunity to change some test class's usages of `search.experiences.blueprint.id` to `search.experiences.blueprint.external.reference.code`.