### PR TITLE
LPS-194732 XSS Vulnerability in Result Rankings search query

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/add_results_rankings.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/add_results_rankings.jsp
@@ -5,15 +5,17 @@
  */
 --%>
 
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
-taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
+page import="com.liferay.portal.kernel.servlet.SessionErrors" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.search.tuning.rankings.web.internal.exception.DuplicateQueryStringException" %>
@@ -36,14 +38,14 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(LanguageUtil.get(request, "new-ranking"));
 %>
 
-<clay:sheet
-	cssClass="result-rankings-alert-container"
->
-	<liferay-ui:error exception="<%= DuplicateQueryStringException.class %>" message="ranking-with-that-search-query-already-exists" />
-	<liferay-ui:error exception="<%= Exception.class %>" message="an-unexpected-error-occurred" />
+<c:if test="<%= !SessionErrors.isEmpty(renderRequest) %>">
+	<div class="result-rankings-alert-container">
+		<liferay-ui:error exception="<%= DuplicateQueryStringException.class %>" message="ranking-with-that-search-query-already-exists" />
+		<liferay-ui:error exception="<%= Exception.class %>" message="an-unexpected-error-occurred" />
 
-	<liferay-ui:error-principal />
-</clay:sheet>
+		<liferay-ui:error-principal />
+	</div>
+</c:if>
 
 <portlet:actionURL name="/result_rankings/edit_ranking" var="addResultsRankingEntryURL" />
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/css/_page.scss
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/css/_page.scss
@@ -1,6 +1,6 @@
 .result-rankings-alert-container {
 	.alert {
-		margin-bottom: 0;
-		margin-top: 1.5rem;
+		margin: 1.5rem auto 0;
+		max-width: 800px;
 	}
 }

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsForm.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsForm.es.js
@@ -483,7 +483,7 @@ class ResultRankingsForm extends Component {
 			if (response.errors.length) {
 				response.errors.forEach((message) => {
 					openToast({
-						message,
+						message: Liferay.Util.escapeHTML(message),
 						type: 'danger',
 					});
 				});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-194732 - XSS with result ranking's search query
https://liferay.atlassian.net/browse/LPS-183706 - Result Rankings alert container shows even when there is no alert

Two bug fixes:
- Escape the message that appears inside the toast for having a duplicate search query 
- Do not show the alert container when there is no alert

Demo of first 🐛 : https://github.com/liferay-search/liferay-portal/assets/14063502/bd760c65-1fd8-4b88-a6b7-0e7548c02e6c

Screenshot of second 🐛: 
<img width="1456" alt="Screenshot 2023-09-05 at 4 50 12 PM" src="https://github.com/liferay-search/liferay-portal/assets/14063502/ed3e0f08-4658-4819-a825-509b02c3dc7d">
