### PR TITLE
LPD-17509 Disabling search suggestions conflicts with impersonation

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/SearchBar.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-export default function ({namespace: portletNamespace}) {
-	const form = document.getElementById(`${portletNamespace}fm`);
+export default function ({formId}) {
+	const form = document.getElementById(formId);
 
 	if (!form) {
 		return;

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
@@ -54,7 +54,7 @@ SearchBarPortletDisplayContext searchBarPortletDisplayContext = (SearchBarPortle
 		</div>
 	</c:when>
 	<c:otherwise>
-		<form action="<%= searchBarPortletDisplayContext.getSearchURL() %>" id="<portlet:namespace />fm" method="get" name="<portlet:namespace />fm">
+		<form action="<%= searchBarPortletDisplayContext.getSearchURL() %>" id="<%= randomNamespace %>fm" method="get" name="<%= randomNamespace %>fm">
 			<c:if test="<%= !Validator.isBlank(searchBarPortletDisplayContext.getPaginationStartParameterName()) %>">
 				<input class="search-bar-reset-start-page" name="<%= searchBarPortletDisplayContext.getPaginationStartParameterName() %>" type="hidden" value="0" />
 			</c:if>
@@ -172,7 +172,7 @@ SearchBarPortletDisplayContext searchBarPortletDisplayContext = (SearchBarPortle
 		<liferay-frontend:component
 			context='<%=
 				HashMapBuilder.<String, Object>put(
-					"namespace", liferayPortletResponse.getNamespace()
+					"formId", randomNamespace + "fm"
 				).build()
 			%>'
 			module="{SearchBar} from portal-search-web"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPD-17509 - Disabling search suggestions conflicts with impersonation

Use the `randomNamespace` (already established in the JSP) in order to allow the `SearchBar.js` to find the form and apply the event listener! This is because two searchbars on the same page could be using the same namespace `com_liferay_portal_search_web_search_bar_portlet_SearchBarPortlet_INSTANCE_templateSearch`, like the case in the bug description.

cc @AlmirFe 