### PR TITLE
LPS-197195 [FE] Connect sites MVCResourceCommand with UI

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/display/context/EditRankingDisplayBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/display/context/EditRankingDisplayBuilder.java
@@ -134,18 +134,18 @@ public class EditRankingDisplayBuilder {
 
 	private Map<String, Object> _getProps() {
 		return HashMapBuilder.<String, Object>put(
-			"cancelUrl", HtmlUtil.escape(_getRedirect())
+			"cancelURL", HtmlUtil.escape(_getRedirect())
 		).put(
-			"fetchDocumentsHiddenUrl", _getHiddenResultRankingsResourceURL()
+			"fetchDocumentsHiddenURL", _getHiddenResultRankingsResourceURL()
 		).put(
-			"fetchDocumentsSearchUrl", _getSearchResultRankingsResourceURL()
+			"fetchDocumentsSearchURL", _getSearchResultRankingsResourceURL()
 		).put(
-			"fetchDocumentsVisibleUrl", _getVisibleResultRankingsResourceURL()
+			"fetchDocumentsVisibleURL", _getVisibleResultRankingsResourceURL()
 		).put(
-			"fetchSiteByExternalReferenceCodeUrl",
+			"fetchSiteByExternalReferenceCodeURL",
 			_getSiteByExternalReferenceCodeResourceURL()
 		).put(
-			"fetchSitesUrl", _getSitesResourceURL()
+			"fetchSitesURL", _getSitesResourceURL()
 		).put(
 			"formName", _renderResponse.getNamespace() + _getFormName()
 		).put(
@@ -167,7 +167,7 @@ public class EditRankingDisplayBuilder {
 		).put(
 			"searchQuery", _getKeywords()
 		).put(
-			"validateFormUrl", _getValidateResultRankingsResourceURL()
+			"validateFormURL", _getValidateResultRankingsResourceURL()
 		).build();
 	}
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/add_results_rankings.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/add_results_rankings.jsp
@@ -17,6 +17,7 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.learn.LearnMessageUtil" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
+page import="com.liferay.portal.kernel.portlet.url.builder.ResourceURLBuilder" %><%@
 page import="com.liferay.portal.kernel.servlet.SessionErrors" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
@@ -73,6 +74,15 @@ renderResponse.setTitle(LanguageUtil.get(request, "new-ranking"));
 			props='<%=
 				HashMapBuilder.<String, Object>put(
 					"cancelUrl", redirect
+				).put(
+					"fetchSitesUrl",
+					ResourceURLBuilder.createResourceURL(
+						renderResponse
+					).setCMD(
+						"getSitesJSONObject"
+					).setResourceID(
+						"/result_rankings/get_sites"
+					).buildString()
 				).put(
 					"formName", formName
 				).put(

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/add_results_rankings.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/add_results_rankings.jsp
@@ -73,9 +73,9 @@ renderResponse.setTitle(LanguageUtil.get(request, "new-ranking"));
 			module="js/components/ResultRankingsAdd.es"
 			props='<%=
 				HashMapBuilder.<String, Object>put(
-					"cancelUrl", redirect
+					"cancelURL", redirect
 				).put(
-					"fetchSitesUrl",
+					"fetchSitesURL",
 					ResourceURLBuilder.createResourceURL(
 						renderResponse
 					).setCMD(

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsAdd.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsAdd.es.js
@@ -35,7 +35,7 @@ const SCOPE_INFO = {
 	},
 };
 
-function ResultRankingsAdd({cancelUrl, fetchSitesUrl, formName, namespace}) {
+function ResultRankingsAdd({cancelURL, fetchSitesURL, formName, namespace}) {
 	const [errors, setErrors] = useState({});
 	const [scopeType, setScopeType] = useState(SCOPE_TYPES.EVERYTHING);
 	const [scope, setScope] = useState('');
@@ -84,7 +84,7 @@ function ResultRankingsAdd({cancelUrl, fetchSitesUrl, formName, namespace}) {
 	};
 
 	const _handleCancel = () => {
-		navigate(cancelUrl);
+		navigate(cancelURL);
 	};
 
 	const _handleSearchQueryChange = (event) => {
@@ -243,7 +243,7 @@ function ResultRankingsAdd({cancelUrl, fetchSitesUrl, formName, namespace}) {
 					<ScopeSelect
 						disabled={false}
 						error={errors.scope}
-						fetchItemsUrl={fetchSitesUrl}
+						fetchItemsUrl={fetchSitesURL}
 						locator={{
 							id: 'externalReferenceCode',
 							label: 'descriptiveName',
@@ -316,8 +316,8 @@ function ResultRankingsAdd({cancelUrl, fetchSitesUrl, formName, namespace}) {
 }
 
 export default function ({
-	cancelUrl,
-	fetchSitesUrl,
+	cancelURL,
+	fetchSitesURL,
 	formName,
 	learnResources,
 	namespace = '',
@@ -325,8 +325,8 @@ export default function ({
 	return (
 		<LearnResourcesContext.Provider value={learnResources}>
 			<ResultRankingsAdd
-				cancelUrl={cancelUrl}
-				fetchSitesUrl={fetchSitesUrl}
+				cancelURL={cancelURL}
+				fetchSitesURL={fetchSitesURL}
 				formName={formName}
 				namespace={namespace}
 			/>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsAdd.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsAdd.es.js
@@ -35,7 +35,7 @@ const SCOPE_INFO = {
 	},
 };
 
-function ResultRankingsAdd({cancelUrl, formName, namespace}) {
+function ResultRankingsAdd({cancelUrl, fetchSitesUrl, formName, namespace}) {
 	const [errors, setErrors] = useState({});
 	const [scopeType, setScopeType] = useState(SCOPE_TYPES.EVERYTHING);
 	const [scope, setScope] = useState('');
@@ -243,7 +243,7 @@ function ResultRankingsAdd({cancelUrl, formName, namespace}) {
 					<ScopeSelect
 						disabled={false}
 						error={errors.scope}
-						fetchItemsUrl="/o/headless-admin-user/v1.0/sites"
+						fetchItemsUrl={fetchSitesUrl}
 						locator={{
 							id: 'externalReferenceCode',
 							label: 'descriptiveName',
@@ -272,7 +272,9 @@ function ResultRankingsAdd({cancelUrl, formName, namespace}) {
 					<ScopeSelect
 						disabled={false}
 						error={errors.scope}
-						fetchItemsUrl="/o/search-experiences-rest/v1.0/sxp-blueprints"
+						fetchItemsUrl={`${
+							window.location.origin
+						}${Liferay.ThemeDisplay.getPathContext()}/o/search-experiences-rest/v1.0/sxp-blueprints`}
 						locator={{
 							id: 'externalReferenceCode',
 							label: 'title',
@@ -313,11 +315,18 @@ function ResultRankingsAdd({cancelUrl, formName, namespace}) {
 	);
 }
 
-export default function ({cancelUrl, formName, learnResources, namespace}) {
+export default function ({
+	cancelUrl,
+	fetchSitesUrl,
+	formName,
+	learnResources,
+	namespace = '',
+}) {
 	return (
 		<LearnResourcesContext.Provider value={learnResources}>
 			<ResultRankingsAdd
 				cancelUrl={cancelUrl}
+				fetchSitesUrl={fetchSitesUrl}
 				formName={formName}
 				namespace={namespace}
 			/>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsAdd.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsAdd.es.js
@@ -170,7 +170,7 @@ function ResultRankingsAdd({cancelUrl, formName, namespace}) {
 			{(Liferay.FeatureFlags['LPS-159650'] ||
 				Liferay.FeatureFlags['LPS-157988']) && (
 				<ClayForm.Group>
-					<label htmlFor="searchScope">
+					<label htmlFor="searchScopeType">
 						{Liferay.Language.get('scope')}
 
 						<ClayIcon
@@ -183,6 +183,7 @@ function ResultRankingsAdd({cancelUrl, formName, namespace}) {
 						aria-label={Liferay.Language.get('scope')}
 						className="form-control form-control-select"
 						displayType="unstyled"
+						id="searchScopeType"
 						onClick={_handleScopeDropdownChange}
 						ref={alignElementRef}
 					>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsForm.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsForm.es.js
@@ -32,10 +32,10 @@ class ResultRankingsForm extends Component {
 	static contextType = ThemeContext;
 
 	static propTypes = {
-		cancelUrl: PropTypes.string.isRequired,
-		fetchDocumentsHiddenUrl: PropTypes.string.isRequired,
-		fetchDocumentsSearchUrl: PropTypes.string.isRequired,
-		fetchDocumentsVisibleUrl: PropTypes.string.isRequired,
+		cancelURL: PropTypes.string.isRequired,
+		fetchDocumentsHiddenURL: PropTypes.string.isRequired,
+		fetchDocumentsSearchURL: PropTypes.string.isRequired,
+		fetchDocumentsVisibleURL: PropTypes.string.isRequired,
 		formName: PropTypes.string.isRequired,
 		initialAliases: PropTypes.arrayOf(String),
 		initialGroupExternalReferenceCode: PropTypes.string,
@@ -43,7 +43,7 @@ class ResultRankingsForm extends Component {
 		initialSXPBlueprintExternalReferenceCode: PropTypes.string,
 		resultsRankingUid: PropTypes.string,
 		searchQuery: PropTypes.string.isRequired,
-		validateFormUrl: PropTypes.string.isRequired,
+		validateFormURL: PropTypes.string.isRequired,
 	};
 
 	static defaultProps = {
@@ -296,7 +296,7 @@ class ResultRankingsForm extends Component {
 			const scopeInfo = this.props.initialGroupExternalReferenceCode
 				? {
 						fetchItemByIdUrl: this.props
-							.fetchSiteByExternalReferenceCodeUrl,
+							.fetchSiteByExternalReferenceCodeURL,
 						label: 'descriptiveName',
 						value: this.props.initialGroupExternalReferenceCode,
 				  }
@@ -342,7 +342,7 @@ class ResultRankingsForm extends Component {
 
 		const {companyId, namespace} = this.context;
 
-		return fetchDocuments(this.props.fetchDocumentsVisibleUrl, {
+		return fetchDocuments(this.props.fetchDocumentsVisibleURL, {
 			[`${namespace}companyId`]: companyId,
 			[`${namespace}from`]: DELTA * this.state.visibleCur,
 			[`${namespace}keywords`]: this.props.searchQuery,
@@ -448,7 +448,7 @@ class ResultRankingsForm extends Component {
 
 		const {companyId, namespace} = this.context;
 
-		return fetchDocuments(this.props.fetchDocumentsHiddenUrl, {
+		return fetchDocuments(this.props.fetchDocumentsHiddenURL, {
 			[`${namespace}companyId`]: companyId,
 			[`${namespace}from`]: DELTA * this.state.hiddenCur,
 			[`${namespace}keywords`]: this.props.searchQuery,
@@ -549,7 +549,7 @@ class ResultRankingsForm extends Component {
 	_handlePublish = () => {
 		const {namespace} = this.context;
 
-		fetchResponse(this.props.validateFormUrl, {
+		fetchResponse(this.props.validateFormURL, {
 			[`${namespace}aliases`]: this.state.aliases,
 			[`${namespace}inactive`]: this.state.inactive,
 			[`${namespace}keywords`]: this.props.searchQuery,
@@ -722,8 +722,8 @@ class ResultRankingsForm extends Component {
 		const {namespace} = this.context;
 
 		const {
-			cancelUrl,
-			fetchDocumentsSearchUrl,
+			cancelURL,
+			fetchDocumentsSearchURL,
 			initialGroupExternalReferenceCode,
 			initialSXPBlueprintExternalReferenceCode,
 			searchQuery,
@@ -769,7 +769,7 @@ class ResultRankingsForm extends Component {
 
 				<PageToolbar
 					inactive={inactive}
-					onCancel={cancelUrl}
+					onCancel={cancelURL}
 					onChangeActive={this._handleActive}
 					onPublish={this._handlePublish}
 				/>
@@ -864,8 +864,8 @@ class ResultRankingsForm extends Component {
 											dataLoading={dataLoadingVisible}
 											dataMap={dataMap}
 											displayError={displayError}
-											fetchDocumentsSearchUrl={
-												fetchDocumentsSearchUrl
+											fetchDocumentsSearchURL={
+												fetchDocumentsSearchURL
 											}
 											onAddResultSubmit={
 												this._handleUpdateAddResultIds

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsForm.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsForm.es.js
@@ -295,27 +295,25 @@ class ResultRankingsForm extends Component {
 		) {
 			const scopeInfo = this.props.initialGroupExternalReferenceCode
 				? {
-						fetchItemByIdUrl:
-							'/o/headless-admin-user/v1.0/sites/by-external-reference-code/',
+						fetchItemByIdUrl: this.props
+							.fetchSiteByExternalReferenceCodeUrl,
 						label: 'descriptiveName',
 						value: this.props.initialGroupExternalReferenceCode,
 				  }
 				: {
-						fetchItemByIdUrl:
-							'/o/search-experiences-rest/v1.0/sxp-blueprints/by-external-reference-code/',
+						fetchItemByIdUrl: `${
+							window.location.origin
+						}${Liferay.ThemeDisplay.getPathContext()}/o/search-experiences-rest/v1.0/sxp-blueprints/by-external-reference-code/${
+							this.props.initialSXPBlueprintExternalReferenceCode
+						}`,
 						label: 'title',
 						value: this.props
 							.initialSXPBlueprintExternalReferenceCode,
 				  };
 
-			fetchResponse(
-				`${
-					window.location.origin
-				}${Liferay.ThemeDisplay.getPathContext()}${
-					scopeInfo.fetchItemByIdUrl
-				}${scopeInfo.value}`,
-				{}
-			)
+			fetchResponse(scopeInfo.fetchItemByIdUrl, {
+				[`${this.context.namespace}externalReferenceCode`]: scopeInfo.value,
+			})
 				.then((response) => {
 					this.setState(() => ({
 						scopeDisplayName:

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsForm.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsForm.es.js
@@ -5,7 +5,7 @@
 
 import ClayLayout from '@clayui/layout';
 import ClayTabs from '@clayui/tabs';
-import {fetch, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-web';
 import {PropTypes} from 'prop-types';
 import React, {Component} from 'react';
 
@@ -308,32 +308,20 @@ class ResultRankingsForm extends Component {
 							.initialSXPBlueprintExternalReferenceCode,
 				  };
 
-			fetch(
+			fetchResponse(
 				`${
 					window.location.origin
 				}${Liferay.ThemeDisplay.getPathContext()}${
 					scopeInfo.fetchItemByIdUrl
 				}${scopeInfo.value}`,
-				{
-					credentials: 'include',
-					headers: new Headers({
-						'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
-						'x-csrf-token': Liferay.authToken,
-					}),
-					method: 'GET',
-				}
+				{}
 			)
 				.then((response) => {
-					if (response.ok) {
-						return response.json();
-					}
-
-					throw new Error();
-				})
-				.then((item) => {
 					this.setState(() => ({
 						scopeDisplayName:
-							item[scopeInfo.label] || scopeInfo.value,
+							response.status !== 'NOT_FOUND'
+								? response[scopeInfo.label]
+								: scopeInfo.value,
 					}));
 				})
 				.catch(() => {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/add_result/AddResult.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/add_result/AddResult.es.js
@@ -14,7 +14,7 @@ import AddResultModal from './AddResultModal.es';
 /**
  * A button that opens a modal to be able to search, select, and add results.
  */
-function AddResult({fetchDocumentsSearchUrl, onAddResultSubmit}) {
+function AddResult({fetchDocumentsSearchURL, onAddResultSubmit}) {
 	const [showModal, setShowModal] = useState(false);
 
 	const {observer, onClose} = useModal({
@@ -41,7 +41,7 @@ function AddResult({fetchDocumentsSearchUrl, onAddResultSubmit}) {
 			<ErrorBoundary component={Liferay.Language.get('add-result')} toast>
 				{showModal ? (
 					<AddResultModal
-						fetchDocumentsSearchUrl={fetchDocumentsSearchUrl}
+						fetchDocumentsSearchURL={fetchDocumentsSearchURL}
 						observer={observer}
 						onAddResultSubmit={onAddResultSubmit}
 						onClose={onClose}
@@ -53,7 +53,7 @@ function AddResult({fetchDocumentsSearchUrl, onAddResultSubmit}) {
 }
 
 AddResult.propTypes = {
-	fetchDocumentsSearchUrl: PropTypes.string.isRequired,
+	fetchDocumentsSearchURL: PropTypes.string.isRequired,
 	onAddResultSubmit: PropTypes.func.isRequired,
 };
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/add_result/AddResultModal.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/add_result/AddResultModal.es.js
@@ -34,7 +34,7 @@ import AddResultSearchBar from './AddResultSearchBar.es';
  * A button that opens a modal to be able to search, select, and add results.
  */
 function AddResultModal({
-	fetchDocumentsSearchUrl,
+	fetchDocumentsSearchURL,
 	observer,
 	onAddResultSubmit,
 	onClose,
@@ -70,7 +70,7 @@ function AddResultModal({
 
 	const {refetch, resource} = useResource({
 		fetchOptions: FETCH_OPTIONS,
-		link: buildUrl(fetchDocumentsSearchUrl, {
+		link: buildUrl(fetchDocumentsSearchURL, {
 			[`${namespace}companyId`]: companyId,
 			[`${namespace}from`]: page * delta - delta,
 			[`${namespace}keywords`]: searchQuery,
@@ -491,7 +491,7 @@ function AddResultModal({
 }
 
 AddResultModal.propTypes = {
-	fetchDocumentsSearchUrl: PropTypes.string.isRequired,
+	fetchDocumentsSearchURL: PropTypes.string.isRequired,
 	onAddResultSubmit: PropTypes.func.isRequired,
 	onClose: PropTypes.func.isRequired,
 };

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/List.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/List.es.js
@@ -23,7 +23,7 @@ class List extends PureComponent {
 		dataLoading: PropTypes.bool,
 		dataMap: PropTypes.object,
 		displayError: PropTypes.bool,
-		fetchDocumentsSearchUrl: PropTypes.string,
+		fetchDocumentsSearchURL: PropTypes.string,
 		onAddResultSubmit: PropTypes.func,
 		onClickHide: PropTypes.func,
 		onClickPin: PropTypes.func,
@@ -215,7 +215,7 @@ class List extends PureComponent {
 			dataLoading,
 			dataMap,
 			displayError,
-			fetchDocumentsSearchUrl,
+			fetchDocumentsSearchURL,
 			onAddResultSubmit,
 			onClickHide,
 			onClickPin,
@@ -232,7 +232,7 @@ class List extends PureComponent {
 
 					<SearchBar
 						dataMap={dataMap}
-						fetchDocumentsSearchUrl={fetchDocumentsSearchUrl}
+						fetchDocumentsSearchURL={fetchDocumentsSearchURL}
 						onAddResultSubmit={onAddResultSubmit}
 						onClickHide={onClickHide}
 						onClickPin={onClickPin}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/SearchBar.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/SearchBar.es.js
@@ -26,7 +26,7 @@ class SearchBar extends Component {
 		 */
 		dataMap: PropTypes.object.isRequired,
 		disableSearch: PropTypes.bool,
-		fetchDocumentsSearchUrl: PropTypes.string,
+		fetchDocumentsSearchURL: PropTypes.string,
 		onAddResultSubmit: PropTypes.func,
 		onClickHide: PropTypes.func,
 		onClickPin: PropTypes.func,
@@ -107,7 +107,7 @@ class SearchBar extends Component {
 
 	render() {
 		const {
-			fetchDocumentsSearchUrl,
+			fetchDocumentsSearchURL,
 			onAddResultSubmit,
 			resultIds,
 			selectedIds,
@@ -278,8 +278,8 @@ class SearchBar extends Component {
 									<ManagementToolbar.ItemList>
 										<ManagementToolbar.Item>
 											<AddResult
-												fetchDocumentsSearchUrl={
-													fetchDocumentsSearchUrl
+												fetchDocumentsSearchURL={
+													fetchDocumentsSearchURL
 												}
 												onAddResultSubmit={
 													onAddResultSubmit

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelect.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelect.es.js
@@ -53,12 +53,10 @@ const ScopeSelect = ({
 	const _fetchDropdownItems = () => {
 		setLoading(true);
 
-		fetchResponse(
-			`${
-				window.location.origin
-			}${Liferay.ThemeDisplay.getPathContext()}${fetchItemsUrl}`,
-			{activePage: 1, pageSize: 5}
-		)
+		fetchResponse(fetchItemsUrl, {
+			activePage: 1,
+			pageSize: 5,
+		})
 			.then(({items}) => {
 				setResourceItems(items || []);
 			})

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelect.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelect.es.js
@@ -54,7 +54,7 @@ const ScopeSelect = ({
 		setLoading(true);
 
 		fetchResponse(fetchItemsUrl, {
-			activePage: 1,
+			page: 1,
 			pageSize: 5,
 		})
 			.then(({items}) => {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelect.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelect.es.js
@@ -9,9 +9,9 @@ import ClayForm from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import getCN from 'classnames';
-import {addParams, fetch} from 'frontend-js-web';
 import React, {useRef, useState} from 'react';
 
+import {fetchResponse} from '../../utils/api.es';
 import {SCOPE_TYPES} from '../../utils/constants.es';
 import {sub} from '../../utils/language.es';
 import ScopeSelectModal from './ScopeSelectModal.es';
@@ -53,31 +53,14 @@ const ScopeSelect = ({
 	const _fetchDropdownItems = () => {
 		setLoading(true);
 
-		fetch(
-			addParams(
-				{activePage: 1, pageSize: 5},
-				`${
-					window.location.origin
-				}${Liferay.ThemeDisplay.getPathContext()}${fetchItemsUrl}`
-			),
-			{
-				credentials: 'include',
-				headers: new Headers({
-					'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
-					'x-csrf-token': Liferay.authToken,
-				}),
-				method: 'GET',
-			}
+		fetchResponse(
+			`${
+				window.location.origin
+			}${Liferay.ThemeDisplay.getPathContext()}${fetchItemsUrl}`,
+			{activePage: 1, pageSize: 5}
 		)
-			.then((response) => {
-				if (response.ok) {
-					return response.json();
-				}
-
-				throw new Error();
-			})
 			.then(({items}) => {
-				setResourceItems(items);
+				setResourceItems(items || []);
 			})
 			.catch(() => {
 				setResourceItems([]);

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelectModal.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelectModal.es.js
@@ -57,7 +57,7 @@ const ScopeSelectModal = ({
 			.finally(() => {
 				setLoading(false);
 			});
-	}, [activePage, delta, fetchItemsUrl, type]);
+	}, [activePage, delta, fetchItemsUrl]);
 
 	/**
 	 * Handles what is displayed depending on loading/error/results/no results.

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelectModal.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelectModal.es.js
@@ -39,15 +39,7 @@ const ScopeSelectModal = ({
 	useEffect(() => {
 		setLoading(true);
 
-		fetchResponse(
-			`${
-				window.location.origin
-			}${Liferay.ThemeDisplay.getPathContext()}${fetchItemsUrl}`,
-			{
-				page: activePage,
-				pageSize: delta,
-			}
-		)
+		fetchResponse(fetchItemsUrl, {activePage, pageSize: delta})
 			.then((response) => {
 				setResource(response);
 			})

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelectModal.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelectModal.es.js
@@ -39,7 +39,7 @@ const ScopeSelectModal = ({
 	useEffect(() => {
 		setLoading(true);
 
-		fetchResponse(fetchItemsUrl, {activePage, pageSize: delta})
+		fetchResponse(fetchItemsUrl, {page: activePage, pageSize: delta})
 			.then((response) => {
 				setResource(response);
 			})

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelectModal.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelectModal.es.js
@@ -9,9 +9,9 @@ import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal, {useModal} from '@clayui/modal';
 import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
 import ClayTable from '@clayui/table';
-import {addParams, fetch} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
+import {fetchResponse} from '../../utils/api.es';
 import {DELTAS, SCOPE_TYPES} from '../../utils/constants.es';
 import {sub} from '../../utils/language.es';
 
@@ -39,28 +39,17 @@ const ScopeSelectModal = ({
 	useEffect(() => {
 		setLoading(true);
 
-		fetch(
-			addParams(
-				{
-					page: activePage,
-					pageSize: delta,
-				},
-				`${
-					window.location.origin
-				}${Liferay.ThemeDisplay.getPathContext()}${fetchItemsUrl}`
-			),
+		fetchResponse(
+			`${
+				window.location.origin
+			}${Liferay.ThemeDisplay.getPathContext()}${fetchItemsUrl}`,
 			{
-				credentials: 'include',
-				headers: new Headers({
-					'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
-					'x-csrf-token': Liferay.authToken,
-				}),
-				method: 'GET',
+				page: activePage,
+				pageSize: delta,
 			}
 		)
-			.then((response) => response.json())
-			.then((json) => {
-				setResource(json);
+			.then((response) => {
+				setResource(response);
 			})
 			.catch((error) => {
 				setError(error);

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/test/js/components/ResultRankingsForm.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/test/js/components/ResultRankingsForm.es.js
@@ -25,14 +25,14 @@ const UNPIN_BUTTON_LABEL = 'unpin-result';
 function renderTestResultRankingsForm(props) {
 	return render(
 		<ResultRankingsForm
-			cancelUrl="cancel"
-			fetchDocumentsHiddenUrl={FETCH_HIDDEN_DOCUMENTS_URL}
-			fetchDocumentsSearchUrl={FETCH_SEARCH_DOCUMENTS_URL}
-			fetchDocumentsVisibleUrl={FETCH_VISIBLE_DOCUMENTS_URL}
+			cancelURL="cancel"
+			fetchDocumentsHiddenURL={FETCH_HIDDEN_DOCUMENTS_URL}
+			fetchDocumentsSearchURL={FETCH_SEARCH_DOCUMENTS_URL}
+			fetchDocumentsVisibleURL={FETCH_VISIBLE_DOCUMENTS_URL}
 			formName={FORM_NAME}
 			initialInactive={false}
 			searchQuery=""
-			validateFormUrl={VALIDATE_FORM_URL}
+			validateFormURL={VALIDATE_FORM_URL}
 			{...props}
 		/>
 	);

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/test/js/components/add_result/AddResult.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/test/js/components/add_result/AddResult.es.js
@@ -24,7 +24,7 @@ describe('AddResult', () => {
 	it('shows an add result button', async () => {
 		const {getByText} = render(
 			<AddResult
-				fetchDocumentsSearchUrl={FETCH_SEARCH_DOCUMENTS_URL}
+				fetchDocumentsSearchURL={FETCH_SEARCH_DOCUMENTS_URL}
 				onAddResultSubmit={jest.fn()}
 			/>
 		);
@@ -35,7 +35,7 @@ describe('AddResult', () => {
 	it('shows a modal when the add a result button gets clicked', async () => {
 		const {findByTestId, getByText} = render(
 			<AddResult
-				fetchDocumentsSearchUrl={FETCH_SEARCH_DOCUMENTS_URL}
+				fetchDocumentsSearchURL={FETCH_SEARCH_DOCUMENTS_URL}
 				onAddResultSubmit={jest.fn()}
 			/>
 		);

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/test/js/components/add_result/AddResultModal.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/test/js/components/add_result/AddResultModal.es.js
@@ -32,7 +32,7 @@ const AddResultModalWithModalMock = (props) => {
 
 	return (
 		<AddResultModal
-			fetchDocumentsSearchUrl={FETCH_SEARCH_DOCUMENTS_URL}
+			fetchDocumentsSearchURL={FETCH_SEARCH_DOCUMENTS_URL}
 			observer={observer}
 			onAddResultSubmit={jest.fn()}
 			onClose={onClose}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/test/js/components/list/SearchBar.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/test/js/components/list/SearchBar.es.js
@@ -23,7 +23,7 @@ function renderTestSearchBar(props) {
 	return render(
 		<SearchBar
 			dataMap={DATA_MAP}
-			fetchDocumentsSearchUrl={FETCH_SEARCH_DOCUMENTS_URL}
+			fetchDocumentsSearchURL={FETCH_SEARCH_DOCUMENTS_URL}
 			onClickHide={jest.fn()}
 			onClickPin={jest.fn()}
 			onSelectAll={jest.fn()}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/test/stories/index.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/test/stories/index.es.js
@@ -64,29 +64,29 @@ const withSheet = (storyFn) => (
 
 storiesOf('Pages|ResultRankingsForm', module).add('default', () => (
 	<ResultRankingsForm
-		cancelUrl=""
-		fetchDocumentsHiddenUrl="http://www.mocky.io/v2/5e8366a4300000580fcf3df1"
-		fetchDocumentsSearchUrl="http://www.mocky.io/v2/5e83720e3000007612cf3e32"
-		fetchDocumentsVisibleUrl="http://www.mocky.io/v2/5ea0e59d320000204394b198"
+		cancelURL=""
+		fetchDocumentsHiddenURL="http://www.mocky.io/v2/5e8366a4300000580fcf3df1"
+		fetchDocumentsSearchURL="http://www.mocky.io/v2/5e83720e3000007612cf3e32"
+		fetchDocumentsVisibleURL="http://www.mocky.io/v2/5ea0e59d320000204394b198"
 		formName="testFm"
 		initialAliases={['one', 'two', 'three']}
 		saveActionUrl="#"
 		searchQuery={text('Search Term', 'example')}
 		status={1}
-		validateFormUrl="http://www.mocky.io/v2/5d9dfbea3200008407329b6f"
+		validateFormURL="http://www.mocky.io/v2/5d9dfbea3200008407329b6f"
 	/>
 ));
 
 storiesOf('Components|AddResult', module)
 	.add('AddResult', () => (
 		<AddResult
-			fetchDocumentsSearchUrl="http://www.mocky.io/v2/5db37f913000005f0057b68e"
+			fetchDocumentsSearchURL="http://www.mocky.io/v2/5db37f913000005f0057b68e"
 			onAddResultSubmit={action('onAddResultSubmit')}
 		/>
 	))
 	.add('AddResultModal', () => (
 		<AddResultModal
-			fetchDocumentsSearchUrl="http://www.mocky.io/v2/5db37f913000005f0057b68e"
+			fetchDocumentsSearchURL="http://www.mocky.io/v2/5db37f913000005f0057b68e"
 			onAddResultSubmit={action('onAddResultSubmit')}
 			onCloseModal={action('onCloseModal')}
 		/>
@@ -143,7 +143,7 @@ storiesOf('Components|List', module)
 		<List
 			dataLoading={false}
 			dataMap={mockDataMap}
-			fetchDocumentsSearchUrl=""
+			fetchDocumentsSearchURL=""
 			onAddResultSubmit={action('onAddResultSubmit')}
 			onClickHide={action('onClickHide')}
 			onClickPin={action('onClickPin')}
@@ -155,7 +155,7 @@ storiesOf('Components|List', module)
 		<List
 			dataLoading={false}
 			dataMap={{}}
-			fetchDocumentsSearchUrl=""
+			fetchDocumentsSearchURL=""
 			onAddResultSubmit={action('onAddResultSubmit')}
 		/>
 	))
@@ -164,7 +164,7 @@ storiesOf('Components|List', module)
 			dataLoading={false}
 			dataMap={{}}
 			displayError
-			fetchDocumentsSearchUrl=""
+			fetchDocumentsSearchURL=""
 			onAddResultSubmit={action('onAddResultSubmit')}
 			onLoadResults={action('load-results')}
 		/>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-126745 - Allow to scope Result Rankings to a specific site so that it will be applied on matching Search Bar searches with "This Site" as scope
https://liferay.atlassian.net/browse/LPS-197195 - (Subtask) Connect sites MVCResourceCommand with UI

Plus https://github.com/brianchandotcom/liferay-portal/pull/141510#issuecomment-1740179309

Rebased on master and includes changes from https://github.com/liferay-search/liferay-portal/pull/1084

These are the frontend changes to supplement https://liferay.atlassian.net/browse/LPS-196342, where fetchSitesUrl was created. Now the sites are available for selection on the dropdown menu when creating a result ranking, and the name of the site should be available next to the scope (if selected).

Screenshots:
![image](https://github.com/liferay-search/liferay-portal/assets/76820333/6df8ed82-29bc-4553-9dcc-bee9eeacdfe1)
![image](https://github.com/liferay-search/liferay-portal/assets/76820333/af34cfd4-3c12-45a6-9e53-904c599d3fc7)
![image](https://github.com/liferay-search/liferay-portal/assets/76820333/3a4df0d2-3628-463d-b5d5-0ddfac241e7c)
