### PR TITLE
LPD-1549 Search results portlet doesn't display custom template in live

### DIFF
--- a/modules/apps/portal-search/portal-search-web/build.gradle
+++ b/modules/apps/portal-search/portal-search-web/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 	compileOnly project(":apps:configuration-admin:configuration-admin-api")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-taglib")
+	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:fragment:fragment-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/BaseSearchWidgetsExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/BaseSearchWidgetsExportImportPortletPreferencesProcessor.java
@@ -1,0 +1,60 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.exportimport.portlet.preferences.processor;
+
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.PortletDataException;
+import com.liferay.exportimport.portlet.preferences.processor.Capability;
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.portal.kernel.util.ListUtil;
+
+import java.util.List;
+
+import javax.portlet.PortletPreferences;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Felipe Lorenz
+ */
+public abstract class BaseSearchWidgetsExportImportPortletPreferencesProcessor
+	implements ExportImportPortletPreferencesProcessor {
+
+	@Override
+	public List<Capability> getExportCapabilities() {
+		return ListUtil.fromArray(exportCapability);
+	}
+
+	@Override
+	public List<Capability> getImportCapabilities() {
+		return ListUtil.fromArray(importCapability);
+	}
+
+	@Override
+	public PortletPreferences processExportPortletPreferences(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		return null;
+	}
+
+	@Override
+	public PortletPreferences processImportPortletPreferences(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		return null;
+	}
+
+	@Reference(target = "(name=PortletDisplayTemplateExporter)")
+	protected Capability exportCapability;
+
+	@Reference(target = "(name=PortletDisplayTemplateImporter)")
+	protected Capability importCapability;
+
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/CategoryFacetExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/CategoryFacetExportImportPortletPreferencesProcessor.java
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.exportimport.portlet.preferences.processor;
+
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.portal.search.web.internal.category.facet.constants.CategoryFacetPortletKeys;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Felipe Lorenz
+ */
+@Component(
+	property = "javax.portlet.name=" + CategoryFacetPortletKeys.CATEGORY_FACET,
+	service = ExportImportPortletPreferencesProcessor.class
+)
+public class CategoryFacetExportImportPortletPreferencesProcessor
+	extends BaseSearchWidgetsExportImportPortletPreferencesProcessor {
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/CustomFacetExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/CustomFacetExportImportPortletPreferencesProcessor.java
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.exportimport.portlet.preferences.processor;
+
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.portal.search.web.internal.custom.facet.constants.CustomFacetPortletKeys;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Felipe Lorenz
+ */
+@Component(
+	property = "javax.portlet.name=" + CustomFacetPortletKeys.CUSTOM_FACET,
+	service = ExportImportPortletPreferencesProcessor.class
+)
+public class CustomFacetExportImportPortletPreferencesProcessor
+	extends BaseSearchWidgetsExportImportPortletPreferencesProcessor {
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/CustomFilterExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/CustomFilterExportImportPortletPreferencesProcessor.java
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.exportimport.portlet.preferences.processor;
+
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.portal.search.web.internal.custom.filter.constants.CustomFilterPortletKeys;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Felipe Lorenz
+ */
+@Component(
+	property = "javax.portlet.name=" + CustomFilterPortletKeys.CUSTOM_FILTER,
+	service = ExportImportPortletPreferencesProcessor.class
+)
+public class CustomFilterExportImportPortletPreferencesProcessor
+	extends BaseSearchWidgetsExportImportPortletPreferencesProcessor {
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/FolderFacetExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/FolderFacetExportImportPortletPreferencesProcessor.java
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.exportimport.portlet.preferences.processor;
+
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.portal.search.web.internal.folder.facet.constants.FolderFacetPortletKeys;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Felipe Lorenz
+ */
+@Component(
+	property = "javax.portlet.name=" + FolderFacetPortletKeys.FOLDER_FACET,
+	service = ExportImportPortletPreferencesProcessor.class
+)
+public class FolderFacetExportImportPortletPreferencesProcessor
+	extends BaseSearchWidgetsExportImportPortletPreferencesProcessor {
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/ModifiedFacetExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/ModifiedFacetExportImportPortletPreferencesProcessor.java
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.exportimport.portlet.preferences.processor;
+
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.portal.search.web.internal.modified.facet.constants.ModifiedFacetPortletKeys;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Felipe Lorenz
+ */
+@Component(
+	property = "javax.portlet.name=" + ModifiedFacetPortletKeys.MODIFIED_FACET,
+	service = ExportImportPortletPreferencesProcessor.class
+)
+public class ModifiedFacetExportImportPortletPreferencesProcessor
+	extends BaseSearchWidgetsExportImportPortletPreferencesProcessor {
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/SearchBarExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/SearchBarExportImportPortletPreferencesProcessor.java
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.exportimport.portlet.preferences.processor;
+
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.portal.search.web.constants.SearchBarPortletKeys;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Felipe Lorenz
+ */
+@Component(
+	property = "javax.portlet.name=" + SearchBarPortletKeys.SEARCH_BAR,
+	service = ExportImportPortletPreferencesProcessor.class
+)
+public class SearchBarExportImportPortletPreferencesProcessor
+	extends BaseSearchWidgetsExportImportPortletPreferencesProcessor {
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/SearchResultsExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/SearchResultsExportImportPortletPreferencesProcessor.java
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.exportimport.portlet.preferences.processor;
+
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.portal.search.web.constants.SearchResultsPortletKeys;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Felipe Lorenz
+ */
+@Component(
+	property = "javax.portlet.name=" + SearchResultsPortletKeys.SEARCH_RESULTS,
+	service = ExportImportPortletPreferencesProcessor.class
+)
+public class SearchResultsExportImportPortletPreferencesProcessor
+	extends BaseSearchWidgetsExportImportPortletPreferencesProcessor {
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/SiteFacetExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/SiteFacetExportImportPortletPreferencesProcessor.java
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.exportimport.portlet.preferences.processor;
+
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.portal.search.web.internal.site.facet.constants.SiteFacetPortletKeys;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Felipe Lorenz
+ */
+@Component(
+	property = "javax.portlet.name=" + SiteFacetPortletKeys.SITE_FACET,
+	service = ExportImportPortletPreferencesProcessor.class
+)
+public class SiteFacetExportImportPortletPreferencesProcessor
+	extends BaseSearchWidgetsExportImportPortletPreferencesProcessor {
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/SortExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/SortExportImportPortletPreferencesProcessor.java
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.exportimport.portlet.preferences.processor;
+
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.portal.search.web.internal.sort.constants.SortPortletKeys;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Felipe Lorenz
+ */
+@Component(
+	property = "javax.portlet.name=" + SortPortletKeys.SORT,
+	service = ExportImportPortletPreferencesProcessor.class
+)
+public class SortExportImportPortletPreferencesProcessor
+	extends BaseSearchWidgetsExportImportPortletPreferencesProcessor {
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/TagFacetExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/TagFacetExportImportPortletPreferencesProcessor.java
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.exportimport.portlet.preferences.processor;
+
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.portal.search.web.internal.tag.facet.constants.TagFacetPortletKeys;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Felipe Lorenz
+ */
+@Component(
+	property = "javax.portlet.name=" + TagFacetPortletKeys.TAG_FACET,
+	service = ExportImportPortletPreferencesProcessor.class
+)
+public class TagFacetExportImportPortletPreferencesProcessor
+	extends BaseSearchWidgetsExportImportPortletPreferencesProcessor {
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/TypeFacetExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/TypeFacetExportImportPortletPreferencesProcessor.java
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.exportimport.portlet.preferences.processor;
+
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.portal.search.web.internal.type.facet.constants.TypeFacetPortletKeys;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Felipe Lorenz
+ */
+@Component(
+	property = "javax.portlet.name=" + TypeFacetPortletKeys.TYPE_FACET,
+	service = ExportImportPortletPreferencesProcessor.class
+)
+public class TypeFacetExportImportPortletPreferencesProcessor
+	extends BaseSearchWidgetsExportImportPortletPreferencesProcessor {
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/UserFacetExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/UserFacetExportImportPortletPreferencesProcessor.java
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.exportimport.portlet.preferences.processor;
+
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.portal.search.web.internal.user.facet.constants.UserFacetPortletKeys;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Felipe Lorenz
+ */
+@Component(
+	property = "javax.portlet.name=" + UserFacetPortletKeys.USER_FACET,
+	service = ExportImportPortletPreferencesProcessor.class
+)
+public class UserFacetExportImportPortletPreferencesProcessor
+	extends BaseSearchWidgetsExportImportPortletPreferencesProcessor {
+}

--- a/modules/dxp/apps/portal-search-similar-results/portal-search-similar-results-web/build.gradle
+++ b/modules/dxp/apps/portal-search-similar-results/portal-search-similar-results-web/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	compileOnly project(":apps:blogs:blogs-api")
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-taglib")
+	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:journal:journal-api")

--- a/modules/dxp/apps/portal-search-similar-results/portal-search-similar-results-web/src/main/java/com/liferay/portal/search/similar/results/web/internal/exportimport/portlet/preferences/processor/SimilarResultsExportImportPortletPreferencesProcessor.java
+++ b/modules/dxp/apps/portal-search-similar-results/portal-search-similar-results-web/src/main/java/com/liferay/portal/search/similar/results/web/internal/exportimport/portlet/preferences/processor/SimilarResultsExportImportPortletPreferencesProcessor.java
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.similar.results.web.internal.exportimport.portlet.preferences.processor;
+
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.PortletDataException;
+import com.liferay.exportimport.portlet.preferences.processor.Capability;
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.search.similar.results.web.internal.constants.SimilarResultsPortletKeys;
+
+import java.util.List;
+
+import javax.portlet.PortletPreferences;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Felipe Lorenz
+ */
+@Component(
+	property = "javax.portlet.name=" + SimilarResultsPortletKeys.SIMILAR_RESULTS,
+	service = ExportImportPortletPreferencesProcessor.class
+)
+public class SimilarResultsExportImportPortletPreferencesProcessor
+	implements ExportImportPortletPreferencesProcessor {
+
+	@Override
+	public List<Capability> getExportCapabilities() {
+		return ListUtil.fromArray(_exportCapability);
+	}
+
+	@Override
+	public List<Capability> getImportCapabilities() {
+		return ListUtil.fromArray(_importCapability);
+	}
+
+	@Override
+	public PortletPreferences processExportPortletPreferences(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		return null;
+	}
+
+	@Override
+	public PortletPreferences processImportPortletPreferences(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		return null;
+	}
+
+	@Reference(target = "(name=PortletDisplayTemplateExporter)")
+	private Capability _exportCapability;
+
+	@Reference(target = "(name=PortletDisplayTemplateImporter)")
+	private Capability _importCapability;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-1549

The problem on this is caused because on the remote live the `displayStyleGroupId` of the search widgets are from staging site instead of the remote live.

On `PortletDisplayTemplateImportCapability` this [piece of code](https://github.com/liferay/liferay-portal/blob/8dfef2a8d6ed76cdd4738a1dd5172f1e3952314c/modules/apps/portlet-display-template/portlet-display-template-impl/src/main/java/com/liferay/portlet/display/template/internal/exportimport/portlet/preferences/processor/PortletDisplayTemplateImportCapability.java#L108-L110) is responsible to change the value from staging to remote live, but for the search widgets portlets this class is not called.

This happens because on the `PortletImportControllerImpl` in [this piece of code](https://github.com/liferay/liferay-portal/blob/b6c6af5b39141862e2ecbba3e861063b8f1a4759/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java#L584-L593) the ExportImportPortletPreferencesProcessor is null and the PortletDisplayTemplateImportCapability is not called for search widgets portlets, so to solve this is, it was necessary to created components for the search widgets implementing the ExportImportPortletPreferencesProcessor interface.

I think to use one class with multiple values property similar on with objects did in [ListObjectFieldFilterContributor](https://github.com/liferay/liferay-portal/blob/5672c26c87d670b9372a97e33598c7bb7c419267/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/filter/parser/ListObjectFieldFilterContributor.java#L42-L45), but the `ExportImportPortletPreferencesProcessor` API doesn't support multiple values property for the `javax.portlet.name` ([see here](https://github.com/liferay/liferay-portal/blob/master/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/portlet/preferences/processor/ExportImportPortletPreferencesProcessorRegistryUtil.java#L95-L97))