### PR TITLE
LPS-196521 com.liferay.search.experiences.rest.resource.v1_0.test.SXPBlueprintResourceTest integration test is failing because it is taking longer than 45 minutes to run

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/SXPBlueprintResourceTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/SXPBlueprintResourceTest.java
@@ -24,7 +24,6 @@ import org.junit.runner.RunWith;
 /**
  * @author Brian Wing Shun Chan
  */
-@Ignore
 @RunWith(Arquillian.class)
 public class SXPBlueprintResourceTest extends BaseSXPBlueprintResourceTestCase {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-196521