### PR TITLE
LPS-199146 Special characters in quotes breaks search

### DIFF
--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/configuration/CPDefinitionLinkTypeConfigurationWrapper.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/configuration/CPDefinitionLinkTypeConfigurationWrapper.java
@@ -20,8 +20,7 @@ import org.osgi.service.component.annotations.Modified;
  */
 @Component(
 	configurationPid = "com.liferay.commerce.product.configuration.CPDefinitionLinkTypeConfiguration",
-	configurationPolicy = ConfigurationPolicy.REQUIRE,
-	service = CPDefinitionLinkTypeConfigurationWrapper.class
+	configurationPolicy = ConfigurationPolicy.REQUIRE, service = {}
 )
 public class CPDefinitionLinkTypeConfigurationWrapper {
 

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/search/spi/model/query/contributor/CPDefinitionKeywordQueryContributor.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/search/spi/model/query/contributor/CPDefinitionKeywordQueryContributor.java
@@ -50,7 +50,8 @@ public class CPDefinitionKeywordQueryContributor
 			keywordQueryContributorHelper.getSearchContext();
 
 		_queryHelper.addSearchTerm(
-			booleanQuery, searchContext, CPField.ASSET_CATEGORY_NAMES, false);
+			booleanQuery, searchContext, CPField.ASSET_CATEGORY_NAMES + ".text",
+			false);
 		_queryHelper.addSearchTerm(
 			booleanQuery, searchContext, CPField.EXTERNAL_REFERENCE_CODE,
 			false);


### PR DESCRIPTION
## **LPS Link:** [LPS-199146](https://liferay.atlassian.net/browse/LPS-199146)

# Context

When performing a search containing quotation marks, the exception below is thrown:

```
org.elasticsearch.client.ResponseException: method [POST], host [http://127.0.0.1:9201/], URI [/liferay-20095/_search?typed_keys=true&max_concurrent_shard_requests=5&search_type=query_then_fetch&batched_reduce_size=512], status line [HTTP/1.1 400 Bad Request]
{"error":{"root_cause":[{"type":"query_shard_exception","reason":"failed to create query: Can only use phrase prefix queries on text fields - not on [assetCategoryNames] which is of type [keyword]","index_uuid":"MfLePEqXSfi4VG_QasNx3g","index":"liferay-20095"}],"type":"search_phase_execution_exception","reason":"all shards failed","phase":"query","grouped":true,"failed_shards":[{"shard":0,"index":"liferay-20095","node":"yNCxJztAQUG_1CpHJq5Nyw","reason":{"type":"query_shard_exception","reason":"failed to create query: Can only use phrase prefix queries on text fields - not on [assetCategoryNames] which is of type [keyword]","index_uuid":"MfLePEqXSfi4VG_QasNx3g","index":"liferay-20095","caused_by":{"type":"illegal_argument_exception","reason":"Can only use phrase prefix queries on text fields - not on [assetCategoryNames] which is of type [keyword]"}}}]},"status":400}
```

When investigating this problem, I noticed that the error is occurring due to changes in this [PR](https://github.com/liferay-commerce/liferay-portal/pull/4124/files). The problem reported in [LPS-199146](https://liferay.atlassian.net/browse/LPS-199146) is similar to [LPS-189127](https://liferay.atlassian.net/browse/LPS-189127).

# Proposed solution

The `assetCategoryNames` field in [CPDefinitionKeywordQueryContributor](https://github.com/liferay/liferay-portal/blob/7.4.3.99-ga99/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/search/spi/model/query/contributor/CPDefinitionKeywordQueryContributor.java) class was changed to `assetCategoryNames.text`  as default field type is keyword as per its index mapping.

```
_queryHelper.addSearchTerm(
			booleanQuery, searchContext, CPField.ASSET_CATEGORY_NAMES + ".text",
			false);
```

Another way to solve this problem would be to change the type of the `assetCategoryNames` field directly in [additional-type-mappings.json](https://github.com/liferay/liferay-portal/blob/7.4.3.99-ga99/modules/apps/commerce/commerce-elasticsearch7/src/main/resources/com/liferay/commerce/elasticsearch7/internal/index/settings/contributor/dependencies/additional-type-mappings.json#L61C4-L61C21). But I chose to do it this way following the way  [LPS-189127](https://liferay.atlassian.net/browse/LPS-189127) was resolved.



