### PR TITLE
LPD-1961 portal-search-opensearch2-impl: Fix Incorrect usage of NooHostnameVerifier.INSTANCE for SSL-Enabled Connections

### DIFF
--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/connection/OpenSearchConnection.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/connection/OpenSearchConnection.java
@@ -30,7 +30,6 @@ import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
-import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.apache.hc.core5.ssl.SSLContexts;
@@ -309,8 +308,6 @@ public class OpenSearchConnection {
 						ClientTlsStrategyBuilder.create(
 						).setSslContext(
 							_createSSLContext()
-						).setHostnameVerifier(
-							new DefaultHostnameVerifier()
 						).build());
 				}
 

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/connection/OpenSearchConnection.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/connection/OpenSearchConnection.java
@@ -30,7 +30,7 @@ import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
-import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.apache.hc.core5.ssl.SSLContexts;
@@ -310,7 +310,7 @@ public class OpenSearchConnection {
 						).setSslContext(
 							_createSSLContext()
 						).setHostnameVerifier(
-							NoopHostnameVerifier.INSTANCE
+							new DefaultHostnameVerifier()
 						).build());
 				}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-1961

DefaultHostnameVerifier performs a strict check according to RFC 2818. The hostname must match any of the alternative names specified by the certificate, or in case no alternative names are given, the most specific Common Name (CN) of the certificate subject. A wildcard can occur in the CN, and in any of the subject-alts

On the other hand, NoopHostnameVerifier essentially turns hostname verification off. It accepts any SSL session as valid and matching the target host, regardless of the hostname in the certificate