### PR TITLE
LPS-198941 search-experiences: Update validation when creating SXPElement

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SXPElementResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SXPElementResourceImpl.java
@@ -28,6 +28,7 @@ import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.search.experiences.constants.SXPActionKeys;
 import com.liferay.search.experiences.constants.SXPConstants;
 import com.liferay.search.experiences.exception.DuplicateSXPElementExternalReferenceCodeException;
+import com.liferay.search.experiences.exception.SXPElementTitleException;
 import com.liferay.search.experiences.rest.dto.v1_0.SXPElement;
 import com.liferay.search.experiences.rest.dto.v1_0.util.ElementDefinitionUtil;
 import com.liferay.search.experiences.rest.dto.v1_0.util.SXPElementUtil;
@@ -42,6 +43,7 @@ import com.liferay.search.experiences.service.SXPElementService;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.ws.rs.core.MultivaluedMap;
@@ -231,6 +233,8 @@ public class SXPElementResourceImpl extends BaseSXPElementResourceImpl {
 
 	@Override
 	public SXPElement postSXPElement(SXPElement sxpElement) throws Exception {
+		_validateTitleI18n(sxpElement.getTitle_i18n());
+
 		return _sxpElementDTOConverter.toDTO(
 			new DefaultDTOConverterContext(
 				contextAcceptLanguage.isAcceptAllLanguages(), new HashMap<>(),
@@ -371,6 +375,8 @@ public class SXPElementResourceImpl extends BaseSXPElementResourceImpl {
 			Long sxpElementId, SXPElement sxpElement)
 		throws Exception {
 
+		_validateTitleI18n(sxpElement.getTitle_i18n());
+
 		return _sxpElementDTOConverter.toDTO(
 			new DefaultDTOConverterContext(
 				contextAcceptLanguage.isAcceptAllLanguages(), new HashMap<>(),
@@ -410,6 +416,22 @@ public class SXPElementResourceImpl extends BaseSXPElementResourceImpl {
 				sxpElement.getId())) {
 
 			throw new DuplicateSXPElementExternalReferenceCodeException();
+		}
+	}
+
+	private void _validateTitleI18n(Map<String, String> titleI18n)
+		throws Exception {
+
+		if (!titleI18n.containsKey(
+				LocaleUtil.getDefault(
+				).toString()) &&
+			!titleI18n.containsKey(
+				LocaleUtil.toBCP47LanguageId(LocaleUtil.getDefault()))) {
+
+			throw new SXPElementTitleException(
+				"The title for the default locale " +
+					LocaleUtil.toLanguageId(LocaleUtil.getDefault()) +
+						" cannot be blank");
 		}
 	}
 

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/validator/SXPElementValidatorImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/validator/SXPElementValidatorImpl.java
@@ -5,8 +5,7 @@
 
 package com.liferay.search.experiences.internal.validator;
 
-import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.search.experiences.exception.SXPElementTitleException;
 import com.liferay.search.experiences.validator.SXPElementValidator;
 
@@ -25,11 +24,8 @@ public class SXPElementValidatorImpl implements SXPElementValidator {
 	public void validate(Map<Locale, String> titleMap, int type)
 		throws SXPElementTitleException {
 
-		if (Validator.isBlank(titleMap.get(LocaleUtil.getDefault()))) {
-			throw new SXPElementTitleException(
-				"The title for the default locale " +
-					LocaleUtil.toLanguageId(LocaleUtil.getDefault()) +
-						" cannot be blank");
+		if (MapUtil.isEmpty(titleMap)) {
+			throw new SXPElementTitleException("Title is empty");
 		}
 	}
 

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPBlueprintLocalServiceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPBlueprintLocalServiceImpl.java
@@ -195,10 +195,8 @@ public class SXPBlueprintLocalServiceImpl
 						"#_validate"),
 				true)) {
 
-			return;
+			_sxpBlueprintValidator.validate(titleMap);
 		}
-
-		_sxpBlueprintValidator.validate(titleMap);
 	}
 
 	@Reference

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/test/SXPBlueprintLocalServiceTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/test/SXPBlueprintLocalServiceTest.java
@@ -6,7 +6,9 @@
 package com.liferay.search.experiences.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
@@ -20,12 +22,15 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.search.experiences.exception.DuplicateSXPBlueprintExternalReferenceCodeException;
 import com.liferay.search.experiences.exception.NoSuchSXPBlueprintException;
+import com.liferay.search.experiences.exception.SXPBlueprintTitleException;
 import com.liferay.search.experiences.model.SXPBlueprint;
 import com.liferay.search.experiences.service.SXPBlueprintLocalService;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -62,7 +67,11 @@ public class SXPBlueprintLocalServiceTest {
 			CompanyTestUtil.addCompany());
 
 		SXPBlueprint differentCompanySXPBlueprint = _addSXPBlueprint(
-			sxpBlueprint.getExternalReferenceCode(), user.getUserId());
+			sxpBlueprint.getExternalReferenceCode(), user.getUserId(),
+			Collections.singletonMap(LocaleUtil.US, StringPool.BLANK),
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			ServiceContextTestUtil.getServiceContext());
 
 		Assert.assertEquals(
 			sxpBlueprint.getExternalReferenceCode(),
@@ -156,23 +165,67 @@ public class SXPBlueprintLocalServiceTest {
 		_sxpBlueprintLocalService.updateSXPBlueprint(sxpBlueprint2);
 	}
 
+	@Test
+	public void testValidateSXPBlueprint() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		String attribute =
+			"com.liferay.search.experiences.service.impl." +
+				"SXPBlueprintLocalServiceImpl#_validate";
+
+		try {
+			_addSXPBlueprint(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				Collections.singletonMap(LocaleUtil.US, StringPool.BLANK),
+				Collections.emptyMap(), serviceContext);
+		}
+		catch (SXPBlueprintTitleException sxpBlueprintTitleException) {
+			Assert.assertNotNull(sxpBlueprintTitleException);
+		}
+
+		serviceContext.setAttribute(attribute, Boolean.TRUE);
+
+		try {
+			_addSXPBlueprint(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				Collections.singletonMap(LocaleUtil.US, StringPool.BLANK),
+				Collections.emptyMap(), serviceContext);
+		}
+		catch (SXPBlueprintTitleException sxpBlueprintTitleException) {
+			Assert.assertNotNull(sxpBlueprintTitleException);
+		}
+
+		serviceContext.setAttribute(attribute, Boolean.FALSE);
+
+		SXPBlueprint sxpBlueprint = _addSXPBlueprint(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			Collections.singletonMap(LocaleUtil.US, StringPool.BLANK),
+			Collections.emptyMap(), serviceContext);
+
+		Assert.assertEquals(Collections.emptyMap(), sxpBlueprint.getTitleMap());
+	}
+
 	private SXPBlueprint _addSXPBlueprint(String externalReferenceCode)
 		throws Exception {
 
 		return _addSXPBlueprint(
-			externalReferenceCode, TestPropsValues.getUserId());
-	}
-
-	private SXPBlueprint _addSXPBlueprint(
-			String externalReferenceCode, long userId)
-		throws Exception {
-
-		SXPBlueprint sxpBlueprint = _sxpBlueprintLocalService.addSXPBlueprint(
-			externalReferenceCode, userId, "{}",
-			Collections.singletonMap(LocaleUtil.US, ""), null, "",
+			externalReferenceCode, TestPropsValues.getUserId(),
+			Collections.singletonMap(LocaleUtil.US, StringPool.BLANK),
 			Collections.singletonMap(
 				LocaleUtil.US, RandomTestUtil.randomString()),
 			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private SXPBlueprint _addSXPBlueprint(
+			String externalReferenceCode, long userId,
+			Map<Locale, String> descriptionMap, Map<Locale, String> titleMap,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		SXPBlueprint sxpBlueprint = _sxpBlueprintLocalService.addSXPBlueprint(
+			externalReferenceCode, userId, "{}", descriptionMap, null,
+			StringPool.BLANK, titleMap, serviceContext);
 
 		_sxpBlueprints.add(sxpBlueprint);
 

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/test/SXPElementLocalServiceTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/test/SXPElementLocalServiceTest.java
@@ -6,7 +6,9 @@
 package com.liferay.search.experiences.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
@@ -106,7 +108,8 @@ public class SXPElementLocalServiceTest {
 			RandomTestUtil.randomString(), fallbackDescription, fallbackTitle,
 			Collections.singletonMap(
 				LocaleUtil.US, RandomTestUtil.randomString()),
-			TestPropsValues.getUserId());
+			TestPropsValues.getUserId(),
+			ServiceContextTestUtil.getServiceContext());
 
 		Assert.assertEquals(
 			fallbackDescription,
@@ -121,26 +124,13 @@ public class SXPElementLocalServiceTest {
 			Collections.singletonMap(LocaleUtil.US, description),
 			RandomTestUtil.randomString(), null, null,
 			Collections.singletonMap(LocaleUtil.US, title),
-			TestPropsValues.getUserId());
+			TestPropsValues.getUserId(),
+			ServiceContextTestUtil.getServiceContext());
 
 		Assert.assertEquals(
 			description, noFallbackFieldsSXPElement.getFallbackDescription());
 		Assert.assertEquals(
 			title, noFallbackFieldsSXPElement.getFallbackTitle());
-
-		// Title
-
-		try {
-			_addSXPElement(
-				Collections.singletonMap(LocaleUtil.SPAIN, description),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(),
-				Collections.singletonMap(LocaleUtil.SPAIN, title),
-				TestPropsValues.getUserId());
-		}
-		catch (SXPElementTitleException sxpElementTitleException) {
-			Assert.assertNotNull(sxpElementTitleException);
-		}
 	}
 
 	@Test
@@ -206,17 +196,61 @@ public class SXPElementLocalServiceTest {
 		_sxpElementLocalService.updateSXPElement(sxpElement2);
 	}
 
+	@Test
+	public void testValidateSXPElement() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		String attribute =
+			"com.liferay.search.experiences.service.impl." +
+				"SXPElementLocalServiceImpl#_validate";
+
+		try {
+			_addSXPElement(
+				Collections.singletonMap(LocaleUtil.US, StringPool.BLANK),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), Collections.emptyMap(),
+				TestPropsValues.getUserId(), serviceContext);
+		}
+		catch (SXPElementTitleException sxpElementTitleException) {
+			Assert.assertNotNull(sxpElementTitleException);
+		}
+
+		serviceContext.setAttribute(attribute, Boolean.TRUE);
+
+		try {
+			_addSXPElement(
+				Collections.singletonMap(LocaleUtil.US, StringPool.BLANK),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), Collections.emptyMap(),
+				TestPropsValues.getUserId(), serviceContext);
+		}
+		catch (SXPElementTitleException sxpElementTitleException) {
+			Assert.assertNotNull(sxpElementTitleException);
+		}
+
+		serviceContext.setAttribute(attribute, Boolean.FALSE);
+
+		SXPElement sxpElement = _addSXPElement(
+			Collections.emptyMap(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			Collections.emptyMap(), TestPropsValues.getUserId(),
+			serviceContext);
+
+		Assert.assertEquals(Collections.emptyMap(), sxpElement.getTitleMap());
+	}
+
 	private SXPElement _addSXPElement(
 			Map<Locale, String> descriptionMap, String externalReferenceCode,
 			String fallbackDescription, String fallbackTitle,
-			Map<Locale, String> titleMap, long userId)
+			Map<Locale, String> titleMap, long userId,
+			ServiceContext serviceContext)
 		throws Exception {
 
 		SXPElement sxpElement = _sxpElementLocalService.addSXPElement(
 			externalReferenceCode, userId, descriptionMap, "{}",
 			fallbackDescription, fallbackTitle, false,
-			RandomTestUtil.randomString(), titleMap, 0,
-			ServiceContextTestUtil.getServiceContext());
+			RandomTestUtil.randomString(), titleMap, 0, serviceContext);
 
 		_sxpElements.add(sxpElement);
 
@@ -233,7 +267,7 @@ public class SXPElementLocalServiceTest {
 			RandomTestUtil.randomString(),
 			Collections.singletonMap(
 				LocaleUtil.US, RandomTestUtil.randomString()),
-			userId);
+			userId, ServiceContextTestUtil.getServiceContext());
 	}
 
 	@Inject


### PR DESCRIPTION
For the task [LPS-198941](https://liferay.atlassian.net/browse/LPS-198941), the key information is detailed in the commit message.

Move this logic to Resource is necessary because of OOTB Elements, which are read-only and thus not subject to editing. This approach is essential to address a specific scenario: if there's a change in the defaultLocale and concurrently the originalDefaultLocale from the Element is removed, it could result in significant issues, such as be not possible to copy an Element.

https://liferay.atlassian.net/browse/LPS-202540

sending tests together