### PR TITLE
LPD-17372 Fix incorrect number of pages in the paginated results in the SearchResultsPortlet

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/shared/search/SearchResultsPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/shared/search/SearchResultsPortletSharedSearchContributor.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.search.web.internal.search.results.portlet.shared.search;
 
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.search.searcher.SearchRequestBuilder;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.web.constants.SearchResultsPortletKeys;
@@ -62,8 +63,13 @@ public class SearchResultsPortletSharedSearchContributor
 		PortletSharedSearchSettings portletSharedSearchSettings,
 		SearchRequestBuilder searchRequestBuilder) {
 
-		String paginationStartParameterName =
-			searchResultsPortletPreferences.getPaginationStartParameterName();
+		String namespace = _portal.getPortletNamespace(
+			portletSharedSearchSettings.getPortletId());
+
+		String paginationStartParameterName = namespace.concat(
+			searchResultsPortletPreferences.getPaginationStartParameterName());
+		String paginationDeltaParameterName = namespace.concat(
+			searchResultsPortletPreferences.getPaginationDeltaParameterName());
 
 		portletSharedSearchSettings.setPaginationStartParameterName(
 			paginationStartParameterName);
@@ -72,8 +78,7 @@ public class SearchResultsPortletSharedSearchContributor
 
 		int paginationDelta = GetterUtil.getInteger(
 			portletSharedSearchSettings.getParameter(
-				searchResultsPortletPreferences.
-					getPaginationDeltaParameterName()),
+				paginationDeltaParameterName),
 			searchResultsPortletPreferences.getPaginationDelta());
 
 		portletSharedSearchSettings.setPaginationDelta(paginationDelta);
@@ -89,5 +94,8 @@ public class SearchResultsPortletSharedSearchContributor
 			searchRequestBuilder.from((paginationStart - 1) * paginationDelta);
 		}
 	}
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/results/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/results/view.jsp
@@ -72,7 +72,7 @@ SearchContainer<Document> searchContainer = searchResultsPortletDisplayContext.g
 		/>
 
 		<c:if test="<%= searchResultsPortletDisplayContext.isShowPagination() %>">
-			<aui:form action="#" useNamespace="<%= false %>">
+			<aui:form action="#" useNamespace="<%= true %>">
 				<liferay-ui:search-paginator
 					id='<%= liferayPortletResponse.getNamespace() + "searchContainerTag" %>'
 					markupView="lexicon"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-17372 - Incorrect number of pages in the paginated results in the SearchResultsPortlet

Based on the conversation in https://liferay.atlassian.net/browse/LPP-52649, in order for the pagination to keep proper track for the items in its dropdown, `useNamespace` should be set to `true`. This means the parameters for `delta` and `start` would then be namespaced.

Demo of bug fix and what the URL looks like now:

https://github.com/liferay-search/liferay-portal/assets/14063502/b77e2d2c-74e3-462e-a5c1-e2565b5cf552


