### PR TITLE
LPS-204759 Result Rankings should automatically have typed entries in Aliases persist

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/alias/Alias.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/alias/Alias.es.js
@@ -69,6 +69,11 @@ class Alias extends Component {
 		inputValue: '',
 	};
 
+	/*
+	 * Any time the input is blurred, adds the current input value to the
+	 * list of aliases. This ensures that the user does not lose the value
+	 * if they save the Result Ranking without hitting enter or comma.
+	 */
 	_handleBlur = () => {
 		if (this.state.inputValue.trim()) {
 			this.props.onChange(

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/alias/Alias.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/alias/Alias.es.js
@@ -69,6 +69,21 @@ class Alias extends Component {
 		inputValue: '',
 	};
 
+	_handleBlur = () => {
+		if (this.state.inputValue.trim()) {
+			this.props.onChange(
+				filterDuplicates(
+					transformListOfStringsToObjects([
+						...this.props.keywords,
+						this.state.inputValue,
+					])
+				)
+			);
+		}
+
+		this.setState({inputValue: ''});
+	};
+
 	_handleInputChange = (value) => {
 		this.setState({inputValue: value});
 	};
@@ -103,6 +118,7 @@ class Alias extends Component {
 						<ClayMultiSelect
 							id="aliases-input"
 							items={transformListOfStringsToObjects(keywords)}
+							onBlur={this._handleBlur}
 							onChange={this._handleInputChange}
 							onItemsChange={this._handleItemsChange}
 							value={inputValue}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/js/components/SynonymSetsForm.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/js/components/SynonymSetsForm.es.js
@@ -77,6 +77,11 @@ class SynonymSetsForm extends Component {
 		}
 	}
 
+	/*
+	 * Any time the input is blurred, adds the current input value to the
+	 * list of synonyms. This ensures that the user does not lose the value
+	 * if they publish without hitting enter or comma.
+	 */
 	_handleBlur = () => {
 		if (this.state.inputValue.trim()) {
 			this.setState({

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/js/components/SynonymSetsForm.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/js/components/SynonymSetsForm.es.js
@@ -77,6 +77,22 @@ class SynonymSetsForm extends Component {
 		}
 	}
 
+	_handleBlur = () => {
+		if (this.state.inputValue.trim()) {
+			this.setState({
+				synonyms: filterDuplicates([
+					...this.state.synonyms,
+					{
+						label: this.state.inputValue,
+						value: this.state.inputValue,
+					},
+				]),
+			});
+		}
+
+		this.setState({inputValue: ''});
+	};
+
 	_handleCancel = () => {
 		window.history.back();
 	};
@@ -130,6 +146,7 @@ class SynonymSetsForm extends Component {
 							<ClayMultiSelect
 								id="synonym-sets-input"
 								items={synonyms}
+								onBlur={this._handleBlur}
 								onChange={this._handleInputChange}
 								onItemsChange={this._handleItemsChange}
 								value={inputValue}
@@ -148,7 +165,7 @@ class SynonymSetsForm extends Component {
 
 				<ClayLayout.SheetFooter>
 					<ClayButton
-						disabled={!synonyms.length}
+						disabled={!synonyms.length && !inputValue.trim()}
 						displayType="primary"
 						onClick={this._handleSubmit}
 						type="submit"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-204759 - Result Rankings should automatically have typed entries in Aliases persist

These changes basically update the multiselect inside Result Rankings and Synonyms to save the input value as one of the entries upon blur (that way, clicking on save will automatically make sure it's saved as an alias).