### PR TITLE
LPD-8052 Review and bump third-party other dependencies in the Elasticsearch 7 connector on all versions to the latest available compatible version

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -536,7 +536,7 @@
 					</license>
 				</licenses>
 			</library>
-			<library>
+<library>
 				<file-name>com.liferay.commerce.shipping.engine.fedex.jar!com.fedex.ws.jar</file-name>
 				<version>1.0.0</version>
 				<project-name>com.fedex.ws</project-name>
@@ -2797,31 +2797,31 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.search.elasticsearch7.impl.jar!jackson-dataformat-cbor.jar</file-name>
-				<version>2.12.6</version>
+				<version>2.16.1</version>
 				<project-name>Jackson dataformat: CBOR</project-name>
-				<project-url>http://github.com/FasterXML/jackson-dataformats-binary</project-url>
+				<project-url>https://github.com/FasterXML/jackson-dataformats-binary</project-url>
 				<licenses>
 					<license>
 						<license-name>The Apache Software License, Version 2.0</license-name>
-						<license-url>http://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
+						<license-url>https://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
 					</license>
 				</licenses>
 			</library>
 			<library>
 				<file-name>com.liferay.portal.search.elasticsearch7.impl.jar!jackson-dataformat-smile.jar</file-name>
-				<version>2.13.2</version>
+				<version>2.16.1</version>
 				<project-name>Jackson dataformat: Smile</project-name>
-				<project-url>http://github.com/FasterXML/jackson-dataformats-binary</project-url>
+				<project-url>https://github.com/FasterXML/jackson-dataformats-binary</project-url>
 				<licenses>
 					<license>
 						<license-name>The Apache Software License, Version 2.0</license-name>
-						<license-url>http://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
+						<license-url>https://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
 					</license>
 				</licenses>
 			</library>
 			<library>
 				<file-name>com.liferay.portal.search.elasticsearch7.impl.jar!jackson-dataformat-yaml.jar</file-name>
-				<version>2.14.2</version>
+				<version>2.16.1</version>
 				<project-name>Jackson-dataformat-YAML</project-name>
 				<project-url>https://github.com/FasterXML/jackson-dataformats-text</project-url>
 				<licenses>
@@ -6750,7 +6750,7 @@
 					</license>
 				</licenses>
 			</library>
-			<library>
+						<library>
 				<file-name>lib/development/spring-instrument-tomcat.jar</file-name>
 				<version>4.3.23</version>
 				<project-name>Spring</project-name>

--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -2418,7 +2418,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.k8s.agent.impl.jar!snakeyaml.jar</file-name>
-				<version>2.0</version>
+				<version>2.2</version>
 				<project-name>SnakeYAML</project-name>
 				<project-url>https://bitbucket.org/snakeyaml/snakeyaml</project-url>
 				<licenses>
@@ -2607,7 +2607,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.search.elasticsearch7.impl.jar!asm-debug-all.jar</file-name>
-				<version>5.1</version>
+				<version>5.2</version>
 				<project-name>ASM all classes with debug info</project-name>
 				<project-url>http://asm.objectweb.org</project-url>
 				<licenses>
@@ -2971,7 +2971,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.search.elasticsearch7.impl.jar!snakeyaml.jar</file-name>
-				<version>2.0</version>
+				<version>2.2</version>
 				<project-name>SnakeYAML</project-name>
 				<project-url>https://bitbucket.org/snakeyaml/snakeyaml</project-url>
 				<licenses>
@@ -4067,7 +4067,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.vulcan.api.jar!snakeyaml.jar</file-name>
-				<version>2.0</version>
+				<version>2.2</version>
 				<project-name>SnakeYAML</project-name>
 				<project-url>https://bitbucket.org/snakeyaml/snakeyaml</project-url>
 				<licenses>
@@ -4294,7 +4294,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.vulcan.impl.jar!snakeyaml.jar</file-name>
-				<version>2.0</version>
+				<version>2.2</version>
 				<project-name>SnakeYAML</project-name>
 				<project-url>https://bitbucket.org/snakeyaml/snakeyaml</project-url>
 				<licenses>

--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -536,40 +536,6 @@
 					</license>
 				</licenses>
 			</library>
-<library>
-				<file-name>com.liferay.commerce.shipping.engine.fedex.jar!com.fedex.ws.jar</file-name>
-				<version>1.0.0</version>
-				<project-name>com.fedex.ws</project-name>
-				<licenses>
-					<license>
-						<license-name>LGPL 2.1</license-name>
-						<license-url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt</license-url>
-					</license>
-				</licenses>
-			</library>
-			<library>
-				<file-name>com.liferay.commerce.shipping.engine.fedex.jar!commons-discovery.jar</file-name>
-				<version>0.4</version>
-				<project-name>org.apache.commons.discovery</project-name>
-				<project-url>http://jakarta.apache.org/commons/${pom.artifactId.substring(8)}/</project-url>
-				<licenses>
-					<license>
-						<license-name>The Apache Software License, Version 2.0</license-name>
-						<license-url>/LICENSE.txt</license-url>
-					</license>
-				</licenses>
-			</library>
-			<library>
-				<file-name>com.liferay.commerce.shipping.engine.fedex.jar!org.apache.axis.jar</file-name>
-				<version>1.4.LIFERAY-PATCHED-8</version>
-				<project-name>org.apache.axis</project-name>
-				<licenses>
-					<license>
-						<license-name>LGPL 2.1</license-name>
-						<license-url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt</license-url>
-					</license>
-				</licenses>
-			</library>
 			<library>
 				<file-name>com.liferay.content.dashboard.web.jar!commons-lang3.jar</file-name>
 				<version>3.12.0</version>
@@ -3041,7 +3007,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.security.antisamy.jar!antisamy.jar</file-name>
-				<version>1.7.4</version>
+				<version>1.7.5</version>
 				<project-name>OWASP AntiSamy</project-name>
 				<project-url>https://github.com/nahsra/antisamy</project-url>
 				<licenses>
@@ -3130,7 +3096,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.security.antisamy.jar!neko-htmlunit.jar</file-name>
-				<version>3.6.0</version>
+				<version>3.11.1</version>
 				<project-name>HtmlUnit NekoHtml</project-name>
 				<project-url>https://www.htmlunit.org</project-url>
 				<licenses>
@@ -6750,7 +6716,19 @@
 					</license>
 				</licenses>
 			</library>
-						<library>
+			<library>
+				<file-name>lib/development/snakeyaml.jar</file-name>
+				<version>2.0</version>
+				<project-name>SnakeYAML</project-name>
+				<project-url>https://bitbucket.org/snakeyaml/snakeyaml</project-url>
+				<licenses>
+					<license>
+						<license-name>Apache License, Version 2.0</license-name>
+						<license-url>http://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
+					</license>
+				</licenses>
+			</library>
+			<library>
 				<file-name>lib/development/spring-instrument-tomcat.jar</file-name>
 				<version>4.3.23</version>
 				<project-name>Spring</project-name>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -314,24 +314,6 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.commerce.shipping.engine.fedex.jar!com.fedex.ws.jar</td><td nowrap="nowrap">1.0.0</td><td nowrap="nowrap">com.fedex.ws</td><td nowrap><a href="http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt">LGPL 2.1</a>
-<br>
-</td><td></td>
-</tr>
-			
-<tr>
-<td nowrap="nowrap">com.liferay.commerce.shipping.engine.fedex.jar!commons-discovery.jar</td><td nowrap="nowrap">0.4</td><td nowrap="nowrap"><a href="http://jakarta.apache.org/commons/${pom.artifactId.substring(8)}/">org.apache.commons.discovery</a></td><td nowrap><a href="/LICENSE.txt">The Apache Software License, Version 2.0</a>
-<br>
-</td><td></td>
-</tr>
-			
-<tr>
-<td nowrap="nowrap">com.liferay.commerce.shipping.engine.fedex.jar!org.apache.axis.jar</td><td nowrap="nowrap">1.4.LIFERAY-PATCHED-8</td><td nowrap="nowrap">org.apache.axis</td><td nowrap><a href="http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt">LGPL 2.1</a>
-<br>
-</td><td></td>
-</tr>
-			
-<tr>
 <td nowrap="nowrap">com.liferay.content.dashboard.web.jar!commons-lang3.jar</td><td nowrap="nowrap">3.12.0</td><td nowrap="nowrap"><a href="https://commons.apache.org/proper/commons-lang/">Apache Commons Lang</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
 <br>
 </td><td></td>
@@ -1022,7 +1004,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.oauth.client.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html?">Apache License, version 2.0</a>
+<td nowrap="nowrap">com.liferay.oauth.client.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html&lrm;">Apache License, version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1598,7 +1580,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.security.antisamy.jar!antisamy.jar</td><td nowrap="nowrap">1.7.4</td><td nowrap="nowrap"><a href="https://github.com/nahsra/antisamy">OWASP AntiSamy</a></td><td nowrap><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3</a>
+<td nowrap="nowrap">com.liferay.portal.security.antisamy.jar!antisamy.jar</td><td nowrap="nowrap">1.7.5</td><td nowrap="nowrap"><a href="https://github.com/nahsra/antisamy">OWASP AntiSamy</a></td><td nowrap><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3</a>
 <br>
 </td><td></td>
 </tr>
@@ -1646,7 +1628,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.security.antisamy.jar!neko-htmlunit.jar</td><td nowrap="nowrap">3.6.0</td><td nowrap="nowrap"><a href="https://www.htmlunit.org">HtmlUnit NekoHtml</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.security.antisamy.jar!neko-htmlunit.jar</td><td nowrap="nowrap">3.11.1</td><td nowrap="nowrap"><a href="https://www.htmlunit.org">HtmlUnit NekoHtml</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1724,7 +1706,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.impl.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html?">Apache License, version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.impl.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html&lrm;">Apache License, version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1754,7 +1736,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html?">Apache License, version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html&lrm;">Apache License, version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -3477,6 +3459,12 @@
 			
 <tr>
 <td nowrap="nowrap">lib/development/smtp.jar</td><td nowrap="nowrap">1.5.4</td><td nowrap="nowrap"><a href="http://java.sun.com/products/javamail">JavaMail</a></td><td nowrap><a href="https://opensource.org/licenses/CDDL-1.0">Common Development and Distribution License 1.0</a>
+<br>
+</td><td></td>
+</tr>
+			
+<tr>
+<td nowrap="nowrap">lib/development/snakeyaml.jar</td><td nowrap="nowrap">2.0</td><td nowrap="nowrap"><a href="https://bitbucket.org/snakeyaml/snakeyaml">SnakeYAML</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -1472,19 +1472,19 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.search.elasticsearch7.impl.jar!jackson-dataformat-cbor.jar</td><td nowrap="nowrap">2.12.6</td><td nowrap="nowrap"><a href="http://github.com/FasterXML/jackson-dataformats-binary">Jackson dataformat: CBOR</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.search.elasticsearch7.impl.jar!jackson-dataformat-cbor.jar</td><td nowrap="nowrap">2.16.1</td><td nowrap="nowrap"><a href="https://github.com/FasterXML/jackson-dataformats-binary">Jackson dataformat: CBOR</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.search.elasticsearch7.impl.jar!jackson-dataformat-smile.jar</td><td nowrap="nowrap">2.13.2</td><td nowrap="nowrap"><a href="http://github.com/FasterXML/jackson-dataformats-binary">Jackson dataformat: Smile</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.search.elasticsearch7.impl.jar!jackson-dataformat-smile.jar</td><td nowrap="nowrap">2.16.1</td><td nowrap="nowrap"><a href="https://github.com/FasterXML/jackson-dataformats-binary">Jackson dataformat: Smile</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.search.elasticsearch7.impl.jar!jackson-dataformat-yaml.jar</td><td nowrap="nowrap">2.14.2</td><td nowrap="nowrap"><a href="https://github.com/FasterXML/jackson-dataformats-text">Jackson-dataformat-YAML</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.search.elasticsearch7.impl.jar!jackson-dataformat-yaml.jar</td><td nowrap="nowrap">2.16.1</td><td nowrap="nowrap"><a href="https://github.com/FasterXML/jackson-dataformats-text">Jackson-dataformat-YAML</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -1280,7 +1280,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.k8s.agent.impl.jar!snakeyaml.jar</td><td nowrap="nowrap">2.0</td><td nowrap="nowrap"><a href="https://bitbucket.org/snakeyaml/snakeyaml">SnakeYAML</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.k8s.agent.impl.jar!snakeyaml.jar</td><td nowrap="nowrap">2.2</td><td nowrap="nowrap"><a href="https://bitbucket.org/snakeyaml/snakeyaml">SnakeYAML</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1376,7 +1376,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.search.elasticsearch7.impl.jar!asm-debug-all.jar</td><td nowrap="nowrap">5.1</td><td nowrap="nowrap"><a href="http://asm.objectweb.org">ASM all classes with debug info</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.search.elasticsearch7.impl.jar!asm-debug-all.jar</td><td nowrap="nowrap">5.2</td><td nowrap="nowrap"><a href="http://asm.objectweb.org">ASM all classes with debug info</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1562,7 +1562,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.search.elasticsearch7.impl.jar!snakeyaml.jar</td><td nowrap="nowrap">2.0</td><td nowrap="nowrap"><a href="https://bitbucket.org/snakeyaml/snakeyaml">SnakeYAML</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.search.elasticsearch7.impl.jar!snakeyaml.jar</td><td nowrap="nowrap">2.2</td><td nowrap="nowrap"><a href="https://bitbucket.org/snakeyaml/snakeyaml">SnakeYAML</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -2120,7 +2120,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.vulcan.api.jar!snakeyaml.jar</td><td nowrap="nowrap">2.0</td><td nowrap="nowrap"><a href="https://bitbucket.org/snakeyaml/snakeyaml">SnakeYAML</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.vulcan.api.jar!snakeyaml.jar</td><td nowrap="nowrap">2.2</td><td nowrap="nowrap"><a href="https://bitbucket.org/snakeyaml/snakeyaml">SnakeYAML</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -2234,7 +2234,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.vulcan.impl.jar!snakeyaml.jar</td><td nowrap="nowrap">2.0</td><td nowrap="nowrap"><a href="https://bitbucket.org/snakeyaml/snakeyaml">SnakeYAML</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.vulcan.impl.jar!snakeyaml.jar</td><td nowrap="nowrap">2.2</td><td nowrap="nowrap"><a href="https://bitbucket.org/snakeyaml/snakeyaml">SnakeYAML</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>

--- a/modules/apps/object/object-rest-test/build.gradle
+++ b/modules/apps/object/object-rest-test/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 	testIntegrationImplementation group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	testIntegrationImplementation group: "org.apache.cxf", name: "cxf-core", version: "3.4.10"
 	testIntegrationImplementation group: "org.skyscreamer", name: "jsonassert", version: "1.2.3"
-	testIntegrationImplementation group: "org.yaml", name: "snakeyaml", version: "2.0"
+	testIntegrationImplementation group: "org.yaml", name: "snakeyaml", version: "2.2"
 	testIntegrationImplementation project(":apps:account:account-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-test-util")

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/build.gradle
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/build.gradle
@@ -29,9 +29,9 @@ cleanSidecar {
 
 dependencies {
 	compileInclude group: "com.carrotsearch", name: "hppc", version: "0.8.1"
-	compileInclude group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-cbor", version: "2.12.6"
-	compileInclude group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-smile", version: "2.13.2"
-	compileInclude group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-yaml", version: "2.14.2"
+	compileInclude group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-cbor", version: "2.16.1"
+	compileInclude group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-smile", version: "2.16.1"
+	compileInclude group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-yaml", version: "2.16.1"
 	compileInclude group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"
 	compileInclude group: "com.liferay", name: "org.apache.logging.log4j", version: "2.17.1.LIFERAY-PATCHED-1"
 	compileInclude group: "com.liferay", name: "org.apache.logging.log4j.core", version: "2.17.1.LIFERAY-PATCHED-1"

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/build.gradle
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/build.gradle
@@ -60,8 +60,8 @@ dependencies {
 	compileInclude group: "org.elasticsearch.plugin", name: "rank-eval-client", version: elasticsearchClientVersion
 	compileInclude group: "org.locationtech.jts", name: "jts-core", version: "1.15.0"
 	compileInclude group: "org.locationtech.spatial4j", name: "spatial4j", version: "0.7"
-	compileInclude group: "org.ow2.asm", name: "asm-debug-all", version: "5.1"
-	compileInclude group: "org.yaml", name: "snakeyaml", version: "2.0"
+	compileInclude group: "org.ow2.asm", name: "asm-debug-all", version: "5.2"
+	compileInclude group: "org.yaml", name: "snakeyaml", version: "2.2"
 
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.16.1"
 	compileOnly group: "com.fasterxml.woodstox", name: "woodstox-core", version: "6.4.0"

--- a/modules/apps/portal-vulcan/portal-vulcan-api/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
 	compileInclude group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-xml", version: "2.9.8"
-	compileInclude group: "org.yaml", name: "snakeyaml", version: "2.0"
+	compileInclude group: "org.yaml", name: "snakeyaml", version: "2.2"
 
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.16.1"
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.16.1"

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	compileInclude group: "org.javassist", name: "javassist", version: "3.23.1-GA"
 	compileInclude group: "org.reactivestreams", name: "reactive-streams", version: "1.0.2"
 	compileInclude group: "org.reflections", name: "reflections", version: "0.9.11"
-	compileInclude group: "org.yaml", name: "snakeyaml", version: "2.0"
+	compileInclude group: "org.yaml", name: "snakeyaml", version: "2.2"
 
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "4.2.0"
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.16.1"

--- a/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/build.gradle
+++ b/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 	compileInclude group: "io.fabric8", name: "kubernetes-model-storageclass", version: "5.12.2"
 	compileInclude group: "io.fabric8", name: "zjsonpatch", version: "0.3.0"
 	compileInclude group: "org.jetbrains.kotlin", name: "kotlin-stdlib", version: "1.8.0"
-	compileInclude group: "org.yaml", name: "snakeyaml", version: "2.0"
+	compileInclude group: "org.yaml", name: "snakeyaml", version: "2.2"
 
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.16.1"
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.16.1"

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-fido2-web/build.gradle
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-fido2-web/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
 	compileInclude group: "com.augustcellars.cose", name: "cose-java", version: "1.1.0"
-	compileInclude group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-cbor", version: "2.12.6"
+	compileInclude group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-cbor", version: "2.16.1"
 	compileInclude group: "com.fasterxml.jackson.datatype", name: "jackson-datatype-jdk8", version: "2.11.2"
 	compileInclude group: "com.github.peteroupc", name: "numbers", version: "1.7.4"
 	compileInclude group: "com.upokecenter", name: "cbor", version: "4.5.2"

--- a/modules/util/portal-tools-rest-builder/build.gradle
+++ b/modules/util/portal-tools-rest-builder/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 	api group: "commons-io", name: "commons-io", version: "2.11.0"
 
 	compileInclude group: "com.beust", name: "jcommander", version: "1.48"
-	compileInclude group: "org.yaml", name: "snakeyaml", version: "2.0"
+	compileInclude group: "org.yaml", name: "snakeyaml", version: "2.2"
 	compileInclude project(":apps:portal-vulcan:portal-vulcan-api")
 
 	compileOnly group: "com.liferay", name: "com.liferay.petra.io", version: "5.0.5"

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -690,7 +690,7 @@
         org.springframework.boot:spring-boot-starter-oauth2-resource-server:2.7.18,\
         org.springframework.boot:spring-boot-starter-web:2.7.18,\
         org.springframework.boot:spring-boot-starter-webflux:2.7.18,\
-        org.yaml:snakeyaml:2.0,\
+        org.yaml:snakeyaml:2.2,\
         xerces:xercesImpl:2.12.2,\
         xml-apis:xml-apis:1.4.01
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-8052

The bump of `jackson-dataformat-cbor` was made on modules `portal-search-elasticsearch7-impl` and `multi-factor-authentication-fido2-web` the other module that has CBOR dependencie (`portal-store-s3`) when I made the bump appeared some failures related to this bump, so I kept it the way it was.