### PR TITLE
LPS-194957: A Blueprint collection provider can return (structured) model classes 

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/info/collection/provider/SXPBlueprintAssetEntryInfoCollectionProvider.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/info/collection/provider/SXPBlueprintAssetEntryInfoCollectionProvider.java
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.search.experiences.internal.info.collection.provider;
+
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.util.AssetHelper;
+import com.liferay.info.collection.provider.CollectionQuery;
+import com.liferay.info.collection.provider.FilteredInfoCollectionProvider;
+import com.liferay.info.collection.provider.SingleFormVariationInfoCollectionProvider;
+import com.liferay.info.pagination.InfoPage;
+import com.liferay.info.pagination.Pagination;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.search.searcher.SearchRequestBuilder;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.search.experiences.model.SXPBlueprint;
+
+import java.util.Collections;
+
+/**
+ * @author Tibor Lipusz
+ * @author Gustavo Lima
+ */
+public class SXPBlueprintAssetEntryInfoCollectionProvider
+	extends SXPBlueprintInfoCollectionProvider<AssetEntry>
+	implements FilteredInfoCollectionProvider<AssetEntry>,
+			   SingleFormVariationInfoCollectionProvider<AssetEntry> {
+
+	public SXPBlueprintAssetEntryInfoCollectionProvider(
+		AssetHelper assetHelper, Searcher searcher,
+		SearchRequestBuilderFactory searchRequestBuilderFactory,
+		SXPBlueprint sxpBlueprint) {
+
+		super(assetHelper, searcher, searchRequestBuilderFactory, sxpBlueprint);
+	}
+
+	@Override
+	public InfoPage<AssetEntry> getCollectionInfoPage(
+		CollectionQuery collectionQuery) {
+
+		try {
+			Pagination pagination = collectionQuery.getPagination();
+
+			SearchRequestBuilder searchRequestBuilder = getSearchRequestBuilder(
+				collectionQuery, pagination);
+
+			SearchResponse searchResponse = searcher.search(
+				searchRequestBuilder.build());
+
+			return InfoPage.of(
+				assetHelper.getAssetEntries(searchResponse.getSearchHits()),
+				collectionQuery.getPagination(), searchResponse.getTotalHits());
+		}
+		catch (Exception exception) {
+			_log.error("Unable to get asset entries", exception);
+		}
+
+		return InfoPage.of(
+			Collections.emptyList(), collectionQuery.getPagination(), 0);
+	}
+
+	@Override
+	public String getFormVariationKey() {
+		return sxpBlueprint.getExternalReferenceCode();
+	}
+
+	@Override
+	public String getKey() {
+		return StringBundler.concat(
+			SingleFormVariationInfoCollectionProvider.super.getKey(),
+			StringPool.UNDERLINE, sxpBlueprint.getCompanyId(),
+			StringPool.UNDERLINE, sxpBlueprint.getExternalReferenceCode());
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SXPBlueprintAssetEntryInfoCollectionProvider.class);
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/info/collection/provider/SXPBlueprintJournalArticleInfoCollectionProvider.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/info/collection/provider/SXPBlueprintJournalArticleInfoCollectionProvider.java
@@ -1,0 +1,151 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.search.experiences.internal.info.collection.provider;
+
+import com.liferay.asset.util.AssetHelper;
+import com.liferay.info.collection.provider.CollectionQuery;
+import com.liferay.info.collection.provider.FilteredInfoCollectionProvider;
+import com.liferay.info.collection.provider.SingleFormVariationInfoCollectionProvider;
+import com.liferay.info.pagination.InfoPage;
+import com.liferay.info.pagination.Pagination;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.search.document.Document;
+import com.liferay.portal.search.hits.SearchHit;
+import com.liferay.portal.search.hits.SearchHits;
+import com.liferay.portal.search.searcher.SearchRequestBuilder;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.search.experiences.model.SXPBlueprint;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * @author David Nebinger
+ * @author Petteri Karttunen
+ */
+public class SXPBlueprintJournalArticleInfoCollectionProvider
+	extends SXPBlueprintInfoCollectionProvider<JournalArticle>
+	implements FilteredInfoCollectionProvider<JournalArticle>,
+			   SingleFormVariationInfoCollectionProvider<JournalArticle> {
+
+	public SXPBlueprintJournalArticleInfoCollectionProvider(
+		AssetHelper assetHelper, JournalArticleService journalArticleService,
+		Searcher searcher,
+		SearchRequestBuilderFactory searchRequestBuilderFactory,
+		SXPBlueprint sxpBlueprint) {
+
+		super(assetHelper, searcher, searchRequestBuilderFactory, sxpBlueprint);
+
+		_journalArticleService = journalArticleService;
+	}
+
+	@Override
+	public InfoPage<JournalArticle> getCollectionInfoPage(
+		CollectionQuery collectionQuery) {
+
+		try {
+			Pagination pagination = collectionQuery.getPagination();
+
+			SearchRequestBuilder searchRequestBuilder = getSearchRequestBuilder(
+				collectionQuery, pagination);
+
+			SearchResponse searchResponse = searcher.search(
+				searchRequestBuilder.build());
+
+			return InfoPage.of(
+				_getJournalArticles(searchResponse.getSearchHits()),
+				collectionQuery.getPagination(), searchResponse.getTotalHits());
+		}
+		catch (Exception exception) {
+			_log.error("Unable to get journal articles", exception);
+		}
+
+		return InfoPage.of(
+			Collections.emptyList(), collectionQuery.getPagination(), 0);
+	}
+
+	@Override
+	public String getFormVariationKey() {
+		long ddmStructureId = 0;
+
+		CollectionQuery collectionQuery = new CollectionQuery();
+
+		collectionQuery.setPagination(Pagination.of(1, 0));
+
+		SearchRequestBuilder searchRequestBuilder = getSearchRequestBuilder(
+			collectionQuery, collectionQuery.getPagination());
+
+		SearchResponse searchResponse = searcher.search(
+			searchRequestBuilder.build());
+
+		SearchHits searchHits = searchResponse.getSearchHits();
+
+		try {
+			List<JournalArticle> journalArticles = _getJournalArticles(
+				searchHits);
+
+			if (!journalArticles.isEmpty()) {
+				JournalArticle journalArticle = journalArticles.get(0);
+
+				ddmStructureId = journalArticle.getDDMStructureId();
+			}
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+
+		return String.valueOf(ddmStructureId);
+	}
+
+	@Override
+	public String getKey() {
+		return StringBundler.concat(
+			SingleFormVariationInfoCollectionProvider.super.getKey(),
+			StringPool.UNDERLINE, sxpBlueprint.getCompanyId(),
+			StringPool.UNDERLINE, sxpBlueprint.getExternalReferenceCode(),
+			StringPool.UNDERLINE, JournalArticle.class.getName());
+	}
+
+	@Override
+	public String getLabel(Locale locale) {
+		return sxpBlueprint.getTitle(locale);
+	}
+
+	private List<JournalArticle> _getJournalArticles(SearchHits searchHits)
+		throws PortalException {
+
+		List<JournalArticle> journalArticles = new ArrayList<>();
+
+		List<SearchHit> searchHitsList = searchHits.getSearchHits();
+
+		for (SearchHit searchHit : searchHitsList) {
+			Document document = searchHit.getDocument();
+
+			journalArticles.add(
+				_journalArticleService.getLatestArticle(
+					document.getLong(Field.ENTRY_CLASS_PK)));
+		}
+
+		return journalArticles;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SXPBlueprintJournalArticleInfoCollectionProvider.class);
+
+	private final JournalArticleService _journalArticleService;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPBlueprintLocalServiceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPBlueprintLocalServiceImpl.java
@@ -5,10 +5,16 @@
 
 package com.liferay.search.experiences.service.impl;
 
+import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.util.AssetHelper;
 import com.liferay.info.collection.provider.InfoCollectionProvider;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
@@ -20,14 +26,20 @@ import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.search.experiences.exception.SXPBlueprintTitleException;
-import com.liferay.search.experiences.internal.info.collection.provider.SXPBlueprintInfoCollectionProvider;
+import com.liferay.search.experiences.internal.info.collection.provider.SXPBlueprintAssetEntryInfoCollectionProvider;
+import com.liferay.search.experiences.internal.info.collection.provider.SXPBlueprintJournalArticleInfoCollectionProvider;
 import com.liferay.search.experiences.model.SXPBlueprint;
+import com.liferay.search.experiences.rest.dto.v1_0.Configuration;
+import com.liferay.search.experiences.rest.dto.v1_0.GeneralConfiguration;
 import com.liferay.search.experiences.service.base.SXPBlueprintLocalServiceBaseImpl;
 import com.liferay.search.experiences.validator.SXPBlueprintValidator;
 
@@ -94,7 +106,7 @@ public class SXPBlueprintLocalServiceImpl
 
 		_resourceLocalService.addModelResources(sxpBlueprint, serviceContext);
 
-		_registerCollectionProvider(sxpBlueprint);
+		_registerCollectionProviders(sxpBlueprint);
 
 		return sxpBlueprint;
 	}
@@ -134,7 +146,7 @@ public class SXPBlueprintLocalServiceImpl
 		_resourceLocalService.deleteResource(
 			sxpBlueprint, ResourceConstants.SCOPE_INDIVIDUAL);
 
-		_unregisterCollectionProvider(sxpBlueprint);
+		_unregisterCollectionProviders(sxpBlueprint);
 
 		return sxpBlueprint;
 	}
@@ -159,7 +171,7 @@ public class SXPBlueprintLocalServiceImpl
 					sxpBlueprintLocalService.getSXPBlueprints(companyId);
 
 				for (SXPBlueprint sxpBlueprint : sxpBlueprints) {
-					_registerCollectionProvider(sxpBlueprint);
+					_registerCollectionProviders(sxpBlueprint);
 				}
 			});
 	}
@@ -187,7 +199,7 @@ public class SXPBlueprintLocalServiceImpl
 
 		sxpBlueprint.setStatusDate(serviceContext.getModifiedDate(null));
 
-		_registerCollectionProvider(sxpBlueprint);
+		_registerCollectionProviders(sxpBlueprint);
 
 		return sxpBlueprintPersistence.update(sxpBlueprint);
 	}
@@ -215,7 +227,7 @@ public class SXPBlueprintLocalServiceImpl
 				"%.1f",
 				GetterUtil.getFloat(sxpBlueprint.getVersion(), 0.9F) + 0.1));
 
-		_registerCollectionProvider(sxpBlueprint);
+		_registerCollectionProviders(sxpBlueprint);
 
 		return updateSXPBlueprint(sxpBlueprint);
 	}
@@ -225,36 +237,108 @@ public class SXPBlueprintLocalServiceImpl
 		_bundleContext = bundleContext;
 	}
 
-	private void _registerCollectionProvider(SXPBlueprint sxpBlueprint) {
-		_unregisterCollectionProvider(sxpBlueprint);
+	private String _getSingleSearchableAssetType(SXPBlueprint sxpBlueprint) {
+		Configuration configuration = Configuration.unsafeToDTO(
+			sxpBlueprint.getConfigurationJSON());
+
+		GeneralConfiguration generalConfiguration =
+			configuration.getGeneralConfiguration();
+
+		if (generalConfiguration == null) {
+			return null;
+		}
+
+		String[] searchableAssetTypes =
+			generalConfiguration.getSearchableAssetTypes();
+
+		if (ArrayUtil.isEmpty(searchableAssetTypes) ||
+			(searchableAssetTypes.length > 1)) {
+
+			return null;
+		}
+
+		return searchableAssetTypes[0];
+	}
+
+	private void _registerCollectionProvider(
+		long companyId, String infoCollectionProviderServiceRegistrationKey,
+		String itemClassName,
+		InfoCollectionProvider<?> infoCollectionProvider) {
+
+		_unregisterCollectionProvider(
+			infoCollectionProviderServiceRegistrationKey);
 
 		ServiceRegistration<InfoCollectionProvider>
 			infoCollectionProviderServiceRegistration =
 				_bundleContext.registerService(
-					InfoCollectionProvider.class,
-					new SXPBlueprintInfoCollectionProvider(
-						_assetHelper, _searcher, _searchRequestBuilderFactory,
-						sxpBlueprint),
+					InfoCollectionProvider.class, infoCollectionProvider,
 					HashMapDictionaryBuilder.<String, Object>put(
-						"company.id", sxpBlueprint.getCompanyId()
+						"company.id", companyId
 					).put(
-						"item.class.name",
-						"com.liferay.asset.kernel.model.AssetEntry"
+						"item.class.name", itemClassName
 					).build());
 
 		_serviceRegistrations.put(
-			sxpBlueprint.getExternalReferenceCode(),
+			infoCollectionProviderServiceRegistrationKey,
 			infoCollectionProviderServiceRegistration);
 	}
 
-	private void _unregisterCollectionProvider(SXPBlueprint sxpBlueprint) {
+	private void _registerCollectionProviders(SXPBlueprint sxpBlueprint) {
+		_registerCollectionProvider(
+			sxpBlueprint.getCompanyId(),
+			sxpBlueprint.getExternalReferenceCode(), AssetEntry.class.getName(),
+			new SXPBlueprintAssetEntryInfoCollectionProvider(
+				_assetHelper, _searcher, _searchRequestBuilderFactory,
+				sxpBlueprint));
+
+		String singleSearchableAssetType = _getSingleSearchableAssetType(
+			sxpBlueprint);
+
+		if (Validator.isBlank(singleSearchableAssetType)) {
+			return;
+		}
+
+		if (StringUtil.equals(
+				singleSearchableAssetType, JournalArticle.class.getName())) {
+
+			_registerCollectionProvider(
+				sxpBlueprint.getCompanyId(),
+				StringBundler.concat(
+					sxpBlueprint.getExternalReferenceCode(),
+					StringPool.UNDERLINE, JournalArticle.class.getName()),
+				JournalArticle.class.getName(),
+				new SXPBlueprintJournalArticleInfoCollectionProvider(
+					_assetHelper, _journalArticleService, _searcher,
+					_searchRequestBuilderFactory, sxpBlueprint));
+		}
+	}
+
+	private void _unregisterCollectionProvider(
+		String infoCollectionProviderServiceRegistrationKey) {
+
 		_serviceRegistrations.computeIfPresent(
-			sxpBlueprint.getExternalReferenceCode(),
+			infoCollectionProviderServiceRegistrationKey,
 			(key, serviceRegistration) -> {
 				serviceRegistration.unregister();
 
 				return null;
 			});
+	}
+
+	private void _unregisterCollectionProviders(SXPBlueprint sxpBlueprint) {
+		String externalReferenceCode = sxpBlueprint.getExternalReferenceCode();
+
+		_unregisterCollectionProvider(externalReferenceCode);
+
+		String searchableAssetType = _getSingleSearchableAssetType(
+			sxpBlueprint);
+
+		if (!Validator.isBlank(searchableAssetType)) {
+			_unregisterCollectionProvider(
+				StringBundler.concat(
+					externalReferenceCode, StringPool.UNDERLINE,
+					searchableAssetType));
+		}
 	}
 
 	private void _validate(
@@ -280,6 +364,12 @@ public class SXPBlueprintLocalServiceImpl
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private JournalArticleService _journalArticleService;
+
+	@Reference
+	private JSONFactory _jsonFactory;
 
 	@Reference
 	private Language _language;


### PR DESCRIPTION
- **Background**:
   - Spike with links to depending customer cases: https://liferay.atlassian.net/browse/LPS-188797
- **Story**: https://liferay.atlassian.net/browse/LPS-194956
- **Task**: https://liferay.atlassian.net/browse/LPS-194957

### Description

The request for this feature comes from a customer case where Blueprint collection providers are in use. It has however identified as a significant limitation that the Blueprint collection provider can only return Asset Entries, but not model classes, which would then allow mapping the model fields conveniently to collection item fragments.

This PR extends the Blueprint collection provider functionality as follows:

1. **Multiple searchable types selected in a Blueprint** -> Like currently, a single collection provider returning asset entries is registered
2. **A single searchable type is selected in a Blueprint** -> 2 collection providers are registered. The first one returns Asset Entries as before. The second one (structured) model class instances. Currently only Journal Article is supported, but  support for more models can be added later if requested. In selecting the Collection Provider in the dialog, the description of the provider displays, which model it returns.

###  Detecting the DDM Structure
Detecting the subtype / DDM structure to be used for the articles of collection is difficult. This is a critical issue in making the whole initiative worth it as it would allow mapping structure fields to fragment fields in the collection display.
The challenge is, that in the case of JournalArticles, for example, a Blueprint can return articles of multiple DDM structures. How should the collection provider know what to use? The other problem is that Blueprints are dynamic: they can even return different results for different users. What DDM structures the Blueprint returns is not possible to detect with 100% certainty.

This PR simply fetches one search result and uses the first DDM structure of it. That means that the responsibility to add proper filters in the Blueprint is on the Blueprint authors shoulders. This behaviour will be properly documented. 
