### PR TITLE
LPS-202379 search-experiences-web: Display error message for copy and edit actions

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/model/SXPBlueprintModel.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/model/SXPBlueprintModel.java
@@ -350,6 +350,36 @@ public interface SXPBlueprintModel
 	public void setElementInstancesJSON(String elementInstancesJSON);
 
 	/**
+	 * Returns the fallback description of this sxp blueprint.
+	 *
+	 * @return the fallback description of this sxp blueprint
+	 */
+	@AutoEscape
+	public String getFallbackDescription();
+
+	/**
+	 * Sets the fallback description of this sxp blueprint.
+	 *
+	 * @param fallbackDescription the fallback description of this sxp blueprint
+	 */
+	public void setFallbackDescription(String fallbackDescription);
+
+	/**
+	 * Returns the fallback title of this sxp blueprint.
+	 *
+	 * @return the fallback title of this sxp blueprint
+	 */
+	@AutoEscape
+	public String getFallbackTitle();
+
+	/**
+	 * Sets the fallback title of this sxp blueprint.
+	 *
+	 * @param fallbackTitle the fallback title of this sxp blueprint
+	 */
+	public void setFallbackTitle(String fallbackTitle);
+
+	/**
 	 * Returns the schema version of this sxp blueprint.
 	 *
 	 * @return the schema version of this sxp blueprint

--- a/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/model/SXPBlueprintTable.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/model/SXPBlueprintTable.java
@@ -53,6 +53,12 @@ public class SXPBlueprintTable extends BaseTable<SXPBlueprintTable> {
 		createColumn(
 			"elementInstancesJSON", Clob.class, Types.CLOB,
 			Column.FLAG_DEFAULT);
+	public final Column<SXPBlueprintTable, String> fallbackDescription =
+		createColumn(
+			"fallbackDescription", String.class, Types.VARCHAR,
+			Column.FLAG_DEFAULT);
+	public final Column<SXPBlueprintTable, String> fallbackTitle = createColumn(
+		"fallbackTitle", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 	public final Column<SXPBlueprintTable, String> schemaVersion = createColumn(
 		"schemaVersion", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 	public final Column<SXPBlueprintTable, String> title = createColumn(

--- a/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/model/SXPBlueprintWrapper.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/model/SXPBlueprintWrapper.java
@@ -46,6 +46,8 @@ public class SXPBlueprintWrapper
 		attributes.put("configurationJSON", getConfigurationJSON());
 		attributes.put("description", getDescription());
 		attributes.put("elementInstancesJSON", getElementInstancesJSON());
+		attributes.put("fallbackDescription", getFallbackDescription());
+		attributes.put("fallbackTitle", getFallbackTitle());
 		attributes.put("schemaVersion", getSchemaVersion());
 		attributes.put("title", getTitle());
 		attributes.put("version", getVersion());
@@ -131,6 +133,19 @@ public class SXPBlueprintWrapper
 
 		if (elementInstancesJSON != null) {
 			setElementInstancesJSON(elementInstancesJSON);
+		}
+
+		String fallbackDescription = (String)attributes.get(
+			"fallbackDescription");
+
+		if (fallbackDescription != null) {
+			setFallbackDescription(fallbackDescription);
+		}
+
+		String fallbackTitle = (String)attributes.get("fallbackTitle");
+
+		if (fallbackTitle != null) {
+			setFallbackTitle(fallbackTitle);
 		}
 
 		String schemaVersion = (String)attributes.get("schemaVersion");
@@ -315,6 +330,26 @@ public class SXPBlueprintWrapper
 	@Override
 	public String getExternalReferenceCode() {
 		return model.getExternalReferenceCode();
+	}
+
+	/**
+	 * Returns the fallback description of this sxp blueprint.
+	 *
+	 * @return the fallback description of this sxp blueprint
+	 */
+	@Override
+	public String getFallbackDescription() {
+		return model.getFallbackDescription();
+	}
+
+	/**
+	 * Returns the fallback title of this sxp blueprint.
+	 *
+	 * @return the fallback title of this sxp blueprint
+	 */
+	@Override
+	public String getFallbackTitle() {
+		return model.getFallbackTitle();
 	}
 
 	/**
@@ -758,6 +793,26 @@ public class SXPBlueprintWrapper
 	@Override
 	public void setExternalReferenceCode(String externalReferenceCode) {
 		model.setExternalReferenceCode(externalReferenceCode);
+	}
+
+	/**
+	 * Sets the fallback description of this sxp blueprint.
+	 *
+	 * @param fallbackDescription the fallback description of this sxp blueprint
+	 */
+	@Override
+	public void setFallbackDescription(String fallbackDescription) {
+		model.setFallbackDescription(fallbackDescription);
+	}
+
+	/**
+	 * Sets the fallback title of this sxp blueprint.
+	 *
+	 * @param fallbackTitle the fallback title of this sxp blueprint
+	 */
+	@Override
+	public void setFallbackTitle(String fallbackTitle) {
+		model.setFallbackTitle(fallbackTitle);
 	}
 
 	/**

--- a/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/service/SXPBlueprintLocalService.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/service/SXPBlueprintLocalService.java
@@ -63,6 +63,7 @@ public interface SXPBlueprintLocalService
 	public SXPBlueprint addSXPBlueprint(
 			String externalReferenceCode, long userId, String configurationJSON,
 			Map<Locale, String> descriptionMap, String elementInstancesJSON,
+			String fallbackDescription, String fallbackTitle,
 			String schemaVersion, Map<Locale, String> titleMap,
 			ServiceContext serviceContext)
 		throws PortalException;

--- a/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/service/SXPBlueprintLocalServiceUtil.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/service/SXPBlueprintLocalServiceUtil.java
@@ -39,14 +39,16 @@ public class SXPBlueprintLocalServiceUtil {
 	public static SXPBlueprint addSXPBlueprint(
 			String externalReferenceCode, long userId, String configurationJSON,
 			Map<java.util.Locale, String> descriptionMap,
-			String elementInstancesJSON, String schemaVersion,
+			String elementInstancesJSON, String fallbackDescription,
+			String fallbackTitle, String schemaVersion,
 			Map<java.util.Locale, String> titleMap,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addSXPBlueprint(
 			externalReferenceCode, userId, configurationJSON, descriptionMap,
-			elementInstancesJSON, schemaVersion, titleMap, serviceContext);
+			elementInstancesJSON, fallbackDescription, fallbackTitle,
+			schemaVersion, titleMap, serviceContext);
 	}
 
 	/**

--- a/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/service/SXPBlueprintLocalServiceWrapper.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/service/SXPBlueprintLocalServiceWrapper.java
@@ -33,14 +33,16 @@ public class SXPBlueprintLocalServiceWrapper
 	public com.liferay.search.experiences.model.SXPBlueprint addSXPBlueprint(
 			String externalReferenceCode, long userId, String configurationJSON,
 			java.util.Map<java.util.Locale, String> descriptionMap,
-			String elementInstancesJSON, String schemaVersion,
+			String elementInstancesJSON, String fallbackDescription,
+			String fallbackTitle, String schemaVersion,
 			java.util.Map<java.util.Locale, String> titleMap,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _sxpBlueprintLocalService.addSXPBlueprint(
 			externalReferenceCode, userId, configurationJSON, descriptionMap,
-			elementInstancesJSON, schemaVersion, titleMap, serviceContext);
+			elementInstancesJSON, fallbackDescription, fallbackTitle,
+			schemaVersion, titleMap, serviceContext);
 	}
 
 	/**

--- a/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/service/SXPBlueprintService.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/service/SXPBlueprintService.java
@@ -47,6 +47,7 @@ public interface SXPBlueprintService extends BaseService {
 	public SXPBlueprint addSXPBlueprint(
 			String externalReferenceCode, String configurationJSON,
 			Map<Locale, String> descriptionMap, String elementInstancesJSON,
+			String fallbackDescription, String fallbackTitle,
 			String schemaVersion, Map<Locale, String> titleMap,
 			ServiceContext serviceContext)
 		throws PortalException;

--- a/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/service/SXPBlueprintServiceUtil.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/service/SXPBlueprintServiceUtil.java
@@ -32,14 +32,16 @@ public class SXPBlueprintServiceUtil {
 	public static SXPBlueprint addSXPBlueprint(
 			String externalReferenceCode, String configurationJSON,
 			Map<java.util.Locale, String> descriptionMap,
-			String elementInstancesJSON, String schemaVersion,
+			String elementInstancesJSON, String fallbackDescription,
+			String fallbackTitle, String schemaVersion,
 			Map<java.util.Locale, String> titleMap,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addSXPBlueprint(
 			externalReferenceCode, configurationJSON, descriptionMap,
-			elementInstancesJSON, schemaVersion, titleMap, serviceContext);
+			elementInstancesJSON, fallbackDescription, fallbackTitle,
+			schemaVersion, titleMap, serviceContext);
 	}
 
 	public static SXPBlueprint deleteSXPBlueprint(long sxpBlueprintId)

--- a/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/service/SXPBlueprintServiceWrapper.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/service/SXPBlueprintServiceWrapper.java
@@ -29,14 +29,16 @@ public class SXPBlueprintServiceWrapper
 	public com.liferay.search.experiences.model.SXPBlueprint addSXPBlueprint(
 			String externalReferenceCode, String configurationJSON,
 			java.util.Map<java.util.Locale, String> descriptionMap,
-			String elementInstancesJSON, String schemaVersion,
+			String elementInstancesJSON, String fallbackDescription,
+			String fallbackTitle, String schemaVersion,
 			java.util.Map<java.util.Locale, String> titleMap,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _sxpBlueprintService.addSXPBlueprint(
 			externalReferenceCode, configurationJSON, descriptionMap,
-			elementInstancesJSON, schemaVersion, titleMap, serviceContext);
+			elementInstancesJSON, fallbackDescription, fallbackTitle,
+			schemaVersion, titleMap, serviceContext);
 	}
 
 	@Override

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/bnd.bnd
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Search Experiences REST API
 Bundle-SymbolicName: com.liferay.search.experiences.rest.api
-Bundle-Version: 12.9.1
+Bundle-Version: 12.10.0
 Export-Package:\
 	com.liferay.search.experiences.rest.dto.v1_0,\
 	com.liferay.search.experiences.rest.dto.v1_0.util,\

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/dto/v1_0/SXPBlueprint.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/dto/v1_0/SXPBlueprint.java
@@ -257,6 +257,62 @@ public class SXPBlueprint implements Serializable {
 	protected String externalReferenceCode;
 
 	@Schema
+	public String getFallbackDescription() {
+		return fallbackDescription;
+	}
+
+	public void setFallbackDescription(String fallbackDescription) {
+		this.fallbackDescription = fallbackDescription;
+	}
+
+	@JsonIgnore
+	public void setFallbackDescription(
+		UnsafeSupplier<String, Exception> fallbackDescriptionUnsafeSupplier) {
+
+		try {
+			fallbackDescription = fallbackDescriptionUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String fallbackDescription;
+
+	@Schema
+	public String getFallbackTitle() {
+		return fallbackTitle;
+	}
+
+	public void setFallbackTitle(String fallbackTitle) {
+		this.fallbackTitle = fallbackTitle;
+	}
+
+	@JsonIgnore
+	public void setFallbackTitle(
+		UnsafeSupplier<String, Exception> fallbackTitleUnsafeSupplier) {
+
+		try {
+			fallbackTitle = fallbackTitleUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String fallbackTitle;
+
+	@Schema
 	public Long getId() {
 		return id;
 	}
@@ -570,6 +626,34 @@ public class SXPBlueprint implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(externalReferenceCode));
+
+			sb.append("\"");
+		}
+
+		if (fallbackDescription != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fallbackDescription\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(fallbackDescription));
+
+			sb.append("\"");
+		}
+
+		if (fallbackTitle != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fallbackTitle\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(fallbackTitle));
 
 			sb.append("\"");
 		}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/resources/com/liferay/search/experiences/rest/dto/v1_0/packageinfo
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/resources/com/liferay/search/experiences/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 4.4.0
+version 4.5.0

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/dto/v1_0/SXPBlueprint.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/dto/v1_0/SXPBlueprint.java
@@ -177,6 +177,48 @@ public class SXPBlueprint implements Cloneable, Serializable {
 
 	protected String externalReferenceCode;
 
+	public String getFallbackDescription() {
+		return fallbackDescription;
+	}
+
+	public void setFallbackDescription(String fallbackDescription) {
+		this.fallbackDescription = fallbackDescription;
+	}
+
+	public void setFallbackDescription(
+		UnsafeSupplier<String, Exception> fallbackDescriptionUnsafeSupplier) {
+
+		try {
+			fallbackDescription = fallbackDescriptionUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String fallbackDescription;
+
+	public String getFallbackTitle() {
+		return fallbackTitle;
+	}
+
+	public void setFallbackTitle(String fallbackTitle) {
+		this.fallbackTitle = fallbackTitle;
+	}
+
+	public void setFallbackTitle(
+		UnsafeSupplier<String, Exception> fallbackTitleUnsafeSupplier) {
+
+		try {
+			fallbackTitle = fallbackTitleUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String fallbackTitle;
+
 	public Long getId() {
 		return id;
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/serdes/v1_0/SXPBlueprintSerDes.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/serdes/v1_0/SXPBlueprintSerDes.java
@@ -149,6 +149,34 @@ public class SXPBlueprintSerDes {
 			sb.append("\"");
 		}
 
+		if (sxpBlueprint.getFallbackDescription() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fallbackDescription\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(sxpBlueprint.getFallbackDescription()));
+
+			sb.append("\"");
+		}
+
+		if (sxpBlueprint.getFallbackTitle() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fallbackTitle\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(sxpBlueprint.getFallbackTitle()));
+
+			sb.append("\"");
+		}
+
 		if (sxpBlueprint.getId() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -322,6 +350,24 @@ public class SXPBlueprintSerDes {
 				String.valueOf(sxpBlueprint.getExternalReferenceCode()));
 		}
 
+		if (sxpBlueprint.getFallbackDescription() == null) {
+			map.put("fallbackDescription", null);
+		}
+		else {
+			map.put(
+				"fallbackDescription",
+				String.valueOf(sxpBlueprint.getFallbackDescription()));
+		}
+
+		if (sxpBlueprint.getFallbackTitle() == null) {
+			map.put("fallbackTitle", null);
+		}
+		else {
+			map.put(
+				"fallbackTitle",
+				String.valueOf(sxpBlueprint.getFallbackTitle()));
+		}
+
 		if (sxpBlueprint.getId() == null) {
 			map.put("id", null);
 		}
@@ -450,6 +496,19 @@ public class SXPBlueprintSerDes {
 				if (jsonParserFieldValue != null) {
 					sxpBlueprint.setExternalReferenceCode(
 						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "fallbackDescription")) {
+
+				if (jsonParserFieldValue != null) {
+					sxpBlueprint.setFallbackDescription(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "fallbackTitle")) {
+				if (jsonParserFieldValue != null) {
+					sxpBlueprint.setFallbackTitle((String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "id")) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
@@ -442,6 +442,10 @@ components:
                 externalReferenceCode:
                     example: AB-34098-789-N
                     type: string
+                fallbackDescription:
+                    type: string
+                fallbackTitle:
+                    type: string
                 id:
                     format: int64
                     type: integer

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
@@ -603,7 +603,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.search.experiences.rest.client', and version '3.0.24'."
+        'com.liferay.search.experiences.rest.client', and version '3.0.25'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
@@ -603,7 +603,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.search.experiences.rest.client', and version '3.0.23'."
+        'com.liferay.search.experiences.rest.client', and version '3.0.24'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/dto/v1_0/converter/SXPBlueprintDTOConverter.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/dto/v1_0/converter/SXPBlueprintDTOConverter.java
@@ -66,10 +66,10 @@ public class SXPBlueprintDTOConverter
 				configuration = _toConfiguration(
 					sxpBlueprint.getConfigurationJSON());
 				createDate = sxpBlueprint.getCreateDate();
-				description = _language.get(
+				description = SXPDTOConverterUtil.translate(
+					sxpBlueprint.getFallbackDescription(), _language,
 					dtoConverterContext.getLocale(),
-					sxpBlueprint.getDescription(
-						dtoConverterContext.getLocale()));
+					sxpBlueprint.getDescriptionMap());
 				description_i18n = LocalizedMapUtil.getI18nMap(
 					dtoConverterContext.isAcceptAllLanguages(),
 					sxpBlueprint.getDescriptionMap());
@@ -80,9 +80,10 @@ public class SXPBlueprintDTOConverter
 				id = sxpBlueprint.getSXPBlueprintId();
 				modifiedDate = sxpBlueprint.getModifiedDate();
 				schemaVersion = sxpBlueprint.getSchemaVersion();
-				title = _language.get(
+				title = SXPDTOConverterUtil.translate(
+					sxpBlueprint.getFallbackTitle(), _language,
 					dtoConverterContext.getLocale(),
-					sxpBlueprint.getTitle(dtoConverterContext.getLocale()));
+					sxpBlueprint.getTitleMap());
 				title_i18n = LocalizedMapUtil.getI18nMap(
 					dtoConverterContext.isAcceptAllLanguages(),
 					sxpBlueprint.getTitleMap());

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/graphql/query/v1_0/Query.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/graphql/query/v1_0/Query.java
@@ -276,7 +276,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sXPBlueprintByExternalReferenceCode(externalReferenceCode: ___){actions, configuration, createDate, description, description_i18n, elementInstances, externalReferenceCode, id, modifiedDate, schemaVersion, title, title_i18n, userName, version}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sXPBlueprintByExternalReferenceCode(externalReferenceCode: ___){actions, configuration, createDate, description, description_i18n, elementInstances, externalReferenceCode, fallbackDescription, fallbackTitle, id, modifiedDate, schemaVersion, title, title_i18n, userName, version}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public SXPBlueprint sXPBlueprintByExternalReferenceCode(
@@ -294,7 +294,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sXPBlueprint(sxpBlueprintId: ___){actions, configuration, createDate, description, description_i18n, elementInstances, externalReferenceCode, id, modifiedDate, schemaVersion, title, title_i18n, userName, version}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sXPBlueprint(sxpBlueprintId: ___){actions, configuration, createDate, description, description_i18n, elementInstances, externalReferenceCode, fallbackDescription, fallbackTitle, id, modifiedDate, schemaVersion, title, title_i18n, userName, version}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public SXPBlueprint sXPBlueprint(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/jaxrs/exception/SXPBlueprintTitleExceptionMapper.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/jaxrs/exception/SXPBlueprintTitleExceptionMapper.java
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.search.experiences.rest.internal.jaxrs.exception;
+
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+import com.liferay.search.experiences.exception.SXPBlueprintTitleException;
+
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Gustavo Lima
+ */
+@Component(
+	enabled = false,
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Search.Experiences.REST.SXPBlueprintTitleExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+@Provider
+public class SXPBlueprintTitleExceptionMapper
+	extends BaseExceptionMapper<SXPBlueprintTitleException> {
+
+	@Override
+	protected Problem getProblem(
+		SXPBlueprintTitleException sxpBlueprintTitleException) {
+
+		return new Problem(sxpBlueprintTitleException);
+	}
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/jaxrs/exception/SXPElementTitleExceptionMapper.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/jaxrs/exception/SXPElementTitleExceptionMapper.java
@@ -22,12 +22,12 @@ import org.osgi.service.component.annotations.Component;
 	property = {
 		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)",
 		"osgi.jaxrs.extension=true",
-		"osgi.jaxrs.name=Liferay.Search.Experiences.REST.SXPElementTitleExceptionExceptionMapper"
+		"osgi.jaxrs.name=Liferay.Search.Experiences.REST.SXPElementTitleExceptionMapper"
 	},
 	service = ExceptionMapper.class
 )
 @Provider
-public class SXPElementTitleExceptionExceptionMapper
+public class SXPElementTitleExceptionMapper
 	extends BaseExceptionMapper<SXPElementTitleException> {
 
 	@Override

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPBlueprintResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPBlueprintResourceImpl.java
@@ -204,7 +204,7 @@ public abstract class BaseSXPBlueprintResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/search-experiences-rest/v1.0/sxp-blueprints' -d $'{"configuration": ___, "createDate": ___, "description": ___, "description_i18n": ___, "elementInstances": ___, "externalReferenceCode": ___, "id": ___, "modifiedDate": ___, "schemaVersion": ___, "title": ___, "title_i18n": ___, "userName": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/search-experiences-rest/v1.0/sxp-blueprints' -d $'{"configuration": ___, "createDate": ___, "description": ___, "description_i18n": ___, "elementInstances": ___, "externalReferenceCode": ___, "fallbackDescription": ___, "fallbackTitle": ___, "id": ___, "modifiedDate": ___, "schemaVersion": ___, "title": ___, "title_i18n": ___, "userName": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "SXPBlueprint")}
@@ -223,7 +223,7 @@ public abstract class BaseSXPBlueprintResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/search-experiences-rest/v1.0/sxp-blueprints/batch' -d $'{"configuration": ___, "createDate": ___, "description": ___, "description_i18n": ___, "elementInstances": ___, "externalReferenceCode": ___, "id": ___, "modifiedDate": ___, "schemaVersion": ___, "title": ___, "title_i18n": ___, "userName": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/search-experiences-rest/v1.0/sxp-blueprints/batch' -d $'{"configuration": ___, "createDate": ___, "description": ___, "description_i18n": ___, "elementInstances": ___, "externalReferenceCode": ___, "fallbackDescription": ___, "fallbackTitle": ___, "id": ___, "modifiedDate": ___, "schemaVersion": ___, "title": ___, "title_i18n": ___, "userName": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -300,7 +300,7 @@ public abstract class BaseSXPBlueprintResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/search-experiences-rest/v1.0/sxp-blueprints/by-external-reference-code/{externalReferenceCode}' -d $'{"configuration": ___, "createDate": ___, "description": ___, "description_i18n": ___, "elementInstances": ___, "externalReferenceCode": ___, "id": ___, "modifiedDate": ___, "schemaVersion": ___, "title": ___, "title_i18n": ___, "userName": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/search-experiences-rest/v1.0/sxp-blueprints/by-external-reference-code/{externalReferenceCode}' -d $'{"configuration": ___, "createDate": ___, "description": ___, "description_i18n": ___, "elementInstances": ___, "externalReferenceCode": ___, "fallbackDescription": ___, "fallbackTitle": ___, "id": ___, "modifiedDate": ___, "schemaVersion": ___, "title": ___, "title_i18n": ___, "userName": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -463,7 +463,7 @@ public abstract class BaseSXPBlueprintResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/search-experiences-rest/v1.0/sxp-blueprints/{sxpBlueprintId}' -d $'{"configuration": ___, "createDate": ___, "description": ___, "description_i18n": ___, "elementInstances": ___, "externalReferenceCode": ___, "id": ___, "modifiedDate": ___, "schemaVersion": ___, "title": ___, "title_i18n": ___, "userName": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/search-experiences-rest/v1.0/sxp-blueprints/{sxpBlueprintId}' -d $'{"configuration": ___, "createDate": ___, "description": ___, "description_i18n": ___, "elementInstances": ___, "externalReferenceCode": ___, "fallbackDescription": ___, "fallbackTitle": ___, "id": ___, "modifiedDate": ___, "schemaVersion": ___, "title": ___, "title_i18n": ___, "userName": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -509,6 +509,16 @@ public abstract class BaseSXPBlueprintResourceImpl
 				sxpBlueprint.getExternalReferenceCode());
 		}
 
+		if (sxpBlueprint.getFallbackDescription() != null) {
+			existingSXPBlueprint.setFallbackDescription(
+				sxpBlueprint.getFallbackDescription());
+		}
+
+		if (sxpBlueprint.getFallbackTitle() != null) {
+			existingSXPBlueprint.setFallbackTitle(
+				sxpBlueprint.getFallbackTitle());
+		}
+
 		if (sxpBlueprint.getModifiedDate() != null) {
 			existingSXPBlueprint.setModifiedDate(
 				sxpBlueprint.getModifiedDate());
@@ -543,7 +553,7 @@ public abstract class BaseSXPBlueprintResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/search-experiences-rest/v1.0/sxp-blueprints/{sxpBlueprintId}' -d $'{"configuration": ___, "createDate": ___, "description": ___, "description_i18n": ___, "elementInstances": ___, "externalReferenceCode": ___, "id": ___, "modifiedDate": ___, "schemaVersion": ___, "title": ___, "title_i18n": ___, "userName": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/search-experiences-rest/v1.0/sxp-blueprints/{sxpBlueprintId}' -d $'{"configuration": ___, "createDate": ___, "description": ___, "description_i18n": ___, "elementInstances": ___, "externalReferenceCode": ___, "fallbackDescription": ___, "fallbackTitle": ___, "id": ___, "modifiedDate": ___, "schemaVersion": ___, "title": ___, "title_i18n": ___, "userName": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -575,7 +585,7 @@ public abstract class BaseSXPBlueprintResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/search-experiences-rest/v1.0/sxp-blueprints/{sxpBlueprintId}/batch' -d $'{"configuration": ___, "createDate": ___, "description": ___, "description_i18n": ___, "elementInstances": ___, "externalReferenceCode": ___, "id": ___, "modifiedDate": ___, "schemaVersion": ___, "title": ___, "title_i18n": ___, "userName": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/search-experiences-rest/v1.0/sxp-blueprints/{sxpBlueprintId}/batch' -d $'{"configuration": ___, "createDate": ___, "description": ___, "description_i18n": ___, "elementInstances": ___, "externalReferenceCode": ___, "fallbackDescription": ___, "fallbackTitle": ___, "id": ___, "modifiedDate": ___, "schemaVersion": ___, "title": ___, "title_i18n": ___, "userName": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchResponseResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchResponseResourceImpl.java
@@ -52,7 +52,7 @@ public abstract class BaseSearchResponseResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/search-experiences-rest/v1.0/search' -d $'{"configuration": ___, "createDate": ___, "description": ___, "description_i18n": ___, "elementInstances": ___, "externalReferenceCode": ___, "id": ___, "modifiedDate": ___, "schemaVersion": ___, "title": ___, "title_i18n": ___, "userName": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/search-experiences-rest/v1.0/search' -d $'{"configuration": ___, "createDate": ___, "description": ___, "description_i18n": ___, "elementInstances": ___, "externalReferenceCode": ___, "fallbackDescription": ___, "fallbackTitle": ___, "id": ___, "modifiedDate": ___, "schemaVersion": ___, "title": ___, "title_i18n": ___, "userName": ___, "version": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.search.experiences.rest.client', and version '3.0.23'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.search.experiences.rest.client', and version '3.0.24'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.search.experiences.rest.client', and version '3.0.24'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.search.experiences.rest.client', and version '3.0.25'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SXPBlueprintResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SXPBlueprintResourceImpl.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -27,6 +28,7 @@ import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.search.experiences.constants.SXPActionKeys;
 import com.liferay.search.experiences.constants.SXPConstants;
 import com.liferay.search.experiences.exception.DuplicateSXPBlueprintExternalReferenceCodeException;
+import com.liferay.search.experiences.exception.SXPBlueprintTitleException;
 import com.liferay.search.experiences.rest.dto.v1_0.SXPBlueprint;
 import com.liferay.search.experiences.rest.dto.v1_0.util.ElementInstanceUtil;
 import com.liferay.search.experiences.rest.dto.v1_0.util.SXPBlueprintUtil;
@@ -39,6 +41,7 @@ import com.liferay.search.experiences.service.SXPBlueprintService;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.ws.rs.core.MultivaluedMap;
@@ -221,6 +224,8 @@ public class SXPBlueprintResourceImpl extends BaseSXPBlueprintResourceImpl {
 
 		SXPBlueprintUtil.unpack(sxpBlueprint);
 
+		_validateTitleI18n(sxpBlueprint.getTitle_i18n());
+
 		return _sxpBlueprintDTOConverter.toDTO(
 			new DefaultDTOConverterContext(
 				contextAcceptLanguage.isAcceptAllLanguages(), new HashMap<>(),
@@ -343,6 +348,8 @@ public class SXPBlueprintResourceImpl extends BaseSXPBlueprintResourceImpl {
 			Long sxpBlueprintId, SXPBlueprint sxpBlueprint)
 		throws Exception {
 
+		_validateTitleI18n(sxpBlueprint.getTitle_i18n());
+
 		return _sxpBlueprintDTOConverter.toDTO(
 			new DefaultDTOConverterContext(
 				contextAcceptLanguage.isAcceptAllLanguages(), new HashMap<>(),
@@ -385,6 +392,22 @@ public class SXPBlueprintResourceImpl extends BaseSXPBlueprintResourceImpl {
 				sxpBlueprint.getId())) {
 
 			throw new DuplicateSXPBlueprintExternalReferenceCodeException();
+		}
+	}
+
+	private void _validateTitleI18n(Map<String, String> titleI18n)
+		throws Exception {
+
+		if (!titleI18n.containsKey(
+				LocaleUtil.getDefault(
+				).toString()) &&
+			!titleI18n.containsKey(
+				LocaleUtil.toBCP47LanguageId(LocaleUtil.getDefault()))) {
+
+			throw new SXPBlueprintTitleException(
+				"The title for the default locale " +
+					LocaleUtil.toLanguageId(LocaleUtil.getDefault()) +
+						" cannot be blank");
 		}
 	}
 

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SXPBlueprintResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SXPBlueprintResourceImpl.java
@@ -235,7 +235,9 @@ public class SXPBlueprintResourceImpl extends BaseSXPBlueprintResourceImpl {
 					contextAcceptLanguage.getPreferredLocale(),
 					sxpBlueprint.getDescription(),
 					sxpBlueprint.getDescription_i18n()),
-				_getElementInstancesJSON(sxpBlueprint), _getSchemaVersion(),
+				_getElementInstancesJSON(sxpBlueprint),
+				sxpBlueprint.getFallbackDescription(),
+				sxpBlueprint.getFallbackTitle(), _getSchemaVersion(),
 				LocalizedMapUtil.getLocalizedMap(
 					contextAcceptLanguage.getPreferredLocale(),
 					sxpBlueprint.getTitle(), sxpBlueprint.getTitle_i18n()),
@@ -260,6 +262,8 @@ public class SXPBlueprintResourceImpl extends BaseSXPBlueprintResourceImpl {
 				null, sxpBlueprint.getConfigurationJSON(),
 				sxpBlueprint.getDescriptionMap(),
 				sxpBlueprint.getElementInstancesJSON(),
+				sxpBlueprint.getFallbackDescription(),
+				sxpBlueprint.getFallbackTitle(),
 				sxpBlueprint.getSchemaVersion(),
 				TitleMapUtil.copy(sxpBlueprint.getTitleMap()),
 				ServiceContextFactory.getInstance(contextHttpServletRequest)));

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SXPBlueprintResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SXPBlueprintResourceImpl.java
@@ -128,6 +128,10 @@ public class SXPBlueprintResourceImpl extends BaseSXPBlueprintResourceImpl {
 			).put(
 				"externalReferenceCode", sxpBlueprint.getExternalReferenceCode()
 			).put(
+				"fallbackDescription", sxpBlueprint.getFallbackDescription()
+			).put(
+				"fallbackTitle", sxpBlueprint.getFallbackTitle()
+			).put(
 				"schemaVersion", sxpBlueprint.getSchemaVersion()
 			).put(
 				"title_i18n",

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPBlueprintResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPBlueprintResourceTestCase.java
@@ -179,6 +179,8 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 
 		sxpBlueprint.setDescription(regex);
 		sxpBlueprint.setExternalReferenceCode(regex);
+		sxpBlueprint.setFallbackDescription(regex);
+		sxpBlueprint.setFallbackTitle(regex);
 		sxpBlueprint.setSchemaVersion(regex);
 		sxpBlueprint.setTitle(regex);
 		sxpBlueprint.setUserName(regex);
@@ -192,6 +194,8 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 
 		Assert.assertEquals(regex, sxpBlueprint.getDescription());
 		Assert.assertEquals(regex, sxpBlueprint.getExternalReferenceCode());
+		Assert.assertEquals(regex, sxpBlueprint.getFallbackDescription());
+		Assert.assertEquals(regex, sxpBlueprint.getFallbackTitle());
 		Assert.assertEquals(regex, sxpBlueprint.getSchemaVersion());
 		Assert.assertEquals(regex, sxpBlueprint.getTitle());
 		Assert.assertEquals(regex, sxpBlueprint.getUserName());
@@ -1041,6 +1045,24 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals(
+					"fallbackDescription", additionalAssertFieldName)) {
+
+				if (sxpBlueprint.getFallbackDescription() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("fallbackTitle", additionalAssertFieldName)) {
+				if (sxpBlueprint.getFallbackTitle() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("modifiedDate", additionalAssertFieldName)) {
 				if (sxpBlueprint.getModifiedDate() == null) {
 					valid = false;
@@ -1280,6 +1302,30 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 				if (!Objects.deepEquals(
 						sxpBlueprint1.getExternalReferenceCode(),
 						sxpBlueprint2.getExternalReferenceCode())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"fallbackDescription", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						sxpBlueprint1.getFallbackDescription(),
+						sxpBlueprint2.getFallbackDescription())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("fallbackTitle", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						sxpBlueprint1.getFallbackTitle(),
+						sxpBlueprint2.getFallbackTitle())) {
 
 					return false;
 				}
@@ -1609,6 +1655,98 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("fallbackDescription")) {
+			Object object = sxpBlueprint.getFallbackDescription();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("fallbackTitle")) {
+			Object object = sxpBlueprint.getFallbackTitle();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("id")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -1884,6 +2022,10 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 				description = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				externalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				fallbackDescription = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				fallbackTitle = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				id = RandomTestUtil.randomLong();
 				modifiedDate = RandomTestUtil.nextDate();

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/SXPBlueprintResourceTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/SXPBlueprintResourceTest.java
@@ -53,6 +53,10 @@ public class SXPBlueprintResourceTest extends BaseSXPBlueprintResourceTestCase {
 					"externalReferenceCode",
 					sxpBlueprint.getExternalReferenceCode()
 				).put(
+					"fallbackDescription", sxpBlueprint.getFallbackDescription()
+				).put(
+					"fallbackTitle", sxpBlueprint.getFallbackTitle()
+				).put(
 					"schemaVersion", postSXPBlueprint.getSchemaVersion()
 				).put(
 					"title_i18n", JSONUtil.put("en_US", sxpBlueprint.getTitle())
@@ -122,15 +126,23 @@ public class SXPBlueprintResourceTest extends BaseSXPBlueprintResourceTestCase {
 	public void testPostSXPBlueprint() throws Exception {
 		super.testPostSXPBlueprint();
 
-		SXPBlueprint sxpBlueprint = SXPBlueprint.toDTO(
-			JSONUtil.put(
-				"description", RandomTestUtil.randomString()
-			).put(
-				"title", RandomTestUtil.randomString()
-			).toString());
+		String description = RandomTestUtil.randomString();
+		String title = RandomTestUtil.randomString();
 
 		SXPBlueprint postSXPBlueprint = testPostSXPBlueprint_addSXPBlueprint(
-			sxpBlueprint);
+			SXPBlueprint.toDTO(
+				JSONUtil.put(
+					"description_i18n", JSONUtil.put("en_US", description)
+				).put(
+					"title_i18n", JSONUtil.put("en_US", title)
+				).toString()));
+
+		SXPBlueprint sxpBlueprint = SXPBlueprint.toDTO(
+			JSONUtil.put(
+				"description", description
+			).put(
+				"title", title
+			).toString());
 
 		sxpBlueprint.setCreateDate(postSXPBlueprint.getCreateDate());
 		sxpBlueprint.setExternalReferenceCode(
@@ -236,14 +248,6 @@ public class SXPBlueprintResourceTest extends BaseSXPBlueprintResourceTestCase {
 	@Override
 	protected SXPBlueprint
 			testPutSXPBlueprintByExternalReferenceCode_addSXPBlueprint()
-		throws Exception {
-
-		return _addSXPBlueprint(randomSXPBlueprint());
-	}
-
-	@Override
-	protected SXPBlueprint
-			testPutSXPBlueprintByExternalReferenceCode_createSXPBlueprint()
 		throws Exception {
 
 		return _addSXPBlueprint(randomSXPBlueprint());

--- a/modules/dxp/apps/search-experiences/search-experiences-service/bnd.bnd
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/bnd.bnd
@@ -2,6 +2,6 @@ Bundle-Name: Liferay Search Experiences Service
 Bundle-SymbolicName: com.liferay.search.experiences.service
 Bundle-Version: 3.0.56
 Liferay-Enterprise-App: dxp.only=true;product.id=22b7e30f-34d4-4a63-9696-56987ad66e4e
-Liferay-Require-SchemaVersion: 3.1.0
+Liferay-Require-SchemaVersion: 3.2.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/dxp/apps/search-experiences/search-experiences-service/service.xml
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/service.xml
@@ -22,6 +22,8 @@
 		<column name="configurationJSON" type="String" />
 		<column localized="true" name="description" type="String" />
 		<column name="elementInstancesJSON" type="String" />
+		<column name="fallbackDescription" type="String" />
+		<column name="fallbackTitle" type="String" />
 		<column name="schemaVersion" type="String" />
 		<column localized="true" name="title" type="String" />
 		<column name="version" type="String" />

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/registry/SXPServiceUpgradeStepRegistrator.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/registry/SXPServiceUpgradeStepRegistrator.java
@@ -92,6 +92,11 @@ public class SXPServiceUpgradeStepRegistrator
 			"3.0.0", "3.1.0",
 			new com.liferay.search.experiences.internal.upgrade.v3_1_0.
 				SXPBlueprintUpgradeProcess());
+
+		registry.register(
+			"3.1.0", "3.2.0",
+			new com.liferay.search.experiences.internal.upgrade.v3_2_0.
+				SXPBlueprintUpgradeProcess());
 	}
 
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v3_2_0/SXPBlueprintUpgradeProcess.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v3_2_0/SXPBlueprintUpgradeProcess.java
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.search.experiences.internal.upgrade.v3_2_0;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
+import com.liferay.portal.kernel.upgrade.UpgradeStep;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Gustavo Lima
+ */
+public class SXPBlueprintUpgradeProcess extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		_upgradeSXPBlueprint();
+	}
+
+	@Override
+	protected UpgradeStep[] getPreUpgradeSteps() {
+		return new UpgradeStep[] {
+			UpgradeProcessFactory.addColumns(
+				"SXPBlueprint", "fallbackDescription STRING null",
+				"fallbackTitle VARCHAR(500) null")
+		};
+	}
+
+	private String _getDefaultValue(String fieldName, String xml) {
+		if (!Validator.isBlank(xml)) {
+			int start = xml.indexOf(">", xml.indexOf("<" + fieldName));
+
+			int end = xml.indexOf("<", start);
+
+			if ((end != -1) && (start != -1)) {
+				return xml.substring(start + 1, end);
+			}
+		}
+
+		return StringPool.BLANK;
+	}
+
+	private void _upgradeSXPBlueprint() throws Exception {
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				"select description, title, sxpBlueprintId from SXPBlueprint");
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update SXPBlueprint set fallbackDescription = ?, " +
+						"fallbackTitle = ? where sxpBlueprintId = ?")) {
+
+			try (ResultSet resultSet = preparedStatement1.executeQuery()) {
+				while (resultSet.next()) {
+					preparedStatement2.setString(
+						1,
+						_getDefaultValue(
+							"Description", resultSet.getString("description")));
+					preparedStatement2.setString(
+						2,
+						_getDefaultValue(
+							"Title", resultSet.getString("title")));
+					preparedStatement2.setLong(
+						3, resultSet.getLong("sxpBlueprintId"));
+
+					preparedStatement2.addBatch();
+				}
+
+				preparedStatement2.executeBatch();
+			}
+		}
+	}
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/model/impl/SXPBlueprintCacheModel.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/model/impl/SXPBlueprintCacheModel.java
@@ -68,7 +68,7 @@ public class SXPBlueprintCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(39);
+		StringBundler sb = new StringBundler(43);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -94,6 +94,10 @@ public class SXPBlueprintCacheModel
 		sb.append(description);
 		sb.append(", elementInstancesJSON=");
 		sb.append(elementInstancesJSON);
+		sb.append(", fallbackDescription=");
+		sb.append(fallbackDescription);
+		sb.append(", fallbackTitle=");
+		sb.append(fallbackTitle);
 		sb.append(", schemaVersion=");
 		sb.append(schemaVersion);
 		sb.append(", title=");
@@ -179,6 +183,20 @@ public class SXPBlueprintCacheModel
 			sxpBlueprintImpl.setElementInstancesJSON(elementInstancesJSON);
 		}
 
+		if (fallbackDescription == null) {
+			sxpBlueprintImpl.setFallbackDescription("");
+		}
+		else {
+			sxpBlueprintImpl.setFallbackDescription(fallbackDescription);
+		}
+
+		if (fallbackTitle == null) {
+			sxpBlueprintImpl.setFallbackTitle("");
+		}
+		else {
+			sxpBlueprintImpl.setFallbackTitle(fallbackTitle);
+		}
+
 		if (schemaVersion == null) {
 			sxpBlueprintImpl.setSchemaVersion("");
 		}
@@ -241,6 +259,8 @@ public class SXPBlueprintCacheModel
 		configurationJSON = (String)objectInput.readObject();
 		description = objectInput.readUTF();
 		elementInstancesJSON = (String)objectInput.readObject();
+		fallbackDescription = objectInput.readUTF();
+		fallbackTitle = objectInput.readUTF();
 		schemaVersion = objectInput.readUTF();
 		title = objectInput.readUTF();
 		version = objectInput.readUTF();
@@ -307,6 +327,20 @@ public class SXPBlueprintCacheModel
 			objectOutput.writeObject(elementInstancesJSON);
 		}
 
+		if (fallbackDescription == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(fallbackDescription);
+		}
+
+		if (fallbackTitle == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(fallbackTitle);
+		}
+
 		if (schemaVersion == null) {
 			objectOutput.writeUTF("");
 		}
@@ -354,6 +388,8 @@ public class SXPBlueprintCacheModel
 	public String configurationJSON;
 	public String description;
 	public String elementInstancesJSON;
+	public String fallbackDescription;
+	public String fallbackTitle;
 	public String schemaVersion;
 	public String title;
 	public String version;

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/model/impl/SXPBlueprintModelImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/model/impl/SXPBlueprintModelImpl.java
@@ -78,7 +78,9 @@ public class SXPBlueprintModelImpl
 		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
 		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
 		{"configurationJSON", Types.CLOB}, {"description", Types.VARCHAR},
-		{"elementInstancesJSON", Types.CLOB}, {"schemaVersion", Types.VARCHAR},
+		{"elementInstancesJSON", Types.CLOB},
+		{"fallbackDescription", Types.VARCHAR},
+		{"fallbackTitle", Types.VARCHAR}, {"schemaVersion", Types.VARCHAR},
 		{"title", Types.VARCHAR}, {"version", Types.VARCHAR},
 		{"status", Types.INTEGER}, {"statusByUserId", Types.BIGINT},
 		{"statusByUserName", Types.VARCHAR}, {"statusDate", Types.TIMESTAMP}
@@ -100,6 +102,8 @@ public class SXPBlueprintModelImpl
 		TABLE_COLUMNS_MAP.put("configurationJSON", Types.CLOB);
 		TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("elementInstancesJSON", Types.CLOB);
+		TABLE_COLUMNS_MAP.put("fallbackDescription", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("fallbackTitle", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("schemaVersion", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("title", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("version", Types.VARCHAR);
@@ -110,7 +114,7 @@ public class SXPBlueprintModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table SXPBlueprint (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,sxpBlueprintId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,configurationJSON TEXT null,description STRING null,elementInstancesJSON TEXT null,schemaVersion VARCHAR(75) null,title STRING null,version VARCHAR(75) null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
+		"create table SXPBlueprint (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,sxpBlueprintId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,configurationJSON TEXT null,description STRING null,elementInstancesJSON TEXT null,fallbackDescription STRING null,fallbackTitle VARCHAR(500) null,schemaVersion VARCHAR(75) null,title STRING null,version VARCHAR(75) null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
 
 	public static final String TABLE_SQL_DROP = "drop table SXPBlueprint";
 
@@ -283,6 +287,10 @@ public class SXPBlueprintModelImpl
 			attributeGetterFunctions.put(
 				"elementInstancesJSON", SXPBlueprint::getElementInstancesJSON);
 			attributeGetterFunctions.put(
+				"fallbackDescription", SXPBlueprint::getFallbackDescription);
+			attributeGetterFunctions.put(
+				"fallbackTitle", SXPBlueprint::getFallbackTitle);
+			attributeGetterFunctions.put(
 				"schemaVersion", SXPBlueprint::getSchemaVersion);
 			attributeGetterFunctions.put("title", SXPBlueprint::getTitle);
 			attributeGetterFunctions.put("version", SXPBlueprint::getVersion);
@@ -350,6 +358,14 @@ public class SXPBlueprintModelImpl
 				"elementInstancesJSON",
 				(BiConsumer<SXPBlueprint, String>)
 					SXPBlueprint::setElementInstancesJSON);
+			attributeSetterBiConsumers.put(
+				"fallbackDescription",
+				(BiConsumer<SXPBlueprint, String>)
+					SXPBlueprint::setFallbackDescription);
+			attributeSetterBiConsumers.put(
+				"fallbackTitle",
+				(BiConsumer<SXPBlueprint, String>)
+					SXPBlueprint::setFallbackTitle);
 			attributeSetterBiConsumers.put(
 				"schemaVersion",
 				(BiConsumer<SXPBlueprint, String>)
@@ -731,6 +747,46 @@ public class SXPBlueprintModelImpl
 		}
 
 		_elementInstancesJSON = elementInstancesJSON;
+	}
+
+	@JSON
+	@Override
+	public String getFallbackDescription() {
+		if (_fallbackDescription == null) {
+			return "";
+		}
+		else {
+			return _fallbackDescription;
+		}
+	}
+
+	@Override
+	public void setFallbackDescription(String fallbackDescription) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_fallbackDescription = fallbackDescription;
+	}
+
+	@JSON
+	@Override
+	public String getFallbackTitle() {
+		if (_fallbackTitle == null) {
+			return "";
+		}
+		else {
+			return _fallbackTitle;
+		}
+	}
+
+	@Override
+	public void setFallbackTitle(String fallbackTitle) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_fallbackTitle = fallbackTitle;
 	}
 
 	@JSON
@@ -1205,6 +1261,8 @@ public class SXPBlueprintModelImpl
 		sxpBlueprintImpl.setConfigurationJSON(getConfigurationJSON());
 		sxpBlueprintImpl.setDescription(getDescription());
 		sxpBlueprintImpl.setElementInstancesJSON(getElementInstancesJSON());
+		sxpBlueprintImpl.setFallbackDescription(getFallbackDescription());
+		sxpBlueprintImpl.setFallbackTitle(getFallbackTitle());
 		sxpBlueprintImpl.setSchemaVersion(getSchemaVersion());
 		sxpBlueprintImpl.setTitle(getTitle());
 		sxpBlueprintImpl.setVersion(getVersion());
@@ -1244,6 +1302,10 @@ public class SXPBlueprintModelImpl
 			this.<String>getColumnOriginalValue("description"));
 		sxpBlueprintImpl.setElementInstancesJSON(
 			this.<String>getColumnOriginalValue("elementInstancesJSON"));
+		sxpBlueprintImpl.setFallbackDescription(
+			this.<String>getColumnOriginalValue("fallbackDescription"));
+		sxpBlueprintImpl.setFallbackTitle(
+			this.<String>getColumnOriginalValue("fallbackTitle"));
 		sxpBlueprintImpl.setSchemaVersion(
 			this.<String>getColumnOriginalValue("schemaVersion"));
 		sxpBlueprintImpl.setTitle(this.<String>getColumnOriginalValue("title"));
@@ -1416,6 +1478,24 @@ public class SXPBlueprintModelImpl
 			sxpBlueprintCacheModel.elementInstancesJSON = null;
 		}
 
+		sxpBlueprintCacheModel.fallbackDescription = getFallbackDescription();
+
+		String fallbackDescription = sxpBlueprintCacheModel.fallbackDescription;
+
+		if ((fallbackDescription != null) &&
+			(fallbackDescription.length() == 0)) {
+
+			sxpBlueprintCacheModel.fallbackDescription = null;
+		}
+
+		sxpBlueprintCacheModel.fallbackTitle = getFallbackTitle();
+
+		String fallbackTitle = sxpBlueprintCacheModel.fallbackTitle;
+
+		if ((fallbackTitle != null) && (fallbackTitle.length() == 0)) {
+			sxpBlueprintCacheModel.fallbackTitle = null;
+		}
+
 		sxpBlueprintCacheModel.schemaVersion = getSchemaVersion();
 
 		String schemaVersion = sxpBlueprintCacheModel.schemaVersion;
@@ -1536,6 +1616,8 @@ public class SXPBlueprintModelImpl
 	private String _description;
 	private String _descriptionCurrentLanguageId;
 	private String _elementInstancesJSON;
+	private String _fallbackDescription;
+	private String _fallbackTitle;
 	private String _schemaVersion;
 	private String _title;
 	private String _titleCurrentLanguageId;
@@ -1589,6 +1671,8 @@ public class SXPBlueprintModelImpl
 		_columnOriginalValues.put("description", _description);
 		_columnOriginalValues.put(
 			"elementInstancesJSON", _elementInstancesJSON);
+		_columnOriginalValues.put("fallbackDescription", _fallbackDescription);
+		_columnOriginalValues.put("fallbackTitle", _fallbackTitle);
 		_columnOriginalValues.put("schemaVersion", _schemaVersion);
 		_columnOriginalValues.put("title", _title);
 		_columnOriginalValues.put("version", _version);
@@ -1643,19 +1727,23 @@ public class SXPBlueprintModelImpl
 
 		columnBitmasks.put("elementInstancesJSON", 2048L);
 
-		columnBitmasks.put("schemaVersion", 4096L);
+		columnBitmasks.put("fallbackDescription", 4096L);
 
-		columnBitmasks.put("title", 8192L);
+		columnBitmasks.put("fallbackTitle", 8192L);
 
-		columnBitmasks.put("version", 16384L);
+		columnBitmasks.put("schemaVersion", 16384L);
 
-		columnBitmasks.put("status", 32768L);
+		columnBitmasks.put("title", 32768L);
 
-		columnBitmasks.put("statusByUserId", 65536L);
+		columnBitmasks.put("version", 65536L);
 
-		columnBitmasks.put("statusByUserName", 131072L);
+		columnBitmasks.put("status", 131072L);
 
-		columnBitmasks.put("statusDate", 262144L);
+		columnBitmasks.put("statusByUserId", 262144L);
+
+		columnBitmasks.put("statusByUserName", 524288L);
+
+		columnBitmasks.put("statusDate", 1048576L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/http/SXPBlueprintServiceHttp.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/http/SXPBlueprintServiceHttp.java
@@ -46,7 +46,8 @@ public class SXPBlueprintServiceHttp {
 				HttpPrincipal httpPrincipal, String externalReferenceCode,
 				String configurationJSON,
 				java.util.Map<java.util.Locale, String> descriptionMap,
-				String elementInstancesJSON, String schemaVersion,
+				String elementInstancesJSON, String fallbackDescription,
+				String fallbackTitle, String schemaVersion,
 				java.util.Map<java.util.Locale, String> titleMap,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -58,8 +59,8 @@ public class SXPBlueprintServiceHttp {
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, configurationJSON,
-				descriptionMap, elementInstancesJSON, schemaVersion, titleMap,
-				serviceContext);
+				descriptionMap, elementInstancesJSON, fallbackDescription,
+				fallbackTitle, schemaVersion, titleMap, serviceContext);
 
 			Object returnObj = null;
 
@@ -349,7 +350,7 @@ public class SXPBlueprintServiceHttp {
 	private static final Class<?>[] _addSXPBlueprintParameterTypes0 =
 		new Class[] {
 			String.class, String.class, java.util.Map.class, String.class,
-			String.class, java.util.Map.class,
+			String.class, String.class, String.class, java.util.Map.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _deleteSXPBlueprintParameterTypes1 =

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPBlueprintLocalServiceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPBlueprintLocalServiceImpl.java
@@ -47,6 +47,7 @@ public class SXPBlueprintLocalServiceImpl
 	public SXPBlueprint addSXPBlueprint(
 			String externalReferenceCode, long userId, String configurationJSON,
 			Map<Locale, String> descriptionMap, String elementInstancesJSON,
+			String fallbackDescription, String fallbackTitle,
 			String schemaVersion, Map<Locale, String> titleMap,
 			ServiceContext serviceContext)
 		throws PortalException {

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPBlueprintLocalServiceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPBlueprintLocalServiceImpl.java
@@ -68,6 +68,8 @@ public class SXPBlueprintLocalServiceImpl
 		sxpBlueprint.setConfigurationJSON(configurationJSON);
 		sxpBlueprint.setDescriptionMap(descriptionMap);
 		sxpBlueprint.setElementInstancesJSON(elementInstancesJSON);
+		sxpBlueprint.setFallbackDescription(fallbackDescription);
+		sxpBlueprint.setFallbackTitle(fallbackTitle);
 		sxpBlueprint.setSchemaVersion(schemaVersion);
 		sxpBlueprint.setTitleMap(titleMap);
 		sxpBlueprint.setVersion(

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPBlueprintLocalServiceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPBlueprintLocalServiceImpl.java
@@ -17,6 +17,8 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.search.experiences.exception.SXPBlueprintTitleException;
 import com.liferay.search.experiences.model.SXPBlueprint;
@@ -51,6 +53,14 @@ public class SXPBlueprintLocalServiceImpl
 			String schemaVersion, Map<Locale, String> titleMap,
 			ServiceContext serviceContext)
 		throws PortalException {
+
+		if (Validator.isNull(fallbackDescription)) {
+			fallbackDescription = descriptionMap.get(LocaleUtil.getDefault());
+		}
+
+		if (Validator.isNull(fallbackTitle)) {
+			fallbackTitle = titleMap.get(LocaleUtil.getDefault());
+		}
 
 		_validate(titleMap, serviceContext);
 

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPBlueprintServiceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPBlueprintServiceImpl.java
@@ -51,8 +51,8 @@ public class SXPBlueprintServiceImpl extends SXPBlueprintServiceBaseImpl {
 
 		return sxpBlueprintLocalService.addSXPBlueprint(
 			externalReferenceCode, getUserId(), configurationJSON,
-			descriptionMap, elementInstancesJSON, schemaVersion, titleMap,
-			serviceContext);
+			descriptionMap, elementInstancesJSON, fallbackDescription,
+			fallbackTitle, schemaVersion, titleMap, serviceContext);
 	}
 
 	@Override

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPBlueprintServiceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPBlueprintServiceImpl.java
@@ -41,6 +41,7 @@ public class SXPBlueprintServiceImpl extends SXPBlueprintServiceBaseImpl {
 	public SXPBlueprint addSXPBlueprint(
 			String externalReferenceCode, String configurationJSON,
 			Map<Locale, String> descriptionMap, String elementInstancesJSON,
+			String fallbackDescription, String fallbackTitle,
 			String schemaVersion, Map<Locale, String> titleMap,
 			ServiceContext serviceContext)
 		throws PortalException {

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/resources/META-INF/module-hbm.xml
@@ -19,6 +19,8 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="configurationJSON" type="com.liferay.portal.dao.orm.hibernate.StringClobType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="description" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="elementInstancesJSON" type="com.liferay.portal.dao.orm.hibernate.StringClobType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="fallbackDescription" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="fallbackTitle" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="schemaVersion" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="title" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="version" type="com.liferay.portal.dao.orm.hibernate.StringType" />

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -17,14 +17,14 @@
 		<field localized="true" name="description" type="String">
 			<hint-collection name="TEXTAREA" />
 		</field>
+		<field name="elementInstancesJSON" type="String">
+			<hint-collection name="CLOB" />
+		</field>
 		<field name="fallbackDescription" type="String">
 			<hint-collection name="TEXTAREA" />
 		</field>
 		<field name="fallbackTitle" type="String">
 			<hint name="max-length">500</hint>
-		</field>
-		<field name="elementInstancesJSON" type="String">
-			<hint-collection name="CLOB" />
 		</field>
 		<field name="schemaVersion" type="String" />
 		<field localized="true" name="title" type="String">

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -17,6 +17,12 @@
 		<field localized="true" name="description" type="String">
 			<hint-collection name="TEXTAREA" />
 		</field>
+		<field name="fallbackDescription" type="String">
+			<hint-collection name="TEXTAREA" />
+		</field>
+		<field name="fallbackTitle" type="String">
+			<hint name="max-length">500</hint>
+		</field>
 		<field name="elementInstancesJSON" type="String">
 			<hint-collection name="CLOB" />
 		</field>

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/resources/META-INF/sql/tables.sql
@@ -11,6 +11,8 @@ create table SXPBlueprint (
 	configurationJSON TEXT null,
 	description STRING null,
 	elementInstancesJSON TEXT null,
+	fallbackDescription STRING null,
+	fallbackTitle VARCHAR(500) null,
 	schemaVersion VARCHAR(75) null,
 	title STRING null,
 	version VARCHAR(75) null,

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/parameter/test/SXPParameterDataCreatorTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/parameter/test/SXPParameterDataCreatorTest.java
@@ -87,6 +87,7 @@ public class SXPParameterDataCreatorTest {
 				"queryConfiguration", JSONUtil.put("applyIndexerClauses", true)
 			).toString(),
 			Collections.singletonMap(LocaleUtil.US, StringPool.BLANK),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK,
 			Collections.singletonMap(
 				LocaleUtil.US, RandomTestUtil.randomString()),

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/SXPBlueprintSearchRequestContributorFederatedTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/SXPBlueprintSearchRequestContributorFederatedTest.java
@@ -110,7 +110,8 @@ public class SXPBlueprintSearchRequestContributorFederatedTest {
 					testName.getMethodName(), ".json")),
 			Collections.singletonMap(
 				LocaleUtil.US, RandomTestUtil.randomString()),
-			"", "",
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), "",
+			"",
 			Collections.singletonMap(
 				LocaleUtil.US, RandomTestUtil.randomString()),
 			ServiceContextTestUtil.getServiceContext(

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/SXPBlueprintSearchRequestContributorTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/SXPBlueprintSearchRequestContributorTest.java
@@ -98,7 +98,8 @@ public class SXPBlueprintSearchRequestContributorTest {
 					testName.getMethodName(), ".json")),
 			Collections.singletonMap(
 				LocaleUtil.US, RandomTestUtil.randomString()),
-			"", "",
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), "",
+			"",
 			Collections.singletonMap(
 				LocaleUtil.US, RandomTestUtil.randomString()),
 			_serviceContext);

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
@@ -157,7 +157,9 @@ public class SXPBlueprintSearchResultTest {
 			_group, _journalArticles, _serviceContext, _user);
 		_sxpBlueprint = _sxpBlueprintLocalService.addSXPBlueprint(
 			null, _user.getUserId(), _configurationJSONObject.toString(),
-			Collections.singletonMap(LocaleUtil.US, ""), null, "",
+			Collections.singletonMap(LocaleUtil.US, ""),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			"",
 			Collections.singletonMap(
 				LocaleUtil.US, RandomTestUtil.randomString()),
 			_serviceContext);

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/persistence/test/SXPBlueprintPersistenceTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/persistence/test/SXPBlueprintPersistenceTest.java
@@ -139,6 +139,10 @@ public class SXPBlueprintPersistenceTest {
 
 		newSXPBlueprint.setElementInstancesJSON(RandomTestUtil.randomString());
 
+		newSXPBlueprint.setFallbackDescription(RandomTestUtil.randomString());
+
+		newSXPBlueprint.setFallbackTitle(RandomTestUtil.randomString());
+
 		newSXPBlueprint.setSchemaVersion(RandomTestUtil.randomString());
 
 		newSXPBlueprint.setTitle(RandomTestUtil.randomString());
@@ -191,6 +195,12 @@ public class SXPBlueprintPersistenceTest {
 		Assert.assertEquals(
 			existingSXPBlueprint.getElementInstancesJSON(),
 			newSXPBlueprint.getElementInstancesJSON());
+		Assert.assertEquals(
+			existingSXPBlueprint.getFallbackDescription(),
+			newSXPBlueprint.getFallbackDescription());
+		Assert.assertEquals(
+			existingSXPBlueprint.getFallbackTitle(),
+			newSXPBlueprint.getFallbackTitle());
 		Assert.assertEquals(
 			existingSXPBlueprint.getSchemaVersion(),
 			newSXPBlueprint.getSchemaVersion());
@@ -293,9 +303,10 @@ public class SXPBlueprintPersistenceTest {
 			"SXPBlueprint", "mvccVersion", true, "uuid", true,
 			"externalReferenceCode", true, "sxpBlueprintId", true, "companyId",
 			true, "userId", true, "userName", true, "createDate", true,
-			"modifiedDate", true, "description", true, "schemaVersion", true,
-			"title", true, "version", true, "status", true, "statusByUserId",
-			true, "statusByUserName", true, "statusDate", true);
+			"modifiedDate", true, "description", true, "fallbackDescription",
+			true, "fallbackTitle", true, "schemaVersion", true, "title", true,
+			"version", true, "status", true, "statusByUserId", true,
+			"statusByUserName", true, "statusDate", true);
 	}
 
 	@Test
@@ -600,6 +611,10 @@ public class SXPBlueprintPersistenceTest {
 		sxpBlueprint.setDescription(RandomTestUtil.randomString());
 
 		sxpBlueprint.setElementInstancesJSON(RandomTestUtil.randomString());
+
+		sxpBlueprint.setFallbackDescription(RandomTestUtil.randomString());
+
+		sxpBlueprint.setFallbackTitle(RandomTestUtil.randomString());
 
 		sxpBlueprint.setSchemaVersion(RandomTestUtil.randomString());
 

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/test/SXPBlueprintLocalServiceTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/test/SXPBlueprintLocalServiceTest.java
@@ -226,6 +226,7 @@ public class SXPBlueprintLocalServiceTest {
 
 		SXPBlueprint sxpBlueprint = _sxpBlueprintLocalService.addSXPBlueprint(
 			externalReferenceCode, userId, "{}", descriptionMap, null,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			StringPool.BLANK, titleMap, serviceContext);
 
 		_sxpBlueprints.add(sxpBlueprint);

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/test/SXPBlueprintLocalServiceTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/test/SXPBlueprintLocalServiceTest.java
@@ -69,6 +69,7 @@ public class SXPBlueprintLocalServiceTest {
 		SXPBlueprint differentCompanySXPBlueprint = _addSXPBlueprint(
 			sxpBlueprint.getExternalReferenceCode(), user.getUserId(),
 			Collections.singletonMap(LocaleUtil.US, StringPool.BLANK),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			Collections.singletonMap(
 				LocaleUtil.US, RandomTestUtil.randomString()),
 			ServiceContextTestUtil.getServiceContext());
@@ -98,6 +99,36 @@ public class SXPBlueprintLocalServiceTest {
 		Assert.assertNotNull(sxpBlueprint.getExternalReferenceCode());
 		Assert.assertEquals("1.0", sxpBlueprint.getVersion());
 
+		// Fallback description and fallback title
+
+		String fallbackDescription = RandomTestUtil.randomString();
+		String fallbackTitle = RandomTestUtil.randomString();
+
+		sxpBlueprint = _addSXPBlueprint(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			fallbackDescription, fallbackTitle,
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(
+			fallbackDescription, sxpBlueprint.getFallbackDescription());
+		Assert.assertEquals(fallbackTitle, sxpBlueprint.getFallbackTitle());
+
+		String title = RandomTestUtil.randomString();
+		String description = RandomTestUtil.randomString();
+
+		sxpBlueprint = _addSXPBlueprint(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			Collections.singletonMap(LocaleUtil.US, description), null, null,
+			Collections.singletonMap(LocaleUtil.US, title),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(description, sxpBlueprint.getFallbackDescription());
+		Assert.assertEquals(title, sxpBlueprint.getFallbackTitle());
+
 		// Title
 
 		ServiceContext serviceContext =
@@ -107,6 +138,7 @@ public class SXPBlueprintLocalServiceTest {
 			_addSXPBlueprint(
 				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 				Collections.singletonMap(LocaleUtil.US, StringPool.BLANK),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				Collections.emptyMap(), serviceContext);
 		}
 		catch (SXPBlueprintTitleException sxpBlueprintTitleException) {
@@ -125,6 +157,7 @@ public class SXPBlueprintLocalServiceTest {
 			_addSXPBlueprint(
 				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 				Collections.singletonMap(LocaleUtil.US, StringPool.BLANK),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				Collections.emptyMap(), serviceContext);
 		}
 		catch (SXPBlueprintTitleException sxpBlueprintTitleException) {
@@ -136,6 +169,7 @@ public class SXPBlueprintLocalServiceTest {
 		sxpBlueprint = _addSXPBlueprint(
 			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 			Collections.singletonMap(LocaleUtil.US, StringPool.BLANK),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			Collections.emptyMap(), serviceContext);
 
 		Assert.assertEquals(Collections.emptyMap(), sxpBlueprint.getTitleMap());
@@ -213,6 +247,7 @@ public class SXPBlueprintLocalServiceTest {
 		return _addSXPBlueprint(
 			externalReferenceCode, TestPropsValues.getUserId(),
 			Collections.singletonMap(LocaleUtil.US, StringPool.BLANK),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			Collections.singletonMap(
 				LocaleUtil.US, RandomTestUtil.randomString()),
 			ServiceContextTestUtil.getServiceContext());
@@ -220,14 +255,15 @@ public class SXPBlueprintLocalServiceTest {
 
 	private SXPBlueprint _addSXPBlueprint(
 			String externalReferenceCode, long userId,
-			Map<Locale, String> descriptionMap, Map<Locale, String> titleMap,
+			Map<Locale, String> descriptionMap, String fallbackDescription,
+			String fallbackTitle, Map<Locale, String> titleMap,
 			ServiceContext serviceContext)
 		throws Exception {
 
 		SXPBlueprint sxpBlueprint = _sxpBlueprintLocalService.addSXPBlueprint(
 			externalReferenceCode, userId, "{}", descriptionMap, null,
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			StringPool.BLANK, titleMap, serviceContext);
+			fallbackDescription, fallbackTitle, StringPool.BLANK, titleMap,
+			serviceContext);
 
 		_sxpBlueprints.add(sxpBlueprint);
 

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPBlueprintsDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPBlueprintsDisplayContext.java
@@ -96,9 +96,9 @@ public class ViewSXPBlueprintsDisplayContext {
 				LanguageUtil.get(_sxpRequestHelper.getRequest(), "edit"), "get",
 				"get", null),
 			new FDSActionDropdownItem(
-				getAPIURL() + "/{id}/copy", "copy", "copy",
-				LanguageUtil.get(_sxpRequestHelper.getRequest(), "copy"),
-				"post", "create", "async"),
+				"#", "copy", "copy",
+				LanguageUtil.get(_sxpRequestHelper.getRequest(), "copy"), null,
+				"create", null),
 			new FDSActionDropdownItem(
 				"#", "export", "export",
 				LanguageUtil.get(_sxpRequestHelper.getRequest(), "export"),

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPElementsDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPElementsDisplayContext.java
@@ -94,9 +94,9 @@ public class ViewSXPElementsDisplayContext {
 				LanguageUtil.get(_sxpRequestHelper.getRequest(), "view"), "get",
 				"get", null),
 			new FDSActionDropdownItem(
-				getAPIURL() + "/{id}/copy", "copy", "copy",
-				LanguageUtil.get(_sxpRequestHelper.getRequest(), "copy"),
-				"post", "create", "async"),
+				"#", "copy", "copy",
+				LanguageUtil.get(_sxpRequestHelper.getRequest(), "copy"), null,
+				"create", null),
 			new FDSActionDropdownItem(
 				"#", "export", "export",
 				LanguageUtil.get(_sxpRequestHelper.getRequest(), "export"),

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -25,7 +25,6 @@ import Sidebar from '../shared/Sidebar';
 import SubmitWarningModal from '../shared/SubmitWarningModal';
 import ThemeContext from '../shared/ThemeContext';
 import {DEFAULT_INDEX_CONFIGURATION} from '../utils/constants';
-import {DEFAULT_ERROR} from '../utils/errorMessages';
 import addParams from '../utils/fetch/add_params';
 import fetchData, {DEFAULT_HEADERS} from '../utils/fetch/fetch_data';
 import fetchPreviewSearch from '../utils/fetch/fetch_preview_search';
@@ -201,7 +200,7 @@ function EditSXPBlueprintForm({
 						method: 'POST',
 					}
 				).then((response) => response.json());
-			*/
+				*/
 
 				if (validateErrors.errors?.length) {
 					setErrors(validateErrors.errors);
@@ -211,7 +210,7 @@ function EditSXPBlueprintForm({
 				}
 			}
 
-			const responseContent = await fetch(
+			const {ok, responseContent} = await fetch(
 				`/o/search-experiences-rest/v1.0/sxp-blueprints/${sxpBlueprintId}`,
 				{
 					body: JSON.stringify({
@@ -232,21 +231,23 @@ function EditSXPBlueprintForm({
 					method: 'PUT',
 				}
 			).then((response) => {
-				if (!response.ok) {
-					setShowSubmitWarningModal(false);
-
-					throw DEFAULT_ERROR;
-				}
-
-				return response.json();
+				return response.json().then((data) => ({
+					ok: response.ok,
+					responseContent: data,
+				}));
 			});
 
-			if (
-				Object.prototype.hasOwnProperty.call(responseContent, 'errors')
-			) {
-				responseContent.errors.forEach((message) =>
-					openErrorToast({message})
-				);
+			if (!ok) {
+				if (Object.hasOwn(responseContent, 'title')) {
+					openErrorToast({
+						message: responseContent.title,
+					});
+				}
+				else if (Object.hasOwn(responseContent, 'errors')) {
+					responseContent.errors.forEach((message) =>
+						openErrorToast({message})
+					);
+				}
 			}
 			else {
 				setInitialSuccessToast(

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/fdsPropsTransformerActions.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/fdsPropsTransformerActions.js
@@ -8,6 +8,31 @@ import {fetch} from 'frontend-js-web';
 import {DEFAULT_ERROR} from '../utils/errorMessages';
 import {openErrorToast, openSuccessToast} from '../utils/toasts';
 
+export function copy(url, parameters, loadData) {
+	fetch(url, parameters)
+		.then((response) => {
+			return response.json().then((data) => ({
+				ok: response.ok,
+				responseContent: data,
+			}));
+		})
+		.then(({ok, responseContent}) => {
+			if (!ok) {
+				openErrorToast({
+					message: responseContent.title || DEFAULT_ERROR,
+				});
+			}
+			else {
+				loadData();
+
+				openSuccessToast();
+			}
+		})
+		.catch(() => {
+			openErrorToast();
+		});
+}
+
 export function download(url, parameters, title) {
 	fetch(url, parameters)
 		.then((response) => {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/view_sxp_blueprints/ImportSXPBlueprintModal.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/view_sxp_blueprints/ImportSXPBlueprintModal.js
@@ -104,6 +104,9 @@ const ImportSXPBlueprintModal = ({portletNamespace, redirectURL}) => {
 						else if (
 							responseContent.type.includes(
 								'SXPElementTitleException'
+							) ||
+							responseContent.type.includes(
+								'SXPBlueprintTitleException'
 							)
 						) {
 							_handleFormError(

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/view_sxp_blueprints/ViewSXPBlueprintsPropsTransformer.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/view_sxp_blueprints/ViewSXPBlueprintsPropsTransformer.js
@@ -3,14 +3,21 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {download} from '../shared/fdsPropsTransformerActions';
+import {copy, download} from '../shared/fdsPropsTransformerActions';
 import {DEFAULT_HEADERS} from '../utils/fetch/fetch_data';
 
 export default function propsTransformer({...otherProps}) {
 	return {
 		...otherProps,
-		onActionDropdownItemClick({action, itemData}) {
-			if (action.data.id === 'export') {
+		onActionDropdownItemClick({action, itemData, loadData}) {
+			if (action.data.id === 'copy') {
+				copy(
+					`/o/search-experiences-rest/v1.0/sxp-blueprints/${itemData.id}/copy`,
+					{headers: DEFAULT_HEADERS, method: 'POST'},
+					loadData
+				);
+			}
+			else if (action.data.id === 'export') {
 				download(
 					`/o/search-experiences-rest/v1.0/sxp-blueprints/${itemData.id}/export`,
 					{headers: DEFAULT_HEADERS, method: 'GET'},

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/view_sxp_elements/ViewSXPElementsPropsTransformer.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/view_sxp_elements/ViewSXPElementsPropsTransformer.js
@@ -3,14 +3,21 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {download} from '../shared/fdsPropsTransformerActions';
+import {copy, download} from '../shared/fdsPropsTransformerActions';
 import {DEFAULT_HEADERS} from '../utils/fetch/fetch_data';
 
 export default function propsTransformer({...otherProps}) {
 	return {
 		...otherProps,
-		onActionDropdownItemClick({action, itemData}) {
-			if (action.data.id === 'export') {
+		onActionDropdownItemClick({action, itemData, loadData}) {
+			if (action.data.id === 'copy') {
+				copy(
+					`/o/search-experiences-rest/v1.0/sxp-elements/${itemData.id}/copy`,
+					{headers: DEFAULT_HEADERS, method: 'POST'},
+					loadData
+				);
+			}
+			else if (action.data.id === 'export') {
 				download(
 					`/o/search-experiences-rest/v1.0/sxp-elements/${itemData.id}/export`,
 					{headers: DEFAULT_HEADERS, method: 'GET'},


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-202379 - Implement Fallback Title and Description in SXPBlueprint to Mitigate Translation Issues 
https://liferay.atlassian.net/browse/LPS-202393 - [FE] Display error message for copy and edit actions (subtask)

From https://github.com/liferay-search/liferay-portal/pull/1170

- Updating the propsTransformer to customize the error message when making a copy of a blueprint or element
- Updating the logic for error toasts in the blueprint editor (we have existing logic to check for an `error` array, so I didn't remove that)
<img width="1065" alt="Screenshot 2023-12-06 at 4 36 00 PM" src="https://github.com/liferay-search/liferay-portal/assets/14063502/2952fd95-41c8-400f-b753-5adbb02c3d2a">
<img width="1086" alt="Screenshot 2023-12-06 at 4 37 33 PM" src="https://github.com/liferay-search/liferay-portal/assets/14063502/a2e4a51e-1893-4654-a1d6-dd3bb3c56bef">

@gustavolimav feel free to try it out, lmk any updates to add! The message displays response's `title` but let me know if that should change.