### PR TITLE
LPS-200851 Avoid NullPointerException during upgrade process

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v3_0_0/SXPBlueprintUpgradeProcess.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v3_0_0/SXPBlueprintUpgradeProcess.java
@@ -46,6 +46,10 @@ public class SXPBlueprintUpgradeProcess extends UpgradeProcess {
 		for (int i = 0; i < jsonArray.length(); i++) {
 			JSONObject jsonObject = jsonArray.getJSONObject(i);
 
+			if (jsonObject == null) {
+				continue;
+			}
+
 			JSONObject attributesJSONObject = jsonObject.getJSONObject(
 				"attributes");
 

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v3_0_0/SXPBlueprintUpgradeProcess.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v3_0_0/SXPBlueprintUpgradeProcess.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -33,6 +34,10 @@ public class SXPBlueprintUpgradeProcess extends UpgradeProcess {
 
 	private long _getSXPBlueprintIdByLargeValue(String largeValue)
 		throws Exception {
+
+		if (Validator.isNull(largeValue)) {
+			return 0;
+		}
 
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray(
 			StringBundler.concat(


### PR DESCRIPTION
Ticket: [LPS-200851](https://liferay.atlassian.net/browse/LPS-200851)

Although we're not sure exactly how to reproduce the `null` largeValue in the PortletPreferenceValue table, it seems to be possible on a clean instance because we had multiple customers encounter this same `NullPointerException` when they tried to upgrade. I think it's something in low-level Hibernate code that causes the `null` largeValue (rather than a blank one) to be set.