### PR TITLE
[TS] LPS-191765 Missing <prefix>-<companyId>-search-tuning-rankings index after switching embedded/remote ES

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/creation/activator/RankingIndexCreationBundleActivator.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/creation/activator/RankingIndexCreationBundleActivator.java
@@ -5,20 +5,16 @@
 
 package com.liferay.portal.search.tuning.rankings.web.internal.index.creation.activator;
 
-import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
-import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManager;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.CompanyConstants;
-import com.liferay.portal.kernel.model.UserConstants;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.uuid.PortalUUID;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.search.engine.SearchEngineInformation;
-import com.liferay.portal.search.tuning.rankings.web.internal.background.task.RankingIndexCreationBackgroundTaskExecutor;
+import com.liferay.portal.search.tuning.rankings.web.internal.index.RankingIndexCreator;
+import com.liferay.portal.search.tuning.rankings.web.internal.index.RankingIndexReader;
 import com.liferay.portal.search.tuning.rankings.web.internal.index.importer.SingleIndexToMultipleIndexImporter;
+import com.liferay.portal.search.tuning.rankings.web.internal.index.name.RankingIndexName;
+import com.liferay.portal.search.tuning.rankings.web.internal.index.name.RankingIndexNameBuilder;
 
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.osgi.service.component.annotations.Activate;
@@ -41,22 +37,23 @@ public class RankingIndexCreationBundleActivator {
 		}
 
 		if (_singleIndexToMultipleIndexImporter.needImport()) {
-			_addBackgroundTask();
-		}
-	}
+			_companyLocalService.forEachCompanyId(
+				companyId -> {
+					try {
+						RankingIndexName rankingIndexName =
+							_rankingIndexNameBuilder.getRankingIndexName(
+								companyId);
 
-	private void _addBackgroundTask() {
-		try {
-			_backgroundTaskManager.addBackgroundTask(
-				UserConstants.USER_ID_DEFAULT, CompanyConstants.SYSTEM,
-				"createRankingIndex-" + _portalUUID.generate(),
-				RankingIndexCreationBackgroundTaskExecutor.class.getName(),
-				new HashMap<>(), new ServiceContext());
-		}
-		catch (PortalException portalException) {
-			_log.error(
-				"Unable to schedule the job for RankingIndexRename",
-				portalException);
+						if (_rankingIndexReader.isExists(rankingIndexName)) {
+							return;
+						}
+
+						_rankingIndexCreator.create(rankingIndexName);
+					}
+					catch (Exception exception) {
+						_log.error(exception);
+					}
+				});
 		}
 	}
 
@@ -64,15 +61,16 @@ public class RankingIndexCreationBundleActivator {
 		RankingIndexCreationBundleActivator.class);
 
 	@Reference
-	private BackgroundTaskManager _backgroundTaskManager;
+	private CompanyLocalService _companyLocalService;
 
 	@Reference
-	private PortalUUID _portalUUID;
+	private RankingIndexCreator _rankingIndexCreator;
 
-	@Reference(
-		target = "(background.task.executor.class.name=com.liferay.portal.search.tuning.rankings.web.internal.background.task.RankingIndexCreationBackgroundTaskExecutor)"
-	)
-	private BackgroundTaskExecutor _rankingIndexRenameBackgroundTaskExecutor;
+	@Reference
+	private RankingIndexNameBuilder _rankingIndexNameBuilder;
+
+	@Reference
+	private RankingIndexReader _rankingIndexReader;
 
 	@Reference
 	private SearchEngineInformation _searchEngineInformation;

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/creation/activator/RankingIndexCreationBundleActivator.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/creation/activator/RankingIndexCreationBundleActivator.java
@@ -5,8 +5,7 @@
 
 package com.liferay.portal.search.tuning.rankings.web.internal.index.creation.activator;
 
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.search.engine.SearchEngineInformation;
 import com.liferay.portal.search.tuning.rankings.web.internal.index.RankingIndexCreator;
@@ -15,6 +14,7 @@ import com.liferay.portal.search.tuning.rankings.web.internal.index.importer.Sin
 import com.liferay.portal.search.tuning.rankings.web.internal.index.name.RankingIndexName;
 import com.liferay.portal.search.tuning.rankings.web.internal.index.name.RankingIndexNameBuilder;
 
+import java.util.List;
 import java.util.Objects;
 
 import org.osgi.service.component.annotations.Activate;
@@ -37,28 +37,21 @@ public class RankingIndexCreationBundleActivator {
 		}
 
 		if (_singleIndexToMultipleIndexImporter.needImport()) {
-			_companyLocalService.forEachCompanyId(
-				companyId -> {
-					try {
-						RankingIndexName rankingIndexName =
-							_rankingIndexNameBuilder.getRankingIndexName(
-								companyId);
+			List<Company> companies = _companyLocalService.getCompanies();
 
-						if (_rankingIndexReader.isExists(rankingIndexName)) {
-							return;
-						}
+			for (Company company : companies) {
+				RankingIndexName rankingIndexName =
+					_rankingIndexNameBuilder.getRankingIndexName(
+						company.getCompanyId());
 
-						_rankingIndexCreator.create(rankingIndexName);
-					}
-					catch (Exception exception) {
-						_log.error(exception);
-					}
-				});
+				if (_rankingIndexReader.isExists(rankingIndexName)) {
+					continue;
+				}
+
+				_rankingIndexCreator.create(rankingIndexName);
+			}
 		}
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		RankingIndexCreationBundleActivator.class);
 
 	@Reference
 	private CompanyLocalService _companyLocalService;

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/test/java/com/liferay/portal/search/tuning/rankings/web/internal/index/creation/activator/RankingIndexCreationBundleActivatorTest.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/test/java/com/liferay/portal/search/tuning/rankings/web/internal/index/creation/activator/RankingIndexCreationBundleActivatorTest.java
@@ -117,6 +117,24 @@ public class RankingIndexCreationBundleActivatorTest {
 		);
 	}
 
+	@Test
+	public void testActivatorWithMoreThanOneCompany() throws Exception {
+		_setUpSingleIndexToMultipleIndexImporter(true);
+		_setUpCompanyLocalService(3);
+
+		_rankingIndexCreationBundleActivator.activate();
+
+		Mockito.verify(
+			_singleIndexToMultipleIndexImporter, Mockito.times(1)
+		).needImport();
+
+		Mockito.verify(
+			_rankingIndexCreator, Mockito.times(3)
+		).create(
+			Mockito.any(RankingIndexName.class)
+		);
+	}
+
 	private void _setUpCompanyLocalService(int numberOfCompanies) {
 		List<Company> companies = new ArrayList<>();
 		Company company;

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/test/java/com/liferay/portal/search/tuning/rankings/web/internal/index/creation/activator/RankingIndexCreationBundleActivatorTest.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/test/java/com/liferay/portal/search/tuning/rankings/web/internal/index/creation/activator/RankingIndexCreationBundleActivatorTest.java
@@ -5,13 +5,20 @@
 
 package com.liferay.portal.search.tuning.rankings.web.internal.index.creation.activator;
 
-import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManager;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
-import com.liferay.portal.kernel.uuid.PortalUUID;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.engine.SearchEngineInformation;
-import com.liferay.portal.search.tuning.rankings.web.internal.background.task.RankingIndexCreationBackgroundTaskExecutor;
+import com.liferay.portal.search.tuning.rankings.web.internal.index.RankingIndexCreator;
+import com.liferay.portal.search.tuning.rankings.web.internal.index.RankingIndexReader;
 import com.liferay.portal.search.tuning.rankings.web.internal.index.importer.SingleIndexToMultipleIndexImporter;
+import com.liferay.portal.search.tuning.rankings.web.internal.index.name.RankingIndexName;
+import com.liferay.portal.search.tuning.rankings.web.internal.index.name.RankingIndexNameBuilder;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -36,14 +43,17 @@ public class RankingIndexCreationBundleActivatorTest {
 			new RankingIndexCreationBundleActivator();
 
 		ReflectionTestUtil.setFieldValue(
-			_rankingIndexCreationBundleActivator, "_backgroundTaskManager",
-			_backgroundTaskManager);
+			_rankingIndexCreationBundleActivator, "_rankingIndexCreator",
+			_rankingIndexCreator);
 		ReflectionTestUtil.setFieldValue(
-			_rankingIndexCreationBundleActivator, "_portalUUID", _portalUUID);
+			_rankingIndexCreationBundleActivator, "_companyLocalService",
+			_companyLocalService);
 		ReflectionTestUtil.setFieldValue(
-			_rankingIndexCreationBundleActivator,
-			"_rankingIndexRenameBackgroundTaskExecutor",
-			_rankingIndexRenameBackgroundTaskExecutor);
+			_rankingIndexCreationBundleActivator, "_rankingIndexReader",
+			_rankingIndexReader);
+		ReflectionTestUtil.setFieldValue(
+			_rankingIndexCreationBundleActivator, "_rankingIndexNameBuilder",
+			_rankingIndexNameBuilder);
 		ReflectionTestUtil.setFieldValue(
 			_rankingIndexCreationBundleActivator, "_searchEngineInformation",
 			_searchEngineInformation);
@@ -51,6 +61,21 @@ public class RankingIndexCreationBundleActivatorTest {
 			_rankingIndexCreationBundleActivator,
 			"_singleIndexToMultipleIndexImporter",
 			_singleIndexToMultipleIndexImporter);
+
+		Mockito.doReturn(
+			new RankingIndexName() {
+
+				@Override
+				public String getIndexName() {
+					return null;
+				}
+
+			}
+		).when(
+			_rankingIndexNameBuilder
+		).getRankingIndexName(
+			Mockito.anyLong()
+		);
 	}
 
 	@Test
@@ -64,11 +89,11 @@ public class RankingIndexCreationBundleActivatorTest {
 		Mockito.verify(
 			_singleIndexToMultipleIndexImporter, Mockito.times(1)
 		).needImport();
+
 		Mockito.verify(
-			_backgroundTaskManager, Mockito.times(0)
-		).addBackgroundTask(
-			Mockito.anyLong(), Mockito.anyLong(), Mockito.anyString(),
-			Mockito.anyString(), Mockito.anyMap(), Mockito.any()
+			_rankingIndexCreator, Mockito.times(0)
+		).create(
+			Mockito.any(RankingIndexName.class)
 		);
 	}
 
@@ -77,18 +102,41 @@ public class RankingIndexCreationBundleActivatorTest {
 		throws Exception {
 
 		_setUpSingleIndexToMultipleIndexImporter(true);
+		_setUpCompanyLocalService(1);
 
 		_rankingIndexCreationBundleActivator.activate();
 
 		Mockito.verify(
 			_singleIndexToMultipleIndexImporter, Mockito.times(1)
 		).needImport();
+
 		Mockito.verify(
-			_backgroundTaskManager, Mockito.times(1)
-		).addBackgroundTask(
-			Mockito.anyLong(), Mockito.anyLong(), Mockito.anyString(),
-			Mockito.anyString(), Mockito.anyMap(), Mockito.any()
+			_rankingIndexCreator, Mockito.times(1)
+		).create(
+			Mockito.any(RankingIndexName.class)
 		);
+	}
+
+	private void _setUpCompanyLocalService(int numberOfCompanies) {
+		List<Company> companies = new ArrayList<>();
+		Company company;
+
+		for (int i = 0; i < numberOfCompanies; i++) {
+			company = Mockito.mock(Company.class);
+
+			Mockito.doReturn(
+				RandomTestUtil.randomLong()
+			).when(
+				company
+			).getCompanyId();
+			companies.add(company);
+		}
+
+		Mockito.doReturn(
+			companies
+		).when(
+			_companyLocalService
+		).getCompanies();
 	}
 
 	private void _setUpSingleIndexToMultipleIndexImporter(boolean exist) {
@@ -99,14 +147,16 @@ public class RankingIndexCreationBundleActivatorTest {
 		).needImport();
 	}
 
-	private final BackgroundTaskManager _backgroundTaskManager = Mockito.mock(
-		BackgroundTaskManager.class);
-	private final PortalUUID _portalUUID = Mockito.mock(PortalUUID.class);
+	private final CompanyLocalService _companyLocalService = Mockito.mock(
+		CompanyLocalService.class);
 	private RankingIndexCreationBundleActivator
 		_rankingIndexCreationBundleActivator;
-	private final RankingIndexCreationBackgroundTaskExecutor
-		_rankingIndexRenameBackgroundTaskExecutor = Mockito.mock(
-			RankingIndexCreationBackgroundTaskExecutor.class);
+	private final RankingIndexCreator _rankingIndexCreator = Mockito.mock(
+		RankingIndexCreator.class);
+	private final RankingIndexNameBuilder _rankingIndexNameBuilder =
+		Mockito.mock(RankingIndexNameBuilder.class);
+	private final RankingIndexReader _rankingIndexReader = Mockito.mock(
+		RankingIndexReader.class);
 	private final SearchEngineInformation _searchEngineInformation =
 		Mockito.mock(SearchEngineInformation.class);
 	private final SingleIndexToMultipleIndexImporter


### PR DESCRIPTION
### **LPS link:** [LPS-191765](https://liferay.atlassian.net/browse/LPS-191765)
### **LPP link:** [LPP-50233](https://liferay.atlassian.net/browse/LPP-50233)

# Context
 
After switching embedded/remote ES, the Ranking index is no longer accessible (because the index is stored inside the Elasticsearch server). Therefore, it is necessary to create a new Ranking index. This new Ranking index should be created through a background task added in the [RankingIndexCreationBundleActivator](https://github.com/liferay/liferay-portal/blob/7.4.3.89-ga89/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/creation/activator/RankingIndexCreationBundleActivator.java) class, as you can see bellow:

```
...

		if (_singleIndexToMultipleIndexImporter.needImport()) {
			_addBackgroundTask();
		}
	}

	private void _addBackgroundTask() {
		try {
			_backgroundTaskManager.addBackgroundTask(
				UserConstants.USER_ID_DEFAULT, CompanyConstants.SYSTEM,
				"createRankingIndex-" + _portalUUID.generate(),
				RankingIndexCreationBackgroundTaskExecutor.class.getName(),
				new HashMap<>(), new ServiceContext());
		}
		catch (PortalException portalException) {
			_log.error(
				"Unable to schedule the job for RankingIndexRename",
				portalException);
		}
	}
...
```
 
However this background task is never executed because the "liferay/background_task" destination is not configured yet when the [sendMessage](https://github.com/liferay/liferay-portal/blob/e7b4deb6b873d5f964882141e352d0b9601138eb/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java#L66C1-L116C3) function is called, as you can see below:

```
...

Destination destination = _destinations.get(destinationName);

		if (destination == null) {
			if (_log.isWarnEnabled()) {
				_log.warn(
					"Destination " + destinationName + " is not configured");
			}

			return;
		}
...
```

After that the liferay-20096-search-tuning-rankings index is not created and the Result Rankings application is not available on the portal.

# Proposed solution

The proposed solution consists of changing the [RankingIndexCreationBundleActivator](https://github.com/liferay/liferay-portal/blob/7.4.3.89-ga89/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/creation/activator/RankingIndexCreationBundleActivator.java) class so that a new ranking index is created directly without the need to add a background task, as you can see bellow:

```
if (_singleIndexToMultipleIndexImporter.needImport()) {
			List<Company> companies = _companyLocalService.getCompanies();

			for (Company company : companies) {
				RankingIndexName rankingIndexName =
					_rankingIndexNameBuilder.getRankingIndexName(
						company.getCompanyId());

				if (_rankingIndexReader.isExists(rankingIndexName)) {
					continue;
				}

				_rankingIndexCreator.create(rankingIndexName);
			}
		}
```