### PR TITLE
LPS-205291 Activating another result ranking with same search query + scope is possible

### DIFF
--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/helper/DispatchTriggerHelper.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/helper/DispatchTriggerHelper.java
@@ -126,7 +126,8 @@ public class DispatchTriggerHelper {
 
 	private String _getGroupName(DispatchTrigger dispatchTrigger) {
 		return String.format(
-			"DISPATCH_GROUP_%07d@%d", dispatchTrigger.getDispatchTriggerId());
+			"DISPATCH_GROUP_%07d@%d", dispatchTrigger.getDispatchTriggerId(),
+			dispatchTrigger.getCompanyId());
 	}
 
 	private String _getJobName(DispatchTrigger dispatchTrigger) {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/EditRankingMVCActionCommand.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/EditRankingMVCActionCommand.java
@@ -351,27 +351,6 @@ public class EditRankingMVCActionCommand extends BaseMVCActionCommand {
 
 	private void _guardDuplicateQueryStrings(
 		EditRankingMVCActionRequest editRankingMVCActionRequest,
-		List<Ranking> rankings) {
-
-		List<String> queryStrings = new ArrayList<>();
-
-		for (Ranking ranking : rankings) {
-			queryStrings.addAll(ranking.getQueryStrings());
-		}
-
-		List<String> uniqueQueryStrings = ListUtil.unique(queryStrings);
-
-		if (queryStrings.size() != uniqueQueryStrings.size()) {
-			throw new DuplicateQueryStringException();
-		}
-
-		for (Ranking ranking : rankings) {
-			_guardDuplicateQueryStrings(editRankingMVCActionRequest, ranking);
-		}
-	}
-
-	private void _guardDuplicateQueryStrings(
-		EditRankingMVCActionRequest editRankingMVCActionRequest,
 		Ranking ranking) {
 
 		if (_resultRankingsConfiguration.allowDuplicateQueryStrings() ||
@@ -580,10 +559,6 @@ public class EditRankingMVCActionCommand extends BaseMVCActionCommand {
 		List<Ranking> rankings = _getRankings(
 			actionRequest, editRankingMVCActionRequest);
 
-		if (status.equals(ResultRankingsConstants.STATUS_ACTIVE)) {
-			_guardDuplicateQueryStrings(editRankingMVCActionRequest, rankings);
-		}
-
 		boolean notApplicableStatus = false;
 
 		for (Ranking ranking : rankings) {
@@ -594,6 +569,11 @@ public class EditRankingMVCActionCommand extends BaseMVCActionCommand {
 				notApplicableStatus = true;
 
 				continue;
+			}
+
+			if (status.equals(ResultRankingsConstants.STATUS_ACTIVE)) {
+				_guardDuplicateQueryStrings(
+					editRankingMVCActionRequest, ranking);
 			}
 
 			Ranking.RankingBuilder rankingBuilder = new Ranking.RankingBuilder(

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/EditRankingMVCActionCommand.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/EditRankingMVCActionCommand.java
@@ -375,7 +375,6 @@ public class EditRankingMVCActionCommand extends BaseMVCActionCommand {
 		Ranking ranking) {
 
 		if (_resultRankingsConfiguration.allowDuplicateQueryStrings() ||
-			_isInactive(editRankingMVCActionRequest) ||
 			editRankingMVCActionRequest.isCmd(
 				ResultRankingsConstants.ACTION_DEACTIVATE)) {
 
@@ -385,6 +384,10 @@ public class EditRankingMVCActionCommand extends BaseMVCActionCommand {
 		Collection<String> queryStrings = ranking.getQueryStrings();
 
 		if (editRankingMVCActionRequest.isCmd(Constants.UPDATE)) {
+			if (_isInactive(editRankingMVCActionRequest)) {
+				return;
+			}
+
 			queryStrings = RankingUtil.getQueryStrings(
 				ranking.getQueryString(),
 				_getAliases(editRankingMVCActionRequest));

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/test/java/com/liferay/portal/search/tuning/rankings/web/internal/display/context/RankingPortletDisplayBuilderTest.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/test/java/com/liferay/portal/search/tuning/rankings/web/internal/display/context/RankingPortletDisplayBuilderTest.java
@@ -96,7 +96,7 @@ public class RankingPortletDisplayBuilderTest extends BaseRankingsWebTestCase {
 		dropdownItems =
 			rankingPortletDisplayContext.getFilterItemsDropdownItems();
 
-		Assert.assertEquals(dropdownItems.toString(), 2, dropdownItems.size());
+		Assert.assertEquals(dropdownItems.toString(), 3, dropdownItems.size());
 	}
 
 	@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-205291 - Activating another result ranking with same search query + scope is possible

Changes:
- Add a check for when inactive result rankings are getting edited (it was returning earlier than expected)
- Throw duplicate exception during process when rankings get activated (original logic would throw duplicate exception at beginning without considering scope)
- Backend test fix in `RankingPortletDisplayBuilderTest`

Demo of behavior. Basically it activates each ranking one by one and stops if it hits the duplicate exception error. If there's no duplicate error, a not-applicable ranking warning would show at the end (if applies): 
https://github.com/liferay-search/liferay-portal/assets/14063502/41f021ed-c90b-4e0b-8f9c-4eabfc3770a1

