### PR TITLE
LPD-17984 portal-search-web: Update id for search results paginator

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/results/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/results/view.jsp
@@ -74,7 +74,7 @@ SearchContainer<Document> searchContainer = searchResultsPortletDisplayContext.g
 		<c:if test="<%= searchResultsPortletDisplayContext.isShowPagination() %>">
 			<aui:form action="#" useNamespace="<%= false %>">
 				<liferay-ui:search-paginator
-					id='<%= liferayPortletResponse.getNamespace() + "searchContainerTag" %>'
+					id="<%= liferayPortletResponse.getNamespace() %>"
 					markupView="lexicon"
 					searchContainer="<%= searchContainer %>"
 				/>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-17372 - Incorrect number of pages in the paginated results in the SearchResultsPortlet
https://liferay.atlassian.net/browse/LPD-17984 (subtask) - Update id in search result's search-paginator

Simple update to remove the appended suffix on the `id` within search result's paginator. This doesn't fix the bug, but this will be helpful for later changes to the `DynamicInlineScroll` component.