### PR TITLE
LPS-196804 Category Facet - Cannot select vocabularies from Asset Libraries

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/build.gradle
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:asset:asset-category-property-api")
+	compileOnly project(":apps:depot:depot-api")
 	compileOnly project(":apps:headless:headless-admin-taxonomy:headless-admin-taxonomy-api")
 	compileOnly project(":apps:headless:headless-common-spi")
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-api")

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -15,6 +15,7 @@ import com.liferay.asset.kernel.model.ClassType;
 import com.liferay.asset.kernel.model.ClassTypeReader;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyService;
+import com.liferay.depot.util.SiteConnectedGroupGroupProviderUtil;
 import com.liferay.headless.admin.taxonomy.dto.v1_0.AssetType;
 import com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyVocabulary;
 import com.liferay.headless.admin.taxonomy.internal.dto.v1_0.util.CreatorUtil;
@@ -653,7 +654,9 @@ public class TaxonomyVocabularyResourceImpl
 			searchContext -> {
 				searchContext.addVulcanAggregation(aggregation);
 				searchContext.setCompanyId(contextCompany.getCompanyId());
-				searchContext.setGroupIds(new long[] {groupId});
+				searchContext.setGroupIds(
+					SiteConnectedGroupGroupProviderUtil.
+						getCurrentAndAncestorSiteAndDepotGroupIds(groupId));
 			},
 			sorts,
 			document -> _toTaxonomyVocabulary(

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SelectVocabularies.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SelectVocabularies.js
@@ -298,22 +298,40 @@ function SelectVocabularies({
 						).then((response) => response.json())
 					)
 				)
-					.then((response) => {
+					.then((responses) => {
 						const ids = [];
 
 						setVocabularyTree(
-							response.map((vocabularies, index) => ({
+							responses.map((response, index) => ({
 								...itemsWithGlobalSite[index],
-								children: (vocabularies?.items || []).map(
-									({id, name}) => {
+								children: (response?.items || [])
+									.filter(({siteId}) => {
+
+										// Filter out global vocabularies for
+										// non-global sites.
+
+										const isGlobalSite =
+											itemsWithGlobalSite[index].id ===
+											Liferay.ThemeDisplay.getCompanyGroupId();
+
+										if (
+											!isGlobalSite &&
+											siteId?.toString() ===
+												Liferay.ThemeDisplay.getCompanyGroupId()
+										) {
+											return false;
+										}
+
+										return true;
+									})
+									.map(({id, name}) => {
 										ids.push(id.toString()); // Collect IDs for _isDisplayInfoSelectedVocabulariesHidden
 
 										return {
 											id: id.toString(),
 											name,
 										};
-									}
-								),
+									}),
 							}))
 						);
 

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/category_selector_input/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/category_selector_input/index.js
@@ -367,21 +367,43 @@ function CategorySelectorInput({
 						.then((response) => response.json())
 						.then((vocabularies) => {
 							tree[siteIndex] = {
-								children: vocabularies.items.map(
-									({
-										id,
-										name,
-										numberOfTaxonomyCategories,
-									}) => ({
+								children: vocabularies.items
+									.filter(({siteId}) => {
 
-										// In certain responses, 'id' is a number,
-										// so JSON.stringify for consistency.
+										// Filter out global vocabularies for
+										// non-global sites.
 
-										id: JSON.stringify(id),
-										name,
-										numberOfTaxonomyCategories,
+										const isGlobalSite =
+											site.id ===
+											Number(
+												Liferay.ThemeDisplay.getCompanyGroupId()
+											);
+
+										if (
+											!isGlobalSite &&
+											siteId?.toString() ===
+												Liferay.ThemeDisplay.getCompanyGroupId()
+										) {
+											return false;
+										}
+
+										return true;
 									})
-								),
+									.map(
+										({
+											id,
+											name,
+											numberOfTaxonomyCategories,
+										}) => ({
+
+											// In certain responses, 'id' is a number,
+											// so JSON.stringify for consistency.
+
+											id: JSON.stringify(id),
+											name,
+											numberOfTaxonomyCategories,
+										})
+									),
 								descriptiveName: site.descriptiveName,
 								id: JSON.stringify(site.id),
 								name: site.name,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-196804

In the category facet configuration:
- Allows vocabularies from asset libraries to display
- Filters out the global vocabularies for the other sites (so only the global vocabularies will be displayed under the "Global" site)

## Screenshot with fix
![Screenshot 2023-09-20 at 6 39 43 PM](https://github.com/liferay-search/liferay-portal/assets/4496722/55ff895b-4d4e-46d8-85e7-cfc7ca0dcfca)

cc @joshuacords 
