### PR TITLE
[TS] LPS-193058 Translate Boost in ES

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/BooleanQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/BooleanQueryTranslatorImpl.java
@@ -50,6 +50,10 @@ public class BooleanQueryTranslatorImpl implements BooleanQueryTranslator {
 				booleanQuery.getAdjustPureNegative());
 		}
 
+		if (booleanQuery.getBoost() != null) {
+			boolQueryBuilder.boost(booleanQuery.getBoost());
+		}
+
 		if (booleanQuery.getMinimumShouldMatch() != null) {
 			boolQueryBuilder.minimumShouldMatch(
 				booleanQuery.getMinimumShouldMatch());

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/CommonTermsQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/CommonTermsQueryTranslatorImpl.java
@@ -36,6 +36,10 @@ public class CommonTermsQueryTranslatorImpl
 				commonTermsQuery.getCutoffFrequency());
 		}
 
+		if (commonTermsQuery.getBoost() != null) {
+			commonTermsQueryBuilder.boost(commonTermsQuery.getBoost());
+		}
+
 		if (commonTermsQuery.getHighFreqMinimumShouldMatch() != null) {
 			commonTermsQueryBuilder.highFreqMinimumShouldMatch(
 				commonTermsQuery.getHighFreqMinimumShouldMatch());

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/DisMaxQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/DisMaxQueryTranslatorImpl.java
@@ -33,6 +33,10 @@ public class DisMaxQueryTranslatorImpl implements DisMaxQueryTranslator {
 			disMaxQueryBuilder.add(queryBuilder);
 		}
 
+		if (disMaxQuery.getBoost() != null) {
+			disMaxQueryBuilder.boost(disMaxQuery.getBoost());
+		}
+
 		if (disMaxQuery.getTieBreaker() != null) {
 			disMaxQueryBuilder.tieBreaker(disMaxQuery.getTieBreaker());
 		}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/ElasticsearchQueryTranslator.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/ElasticsearchQueryTranslator.java
@@ -67,10 +67,6 @@ public class ElasticsearchQueryTranslator
 			queryBuilder = QueryBuilders.queryStringQuery(query.toString());
 		}
 
-		if (query.getBoost() != null) {
-			queryBuilder.boost(query.getBoost());
-		}
-
 		return queryBuilder;
 	}
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/FuzzyQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/FuzzyQueryTranslatorImpl.java
@@ -25,6 +25,10 @@ public class FuzzyQueryTranslatorImpl implements FuzzyQueryTranslator {
 		FuzzyQueryBuilder fuzzyQueryBuilder = QueryBuilders.fuzzyQuery(
 			fuzzyQuery.getField(), fuzzyQuery.getValue());
 
+		if (fuzzyQuery.getBoost() != null) {
+			fuzzyQueryBuilder.boost(fuzzyQuery.getBoost());
+		}
+
 		if (fuzzyQuery.getFuzziness() != null) {
 			fuzzyQueryBuilder.fuzziness(
 				Fuzziness.build(fuzzyQuery.getFuzziness()));

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/MatchAllQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/MatchAllQueryTranslatorImpl.java
@@ -20,7 +20,13 @@ public class MatchAllQueryTranslatorImpl implements MatchAllQueryTranslator {
 
 	@Override
 	public QueryBuilder translate(MatchAllQuery matchAllQuery) {
-		return QueryBuilders.matchAllQuery();
+		QueryBuilder queryBuilder = QueryBuilders.matchAllQuery();
+
+		if (matchAllQuery.getBoost() != null) {
+			queryBuilder.boost(matchAllQuery.getBoost());
+		}
+
+		return queryBuilder;
 	}
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/MatchQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/MatchQueryTranslatorImpl.java
@@ -67,6 +67,14 @@ public class MatchQueryTranslatorImpl
 		throw new IllegalArgumentException("Invalid match query type: " + type);
 	}
 
+	private void _translateBoost(
+		QueryBuilder queryBuilder, MatchQuery matchQuery) {
+
+		if (matchQuery.getBoost() != null) {
+			queryBuilder.boost(matchQuery.getBoost());
+		}
+	}
+
 	private QueryBuilder _translateMatchPhrasePrefixQuery(
 		String field, String value, MatchQuery matchQuery) {
 
@@ -76,6 +84,8 @@ public class MatchQueryTranslatorImpl
 		if (Validator.isNotNull(matchQuery.getAnalyzer())) {
 			matchPhrasePrefixQueryBuilder.analyzer(matchQuery.getAnalyzer());
 		}
+
+		_translateBoost(matchPhrasePrefixQueryBuilder, matchQuery);
 
 		if (matchQuery.getMaxExpansions() != null) {
 			matchPhrasePrefixQueryBuilder.maxExpansions(
@@ -99,6 +109,8 @@ public class MatchQueryTranslatorImpl
 			matchPhraseQueryBuilder.analyzer(matchQuery.getAnalyzer());
 		}
 
+		_translateBoost(matchPhraseQueryBuilder, matchQuery);
+
 		if (matchQuery.getSlop() != null) {
 			matchPhraseQueryBuilder.slop(matchQuery.getSlop());
 		}
@@ -115,6 +127,8 @@ public class MatchQueryTranslatorImpl
 		if (Validator.isNotNull(matchQuery.getAnalyzer())) {
 			matchQueryBuilder.analyzer(matchQuery.getAnalyzer());
 		}
+
+		_translateBoost(matchQueryBuilder, matchQuery);
 
 		if (matchQuery.getCutOffFrequency() != null) {
 			matchQueryBuilder.cutoffFrequency(matchQuery.getCutOffFrequency());

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/MoreLikeThisQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/MoreLikeThisQueryTranslatorImpl.java
@@ -76,6 +76,10 @@ public class MoreLikeThisQueryTranslatorImpl
 			moreLikeThisQueryBuilder.analyzer(moreLikeThisQuery.getAnalyzer());
 		}
 
+		if (moreLikeThisQuery.getBoost() != null) {
+			moreLikeThisQueryBuilder.boost(moreLikeThisQuery.getBoost());
+		}
+
 		if (moreLikeThisQuery.getMaxDocFrequency() != null) {
 			moreLikeThisQueryBuilder.maxDocFreq(
 				moreLikeThisQuery.getMaxDocFrequency());

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/MultiMatchQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/MultiMatchQueryTranslatorImpl.java
@@ -35,6 +35,10 @@ public class MultiMatchQueryTranslatorImpl
 			multiMatchQueryBuilder.analyzer(multiMatchQuery.getAnalyzer());
 		}
 
+		if (multiMatchQuery.getBoost() != null) {
+			multiMatchQueryBuilder.boost(multiMatchQuery.getBoost());
+		}
+
 		if (multiMatchQuery.getCutOffFrequency() != null) {
 			multiMatchQueryBuilder.cutoffFrequency(
 				multiMatchQuery.getCutOffFrequency());

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/NestedQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/NestedQueryTranslatorImpl.java
@@ -28,10 +28,16 @@ public class NestedQueryTranslatorImpl implements NestedQueryTranslator {
 
 		Query query = nestedQuery.getQuery();
 
-		QueryBuilder queryBuilder = query.accept(queryVisitor);
+		QueryBuilder nestedQueryBuilder = query.accept(queryVisitor);
 
-		return QueryBuilders.nestedQuery(
-			nestedQuery.getPath(), queryBuilder, ScoreMode.Total);
+		QueryBuilder queryBuilder = QueryBuilders.nestedQuery(
+			nestedQuery.getPath(), nestedQueryBuilder, ScoreMode.Total);
+
+		if (nestedQuery.getBoost() != null) {
+			queryBuilder.boost(nestedQuery.getBoost());
+		}
+
+		return queryBuilder;
 	}
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/StringQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/StringQueryTranslatorImpl.java
@@ -48,6 +48,10 @@ public class StringQueryTranslatorImpl implements StringQueryTranslator {
 				stringQuery.getAutoGenerateSynonymsPhraseQuery());
 		}
 
+		if (stringQuery.getBoost() != null) {
+			queryStringQueryBuilder.boost(stringQuery.getBoost());
+		}
+
 		if (stringQuery.getDefaultField() != null) {
 			queryStringQueryBuilder.defaultField(stringQuery.getDefaultField());
 		}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/TermQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/TermQueryTranslatorImpl.java
@@ -21,8 +21,14 @@ public class TermQueryTranslatorImpl implements TermQueryTranslator {
 
 	@Override
 	public QueryBuilder translate(TermQuery termQuery) {
-		return QueryBuilders.termQuery(
+		QueryBuilder queryBuilder = QueryBuilders.termQuery(
 			termQuery.getField(), termQuery.getValue());
+
+		if (termQuery.getBoost() != null) {
+			queryBuilder.boost(termQuery.getBoost());
+		}
+
+		return queryBuilder;
 	}
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/WildcardQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/WildcardQueryTranslatorImpl.java
@@ -24,6 +24,10 @@ public class WildcardQueryTranslatorImpl implements WildcardQueryTranslator {
 		WildcardQueryBuilder wildcardQueryBuilder = QueryBuilders.wildcardQuery(
 			wildcardQuery.getField(), wildcardQuery.getValue());
 
+		if (wildcardQuery.getBoost() != null) {
+			wildcardQueryBuilder.boost(wildcardQuery.getBoost());
+		}
+
 		if (wildcardQuery.getRewrite() != null) {
 			wildcardQueryBuilder.rewrite(wildcardQuery.getRewrite());
 		}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/query/ElasticsearchQueryTranslatorTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/query/ElasticsearchQueryTranslatorTest.java
@@ -7,17 +7,25 @@ package com.liferay.portal.search.elasticsearch7.internal.query;
 
 import com.liferay.portal.search.internal.query.BooleanQueryImpl;
 import com.liferay.portal.search.internal.query.CommonTermsQueryImpl;
+import com.liferay.portal.search.internal.query.DisMaxQueryImpl;
 import com.liferay.portal.search.internal.query.FuzzyQueryImpl;
 import com.liferay.portal.search.internal.query.MatchAllQueryImpl;
+import com.liferay.portal.search.internal.query.MatchQueryImpl;
 import com.liferay.portal.search.internal.query.MoreLikeThisQueryImpl;
+import com.liferay.portal.search.internal.query.MultiMatchQueryImpl;
+import com.liferay.portal.search.internal.query.NestedQueryImpl;
+import com.liferay.portal.search.internal.query.StringQueryImpl;
 import com.liferay.portal.search.internal.query.TermQueryImpl;
 import com.liferay.portal.search.internal.query.WildcardQueryImpl;
 import com.liferay.portal.search.query.BooleanQuery;
+import com.liferay.portal.search.query.NestedQuery;
 import com.liferay.portal.search.query.Query;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -50,8 +58,18 @@ public class ElasticsearchQueryTranslatorTest {
 	}
 
 	@Test
+	public void testTranslateBoostBooleanQuery() {
+		_assertBoosts(new BooleanQueryImpl());
+	}
+
+	@Test
 	public void testTranslateBoostCommonTermsQuery() {
 		_assertBoosts(new CommonTermsQueryImpl("test", "test"));
+	}
+
+	@Test
+	public void testTranslateBoostDisMaxQuery() {
+		_assertBoosts(new DisMaxQueryImpl());
 	}
 
 	@Test
@@ -65,9 +83,38 @@ public class ElasticsearchQueryTranslatorTest {
 	}
 
 	@Test
+	public void testTranslateBoostMatchQuery() {
+		_assertBoosts(new MatchQueryImpl("test", "test"));
+		_assertBoosts(new MatchQueryImpl("test", "\"test\""));
+		_assertBoosts(new MatchQueryImpl("test", "\"test*\""));
+	}
+
+	@Test
 	public void testTranslateBoostMoreLikeThisQueryStringQuery() {
 		_assertBoosts(
 			new MoreLikeThisQueryImpl(Collections.emptyList(), "test"));
+	}
+
+	@Test
+	public void testTranslateBoostMultiMatchAllQuery() {
+		Map<String, Float> fieldsBoosts = new HashMap<>();
+
+		fieldsBoosts.put("test", null);
+
+		_assertBoosts(new MultiMatchQueryImpl("test", fieldsBoosts));
+	}
+
+	@Test
+	public void testTranslateBoostNestedQuery() {
+		NestedQuery nestedQuery = new NestedQueryImpl(
+			"test", new MatchAllQueryImpl());
+
+		_assertBoosts(new NestedQueryImpl("test", nestedQuery));
+	}
+
+	@Test
+	public void testTranslateBoostStringQuery() {
+		_assertBoosts(new StringQueryImpl("test"));
 	}
 
 	@Test

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/query/ElasticsearchQueryTranslatorTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/query/ElasticsearchQueryTranslatorTest.java
@@ -5,17 +5,21 @@
 
 package com.liferay.portal.search.elasticsearch7.internal.query;
 
+import com.liferay.portal.search.internal.query.BooleanQueryImpl;
 import com.liferay.portal.search.internal.query.CommonTermsQueryImpl;
 import com.liferay.portal.search.internal.query.FuzzyQueryImpl;
 import com.liferay.portal.search.internal.query.MatchAllQueryImpl;
 import com.liferay.portal.search.internal.query.MoreLikeThisQueryImpl;
 import com.liferay.portal.search.internal.query.TermQueryImpl;
 import com.liferay.portal.search.internal.query.WildcardQueryImpl;
+import com.liferay.portal.search.query.BooleanQuery;
 import com.liferay.portal.search.query.Query;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.Collections;
+import java.util.List;
 
+import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 
 import org.junit.Assert;
@@ -47,33 +51,33 @@ public class ElasticsearchQueryTranslatorTest {
 
 	@Test
 	public void testTranslateBoostCommonTermsQuery() {
-		_assertBoost(new CommonTermsQueryImpl("test", "test"));
+		_assertBoosts(new CommonTermsQueryImpl("test", "test"));
 	}
 
 	@Test
 	public void testTranslateBoostFuzzyQuery() {
-		_assertBoost(new FuzzyQueryImpl("test", "test"));
+		_assertBoosts(new FuzzyQueryImpl("test", "test"));
 	}
 
 	@Test
 	public void testTranslateBoostMatchAllQuery() {
-		_assertBoost(new MatchAllQueryImpl());
+		_assertBoosts(new MatchAllQueryImpl());
 	}
 
 	@Test
 	public void testTranslateBoostMoreLikeThisQueryStringQuery() {
-		_assertBoost(
+		_assertBoosts(
 			new MoreLikeThisQueryImpl(Collections.emptyList(), "test"));
 	}
 
 	@Test
 	public void testTranslateBoostTermQuery() {
-		_assertBoost(new TermQueryImpl("test", "test"));
+		_assertBoosts(new TermQueryImpl("test", "test"));
 	}
 
 	@Test
 	public void testTranslateBoostWildcardQuery() {
-		_assertBoost(new WildcardQueryImpl("test", "test"));
+		_assertBoosts(new WildcardQueryImpl("test", "test"));
 	}
 
 	private void _assertBoost(Query query) {
@@ -85,6 +89,31 @@ public class ElasticsearchQueryTranslatorTest {
 		Assert.assertEquals(
 			queryBuilder.toString(), String.valueOf(_BOOST),
 			String.valueOf(queryBuilder.boost()));
+	}
+
+	private void _assertBoosts(Query query) {
+		_assertBoost(query);
+		_assertInnerBoost(query);
+	}
+
+	private void _assertInnerBoost(Query query) {
+		query.setBoost(_BOOST);
+
+		BooleanQuery booleanQuery = new BooleanQueryImpl();
+
+		booleanQuery.addMustQueryClauses(query);
+
+		QueryBuilder queryBuilder = _elasticsearchQueryTranslator.translate(
+			booleanQuery);
+
+		List<QueryBuilder> mustQueryBuilders =
+			((BoolQueryBuilder)queryBuilder).must();
+
+		QueryBuilder innerQueryBuilder = mustQueryBuilders.get(0);
+
+		Assert.assertEquals(
+			innerQueryBuilder.toString(), String.valueOf(_BOOST),
+			String.valueOf(innerQueryBuilder.boost()));
 	}
 
 	private static final Float _BOOST = 1.5F;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-193058

During the update for QueryTranslators from portal.kernel (legacy) to the search module, it seems we tried to move assigning boost to the [ElasticsearchQueryTranslator](https://github.com/liferay-search/liferay-portal/commit/459ac60303a3257969ba0bf4567011bb06ceb050#diff-15e7323f278db85ed295bcad51e7be8110df1c9eca62f3c9b29af4a6c6e5ae7cL70-L72) while removing it from the legacy Translators such as [TermQueryTranslatorImpl](https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/legacy/query/TermQueryTranslatorImpl.java#L31-L33), however this change only applies the boost to the top level of the query, and any nested queries would be skipped. 

**Author:** @joshuacords 