### PR TITLE
LPS-200686 Prevent JS rounding off companyId numbers when search reindexing

### DIFF
--- a/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/display/context/builder/IndexActionsDisplayContextBuilder.java
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/display/context/builder/IndexActionsDisplayContextBuilder.java
@@ -264,7 +264,7 @@ public class IndexActionsDisplayContextBuilder {
 		if (!ArrayUtil.contains(companyIds, CompanyConstants.SYSTEM)) {
 			jsonArray.put(
 				JSONUtil.put(
-					"id", CompanyConstants.SYSTEM
+					"id", String.valueOf(CompanyConstants.SYSTEM)
 				).put(
 					"name", _language.get(_httpServletRequest, "system")
 				));
@@ -276,7 +276,7 @@ public class IndexActionsDisplayContextBuilder {
 
 				jsonArray.put(
 					JSONUtil.put(
-						"id", companyId
+						"id", String.valueOf(companyId)
 					).put(
 						"name", company.getWebId()
 					));


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-200686 - Prevent JS rounding off companyId numbers when search reindexing

Realized after search indexing failures from [LPS-196393](https://liferay.atlassian.net/browse/LPS-196393) when large companyIds were being generated.

In the submission of the prop `virtualInstances` to the JS component, long companyIds like `5529287947776598415` get rounded off to `5529287947776598000` ([more context](https://stackoverflow.com/questions/1379934/large-numbers-erroneously-rounded-in-javascript)). Sending this data as a String would help prevent this from occurring.