### PR TITLE
LPS-204983 WIP: Playwright tests for Result Rankings

### DIFF
--- a/modules/test/playwright/fixtures/portalSearchTuningWebPages.fixture.ts
+++ b/modules/test/playwright/fixtures/portalSearchTuningWebPages.fixture.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {ResultRankingsPage} from '../pages/portal-search-tuning-web/resultRankings.page';
+
+const portalSearchTuningWebPagesTest = test.extend<{
+	_resultRankingsPage: ResultRankingsPage;
+}>({
+	_resultRankingsPage: async ({page}, use) => {
+		await use(new ResultRankingsPage(page));
+	},
+});
+
+export {portalSearchTuningWebPagesTest};

--- a/modules/test/playwright/helpers/ApiHelpers.ts
+++ b/modules/test/playwright/helpers/ApiHelpers.ts
@@ -8,17 +8,20 @@ import {Page} from '@playwright/test';
 import {liferayConfig} from '../liferay.config';
 import {FeatureFlagApiHelper} from './FeatureFlagApiHelper';
 import {ObjectAdminApiHelper} from './ObjectAdminApiHelper';
+import {SearchExperiencesApiHelper} from './SearchExperiencesApiHelper';
 
 export class ApiHelpers {
 	readonly baseUrl: string;
 	readonly featureFlag: FeatureFlagApiHelper;
 	readonly objectAdmin: ObjectAdminApiHelper;
+	readonly searchExperiences: SearchExperiencesApiHelper;
 	readonly page: Page;
 
 	constructor(page: Page) {
 		this.baseUrl = liferayConfig.environment.baseUrl + '/o/';
 		this.featureFlag = new FeatureFlagApiHelper(page);
 		this.objectAdmin = new ObjectAdminApiHelper(this);
+		this.searchExperiences = new SearchExperiencesApiHelper(this, page);
 		this.page = page;
 	}
 

--- a/modules/test/playwright/helpers/SearchExperiencesApiHelper.ts
+++ b/modules/test/playwright/helpers/SearchExperiencesApiHelper.ts
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page} from '@playwright/test';
+
+import {getRandomInt} from '../utils/util';
+import {ApiHelpers} from './ApiHelpers';
+
+export class SearchExperiencesApiHelper {
+	readonly apiHelpers: ApiHelpers;
+	readonly basePath: string;
+	readonly page: Page;
+
+	constructor(apiHelpers: ApiHelpers, page: Page) {
+		this.apiHelpers = apiHelpers;
+		this.basePath = 'search-experiences-rest/v1.0';
+		this.page = page;
+	}
+
+	async deleteSXPBlueprint(sxpBlueprintId: number) {
+		return this.apiHelpers.delete(
+			`${this.apiHelpers.baseUrl}${this.basePath}/sxp-blueprints/${sxpBlueprintId}`
+		);
+	}
+
+	async postSXPBlueprint(title?: string) {
+		await this.page.goto('/');
+
+		const sxpBlueprintTitle = title || 'SXPBlueprint' + getRandomInt();
+
+		return this.apiHelpers.post(
+			`${this.apiHelpers.baseUrl}${this.basePath}/sxp-blueprints`,
+			{
+				configuration: {
+					advancedConfiguration: {},
+					aggregationConfiguration: {},
+					generalConfiguration: {
+						clauseContributorsExcludes: [],
+						clauseContributorsIncludes: [],
+						searchableAssetTypes: [],
+					},
+					highlightConfiguration: {},
+					parameterConfiguration: {},
+					queryConfiguration: {
+						applyIndexerClauses: true,
+					},
+					sortConfiguration: {},
+				},
+				description_i18n: {en_US: ''},
+				elementInstances: [],
+				title_i18n: {en_US: sxpBlueprintTitle},
+			}
+		);
+	}
+}

--- a/modules/test/playwright/pages/portal-search-tuning-web/resultRankings.page.ts
+++ b/modules/test/playwright/pages/portal-search-tuning-web/resultRankings.page.ts
@@ -1,0 +1,166 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page, expect} from '@playwright/test';
+
+import {ApplicationsMenuPage} from '../product-navigation-applications-menu/applicationsMenu.page';
+
+export class ResultRankingsPage {
+	readonly applicationsMenuPage: ApplicationsMenuPage;
+	readonly newResultRankingsButton: Locator;
+	readonly newResultRankingsSearchQuery: Locator;
+	readonly newResultRankingsCustomizeResults: Locator;
+	readonly editResultRankingsSaveButton: Locator;
+	readonly page: Page;
+
+	constructor(page: Page) {
+		this.applicationsMenuPage = new ApplicationsMenuPage(page);
+		this.newResultRankingsButton = page.getByRole('link', {
+			name: 'New Ranking',
+		});
+		this.newResultRankingsSearchQuery = page.getByLabel('Search Query');
+		this.newResultRankingsCustomizeResults = page.getByRole('button', {
+			name: 'Customize Results',
+		});
+		this.editResultRankingsSaveButton = page.getByRole('button', {
+			name: 'Save',
+		});
+
+		this.page = page;
+	}
+
+	getResultRankingRow(ranking: {
+		scope?: string;
+		searchQuery: string;
+		status?: string;
+	}) {
+		const {scope, searchQuery, status} = ranking;
+
+		let locatorString = `//tr[@data-qa-id="row"][contains(.,"${searchQuery}")]`;
+
+		if (scope) {
+			locatorString += `[contains(.,"${scope}")]`;
+		}
+
+		if (status) {
+			locatorString += `[contains(.,"${status}")]`;
+		}
+
+		return this.page.locator(locatorString);
+	}
+
+	async assertSuccessMessage() {
+		await expect(
+			this.page.getByText('Your request completed successfully.')
+		).toBeVisible();
+	}
+
+	async assertErrorMessage(message: string) {
+		await expect(this.page.getByText(message)).toBeVisible();
+	}
+
+	async createNewResultRanking(ranking: {
+		scope?: string;
+		scopeERF?: string;
+		searchQuery: string;
+		status?: string;
+	}) {
+		// New Result Ranking Form
+
+		await this.newResultRankingsButton.click();
+		await this.newResultRankingsSearchQuery.fill(ranking.searchQuery);
+
+		// Scope Selection
+
+		if (ranking.scopeERF) {
+			await this.page.getByLabel('Scope').click();
+			await this.page
+				.getByRole('menuitem', {
+					exact: false,
+					name: ranking.scope,
+				})
+				.click();
+			await this.page.getByLabel(`Select ${ranking.scope}`).click();
+			await this.page.getByRole('button', {name: 'View More'}).click();
+			await this.page
+				.getByRole('row', {
+					exact: false,
+					name: ranking.scopeERF,
+				})
+				.getByRole('button')
+				.click();
+		}
+
+		await this.newResultRankingsCustomizeResults.click();
+
+		// Edit Result Ranking Form
+
+		await expect(this.page.getByText(ranking.searchQuery)).toBeVisible();
+
+		// Toggle Inactive Status
+
+		if (ranking.status === 'Inactive') {
+			await this.page.getByLabel('Active').uncheck();
+		}
+
+		await this.editResultRankingsSaveButton.click();
+
+		// View Result Rankings Table
+
+		await expect(this.getResultRankingRow(ranking)).toBeVisible();
+	}
+
+	async chooseDropdownAction(
+		ranking: {scope?: string; searchQuery: string; status?: string},
+		action: string
+	) {
+		await this.getResultRankingRow(ranking).getByRole('button').click();
+
+		// Note: This is prone to error since dropdown menu not visible.
+
+		if (action === 'Delete') {
+			this.page.once('dialog', (dialog) => {
+				dialog.accept().catch(() => {});
+			});
+
+			await this.page.getByRole('link', {name: action}).click();
+		} else {
+			await this.page
+				.getByRole('menuitem', {exact: true, name: action})
+				.click();
+		}
+	}
+
+	async chooseManagementToolbarAction(
+		ranking: {scope?: string; searchQuery: string; status?: string},
+		action: string
+	) {
+		await this.getResultRankingRow(ranking).getByTitle('select').click();
+
+		if (action === 'Delete') {
+			this.page.once('dialog', (dialog) => {
+				dialog.accept().catch(() => {});
+			});
+		}
+
+		await this.page
+			.getByRole('button', {exact: true, name: action})
+			.click();
+	}
+
+	async deleteResultRankings() {
+		await this.page.getByLabel('Select All Items on the Page').click();
+
+		this.page.once('dialog', (dialog) => {
+			dialog.accept().catch(() => {});
+		});
+
+		await this.page.getByRole('button', {name: 'Delete'}).click();
+	}
+
+	async goTo() {
+		await this.applicationsMenuPage.goToResultRankings();
+	}
+}

--- a/modules/test/playwright/pages/product-navigation-applications-menu/applicationsMenu.page.ts
+++ b/modules/test/playwright/pages/product-navigation-applications-menu/applicationsMenu.page.ts
@@ -11,6 +11,7 @@ export class ApplicationsMenuPage {
 	readonly instanceSettingsLink: Locator;
 	readonly objectsLink: Locator;
 	readonly objectsMenuItem: Locator;
+	readonly resultRankingsMenuItem: Locator;
 	readonly page: Page;
 	readonly signInButton: Locator;
 	readonly usersAndOrganizationsItem: Locator;
@@ -28,6 +29,10 @@ export class ApplicationsMenuPage {
 		this.objectsMenuItem = page.getByRole('menuitem', {
 			exact: true,
 			name: 'Objects',
+		});
+		this.resultRankingsMenuItem = page.getByRole('menuitem', {
+			exact: true,
+			name: 'Result Rankings',
 		});
 		this.page = page;
 		this.signInButton = page.getByRole('button', {name: 'Sign In'});
@@ -62,5 +67,11 @@ export class ApplicationsMenuPage {
 		await this.applicationMenuButton.click();
 		await this.controlPanelButton.click();
 		await this.usersAndOrganizationsItem.click();
+	}
+
+	async goToResultRankings() {
+		await this.goto();
+		await this.applicationMenuButton.click();
+		await this.resultRankingsMenuItem.click();
 	}
 }

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -7,12 +7,13 @@ import {defineConfig} from '@playwright/test';
 
 import {config as setup} from './tests/global.setup.config';
 import {config as object} from './tests/object-web/config';
+import {config as portalSearchTuningWeb} from './tests/portal-search-tuning-web/config';
 import {config as portalWeb} from './tests/portal-web/config';
 import {config as usersAdminWeb} from './tests/users-admin-web/config';
 
 export default defineConfig({
 	forbidOnly: !!process.env.CI,
-	projects: [object, portalWeb, setup, usersAdminWeb],
+	projects: [object, portalWeb, portalSearchTuningWeb, setup, usersAdminWeb],
 	reporter: [
 		[
 			'html',

--- a/modules/test/playwright/tests/portal-search-tuning-web/config.ts
+++ b/modules/test/playwright/tests/portal-search-tuning-web/config.ts
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {devices} from '@playwright/test';
+
+export const config = {
+	dependencies: ['setup'],
+	name: 'portal',
+	testDir: 'tests/portal-search-tuning-web',
+	timeout: 60 * 1000,
+	use: {
+		...devices['Desktop Chrome'],
+		storageState: 'tmp/.auth/user.json',
+	},
+};

--- a/modules/test/playwright/tests/portal-search-tuning-web/resultRankings.spec.ts
+++ b/modules/test/playwright/tests/portal-search-tuning-web/resultRankings.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpers.fixture';
+import {applicationsMenuPageTest} from '../../fixtures/applicationsMenuPages.fixture';
+import {portalSearchTuningWebPagesTest} from '../../fixtures/portalSearchTuningWebPages.fixture';
+import {getRandomInt} from '../../utils/util';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	applicationsMenuPageTest,
+	portalSearchTuningWebPagesTest
+);
+
+test('can activate a result ranking', async ({_resultRankingsPage}) => {
+	const resultRankingSearchQuery = 'resultRanking' + getRandomInt();
+
+	await _resultRankingsPage.goTo();
+
+	await _resultRankingsPage.createNewResultRanking({
+		searchQuery: resultRankingSearchQuery,
+		status: 'Inactive',
+	});
+
+	await _resultRankingsPage.chooseManagementToolbarAction(
+		{searchQuery: resultRankingSearchQuery, status: 'Inactive'},
+		'Activate'
+	);
+
+	await expect(
+		_resultRankingsPage.getResultRankingRow({
+			searchQuery: resultRankingSearchQuery,
+			status: 'Active',
+		})
+	).toBeVisible();
+
+	// Clean up
+
+	await _resultRankingsPage.deleteResultRankings();
+});
+
+test('changes status of rankings with deleted scope to not-applicable', async ({
+	_apiHelpers,
+	_resultRankingsPage,
+}) => {
+	const sxpBlueprint = await _apiHelpers.searchExperiences.postSXPBlueprint();
+
+	const resultRankingSearchQuery = 'resultRanking' + getRandomInt();
+
+	await _resultRankingsPage.goTo();
+
+	await _resultRankingsPage.createNewResultRanking({
+		scope: 'Blueprint',
+		scopeERF: sxpBlueprint.externalReferenceCode,
+		searchQuery: resultRankingSearchQuery,
+		status: 'Inactive',
+	});
+
+	await _apiHelpers.searchExperiences.deleteSXPBlueprint(sxpBlueprint.id);
+
+	await _resultRankingsPage.goTo();
+
+	await expect(
+		_resultRankingsPage.getResultRankingRow({
+			searchQuery: resultRankingSearchQuery,
+			status: 'Not Applicable',
+		})
+	).toBeVisible();
+
+	// Clean up
+
+	await _resultRankingsPage.deleteResultRankings();
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-204983 - Playwright

WIP: Adding Playwright tests related to Result Rankings :)

Things noticed:
- Locators that match to more than one element will cause the test to fail. So the locator needs to be general enough to be read easily but specific enough to only select that item.
- Had issues getting dropdown menu items to show up on the interactive UI
- "Tear down" step is just part of the test and will not run if the test fails before it gets to that step
- Steps on the Test Report are a little hard to read, assertions are shortened to `expect.toBeVisible`
- UI and codegen are very handy. Codegen commands are not always copy and paste, but are a good start to defining locators.