### PR TITLE
LPS-197723 - [FE] Update sites MVCResourceCommand with certain info + parameters

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/NamespaceContext.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/NamespaceContext.js
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React from 'react';
+
+export default React.createContext({
+	namespace: '',
+});

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsAdd.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsAdd.es.js
@@ -10,8 +10,9 @@ import ClayIcon from '@clayui/icon';
 import getCN from 'classnames';
 import {LearnMessage, LearnResourcesContext} from 'frontend-js-components-web';
 import {navigate} from 'frontend-js-web';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useContext, useEffect, useRef, useState} from 'react';
 
+import NamespaceContext from '../NamespaceContext';
 import {SCOPE_TYPES} from '../utils/constants.es';
 import {sub} from '../utils/language.es';
 import ScopeSelect from './scope/ScopeSelect.es';
@@ -35,7 +36,7 @@ const SCOPE_INFO = {
 	},
 };
 
-function ResultRankingsAdd({cancelURL, fetchSitesURL, formName, namespace}) {
+function ResultRankingsAdd({cancelURL, fetchSitesURL, formName}) {
 	const [errors, setErrors] = useState({});
 	const [scopeType, setScopeType] = useState(SCOPE_TYPES.EVERYTHING);
 	const [scope, setScope] = useState('');
@@ -44,6 +45,8 @@ function ResultRankingsAdd({cancelURL, fetchSitesURL, formName, namespace}) {
 	const [touched, setTouched] = useState({});
 
 	const alignElementRef = useRef();
+
+	const {namespace} = useContext(NamespaceContext);
 
 	const _getErrors = (searchQuery, scopeType, scope) => {
 		const errors = {};
@@ -250,7 +253,6 @@ function ResultRankingsAdd({cancelURL, fetchSitesURL, formName, namespace}) {
 						}}
 						onBlur={_handleBlur('scope')}
 						onSelect={_handleScopeChange}
-						paramPrefix={namespace}
 						selected={scope}
 						title={Liferay.Language.get('select-site')}
 						touched={touched.scope}
@@ -325,12 +327,13 @@ export default function ({
 }) {
 	return (
 		<LearnResourcesContext.Provider value={learnResources}>
-			<ResultRankingsAdd
-				cancelURL={cancelURL}
-				fetchSitesURL={fetchSitesURL}
-				formName={formName}
-				namespace={namespace}
-			/>
+			<NamespaceContext.Provider value={{namespace}}>
+				<ResultRankingsAdd
+					cancelURL={cancelURL}
+					fetchSitesURL={fetchSitesURL}
+					formName={formName}
+				/>
+			</NamespaceContext.Provider>
 		</LearnResourcesContext.Provider>
 	);
 }

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsAdd.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsAdd.es.js
@@ -250,6 +250,7 @@ function ResultRankingsAdd({cancelURL, fetchSitesURL, formName, namespace}) {
 						}}
 						onBlur={_handleBlur('scope')}
 						onSelect={_handleScopeChange}
+						paramPrefix={namespace}
 						selected={scope}
 						title={Liferay.Language.get('select-site')}
 						touched={touched.scope}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelect.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelect.es.js
@@ -9,8 +9,9 @@ import ClayForm from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import getCN from 'classnames';
-import React, {useRef, useState} from 'react';
+import React, {useContext, useRef, useState} from 'react';
 
+import NamespaceContext from '../../NamespaceContext';
 import {fetchResponse} from '../../utils/api.es';
 import {SCOPE_TYPES} from '../../utils/constants.es';
 import {sub} from '../../utils/language.es';
@@ -36,13 +37,14 @@ const ScopeSelect = ({
 		id: 'externalReferenceCode',
 		label: 'descriptiveName',
 	},
-	paramPrefix = '',
 	onSelect,
 	onBlur,
 	title,
 	touched = false,
 	type = SCOPE_TYPES.SITE,
 }) => {
+	const {namespace} = useContext(NamespaceContext);
+
 	const [activeDropdown, setActiveDropdown] = useState(false);
 	const [displayName, setDisplayName] = useState('');
 	const [loading, setLoading] = useState(false);
@@ -53,6 +55,8 @@ const ScopeSelect = ({
 
 	const _fetchDropdownItems = () => {
 		setLoading(true);
+
+		const paramPrefix = type === SCOPE_TYPES.SITE ? namespace : '';
 
 		fetchResponse(fetchItemsUrl, {
 			[`${paramPrefix}page`]: 1,
@@ -179,7 +183,6 @@ const ScopeSelect = ({
 								fetchItemsUrl={fetchItemsUrl}
 								locator={locator}
 								onSubmit={_handleSelect}
-								paramPrefix={paramPrefix}
 								selected={selected}
 								title={title}
 								type={type}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelect.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelect.es.js
@@ -36,6 +36,7 @@ const ScopeSelect = ({
 		id: 'externalReferenceCode',
 		label: 'descriptiveName',
 	},
+	paramPrefix = '',
 	onSelect,
 	onBlur,
 	title,
@@ -54,8 +55,8 @@ const ScopeSelect = ({
 		setLoading(true);
 
 		fetchResponse(fetchItemsUrl, {
-			page: 1,
-			pageSize: 5,
+			[`${paramPrefix}page`]: 1,
+			[`${paramPrefix}pageSize`]: 5,
 		})
 			.then(({items}) => {
 				setResourceItems(items || []);
@@ -151,21 +152,16 @@ const ScopeSelect = ({
 										{item[locator.label]}
 									</div>
 
-									<div className="list-group-text">
-										{type === SCOPE_TYPES.SITE
-											? sub(
-													Liferay.Language.get(
-														'x-child-sites'
-													),
-													[item.sites?.length]
-											  )
-											: sub(
-													Liferay.Language.get(
-														'external-reference-code-x'
-													),
-													[item.externalReferenceCode]
-											  )}
-									</div>
+									{type === SCOPE_TYPES.SXP_BLUEPRINT && (
+										<div className="list-group-text">
+											{sub(
+												Liferay.Language.get(
+													'external-reference-code-x'
+												),
+												[item.externalReferenceCode]
+											)}
+										</div>
+									)}
 								</ClayDropDown.Item>
 							)}
 						</ClayDropDown.Group>
@@ -183,6 +179,7 @@ const ScopeSelect = ({
 								fetchItemsUrl={fetchItemsUrl}
 								locator={locator}
 								onSubmit={_handleSelect}
+								paramPrefix={paramPrefix}
 								selected={selected}
 								title={title}
 								type={type}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelectModal.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelectModal.es.js
@@ -9,8 +9,9 @@ import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal, {useModal} from '@clayui/modal';
 import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
 import ClayTable from '@clayui/table';
-import React, {useEffect, useState} from 'react';
+import React, {useContext, useEffect, useState} from 'react';
 
+import NamespaceContext from '../../NamespaceContext';
 import {fetchResponse} from '../../utils/api.es';
 import {DELTAS, SCOPE_TYPES} from '../../utils/constants.es';
 
@@ -25,11 +26,12 @@ const ScopeSelectModal = ({
 	locator,
 	observer,
 	onSubmit,
-	paramPrefix = '',
 	selected = '',
 	title,
 	type = SCOPE_TYPES.SITE,
 }) => {
+	const {namespace} = useContext(NamespaceContext);
+
 	const [activePage, setActivePage] = useState(1);
 	const [delta, setDelta] = useState(10);
 	const [resource, setResource] = useState({});
@@ -38,6 +40,8 @@ const ScopeSelectModal = ({
 
 	useEffect(() => {
 		setLoading(true);
+
+		const paramPrefix = type === SCOPE_TYPES.SITE ? namespace : '';
 
 		fetchResponse(fetchItemsUrl, {
 			[`${paramPrefix}page`]: activePage,
@@ -52,7 +56,7 @@ const ScopeSelectModal = ({
 			.finally(() => {
 				setLoading(false);
 			});
-	}, [activePage, delta, fetchItemsUrl, paramPrefix]);
+	}, [activePage, delta, fetchItemsUrl, namespace, type]);
 
 	/**
 	 * Handles what is displayed depending on loading/error/results/no results.

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelectModal.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/scope/ScopeSelectModal.es.js
@@ -13,7 +13,6 @@ import React, {useEffect, useState} from 'react';
 
 import {fetchResponse} from '../../utils/api.es';
 import {DELTAS, SCOPE_TYPES} from '../../utils/constants.es';
-import {sub} from '../../utils/language.es';
 
 /**
  * Modal that opens when user clicks on "View More" in ScopeSelect dropdown.
@@ -26,6 +25,7 @@ const ScopeSelectModal = ({
 	locator,
 	observer,
 	onSubmit,
+	paramPrefix = '',
 	selected = '',
 	title,
 	type = SCOPE_TYPES.SITE,
@@ -39,7 +39,10 @@ const ScopeSelectModal = ({
 	useEffect(() => {
 		setLoading(true);
 
-		fetchResponse(fetchItemsUrl, {page: activePage, pageSize: delta})
+		fetchResponse(fetchItemsUrl, {
+			[`${paramPrefix}page`]: activePage,
+			[`${paramPrefix}pageSize`]: delta,
+		})
 			.then((response) => {
 				setResource(response);
 			})
@@ -49,7 +52,7 @@ const ScopeSelectModal = ({
 			.finally(() => {
 				setLoading(false);
 			});
-	}, [activePage, delta, fetchItemsUrl]);
+	}, [activePage, delta, fetchItemsUrl, paramPrefix]);
 
 	/**
 	 * Handles what is displayed depending on loading/error/results/no results.
@@ -94,11 +97,10 @@ const ScopeSelectModal = ({
 								</ClayTable.Cell>
 
 								<ClayTable.Cell expanded headingCell>
-									{type === SCOPE_TYPES.SITE
-										? Liferay.Language.get('child-sites')
-										: Liferay.Language.get(
-												'external-reference-code'
-										  )}
+									{type === SCOPE_TYPES.SXP_BLUEPRINT &&
+										Liferay.Language.get(
+											'external-reference-code'
+										)}
 								</ClayTable.Cell>
 							</ClayTable.Row>
 						</ClayTable.Head>
@@ -111,14 +113,8 @@ const ScopeSelectModal = ({
 									</ClayTable.Cell>
 
 									<ClayTable.Cell>
-										{type === SCOPE_TYPES.SITE
-											? sub(
-													Liferay.Language.get(
-														'x-child-sites'
-													),
-													[item.sites?.length]
-											  )
-											: item.externalReferenceCode}
+										{type === SCOPE_TYPES.SXP_BLUEPRINT &&
+											item.externalReferenceCode}
 									</ClayTable.Cell>
 
 									<ClayTable.Cell align="right">
@@ -194,6 +190,7 @@ export default function ({
 	fetchItemsUrl,
 	locator,
 	onSubmit,
+	paramPrefix,
 	selected,
 	title,
 	type,
@@ -214,6 +211,7 @@ export default function ({
 					locator={locator}
 					observer={observer}
 					onSubmit={_handleSubmit}
+					paramPrefix={paramPrefix}
 					selected={selected}
 					title={title}
 					type={type}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-197723 - [FE] Update sites MVCResourceCommand with certain info + parameters

From https://github.com/liferay-search/liferay-portal/pull/1171 (Just the FE commits to merge, already reviewed)

Updates:
- the child/parent site column info was removed
- in order for the fetch for the sites URL to work, the `pageSize` and `page` parameters were namespaced

Screenshots:
<img width="1006" alt="Screenshot 2023-12-04 at 3 15 59 PM" src="https://github.com/liferay-search/liferay-portal/assets/14063502/1917820f-69ce-4b9e-b21d-b0c77ae8dc11">

<img width="1079" alt="Screenshot 2023-12-04 at 3 15 37 PM" src="https://github.com/liferay-search/liferay-portal/assets/14063502/706803f4-a759-4dd9-8523-4d5d9108b64f">
