### PR TITLE
LPS-177736 + LPS-177738 + LPS177778 - Add context title to back button across Search portlets

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/util/SearchUtil.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/util/SearchUtil.java
@@ -15,18 +15,21 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.search.OpenSearch;
 import com.liferay.portal.kernel.search.OpenSearchRegistryUtil;
 import com.liferay.portal.kernel.search.OpenSearchUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupServiceUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Tuple;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
@@ -155,9 +158,16 @@ public class SearchUtil {
 				WindowState.MAXIMIZED
 			).buildPortletURL();
 
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)renderRequest.getAttribute(WebKeys.THEME_DISPLAY);
+
+			Layout previousLayout = themeDisplay.getLayout();
+
 			if (Validator.isNull(className) || (classPK <= 0)) {
-				return HttpComponentsUtil.setParameter(
-					viewContentURL.toString(), "p_l_back_url", currentURL);
+				return HttpComponentsUtil.addParameters(
+					viewContentURL.toString(), "p_l_back_url", currentURL,
+					"p_l_back_url_title",
+					previousLayout.getName(themeDisplay.getLocale()));
 			}
 
 			AssetEntry assetEntry = AssetEntryLocalServiceUtil.getEntry(
@@ -168,8 +178,10 @@ public class SearchUtil {
 					getAssetRendererFactoryByClassName(className);
 
 			if (assetRendererFactory == null) {
-				return HttpComponentsUtil.setParameter(
-					viewContentURL.toString(), "p_l_back_url", currentURL);
+				return HttpComponentsUtil.addParameters(
+					viewContentURL.toString(), "p_l_back_url", currentURL,
+					"p_l_back_url_title",
+					previousLayout.getName(themeDisplay.getLocale()));
 			}
 
 			viewContentURL.setParameter(
@@ -177,8 +189,10 @@ public class SearchUtil {
 			viewContentURL.setParameter("type", assetRendererFactory.getType());
 
 			if (!viewInContext) {
-				return HttpComponentsUtil.setParameter(
-					viewContentURL.toString(), "p_l_back_url", currentURL);
+				return HttpComponentsUtil.addParameters(
+					viewContentURL.toString(), "p_l_back_url", currentURL,
+					"p_l_back_url_title",
+					previousLayout.getName(themeDisplay.getLocale()));
 			}
 
 			AssetRenderer<?> assetRenderer =
@@ -193,8 +207,9 @@ public class SearchUtil {
 				viewURL = viewContentURL.toString();
 			}
 
-			return HttpComponentsUtil.setParameter(
-				viewURL, "p_l_back_url", currentURL);
+			return HttpComponentsUtil.addParameters(
+				viewURL, "p_l_back_url", currentURL, "p_l_back_url_title",
+				previousLayout.getName(themeDisplay.getLocale()));
 		}
 		catch (Exception exception) {
 			_log.error(

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/asset/AssetURLViewProviderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/asset/AssetURLViewProviderImpl.java
@@ -13,6 +13,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
@@ -90,8 +91,12 @@ public class AssetURLViewProviderImpl implements AssetURLViewProvider {
 				(ThemeDisplay)liferayPortletRequest.getAttribute(
 					WebKeys.THEME_DISPLAY);
 
-			return HttpComponentsUtil.setParameter(
-				viewURL, "p_l_back_url", themeDisplay.getURLCurrent());
+			Layout previousLayout = themeDisplay.getLayout();
+
+			return HttpComponentsUtil.addParameters(
+				viewURL, "p_l_back_url", themeDisplay.getURLCurrent(),
+				"p_l_back_url_title",
+				previousLayout.getName(themeDisplay.getLocale()));
 		}
 		catch (Exception exception) {
 			_log.error(

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/add_results_rankings.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/add_results_rankings.jsp
@@ -41,6 +41,7 @@ String resultActionUid = ParamUtil.getString(request, "resultActionUid");
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(redirect);
+portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 
 renderResponse.setTitle(LanguageUtil.get(request, "new-ranking"));
 %>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/edit_results_rankings.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/edit_results_rankings.jsp
@@ -31,6 +31,7 @@ EditRankingDisplayContext editRankingDisplayContext = (EditRankingDisplayContext
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(editRankingDisplayContext.getBackURL());
+portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 
 renderResponse.setTitle(LanguageUtil.get(request, "customize-results"));
 %>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/edit_synonym_sets.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/edit_synonym_sets.jsp
@@ -24,6 +24,7 @@ EditSynonymSetsDisplayContext editSynonymSetsDisplayContext = (EditSynonymSetsDi
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(editSynonymSetsDisplayContext.getBackURL());
+portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 %>
 
 <portlet:actionURL name="/synonyms/edit_synonym_sets" var="editSynonymSetURL">

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/edit_sxp_blueprint.jsp
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/edit_sxp_blueprint.jsp
@@ -20,6 +20,7 @@ if (Validator.isNull(redirect)) {
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(redirect);
+portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 
 renderResponse.setTitle(LanguageUtil.get(request, "edit-blueprint"));
 %>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/edit_sxp_element.jsp
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/edit_sxp_element.jsp
@@ -22,6 +22,7 @@ if (Validator.isNull(redirect)) {
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(redirect);
+portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 
 renderResponse.setTitle(LanguageUtil.get(request, "view-element"));
 %>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-177736 - [Portal Search Tuning] Add context title to back button
https://liferay.atlassian.net/browse/LPS-177738- [Search Experiences] Add context title to back button
https://liferay.atlassian.net/browse/LPS-177778 - [Portal Search] Add context title to back button

Pages now have a back button with a specified title:
- Search results: `Go to {Page Name}`
- Blueprints: `Go to Blueprints`
- Elements: `Go to Blueprints` (because name of portlet display)
- Rankings: `Go to Result Rankings`
- Synonyms: `Go to Synonyms`

Screenshots:
<img width="335" alt="Screenshot 2024-01-04 at 1 47 22 PM" src="https://github.com/liferay-search/liferay-portal/assets/14063502/87906384-d577-4f7c-845c-25ee1fd3554b">
<img width="363" alt="Screenshot 2024-01-04 at 1 46 26 PM" src="https://github.com/liferay-search/liferay-portal/assets/14063502/06985d4f-6e95-4e9e-acee-8f1163f01a0c">
<img width="282" alt="Screenshot 2024-01-04 at 2 17 07 PM" src="https://github.com/liferay-search/liferay-portal/assets/14063502/75fcee51-1873-4f36-a14c-ff9fdad347f3">
<img width="423" alt="Screenshot 2024-01-04 at 1 46 38 PM" src="https://github.com/liferay-search/liferay-portal/assets/14063502/aa782e84-7d47-4278-a65a-4a615154ba15">
<img width="364" alt="Screenshot 2024-01-04 at 1 46 48 PM" src="https://github.com/liferay-search/liferay-portal/assets/14063502/9dff0e4a-a801-4ccc-bd89-b41621d43a53">
<img width="323" alt="Screenshot 2024-01-04 at 1 47 00 PM" src="https://github.com/liferay-search/liferay-portal/assets/14063502/6ffb7574-c6b3-45c6-90ae-aebe797cea2f">
