### PR TITLE
LPS-196807 Older versions of Web Content are indexed with the newest version's values

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
@@ -59,6 +59,11 @@ public class DepotAssetRendererFactoryWrapper<T>
 	}
 
 	@Override
+	public AssetEntry getAssetEntry(T entry) throws PortalException {
+		return _assetRendererFactory.getAssetEntry(entry);
+	}
+
+	@Override
 	public AssetRenderer<T> getAssetRenderer(long classPK)
 		throws PortalException {
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelDocumentContributor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelDocumentContributor.java
@@ -30,6 +30,7 @@ import com.liferay.portal.search.model.uid.UIDFactory;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 import com.liferay.trash.TrashHelper;
 
+import java.util.Date;
 import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
@@ -94,6 +95,10 @@ public class JournalArticleModelDocumentContributor
 			}
 		}
 
+		if (!document.hasField(Field.CREATE_DATE)) {
+			document.addDate(Field.CREATE_DATE, journalArticle.getCreateDate());
+		}
+
 		String[] descriptionAvailableLanguageIds =
 			_localization.getAvailableLanguageIds(
 				journalArticle.getDescriptionMapAsXML());
@@ -115,6 +120,31 @@ public class JournalArticleModelDocumentContributor
 			Field.EXPIRATION_DATE, journalArticle.getExpirationDate());
 		document.addKeyword(Field.FOLDER_ID, journalArticle.getFolderId());
 		document.addKeyword(Field.LAYOUT_UUID, journalArticle.getLayoutUuid());
+
+		if (!document.hasField("localized_title")) {
+			document.addLocalizedKeyword(
+				"localized_title",
+				_localization.populateLocalizationMap(
+					journalArticle.getTitleMap(),
+					journalArticle.getDefaultLanguageId(),
+					journalArticle.getGroupId()),
+				true, true);
+		}
+
+		if (!document.hasField(Field.MODIFIED_DATE)) {
+			document.addDate(
+				Field.MODIFIED_DATE, journalArticle.getModifiedDate());
+		}
+
+		if (!document.hasField(Field.PUBLISH_DATE)) {
+			if (journalArticle.isApproved()) {
+				document.addDate(
+					Field.PUBLISH_DATE, journalArticle.getDisplayDate());
+			}
+			else {
+				document.addDate(Field.PUBLISH_DATE, new Date(0));
+			}
+		}
 
 		String[] titleAvailableLanguageIds =
 			_localization.getAvailableLanguageIds(

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleAssetEntryReindexTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleAssetEntryReindexTest.java
@@ -132,11 +132,7 @@ public class JournalArticleAssetEntryReindexTest {
 	}
 
 	private void _assertSearch(String keyword, JournalArticle journalArticle) {
-		Document[] documents = _indexerFixture.search(keyword);
-
-		Assert.assertEquals(documents.toString(), 1, documents.length);
-
-		Document document = documents[0];
+		Document document = _indexerFixture.searchOnlyOne(keyword);
 
 		String[] values = document.getValues(Field.ARTICLE_ID);
 

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleAssetEntryReindexTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleAssetEntryReindexTest.java
@@ -12,12 +12,19 @@ import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.journal.constants.JournalArticleConstants;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.petra.string.StringUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -25,15 +32,24 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Localization;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.search.test.util.SearchContextTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
+import java.io.Serializable;
+
 import java.util.Locale;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -131,14 +147,149 @@ public class JournalArticleAssetEntryReindexTest {
 		_assertSearch(updatedAssetTagName, journalArticle);
 	}
 
-	private void _assertSearch(String keyword, JournalArticle journalArticle) {
-		Document document = _indexerFixture.searchOnlyOne(keyword);
+	@Test
+	public void testUpdateJournalArticleTitleWithMultipleVersions()
+		throws Exception {
+
+		Locale locale = _portal.getSiteDefaultLocale(_group);
+
+		String title = RandomTestUtil.randomString();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			JournalArticleConstants.CLASS_NAME_ID_DEFAULT, StringPool.BLANK,
+			true,
+			HashMapBuilder.put(
+				locale, title
+			).build(),
+			RandomTestUtil.randomLocaleStringMap(locale),
+			RandomTestUtil.randomLocaleStringMap(locale), null, locale, null,
+			false, true, serviceContext);
+
+		_assertSearch(title, journalArticle);
+
+		Map<Double, String> versionTitleMap = HashMapBuilder.put(
+			journalArticle.getVersion(), title
+		).build();
+
+		_assertSearchJournalArticleVersions(journalArticle, versionTitleMap);
+
+		journalArticle = _getUpdatedJournalArticle(
+			true, journalArticle, serviceContext, versionTitleMap);
+
+		_assertSearchJournalArticleVersions(journalArticle, versionTitleMap);
+
+		journalArticle = _getUpdatedJournalArticle(
+			true, journalArticle, serviceContext, versionTitleMap);
+
+		_assertSearchJournalArticleVersions(journalArticle, versionTitleMap);
+
+		journalArticle = _getUpdatedJournalArticle(
+			false, journalArticle, serviceContext, versionTitleMap);
+
+		_assertSearchJournalArticleVersions(journalArticle, versionTitleMap);
+	}
+
+	private void _assertArticleId(
+		Document document, JournalArticle journalArticle) {
 
 		String[] values = document.getValues(Field.ARTICLE_ID);
 
 		Assert.assertEquals(values.toString(), 1, values.length);
 
 		Assert.assertEquals(journalArticle.getArticleId(), values[0]);
+	}
+
+	private void _assertSearch(String keyword, JournalArticle journalArticle) {
+		Document document = _indexerFixture.searchOnlyOne(keyword);
+
+		_assertArticleId(document, journalArticle);
+	}
+
+	private void _assertSearchJournalArticleVersions(
+		JournalArticle journalArticle, Map<Double, String> versionTitleMap) {
+
+		Document[] documents = _searchJournalArticleVersions(
+			journalArticle.getDescriptionCurrentValue());
+
+		Assert.assertEquals(
+			documents.toString(), versionTitleMap.size(), documents.length);
+
+		for (Document document : documents) {
+			_assertArticleId(document, journalArticle);
+
+			double version = GetterUtil.getDouble(document.get("versionCount"));
+
+			Assert.assertTrue(versionTitleMap.containsKey(version));
+
+			Assert.assertTrue(document.hasField("localized_title"));
+
+			String localizedTitle = document.get("localized_title");
+
+			Assert.assertTrue(
+				localizedTitle,
+				StringUtil.equalsIgnoreCase(
+					versionTitleMap.get(version), localizedTitle));
+		}
+	}
+
+	private JournalArticle _getUpdatedJournalArticle(
+			boolean approved, JournalArticle journalArticle,
+			ServiceContext serviceContext, Map<Double, String> versionTitleMap)
+		throws Exception {
+
+		if (approved) {
+			serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
+		}
+		else {
+			serviceContext.setWorkflowAction(
+				WorkflowConstants.ACTION_SAVE_DRAFT);
+		}
+
+		String title = RandomTestUtil.randomString();
+
+		JournalArticle updatedJournalArticle = JournalTestUtil.updateArticle(
+			journalArticle, title, journalArticle.getContent(), false, approved,
+			serviceContext);
+
+		if (approved) {
+			_assertSearch(title, updatedJournalArticle);
+		}
+
+		versionTitleMap.put(updatedJournalArticle.getVersion(), title);
+
+		return updatedJournalArticle;
+	}
+
+	private Document[] _searchJournalArticleVersions(String keywords) {
+		try {
+			Indexer<JournalArticle> indexer = _indexerRegistry.getIndexer(
+				JournalArticle.class.getName());
+
+			Hits hits = indexer.search(
+				SearchContextTestUtil.getSearchContext(
+					TestPropsValues.getUserId(),
+					new long[] {_group.getGroupId()}, keywords, null,
+					HashMapBuilder.<String, Serializable>put(
+						Field.STATUS, WorkflowConstants.STATUS_ANY
+					).put(
+						"head", false
+					).put(
+						"latest", false
+					).put(
+						"showNonindexable", false
+					).build()));
+
+			return hits.getDocs();
+		}
+		catch (PortalException portalException) {
+			throw new RuntimeException(portalException);
+		}
 	}
 
 	@Inject
@@ -154,6 +305,15 @@ public class JournalArticleAssetEntryReindexTest {
 	private Group _group;
 
 	private IndexerFixture<JournalArticle> _indexerFixture;
+
+	@Inject
+	private IndexerRegistry _indexerRegistry;
+
+	@Inject
+	private Localization _localization;
+
+	@Inject
+	private Portal _portal;
 
 	@Inject
 	private SearchRequestBuilderFactory _searchRequestBuilderFactory;

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleAssetEntryReindexTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleAssetEntryReindexTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -148,6 +148,77 @@ public class JournalArticleAssetEntryReindexTest {
 	}
 
 	@Test
+	public void testUpdateCategorizationInDraft() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), serviceContext);
+
+		AssetCategory assetCategory1 = _assetCategoryLocalService.addCategory(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			RandomTestUtil.randomString(), assetVocabulary.getVocabularyId(),
+			serviceContext);
+
+		serviceContext.setAssetCategoryIds(
+			new long[] {assetCategory1.getCategoryId()});
+
+		Locale locale = _portal.getSiteDefaultLocale(_group);
+
+		JournalArticle approvedJournalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			JournalArticleConstants.CLASS_NAME_ID_DEFAULT, StringPool.BLANK,
+			true, RandomTestUtil.randomLocaleStringMap(locale),
+			RandomTestUtil.randomLocaleStringMap(locale),
+			RandomTestUtil.randomLocaleStringMap(locale), null, locale, null,
+			false, true, serviceContext);
+
+		AssetCategory assetCategory2 = _assetCategoryLocalService.addCategory(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			RandomTestUtil.randomString(), assetVocabulary.getVocabularyId(),
+			serviceContext);
+
+		serviceContext.setAssetCategoryIds(
+			new long[] {assetCategory2.getCategoryId()});
+
+		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
+
+		JournalArticle draftJournalArticle = JournalTestUtil.updateArticle(
+			approvedJournalArticle, approvedJournalArticle.getTitle(locale),
+			approvedJournalArticle.getContent(), false, false, serviceContext);
+
+		Document[] documents = _searchJournalArticleVersions(
+			draftJournalArticle.getArticleId());
+
+		Assert.assertEquals(documents.toString(), 2, documents.length);
+
+		String fieldName = _localization.getLocalizedName(
+			Field.ASSET_CATEGORY_TITLES, LocaleUtil.toLanguageId(locale));
+
+		for (Document document : documents) {
+			_assertArticleId(document, approvedJournalArticle);
+
+			double version = GetterUtil.getDouble(document.get("versionCount"));
+
+			if (_equals(version, approvedJournalArticle.getVersion())) {
+				_assertFieldValue(
+					document, fieldName, assetCategory1.getTitle(locale));
+			}
+			else if (_equals(version, draftJournalArticle.getVersion())) {
+				_assertFieldValue(
+					document, fieldName, assetCategory2.getTitle(locale));
+			}
+			else {
+				Assert.fail("Unexpected journal article version: " + version);
+			}
+		}
+	}
+
+	@Test
 	public void testUpdateJournalArticleTitleWithMultipleVersions()
 		throws Exception {
 
@@ -205,6 +276,18 @@ public class JournalArticleAssetEntryReindexTest {
 		Assert.assertEquals(journalArticle.getArticleId(), values[0]);
 	}
 
+	private void _assertFieldValue(
+		Document document, String fieldName, String fieldValue) {
+
+		Assert.assertTrue(document.hasField(fieldName));
+
+		String currentFieldValue = document.get(fieldName);
+
+		Assert.assertTrue(
+			currentFieldValue,
+			StringUtil.equalsIgnoreCase(fieldValue, currentFieldValue));
+	}
+
 	private void _assertSearch(String keyword, JournalArticle journalArticle) {
 		Document document = _indexerFixture.searchOnlyOne(keyword);
 
@@ -227,15 +310,17 @@ public class JournalArticleAssetEntryReindexTest {
 
 			Assert.assertTrue(versionTitleMap.containsKey(version));
 
-			Assert.assertTrue(document.hasField("localized_title"));
-
-			String localizedTitle = document.get("localized_title");
-
-			Assert.assertTrue(
-				localizedTitle,
-				StringUtil.equalsIgnoreCase(
-					versionTitleMap.get(version), localizedTitle));
+			_assertFieldValue(
+				document, "localized_title", versionTitleMap.get(version));
 		}
+	}
+
+	private boolean _equals(double double1, double double2) {
+		if (Double.compare(double1, double2) == 0) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private JournalArticle _getUpdatedJournalArticle(

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleAssetEntryReindexTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleAssetEntryReindexTest.java
@@ -121,6 +121,66 @@ public class JournalArticleAssetEntryReindexTest {
 	}
 
 	@Test
+	public void testUpdateAssetTagClassificationInDraft() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		AssetTag assetTag1 = _assetTagLocalService.addTag(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			RandomTestUtil.randomString(), serviceContext);
+
+		serviceContext.setAssetTagNames(new String[] {assetTag1.getName()});
+
+		Locale locale = _portal.getSiteDefaultLocale(_group);
+
+		JournalArticle approvedJournalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			JournalArticleConstants.CLASS_NAME_ID_DEFAULT, StringPool.BLANK,
+			true, RandomTestUtil.randomLocaleStringMap(locale),
+			RandomTestUtil.randomLocaleStringMap(locale),
+			RandomTestUtil.randomLocaleStringMap(locale), null, locale, null,
+			false, true, serviceContext);
+
+		AssetTag assetTag2 = _assetTagLocalService.addTag(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			RandomTestUtil.randomString(), serviceContext);
+
+		serviceContext.setAssetTagNames(new String[] {assetTag2.getName()});
+
+		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
+
+		JournalArticle draftJournalArticle = JournalTestUtil.updateArticle(
+			approvedJournalArticle, approvedJournalArticle.getTitle(locale),
+			approvedJournalArticle.getContent(), false, false, serviceContext);
+
+		Document[] documents = _searchJournalArticleVersions(
+			draftJournalArticle.getArticleId());
+
+		Assert.assertEquals(documents.toString(), 2, documents.length);
+
+		String fieldName = _localization.getLocalizedName(
+			Field.ASSET_TAG_NAMES, LocaleUtil.toLanguageId(locale));
+
+		for (Document document : documents) {
+			_assertArticleId(document, approvedJournalArticle);
+
+			double version = GetterUtil.getDouble(document.get("versionCount"));
+
+			if (_equals(version, approvedJournalArticle.getVersion())) {
+				_assertFieldValue(document, fieldName, assetTag1.getName());
+			}
+			else if (_equals(version, draftJournalArticle.getVersion())) {
+				_assertFieldValue(document, fieldName, assetTag2.getName());
+			}
+			else {
+				Assert.fail("Unexpected journal article version: " + version);
+			}
+		}
+	}
+
+	@Test
 	public void testUpdateAssetTagName() throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleAssetEntryReindexTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleAssetEntryReindexTest.java
@@ -12,6 +12,7 @@ import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.journal.configuration.JournalServiceConfiguration;
 import com.liferay.journal.constants.JournalArticleConstants;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
@@ -26,6 +27,10 @@ import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.settings.CompanyServiceSettingsLocator;
+import com.liferay.portal.kernel.settings.FallbackKeysSettingsUtil;
+import com.liferay.portal.kernel.settings.ModifiableSettings;
+import com.liferay.portal.kernel.settings.Settings;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -51,8 +56,10 @@ import java.io.Serializable;
 import java.util.Locale;
 import java.util.Map;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -70,6 +77,42 @@ public class JournalArticleAssetEntryReindexTest {
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		Settings settings = FallbackKeysSettingsUtil.getSettings(
+			new CompanyServiceSettingsLocator(
+				TestPropsValues.getCompanyId(),
+				JournalServiceConfiguration.class.getName()));
+
+		ModifiableSettings modifiableSettings =
+			settings.getModifiableSettings();
+
+		_originalIndexAllArticleVersionsEnabled = GetterUtil.getBoolean(
+			modifiableSettings.getValue(
+				"indexAllArticleVersionsEnabled", "true"));
+
+		modifiableSettings.setValue("indexAllArticleVersionsEnabled", "true");
+
+		modifiableSettings.store();
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		Settings settings = FallbackKeysSettingsUtil.getSettings(
+			new CompanyServiceSettingsLocator(
+				TestPropsValues.getCompanyId(),
+				JournalServiceConfiguration.class.getName()));
+
+		ModifiableSettings modifiableSettings =
+			settings.getModifiableSettings();
+
+		modifiableSettings.setValue(
+			"indexAllArticleVersionsEnabled",
+			String.valueOf(_originalIndexAllArticleVersionsEnabled));
+
+		modifiableSettings.store();
+	}
 
 	@Before
 	public void setUp() throws Exception {
@@ -436,6 +479,8 @@ public class JournalArticleAssetEntryReindexTest {
 			throw new RuntimeException(portalException);
 		}
 	}
+
+	private static boolean _originalIndexAllArticleVersionsEnabled;
 
 	@Inject
 	private AssetCategoryLocalService _assetCategoryLocalService;

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleAssetEntryTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleAssetEntryTest.java
@@ -69,7 +69,7 @@ import org.junit.runner.RunWith;
  * @author Lourdes Fernández Besada
  */
 @RunWith(Arquillian.class)
-public class JournalArticleAssetEntryReindexTest {
+public class JournalArticleAssetEntryTest {
 
 	@ClassRule
 	@Rule

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRendererFactory.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRendererFactory.java
@@ -48,6 +48,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.Locale;
+import java.util.Objects;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletURL;
@@ -80,6 +81,30 @@ public class JournalArticleAssetRendererFactory
 		setPortletId(JournalPortletKeys.JOURNAL);
 		setSearchable(true);
 		setSupportsClassTypes(true);
+	}
+
+	@Override
+	public AssetEntry getAssetEntry(JournalArticle journalArticle)
+		throws PortalException {
+
+		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
+			getClassName(), journalArticle.getId());
+
+		if (assetEntry != null) {
+			return assetEntry;
+		}
+
+		AssetRenderer<?> assetRenderer = getAssetRenderer(
+			journalArticle.getResourcePrimKey());
+
+		if ((assetRenderer == null) ||
+			!Objects.equals(journalArticle, assetRenderer.getAssetObject())) {
+
+			return null;
+		}
+
+		return _assetEntryLocalService.fetchEntry(
+			getClassName(), assetRenderer.getClassPK());
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/asset/model/KBArticleAssetRendererFactory.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/asset/model/KBArticleAssetRendererFactory.java
@@ -52,13 +52,18 @@ public class KBArticleAssetRendererFactory
 	}
 
 	@Override
+	public AssetEntry getAssetEntry(KBArticle kbArticle)
+		throws PortalException {
+
+		return super.getAssetEntry(getClassName(), kbArticle.getClassPK());
+	}
+
+	@Override
 	public AssetEntry getAssetEntry(String className, long classPK)
 		throws PortalException {
 
-		KBArticle kbArticle = _getKBArticle(
-			classPK, WorkflowConstants.STATUS_ANY);
-
-		return super.getAssetEntry(className, kbArticle.getClassPK());
+		return getAssetEntry(
+			_getKBArticle(classPK, WorkflowConstants.STATUS_ANY));
 	}
 
 	@Override

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/asset/model/LayoutAssetRendererFactory.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/asset/model/LayoutAssetRendererFactory.java
@@ -43,16 +43,7 @@ public class LayoutAssetRendererFactory
 	}
 
 	@Override
-	public AssetEntry getAssetEntry(long assetEntryId) throws PortalException {
-		return getAssetEntry(getClassName(), assetEntryId);
-	}
-
-	@Override
-	public AssetEntry getAssetEntry(String className, long classPK)
-		throws PortalException {
-
-		Layout layout = _layoutLocalService.getLayout(classPK);
-
+	public AssetEntry getAssetEntry(Layout layout) throws PortalException {
 		User user = _userLocalService.fetchUser(layout.getUserId());
 
 		if (user == null) {
@@ -60,7 +51,7 @@ public class LayoutAssetRendererFactory
 		}
 
 		AssetEntry assetEntry = _assetEntryLocalService.createAssetEntry(
-			classPK);
+			layout.getPlid());
 
 		assetEntry.setGroupId(layout.getGroupId());
 		assetEntry.setCompanyId(user.getCompanyId());
@@ -73,6 +64,18 @@ public class LayoutAssetRendererFactory
 		assetEntry.setTitle(layout.getHTMLTitle(LocaleUtil.getSiteDefault()));
 
 		return assetEntry;
+	}
+
+	@Override
+	public AssetEntry getAssetEntry(long assetEntryId) throws PortalException {
+		return getAssetEntry(getClassName(), assetEntryId);
+	}
+
+	@Override
+	public AssetEntry getAssetEntry(String className, long classPK)
+		throws PortalException {
+
+		return getAssetEntry(_layoutLocalService.getLayout(classPK));
 	}
 
 	@Override

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/asset/model/LayoutRevisionAssetRendererFactory.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/asset/model/LayoutRevisionAssetRendererFactory.java
@@ -47,16 +47,8 @@ public class LayoutRevisionAssetRendererFactory
 	}
 
 	@Override
-	public AssetEntry getAssetEntry(long assetEntryId) throws PortalException {
-		return getAssetEntry(getClassName(), assetEntryId);
-	}
-
-	@Override
-	public AssetEntry getAssetEntry(String className, long classPK)
+	public AssetEntry getAssetEntry(LayoutRevision layoutRevision)
 		throws PortalException {
-
-		LayoutRevision layoutRevision =
-			_layoutRevisionLocalService.getLayoutRevision(classPK);
 
 		LayoutSetBranch layoutSetBranch =
 			_layoutSetBranchLocalService.getLayoutSetBranch(
@@ -65,7 +57,7 @@ public class LayoutRevisionAssetRendererFactory
 		User user = _userLocalService.getUserById(layoutRevision.getUserId());
 
 		AssetEntry assetEntry = _assetEntryLocalService.createAssetEntry(
-			classPK);
+			layoutRevision.getLayoutRevisionId());
 
 		assetEntry.setGroupId(layoutRevision.getGroupId());
 		assetEntry.setCompanyId(user.getCompanyId());
@@ -81,6 +73,19 @@ public class LayoutRevisionAssetRendererFactory
 				layoutSetBranch.getName(), "]"));
 
 		return assetEntry;
+	}
+
+	@Override
+	public AssetEntry getAssetEntry(long assetEntryId) throws PortalException {
+		return getAssetEntry(getClassName(), assetEntryId);
+	}
+
+	@Override
+	public AssetEntry getAssetEntry(String className, long classPK)
+		throws PortalException {
+
+		return getAssetEntry(
+			_layoutRevisionLocalService.getLayoutRevision(classPK));
 	}
 
 	@Override

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/BaseModelDocumentFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/BaseModelDocumentFactoryImpl.java
@@ -5,6 +5,12 @@
 
 package com.liferay.portal.search.internal.indexer;
 
+import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.ResourcedModel;
 import com.liferay.portal.kernel.search.DocumentImpl;
@@ -78,7 +84,36 @@ public class BaseModelDocumentFactoryImpl implements BaseModelDocumentFactory {
 			classPK = (Long)baseModel.getPrimaryKeyObj();
 		}
 
-		return new Tuple(classPK, resourcePrimKey);
+		return new Tuple(
+			_getEntryClassPK(baseModel, baseModel.getModelClassName(), classPK),
+			resourcePrimKey);
+	}
+
+	private <T> long _getEntryClassPK(T entry, String className, long classPK) {
+		AssetRendererFactory<T> assetRendererFactory =
+			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
+				className);
+
+		if (assetRendererFactory == null) {
+			return classPK;
+		}
+
+		try {
+			AssetEntry assetEntry = assetRendererFactory.getAssetEntry(entry);
+
+			if (assetEntry != null) {
+				return assetEntry.getClassPK();
+			}
+
+			return 0;
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+
+		return classPK;
 	}
 
 	private Long _getRootEntryClassPK(Tuple classPKResourcePrimKeyTuple) {
@@ -105,5 +140,8 @@ public class BaseModelDocumentFactoryImpl implements BaseModelDocumentFactory {
 
 		return documentImpl;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BaseModelDocumentFactoryImpl.class);
 
 }

--- a/modules/dxp/apps/source-formatter-suppressions.xml
+++ b/modules/dxp/apps/source-formatter-suppressions.xml
@@ -2,6 +2,6 @@
 
 <suppressions>
 	<checkstyle>
-		 <suppress checks="OSGiCommandsCheck" files="antivirus/antivirus-async-store/src/main/java/com/liferay/antivirus/async/store/internal/scheduler/AntivirusAsyncFileStoreSchedulerJobConfiguration\.java" />
+		<suppress checks="OSGiCommandsCheck" files="antivirus/antivirus-async-store/src/main/java/com/liferay/antivirus/async/store/internal/scheduler/AntivirusAsyncFileStoreSchedulerJobConfiguration\.java" />
 	</checkstyle>
 </suppressions>

--- a/portal-kernel/src/com/liferay/asset/kernel/AssetRendererFactoryRegistryUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/AssetRendererFactoryRegistryUtil.java
@@ -48,20 +48,22 @@ public class AssetRendererFactoryRegistryUtil {
 					clazz.getName()));
 	}
 
-	public static AssetRendererFactory<?> getAssetRendererFactoryByClassName(
-		String className) {
+	public static <T> AssetRendererFactory<T>
+		getAssetRendererFactoryByClassName(String className) {
 
 		return _customize(
-			_classNameAssetRenderFactoriesServiceTrackerMap.getService(
-				className));
+			(AssetRendererFactory<T>)
+				_classNameAssetRenderFactoriesServiceTrackerMap.getService(
+					className));
 	}
 
-	public static AssetRendererFactory<?> getAssetRendererFactoryByClassNameId(
-		long classNameId) {
+	public static <T> AssetRendererFactory<T>
+		getAssetRendererFactoryByClassNameId(long classNameId) {
 
 		return _customize(
-			_classNameAssetRenderFactoriesServiceTrackerMap.getService(
-				PortalUtil.getClassName(classNameId)));
+			(AssetRendererFactory<T>)
+				_classNameAssetRenderFactoriesServiceTrackerMap.getService(
+					PortalUtil.getClassName(classNameId)));
 	}
 
 	public static AssetRendererFactory<?> getAssetRendererFactoryByType(

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetRendererFactory.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetRendererFactory.java
@@ -6,7 +6,9 @@
 package com.liferay.asset.kernel.model;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourcedModel;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -35,6 +37,24 @@ public interface AssetRendererFactory<T> {
 
 	public AssetEntry getAssetEntry(String classNameId, long classPK)
 		throws PortalException;
+
+	public default AssetEntry getAssetEntry(T entry) throws PortalException {
+		if (entry instanceof ResourcedModel) {
+			ResourcedModel resourcedModel = (ResourcedModel)entry;
+
+			return getAssetEntry(
+				getClassName(), resourcedModel.getResourcePrimKey());
+		}
+
+		if (entry instanceof BaseModel<?>) {
+			BaseModel<?> baseModel = (BaseModel<?>)entry;
+
+			return getAssetEntry(
+				getClassName(), (Long)baseModel.getPrimaryKeyObj());
+		}
+
+		return null;
+	}
 
 	public AssetRenderer<T> getAssetRenderer(long classPK)
 		throws PortalException;

--- a/portal-kernel/src/com/liferay/asset/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 11.1.0
+version 11.2.0

--- a/portal-kernel/src/com/liferay/portal/kernel/search/BaseIndexer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/BaseIndexer.java
@@ -5,7 +5,9 @@
 
 package com.liferay.portal.kernel.search;
 
+import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
 import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
@@ -1138,7 +1140,8 @@ public abstract class BaseIndexer<T> implements Indexer<T> {
 
 		DocumentHelper documentHelper = new DocumentHelper(document);
 
-		documentHelper.setEntryKey(className, classPK);
+		documentHelper.setEntryKey(
+			className, _getEntryClassPK(baseModel, className, classPK));
 
 		document.addUID(className, classPK);
 
@@ -1449,6 +1452,33 @@ public abstract class BaseIndexer<T> implements Indexer<T> {
 		}
 
 		return entryClassNameIndexerMap;
+	}
+
+	private <T> long _getEntryClassPK(T entry, String className, long classPK) {
+		AssetRendererFactory<T> assetRendererFactory =
+			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
+				className);
+
+		if (assetRendererFactory == null) {
+			return classPK;
+		}
+
+		try {
+			AssetEntry assetEntry = assetRendererFactory.getAssetEntry(entry);
+
+			if (assetEntry != null) {
+				return assetEntry.getClassPK();
+			}
+
+			return 0;
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+
+		return classPK;
 	}
 
 	private SearchResultPermissionFilter _getSearchResultPermissionFilter(


### PR DESCRIPTION
Hello Team :wave: 

This PR has been reviewed by the Echo Team [here](https://github.com/liferay-echo/liferay-portal/pull/13943), but [this commit](https://github.com/liferay-search/liferay-portal/commit/136ebe6cecb633951a2d04e672f412d40ad99e16) is on your components, could you please review it?

Thanks in advance!

This PR fixes two bugs:
https://liferay.atlassian.net/browse/LPS-196807
https://liferay.atlassian.net/browse/LPS-198486
On already existing content, a reindex is needed to fix these issues.

**Motivation**

When content that has asset entries is reindexed, the different AssetEntry contributors add fields to the content based on information related to its assetEntry.
Journal articles have versions and not all of them have asset entries. 
Currently, the no-latest article published versions are processed assuming that their assetEntry was the latest published one, and that is not correct.
This PR adds a new method in AssetRendererFactory to get the AssetEntry from the base model and delegates the calculation of the entryClassPK field to that method. It is taking into account that the base model could have no asset entry, so its entryClassPK is going to be 0. So, from now on, for those articles that do not have any asset entry, its entryClassPK is going to be 0.
Consequently, the AssetEntryDocumentContributor does not add fields for versions that do not have an entry, which fixes the original bug.
The same logic manages to fix LPS-198486 because AssetTagDocumentContributor and AssetCategoryDocumentContributor receive 0 as entryClassPK so they do not use the categories and tags published for the other versions.