### PR TITLE
LPS-191998 Result Rankings error when trying to add two existent queries

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/EditRankingMVCActionCommand.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/EditRankingMVCActionCommand.java
@@ -476,7 +476,9 @@ public class EditRankingMVCActionCommand extends BaseMVCActionCommand {
 				editRankingMVCActionRequest.getRedirect());
 		}
 		catch (Exception exception) {
-			if (exception instanceof DuplicateAliasStringException) {
+			if (exception instanceof DuplicateAliasStringException ||
+				exception instanceof DuplicateQueryStringException) {
+
 				SessionErrors.add(actionRequest, Exception.class);
 
 				actionResponse.setRenderParameter(

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/utils/api.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/utils/api.es.js
@@ -16,9 +16,20 @@ import {isNull} from './util.es';
 export function fetchResponse(url, params) {
 	const fetchUrl = new URL(url);
 
-	Object.keys(params).forEach((property) => {
-		if (!isNull(params[property])) {
-			fetchUrl.searchParams.set(property, params[property]);
+	Object.entries(params).forEach(([property, value]) => {
+		if (!isNull(value)) {
+
+			// If the value is an array, append each item inside array
+			// separately to prevent ambiguity from a comma-separated string.
+
+			if (Array.isArray(value)) {
+				value.forEach((item) =>
+					fetchUrl.searchParams.append(property, item)
+				);
+			}
+			else {
+				fetchUrl.searchParams.append(property, value);
+			}
 		}
 	});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-191998 - Result Rankings error when trying to add two existent queries

Two updates, after reading Petteri's comment:
- Include `DuplicateQueryStringException` in the check for exceptions, in order to forward to the edit page.
- I wasn't sure exactly why an example like "apple,pen" doesn't get split into "apple" and "pen" only in this particular case, but this change just takes the alias array and appends each value individually, to avoid that from happening. This is only in the validate step.

Demo:
https://github.com/liferay-search/liferay-portal/assets/14063502/39d2a246-1a9c-4667-8b4a-6ac627fa5ff8
