### PR TITLE
LPS-193198 Add destination unreachable check

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortlet.java
@@ -85,7 +85,9 @@ public class SearchBarPortlet extends MVCPortlet {
 				WebKeys.PORTLET_DISPLAY_CONTEXT,
 				searchBarPortletDisplayContext);
 
-			if (searchBarPortletDisplayContext.isRenderNothing()) {
+			if (searchBarPortletDisplayContext.isDestinationUnreachable() ||
+				searchBarPortletDisplayContext.isRenderNothing()) {
+
 				renderRequest.setAttribute(
 					WebKeys.PORTLET_CONFIGURATOR_VISIBILITY, Boolean.TRUE);
 			}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-193198

I have added an additional check that it is used here: https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp#L44

Since the message is that the portlet is not viewable yet, we should include the PORTLET_CONFIGURATOR_VISIBILITY to allow hiding it with the toggle controls