### PR TITLE
LPS-178506 Some Solr unit tests are being improperly skipped causing failures on CI

### DIFF
--- a/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/test/java/com/liferay/portal/search/solr8/internal/logging/SolrIndexSearcherLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/test/java/com/liferay/portal/search/solr8/internal/logging/SolrIndexSearcherLogExceptionsOnlyTest.java
@@ -21,7 +21,7 @@ import com.liferay.portal.search.test.util.logging.ExpectedLogMethodTestRule;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import org.junit.Assume;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,8 +38,8 @@ public class SolrIndexSearcherLogExceptionsOnlyTest
 		new AggregateTestRule(
 			ExpectedLogMethodTestRule.INSTANCE, LiferayUnitTestRule.INSTANCE);
 
-	@BeforeClass
-	public static void setUpClass() {
+	@Before
+	public void setUp() {
 		Assume.assumeTrue(
 			SolrUnitTestRequirements.isSolrExternallyStartedByDeveloper());
 	}
@@ -47,7 +47,7 @@ public class SolrIndexSearcherLogExceptionsOnlyTest
 	@ExpectedLog(
 		expectedClass = SolrIndexSearcher.class,
 		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "Cannot parse '+f^eld:text'"
+		expectedLog = "Cannot parse '+f^eld:text'", solrTest = true
 	)
 	@Test
 	public void testExceptionOnlyLoggedWhenQueryMalformedSearch() {
@@ -57,7 +57,7 @@ public class SolrIndexSearcherLogExceptionsOnlyTest
 	@ExpectedLog(
 		expectedClass = SolrIndexSearcher.class,
 		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "Cannot parse '+f^eld:text'"
+		expectedLog = "Cannot parse '+f^eld:text'", solrTest = true
 	)
 	@Test
 	public void testExceptionOnlyLoggedWhenQueryMalformedSearchCount() {

--- a/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/test/java/com/liferay/portal/search/solr8/internal/logging/SolrIndexSearcherLoggingTest.java
+++ b/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/test/java/com/liferay/portal/search/solr8/internal/logging/SolrIndexSearcherLoggingTest.java
@@ -19,7 +19,7 @@ import com.liferay.portal.search.test.util.logging.ExpectedLogMethodTestRule;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import org.junit.Assume;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -35,8 +35,8 @@ public class SolrIndexSearcherLoggingTest extends BaseIndexingTestCase {
 		new AggregateTestRule(
 			ExpectedLogMethodTestRule.INSTANCE, LiferayUnitTestRule.INSTANCE);
 
-	@BeforeClass
-	public static void setUpClass() {
+	@Before
+	public void setUp() {
 		Assume.assumeTrue(
 			SolrUnitTestRequirements.isSolrExternallyStartedByDeveloper());
 	}
@@ -44,7 +44,7 @@ public class SolrIndexSearcherLoggingTest extends BaseIndexingTestCase {
 	@ExpectedLog(
 		expectedClass = CountSearchRequestExecutorImpl.class,
 		expectedLevel = ExpectedLog.Level.FINE,
-		expectedLog = "The search engine processed"
+		expectedLog = "The search engine processed", solrTest = true
 	)
 	@Test
 	public void testCountSearchRequestExecutorLogsViaIndexer() {
@@ -54,7 +54,7 @@ public class SolrIndexSearcherLoggingTest extends BaseIndexingTestCase {
 	@ExpectedLog(
 		expectedClass = SolrIndexSearcher.class,
 		expectedLevel = ExpectedLog.Level.INFO,
-		expectedLog = "The search engine processed"
+		expectedLog = "The search engine processed", solrTest = true
 	)
 	@Test
 	public void testIndexerSearchCountLogs() {
@@ -64,7 +64,7 @@ public class SolrIndexSearcherLoggingTest extends BaseIndexingTestCase {
 	@ExpectedLog(
 		expectedClass = SolrIndexSearcher.class,
 		expectedLevel = ExpectedLog.Level.INFO,
-		expectedLog = "The search engine processed"
+		expectedLog = "The search engine processed", solrTest = true
 	)
 	@Test
 	public void testIndexerSearchLogs() {
@@ -74,7 +74,7 @@ public class SolrIndexSearcherLoggingTest extends BaseIndexingTestCase {
 	@ExpectedLog(
 		expectedClass = SearchSearchRequestExecutorImpl.class,
 		expectedLevel = ExpectedLog.Level.FINE,
-		expectedLog = "The search engine processed"
+		expectedLog = "The search engine processed", solrTest = true
 	)
 	@Test
 	public void testSearchSearchRequestExecutorLogsViaIndexer() {

--- a/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/test/java/com/liferay/portal/search/solr8/internal/logging/SolrIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/test/java/com/liferay/portal/search/solr8/internal/logging/SolrIndexWriterLogExceptionsOnlyTest.java
@@ -28,7 +28,7 @@ import java.util.Collections;
 
 import org.junit.After;
 import org.junit.Assume;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,8 +44,8 @@ public class SolrIndexWriterLogExceptionsOnlyTest extends BaseIndexingTestCase {
 		new AggregateTestRule(
 			ExpectedLogMethodTestRule.INSTANCE, LiferayUnitTestRule.INSTANCE);
 
-	@BeforeClass
-	public static void setUpClass() {
+	@Before
+	public void setUp() {
 		Assume.assumeTrue(
 			SolrUnitTestRequirements.isSolrExternallyStartedByDeveloper());
 	}
@@ -57,7 +57,8 @@ public class SolrIndexWriterLogExceptionsOnlyTest extends BaseIndexingTestCase {
 
 	@ExpectedLog(
 		expectedClass = SolrIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "404 Not Found"
+		expectedLevel = ExpectedLog.Level.WARNING,
+		expectedLog = "404 Not Found", solrTest = true
 	)
 	@Test
 	public void testAddDocument() throws Exception {
@@ -69,7 +70,7 @@ public class SolrIndexWriterLogExceptionsOnlyTest extends BaseIndexingTestCase {
 	@ExpectedLog(
 		expectedClass = SolrIndexWriter.class,
 		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "Bulk add failed"
+		expectedLog = "Bulk add failed", solrTest = true
 	)
 	@Test
 	public void testAddDocuments() {
@@ -86,7 +87,8 @@ public class SolrIndexWriterLogExceptionsOnlyTest extends BaseIndexingTestCase {
 
 	@ExpectedLog(
 		expectedClass = BulkDocumentRequestExecutorImpl.class,
-		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "404 Not Found"
+		expectedLevel = ExpectedLog.Level.WARNING,
+		expectedLog = "404 Not Found", solrTest = true
 	)
 	@Test
 	public void testAddDocumentsBulkExecutor() {
@@ -103,7 +105,8 @@ public class SolrIndexWriterLogExceptionsOnlyTest extends BaseIndexingTestCase {
 
 	@ExpectedLog(
 		expectedClass = SolrIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "404 Not Found"
+		expectedLevel = ExpectedLog.Level.WARNING,
+		expectedLog = "404 Not Found", solrTest = true
 	)
 	@Test
 	public void testCommit() {
@@ -118,7 +121,8 @@ public class SolrIndexWriterLogExceptionsOnlyTest extends BaseIndexingTestCase {
 
 	@ExpectedLog(
 		expectedClass = SolrIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "404 Not Found"
+		expectedLevel = ExpectedLog.Level.WARNING,
+		expectedLog = "404 Not Found", solrTest = true
 	)
 	@Test
 	public void testDeleteDocument() {
@@ -134,7 +138,7 @@ public class SolrIndexWriterLogExceptionsOnlyTest extends BaseIndexingTestCase {
 	@ExpectedLog(
 		expectedClass = SolrIndexWriter.class,
 		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "Bulk delete failed"
+		expectedLog = "Bulk delete failed", solrTest = true
 	)
 	@Test
 	public void testDeleteDocuments() {
@@ -150,7 +154,8 @@ public class SolrIndexWriterLogExceptionsOnlyTest extends BaseIndexingTestCase {
 
 	@ExpectedLog(
 		expectedClass = BulkDocumentRequestExecutorImpl.class,
-		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "404 Not Found"
+		expectedLevel = ExpectedLog.Level.WARNING,
+		expectedLog = "404 Not Found", solrTest = true
 	)
 	@Test
 	public void testDeleteDocumentsBulkExecutor() {
@@ -166,7 +171,8 @@ public class SolrIndexWriterLogExceptionsOnlyTest extends BaseIndexingTestCase {
 
 	@ExpectedLog(
 		expectedClass = SolrIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "null"
+		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "null",
+		solrTest = true
 	)
 	@Test
 	public void testDeleteEntityDocuments() {
@@ -181,7 +187,8 @@ public class SolrIndexWriterLogExceptionsOnlyTest extends BaseIndexingTestCase {
 
 	@ExpectedLog(
 		expectedClass = SolrIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "404 Not Found"
+		expectedLevel = ExpectedLog.Level.WARNING,
+		expectedLog = "404 Not Found", solrTest = true
 	)
 	@Test
 	public void testPartiallyUpdateDocument() {
@@ -198,7 +205,7 @@ public class SolrIndexWriterLogExceptionsOnlyTest extends BaseIndexingTestCase {
 	@ExpectedLog(
 		expectedClass = SolrIndexWriter.class,
 		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "Bulk partial update failed"
+		expectedLog = "Bulk partial update failed", solrTest = true
 	)
 	@Test
 	public void testPartiallyUpdateDocuments() {
@@ -215,7 +222,8 @@ public class SolrIndexWriterLogExceptionsOnlyTest extends BaseIndexingTestCase {
 
 	@ExpectedLog(
 		expectedClass = BulkDocumentRequestExecutorImpl.class,
-		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "404 Not Found"
+		expectedLevel = ExpectedLog.Level.WARNING,
+		expectedLog = "404 Not Found", solrTest = true
 	)
 	@Test
 	public void testPartiallyUpdateDocumentsBulkExecutor() {
@@ -232,7 +240,8 @@ public class SolrIndexWriterLogExceptionsOnlyTest extends BaseIndexingTestCase {
 
 	@ExpectedLog(
 		expectedClass = SolrIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "Update failed"
+		expectedLevel = ExpectedLog.Level.WARNING,
+		expectedLog = "Update failed", solrTest = true
 	)
 	@Test
 	public void testUpdateDocument() {
@@ -248,7 +257,8 @@ public class SolrIndexWriterLogExceptionsOnlyTest extends BaseIndexingTestCase {
 
 	@ExpectedLog(
 		expectedClass = BulkDocumentRequestExecutorImpl.class,
-		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "404 Not Found"
+		expectedLevel = ExpectedLog.Level.WARNING,
+		expectedLog = "404 Not Found", solrTest = true
 	)
 	@Test
 	public void testUpdateDocumentBulkExecutor() {
@@ -264,7 +274,8 @@ public class SolrIndexWriterLogExceptionsOnlyTest extends BaseIndexingTestCase {
 
 	@ExpectedLog(
 		expectedClass = SolrIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "Update failed"
+		expectedLevel = ExpectedLog.Level.WARNING,
+		expectedLog = "Update failed", solrTest = true
 	)
 	@Test
 	public void testUpdateDocuments() {
@@ -281,7 +292,8 @@ public class SolrIndexWriterLogExceptionsOnlyTest extends BaseIndexingTestCase {
 
 	@ExpectedLog(
 		expectedClass = BulkDocumentRequestExecutorImpl.class,
-		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "404 Not Found"
+		expectedLevel = ExpectedLog.Level.WARNING,
+		expectedLog = "404 Not Found", solrTest = true
 	)
 	@Test
 	public void testUpdateDocumentsBulkExecutor() {

--- a/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/test/java/com/liferay/portal/search/solr8/internal/logging/SolrIndexWriterLoggingTest.java
+++ b/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/test/java/com/liferay/portal/search/solr8/internal/logging/SolrIndexWriterLoggingTest.java
@@ -23,7 +23,7 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import java.util.Collections;
 
 import org.junit.Assume;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,8 +39,8 @@ public class SolrIndexWriterLoggingTest extends BaseIndexingTestCase {
 		new AggregateTestRule(
 			ExpectedLogMethodTestRule.INSTANCE, LiferayUnitTestRule.INSTANCE);
 
-	@BeforeClass
-	public static void setUpClass() {
+	@Before
+	public void setUp() {
 		Assume.assumeTrue(
 			SolrUnitTestRequirements.isSolrExternallyStartedByDeveloper());
 	}
@@ -48,7 +48,7 @@ public class SolrIndexWriterLoggingTest extends BaseIndexingTestCase {
 	@ExpectedLog(
 		expectedClass = BulkDocumentRequestExecutorImpl.class,
 		expectedLevel = ExpectedLog.Level.INFO,
-		expectedLog = "response={responseHeader={status=0"
+		expectedLog = "response={responseHeader={status=0", solrTest = true
 	)
 	@Test
 	public void testBulkDocumentRequestExecutorLogs() {

--- a/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/test/java/com/liferay/portal/search/solr8/internal/logging/SolrSearchEngineAdapterLoggingTest.java
+++ b/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/test/java/com/liferay/portal/search/solr8/internal/logging/SolrSearchEngineAdapterLoggingTest.java
@@ -22,7 +22,7 @@ import com.liferay.portal.search.test.util.logging.ExpectedLogMethodTestRule;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import org.junit.Assume;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,8 +39,8 @@ public class SolrSearchEngineAdapterLoggingTest extends BaseIndexingTestCase {
 		new AggregateTestRule(
 			ExpectedLogMethodTestRule.INSTANCE, LiferayUnitTestRule.INSTANCE);
 
-	@BeforeClass
-	public static void setUpClass() {
+	@Before
+	public void setUp() {
 		Assume.assumeTrue(
 			SolrUnitTestRequirements.isSolrExternallyStartedByDeveloper());
 	}
@@ -48,7 +48,7 @@ public class SolrSearchEngineAdapterLoggingTest extends BaseIndexingTestCase {
 	@ExpectedLog(
 		expectedClass = CountSearchRequestExecutorImpl.class,
 		expectedLevel = ExpectedLog.Level.FINE,
-		expectedLog = "The search engine processed"
+		expectedLog = "The search engine processed", solrTest = true
 	)
 	@Test
 	public void testCountSearchRequestExecutorLogs() {
@@ -86,7 +86,7 @@ public class SolrSearchEngineAdapterLoggingTest extends BaseIndexingTestCase {
 	@ExpectedLog(
 		expectedClass = SearchSearchRequestExecutorImpl.class,
 		expectedLevel = ExpectedLog.Level.FINE,
-		expectedLog = "The search engine processed"
+		expectedLog = "The search engine processed", solrTest = true
 	)
 	@Test
 	public void testSearchSearchRequestExecutorLogs() {

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/logging/ExpectedLog.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/logging/ExpectedLog.java
@@ -27,6 +27,8 @@ public @interface ExpectedLog {
 
 	public String expectedLog();
 
+	public boolean solrTest() default false;
+
 	public enum Level {
 
 		FINE, FINEST, INFO, WARNING

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/logging/ExpectedLogMethodTestRule.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/logging/ExpectedLogMethodTestRule.java
@@ -47,7 +47,9 @@ public class ExpectedLogMethodTestRule extends MethodTestRule<Void> {
 
 		ExpectedLog expectedLog = description.getAnnotation(ExpectedLog.class);
 
-		if (expectedLog == null) {
+		if ((expectedLog == null) ||
+			(!_SOLR_AVAILABLE && expectedLog.solrTest())) {
+
 			return;
 		}
 
@@ -203,6 +205,14 @@ public class ExpectedLogMethodTestRule extends MethodTestRule<Void> {
 		closeCaptureHandler();
 
 		openCaptureHandler(name, level);
+	}
+
+	private static final boolean _SOLR_AVAILABLE;
+
+	static {
+		_SOLR_AVAILABLE = Boolean.valueOf(
+			System.getProperty(
+				"com.liferay.portal.search.solr8.test.unit.started"));
 	}
 
 	private LogCapture _logCapture;


### PR DESCRIPTION
## **LPS link:** [LPS-178506](https://liferay.atlassian.net/browse/LPS-178506)

# Context

When tests in some classes are skipped, no explicit message appears showing that each test for a given class was skipped. The example below shows what should appear when each test is skipped:
```
com.liferay.portal.search.solr8.internal.suggest.SolrSuggestTest > testNull STARTED

com.liferay.portal.search.solr8.internal.suggest.SolrSuggestTest > testNull SKIPPED
```
(the example is of a class where the problem does not occur)

This issue occurs in classes that use the method below to skip all tests if the value `com.liferay.portal.search.solr8.test.unit.started=true` is not set.

```
@BeforeClass
public static void setUpClass() {
	Assume.assumeTrue(
		SolrUnitTestRequirements.isSolrExternallyStartedByDeveloper());
}
```
Using this method with the **@BeforeClass** annotation causes tests to be skipped before they even start, that is, the tests are never executed when the value `com.liferay.portal.search.solr8.test.unit.started=true` is not set. This way of skipping tests means that the STARTED and SKIPPED messages are never displayed in the log.

# Proposed solution

1. The boolean field `solrTest` was added to the ExpectedLog annotation to make it possible to differentiate between solr tests and elasticsearch tests. So solr tests that use the **@ExpectedLog** annotation need to pass `solrTest = true`

2. Logic has been added to avoid checking the log if the value of the `com.liferay.portal.search.solr8.test.unit.started` property is false and `solrTest` is true.

3. The `@BeforeClass` annotation has been replaced by the `@Before` annotation so that tests can be started and skipped. Thus enabling the STARTED and SKIPPED messages to be displayed.

cc: @gustavolimav 