### PR TITLE
LPD-6591 Isolate Clause Contributors

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/query/contributor/DLFileEntryKeywordQueryContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/query/contributor/DLFileEntryKeywordQueryContributor.java
@@ -5,8 +5,11 @@
 
 package com.liferay.document.library.internal.search.spi.model.query.contributor;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Field;
@@ -60,10 +63,9 @@ public class DLFileEntryKeywordQueryContributor
 			booleanQuery, searchContext, "extension", false);
 		_queryHelper.addSearchTerm(
 			booleanQuery, searchContext, "fileEntryTypeId", false);
-		_queryHelper.addSearchLocalizedTerm(
-			booleanQuery, searchContext, Field.CONTENT, false);
-		_queryHelper.addSearchLocalizedTerm(
-			booleanQuery, searchContext, Field.TITLE, false);
+
+		_addSearchLocalizedTerm(booleanQuery, Field.CONTENT, searchContext);
+		_addSearchLocalizedTerm(booleanQuery, Field.TITLE, searchContext);
 
 		if (Validator.isNotNull(keywords)) {
 			try {
@@ -125,6 +127,42 @@ public class DLFileEntryKeywordQueryContributor
 		}
 	}
 
+	private void _addSearchLocalizedTerm(
+		BooleanQuery booleanQuery, String fieldName,
+		SearchContext searchContext) {
+
+		String value = searchContext.getKeywords();
+
+		if (Validator.isBlank(value)) {
+			return;
+		}
+
+		String[] localizedFieldNames =
+			_searchLocalizationHelper.getLocalizedFieldNames(
+				new String[] {fieldName}, searchContext);
+
+		for (String localizedFieldName : localizedFieldNames) {
+			_addTerm(booleanQuery, localizedFieldName, value);
+		}
+	}
+
+	private void _addTerm(
+		BooleanQuery booleanQuery, String field, String value) {
+
+		try {
+			booleanQuery.addTerm(field, value, false);
+		}
+		catch (ParseException parseException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					StringBundler.concat(
+						"Unable to add search term to query field:", field,
+						" value:", value, " like:", false),
+					parseException);
+			}
+		}
+	}
+
 	private MatchQuery _getMatchQuery(
 		String field, String keywords, MatchQuery.Type phrase) {
 
@@ -148,6 +186,9 @@ public class DLFileEntryKeywordQueryContributor
 
 		return booleanQuery;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DLFileEntryKeywordQueryContributor.class);
 
 	@Reference
 	private QueryHelper _queryHelper;

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/KBArticleIndexer.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/KBArticleIndexer.java
@@ -114,7 +114,7 @@ public class KBArticleIndexer extends BaseIndexer<KBArticle> {
 				BooleanClauseOccur.MUST);
 
 			modelBooleanQuery.add(
-				keywordsBooleanQuery, BooleanClauseOccur.SHOULD);
+				keywordsBooleanQuery, BooleanClauseOccur.MUST);
 
 			searchQuery.add(modelBooleanQuery, BooleanClauseOccur.SHOULD);
 		}

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/KBArticleIndexer.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/KBArticleIndexer.java
@@ -16,10 +16,12 @@ import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.search.BaseIndexer;
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
@@ -27,10 +29,13 @@ import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.IndexWriterHelper;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.search.ParseException;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.search.Summary;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
+import com.liferay.portal.kernel.search.generic.TermQueryImpl;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
@@ -92,10 +97,30 @@ public class KBArticleIndexer extends BaseIndexer<KBArticle> {
 			SearchContext searchContext)
 		throws Exception {
 
-		addSearchTerm(searchQuery, searchContext, Field.CONTENT, true);
-		addSearchTerm(searchQuery, searchContext, Field.DESCRIPTION, true);
-		addSearchTerm(searchQuery, searchContext, Field.TITLE, true);
-		addSearchTerm(searchQuery, searchContext, Field.USER_NAME, true);
+		BooleanQuery keywordsBooleanQuery = new BooleanQueryImpl();
+
+		addSearchTerm(keywordsBooleanQuery, searchContext, Field.CONTENT, true);
+		addSearchTerm(
+			keywordsBooleanQuery, searchContext, Field.DESCRIPTION, true);
+		addSearchTerm(keywordsBooleanQuery, searchContext, Field.TITLE, true);
+		addSearchTerm(
+			keywordsBooleanQuery, searchContext, Field.USER_NAME, true);
+
+		try {
+			BooleanQuery modelBooleanQuery = new BooleanQueryImpl();
+
+			modelBooleanQuery.add(
+				new TermQueryImpl("entryClassName", CLASS_NAME),
+				BooleanClauseOccur.MUST);
+
+			modelBooleanQuery.add(
+				keywordsBooleanQuery, BooleanClauseOccur.SHOULD);
+
+			searchQuery.add(modelBooleanQuery, BooleanClauseOccur.SHOULD);
+		}
+		catch (ParseException parseException) {
+			throw new SystemException(parseException);
+		}
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/KBArticleIndexer.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/KBArticleIndexer.java
@@ -97,6 +97,17 @@ public class KBArticleIndexer extends BaseIndexer<KBArticle> {
 			SearchContext searchContext)
 		throws Exception {
 
+		if (searchContext.isIncludeAttachments() ||
+			searchContext.isIncludeDiscussions()) {
+
+			addSearchTerm(searchQuery, searchContext, Field.CONTENT, true);
+			addSearchTerm(searchQuery, searchContext, Field.DESCRIPTION, true);
+			addSearchTerm(searchQuery, searchContext, Field.TITLE, true);
+			addSearchTerm(searchQuery, searchContext, Field.USER_NAME, true);
+
+			return;
+		}
+
 		BooleanQuery keywordsBooleanQuery = new BooleanQueryImpl();
 
 		addSearchTerm(keywordsBooleanQuery, searchContext, Field.CONTENT, true);
@@ -105,6 +116,10 @@ public class KBArticleIndexer extends BaseIndexer<KBArticle> {
 		addSearchTerm(keywordsBooleanQuery, searchContext, Field.TITLE, true);
 		addSearchTerm(
 			keywordsBooleanQuery, searchContext, Field.USER_NAME, true);
+
+		if (!keywordsBooleanQuery.hasClauses()) {
+			return;
+		}
 
 		try {
 			BooleanQuery modelBooleanQuery = new BooleanQueryImpl();

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/clause/contributors/test/IndexerClauseContributorsTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/clause/contributors/test/IndexerClauseContributorsTest.java
@@ -208,88 +208,74 @@ public class IndexerClauseContributorsTest {
 				"gamma"
 			);
 
-		String titleContributorId =
+		String alwaysPresentContributor =
 			"com.liferay.portal.search.internal.spi.model.query.contributor." +
 				"AlwaysPresentFieldsKeywordQueryContributor";
-		String titleMultilangContributorId1 =
+		String blogsContributor =
 			"com.liferay.blogs.internal.search.spi.model.query.contributor." +
 				"BlogsEntryKeywordQueryContributor";
-		String titleMultilangContributorId2 =
+		String journalArticleContributor =
 			"com.liferay.journal.internal.search.spi.model.query.contributor." +
 				"JournalArticleKeywordQueryContributor";
-		String titleMultilangContributorId3 =
+		String mbMessageContributor =
 			"com.liferay.message.boards.internal.search.spi.model.query." +
 				"contributor.MBMessageKeywordQueryContributor";
 
 		assertSearch(
 			"[Gamma Article, Gamma Blog, Gamma Message]",
 			withIncludes(
-				titleContributorId, titleMultilangContributorId1,
-				titleMultilangContributorId2, titleMultilangContributorId3),
+				alwaysPresentContributor, blogsContributor,
+				journalArticleContributor, mbMessageContributor),
 			consumer);
 
 		assertSearch(
 			"[Gamma Article, Gamma Blog, Gamma Message]",
 			withIncludes(
-				titleContributorId, titleMultilangContributorId1,
-				titleMultilangContributorId2, titleMultilangContributorId3),
-			withExcludes(titleContributorId), consumer);
+				alwaysPresentContributor, blogsContributor,
+				journalArticleContributor, mbMessageContributor),
+			withExcludes(alwaysPresentContributor), consumer);
 
 		assertSearch(
-			"[Gamma Article, Gamma Blog, Gamma Message]",
+			"[Gamma Blog, Gamma Message]",
 			withIncludes(
-				titleContributorId, titleMultilangContributorId1,
-				titleMultilangContributorId2, titleMultilangContributorId3),
-			withExcludes(
-				titleMultilangContributorId1, titleMultilangContributorId2),
+				alwaysPresentContributor, blogsContributor,
+				journalArticleContributor, mbMessageContributor),
+			withExcludes(blogsContributor, journalArticleContributor),
 			consumer);
 
 		assertSearch(
-			"[Gamma Article, Gamma Blog, Gamma Message]",
+			"[Gamma Message]",
 			withIncludes(
-				titleContributorId, titleMultilangContributorId1,
-				titleMultilangContributorId2, titleMultilangContributorId3),
+				alwaysPresentContributor, blogsContributor,
+				journalArticleContributor, mbMessageContributor),
 			withExcludes(
-				titleContributorId, titleMultilangContributorId1,
-				titleMultilangContributorId2),
+				alwaysPresentContributor, blogsContributor,
+				journalArticleContributor),
 			consumer);
 
 		assertSearch(
-			"[Gamma Article, Gamma Blog, Gamma Message]",
+			"[Gamma Article, Gamma Blog]",
 			withIncludes(
-				titleContributorId, titleMultilangContributorId1,
-				titleMultilangContributorId2, titleMultilangContributorId3),
+				alwaysPresentContributor, blogsContributor,
+				journalArticleContributor, mbMessageContributor),
+			withExcludes(blogsContributor, mbMessageContributor), consumer);
+
+		assertSearch(
+			"[Gamma Article]",
+			withIncludes(
+				alwaysPresentContributor, blogsContributor,
+				journalArticleContributor, mbMessageContributor),
 			withExcludes(
-				titleMultilangContributorId1, titleMultilangContributorId3),
+				alwaysPresentContributor, blogsContributor,
+				mbMessageContributor),
 			consumer);
 
 		assertSearch(
-			"[Gamma Article, Gamma Blog, Gamma Message]",
+			"[Gamma Blog]",
 			withIncludes(
-				titleContributorId, titleMultilangContributorId1,
-				titleMultilangContributorId2, titleMultilangContributorId3),
-			withExcludes(
-				titleContributorId, titleMultilangContributorId1,
-				titleMultilangContributorId3),
-			consumer);
-
-		assertSearch(
-			"[Gamma Article, Gamma Blog, Gamma Message]",
-			withIncludes(
-				titleContributorId, titleMultilangContributorId1,
-				titleMultilangContributorId2, titleMultilangContributorId3),
-			withExcludes(
-				titleMultilangContributorId2, titleMultilangContributorId3),
-			consumer);
-
-		assertSearch(
-			"[Gamma Article, Gamma Blog, Gamma Message]",
-			withIncludes(
-				titleContributorId, titleMultilangContributorId1,
-				titleMultilangContributorId2, titleMultilangContributorId3),
-			withExcludes(
-				titleContributorId, titleMultilangContributorId2,
-				titleMultilangContributorId3),
+				alwaysPresentContributor, blogsContributor,
+				journalArticleContributor, mbMessageContributor),
+			withExcludes(journalArticleContributor, mbMessageContributor),
 			consumer);
 	}
 

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/scores/test/IndexerScoreDistortionTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/scores/test/IndexerScoreDistortionTest.java
@@ -134,14 +134,21 @@ public class IndexerScoreDistortionTest {
 		SearchResponse searchResponse1 = search(title, locale, classes);
 
 		assertValuesIgnoreRelevance(
-			Field.ENTRY_CLASS_NAME,
-			getClassNamesAsString(
-				BlogsEntry.class, MBMessage.class, WikiPage.class),
-			_limit(searchResponse1.getDocuments(), 3), searchResponse1);
+			Field.ENTRY_CLASS_NAME, getClassNamesAsString(WikiPage.class),
+			_sublist(searchResponse1.getDocuments(), 0, 1), searchResponse1);
+
+		assertValuesIgnoreRelevance(
+			Field.ENTRY_CLASS_NAME, getClassNamesAsString(DLFileEntry.class),
+			_sublist(searchResponse1.getDocuments(), 1, 2), searchResponse1);
+
+		assertValuesIgnoreRelevance(
+			Field.ENTRY_CLASS_NAME, getClassNamesAsString(BlogsEntry.class),
+			_sublist(searchResponse1.getDocuments(), 2, 3), searchResponse1);
+
 		assertValuesIgnoreRelevance(
 			Field.ENTRY_CLASS_NAME,
-			getClassNamesAsString(DLFileEntry.class, JournalArticle.class),
-			_skip(searchResponse1.getDocuments(), 3), searchResponse1);
+			getClassNamesAsString(JournalArticle.class, MBMessage.class),
+			_sublist(searchResponse1.getDocuments(), 3, 5), searchResponse1);
 
 		SearchResponse searchResponse2 = search(
 			title, locale, classes,
@@ -345,12 +352,10 @@ public class IndexerScoreDistortionTest {
 			_group.getGroupId(), _user.getUserId());
 	}
 
-	private List<Document> _limit(List<Document> documents, int maxSize) {
-		return documents.subList(0, maxSize);
-	}
+	private List<Document> _sublist(
+		List<Document> documents, int start, int finish) {
 
-	private List<Document> _skip(List<Document> documents, int n) {
-		return documents.subList(n, documents.size());
+		return documents.subList(start, finish);
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerQueryBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerQueryBuilderImpl.java
@@ -125,18 +125,17 @@ public class IndexerQueryBuilderImpl<T extends BaseModel<?>>
 			return;
 		}
 
+		if (searchContext.isIncludeAttachments() ||
+			searchContext.isIncludeDiscussions()) {
+
+			_contributeFilters(booleanQuery, searchContext);
+
+			return;
+		}
+
 		BooleanQuery keywordsBooleanQuery = new BooleanQueryImpl();
 
-		contribute(
-			_modelKeywordQueryContributorsRegistry.
-				filterKeywordQueryContributors(
-					_getStrings(
-						"search.full.query.clause.contributors.excludes",
-						searchContext),
-					_getStrings(
-						"search.full.query.clause.contributors.includes",
-						searchContext)),
-			keywordsBooleanQuery, searchContext);
+		_contributeFilters(keywordsBooleanQuery, searchContext);
 
 		if (!keywordsBooleanQuery.hasClauses()) {
 			return;
@@ -250,6 +249,21 @@ public class IndexerQueryBuilderImpl<T extends BaseModel<?>>
 					throw new SystemException(exception);
 				}
 			});
+	}
+
+	private void _contributeFilters(
+		BooleanQuery booleanQuery, SearchContext searchContext) {
+
+		contribute(
+			_modelKeywordQueryContributorsRegistry.
+				filterKeywordQueryContributors(
+					_getStrings(
+						"search.full.query.clause.contributors.excludes",
+						searchContext),
+					_getStrings(
+						"search.full.query.clause.contributors.includes",
+						searchContext)),
+			booleanQuery, searchContext);
 	}
 
 	private void _contributeSearchContext(SearchContext searchContext) {

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerQueryBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerQueryBuilderImpl.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.search.RelatedEntryIndexerRegistry;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
+import com.liferay.portal.kernel.search.generic.TermQueryImpl;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.indexer.IndexerQueryBuilder;
@@ -124,6 +125,8 @@ public class IndexerQueryBuilderImpl<T extends BaseModel<?>>
 			return;
 		}
 
+		BooleanQuery keywordsBooleanQuery = new BooleanQueryImpl();
+
 		contribute(
 			_modelKeywordQueryContributorsRegistry.
 				filterKeywordQueryContributors(
@@ -133,7 +136,24 @@ public class IndexerQueryBuilderImpl<T extends BaseModel<?>>
 					_getStrings(
 						"search.full.query.clause.contributors.includes",
 						searchContext)),
-			booleanQuery, searchContext);
+			keywordsBooleanQuery, searchContext);
+
+		try {
+			BooleanQuery modelBooleanQuery = new BooleanQueryImpl();
+
+			modelBooleanQuery.add(
+				new TermQueryImpl(
+					"entryClassName", _modelSearchSettings.getClassName()),
+				BooleanClauseOccur.MUST);
+
+			modelBooleanQuery.add(
+				keywordsBooleanQuery, BooleanClauseOccur.SHOULD);
+
+			booleanQuery.add(modelBooleanQuery, BooleanClauseOccur.SHOULD);
+		}
+		catch (ParseException parseException) {
+			throw new SystemException(parseException);
+		}
 	}
 
 	protected void contribute(

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerQueryBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerQueryBuilderImpl.java
@@ -138,6 +138,10 @@ public class IndexerQueryBuilderImpl<T extends BaseModel<?>>
 						searchContext)),
 			keywordsBooleanQuery, searchContext);
 
+		if (!keywordsBooleanQuery.hasClauses()) {
+			return;
+		}
+
 		try {
 			BooleanQuery modelBooleanQuery = new BooleanQueryImpl();
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerQueryBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerQueryBuilderImpl.java
@@ -147,7 +147,7 @@ public class IndexerQueryBuilderImpl<T extends BaseModel<?>>
 				BooleanClauseOccur.MUST);
 
 			modelBooleanQuery.add(
-				keywordsBooleanQuery, BooleanClauseOccur.SHOULD);
+				keywordsBooleanQuery, BooleanClauseOccur.MUST);
 
 			booleanQuery.add(modelBooleanQuery, BooleanClauseOccur.SHOULD);
 		}

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiPageIndexer.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiPageIndexer.java
@@ -170,6 +170,10 @@ public class WikiPageIndexer extends BaseIndexer<WikiPage> {
 		addSearchLocalizedTerm(
 			keywordsBooleanQuery, searchContext, Field.TITLE, false);
 
+		if (!keywordsBooleanQuery.hasClauses()) {
+			return;
+		}
+
 		try {
 			BooleanQuery modelBooleanQuery = new BooleanQueryImpl();
 

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiPageIndexer.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiPageIndexer.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -26,12 +27,15 @@ import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.IndexWriterHelper;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.search.ParseException;
 import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.search.Summary;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.TermsFilter;
+import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
+import com.liferay.portal.kernel.search.generic.TermQueryImpl;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
@@ -148,9 +152,28 @@ public class WikiPageIndexer extends BaseIndexer<WikiPage> {
 			SearchContext searchContext)
 		throws Exception {
 
+		BooleanQuery keywordsBooleanQuery = new BooleanQueryImpl();
+
 		addSearchLocalizedTerm(
-			searchQuery, searchContext, Field.CONTENT, false);
-		addSearchLocalizedTerm(searchQuery, searchContext, Field.TITLE, false);
+			keywordsBooleanQuery, searchContext, Field.CONTENT, false);
+		addSearchLocalizedTerm(
+			keywordsBooleanQuery, searchContext, Field.TITLE, false);
+
+		try {
+			BooleanQuery modelBooleanQuery = new BooleanQueryImpl();
+
+			modelBooleanQuery.add(
+				new TermQueryImpl("entryClassName", CLASS_NAME),
+				BooleanClauseOccur.MUST);
+
+			modelBooleanQuery.add(
+				keywordsBooleanQuery, BooleanClauseOccur.SHOULD);
+
+			searchQuery.add(modelBooleanQuery, BooleanClauseOccur.SHOULD);
+		}
+		catch (ParseException parseException) {
+			throw new SystemException(parseException);
+		}
 
 		QueryConfig queryConfig = searchContext.getQueryConfig();
 

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiPageIndexer.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiPageIndexer.java
@@ -167,7 +167,7 @@ public class WikiPageIndexer extends BaseIndexer<WikiPage> {
 				BooleanClauseOccur.MUST);
 
 			modelBooleanQuery.add(
-				keywordsBooleanQuery, BooleanClauseOccur.SHOULD);
+				keywordsBooleanQuery, BooleanClauseOccur.MUST);
 
 			searchQuery.add(modelBooleanQuery, BooleanClauseOccur.SHOULD);
 		}

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiPageIndexer.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiPageIndexer.java
@@ -152,6 +152,17 @@ public class WikiPageIndexer extends BaseIndexer<WikiPage> {
 			SearchContext searchContext)
 		throws Exception {
 
+		if (searchContext.isIncludeAttachments() ||
+			searchContext.isIncludeDiscussions()) {
+
+			addSearchLocalizedTerm(
+				searchQuery, searchContext, Field.CONTENT, false);
+			addSearchLocalizedTerm(
+				searchQuery, searchContext, Field.TITLE, false);
+
+			return;
+		}
+
 		BooleanQuery keywordsBooleanQuery = new BooleanQueryImpl();
 
 		addSearchLocalizedTerm(


### PR DESCRIPTION
Story:
https://liferay.atlassian.net/browse/LPD-6591

Sub-tasks:
https://liferay.atlassian.net/browse/LPD-18244
https://liferay.atlassian.net/browse/LPD-18296

In https://liferay.atlassian.net/browse/LPD-18244 it was discovered that certain Administrator searches rely on query clause pollution to return related assets. They do this for comments when searchContext.isIncludeDiscussions is set, and for attachments when searchContext.isIncludeAttachments is set. I'll be [creating a ticket](https://liferay.atlassian.net/browse/LPD-19865) to improve this behavior in the future. For now, when these relatedAssets are needed, we will use the old behavior of non-isolated query clauses.

**Author:** @joshuacords 
