### PR TITLE
LPS-192640 LPS-196113 Allow duplicate ERC error to display

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/EditERCModal.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/EditERCModal.js
@@ -76,31 +76,39 @@ export function ERCModal({
 			method: 'POST',
 		})
 			.then((response) => {
-				if (!response.ok) {
-					throw Error();
-				}
-
-				return response.json();
+				return response.json().then((data) => ({
+					ok: response.ok,
+					responseContent: data,
+				}));
 			})
-			.then((jsonResponse) => {
-				if (
-					jsonResponse.type ===
-						'DuplicateSXPBlueprintExternalReferenceCodeException' ||
-					jsonResponse.type ===
-						'DuplicateSXPElementExternalReferenceCodeException'
-				) {
-					setError(
-						sub(
-							Liferay.Language.get(
-								'the-x-is-already-in-use-please-enter-a-unique-x'
-							),
-							[Liferay.Language.get('external-reference-code')]
-						)
-					);
+			.then(({ok, responseContent}) => {
+				if (!ok) {
+					if (
+						responseContent.type ===
+							'DuplicateSXPBlueprintExternalReferenceCodeException' ||
+						responseContent.type ===
+							'DuplicateSXPElementExternalReferenceCodeException'
+					) {
+						setError(
+							sub(
+								Liferay.Language.get(
+									'the-x-is-already-in-use-please-enter-a-unique-x'
+								),
+								[
+									Liferay.Language.get(
+										'external-reference-code'
+									),
+								]
+							)
+						);
 
-					externalReferenceCodeInputRef.current.focus();
+						externalReferenceCodeInputRef.current.focus();
 
-					return;
+						return;
+					}
+					else {
+						throw Error();
+					}
 				}
 
 				onSubmit(externalReferenceCode.trim());


### PR DESCRIPTION
**Story:** https://liferay.atlassian.net/browse/LPS-192640
**Subtask:** https://liferay.atlassian.net/browse/LPS-196113

The early `!response.ok` check was preventing the error message from returning.

This also follows the same pattern found in https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/view_sxp_blueprints/ImportSXPBlueprintModal.js#L78-L129

## Screenshot with fix

![Screenshot 2023-09-26 at 4 07 36 PM](https://github.com/liferay-search/liferay-portal/assets/4496722/1e4ac406-c5d0-46e0-8ecc-22171abceaf1)
