### PR TITLE
LPD-23621 portal-search-web: Update aria attributes and ids inside category facet

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/category/facet/portlet/display/template/dependencies/portlet_display_template_vocabulary.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/category/facet/portlet/display/template/dependencies/portlet_display_template_vocabulary.ftl
@@ -11,7 +11,7 @@
 	<li class="treeview-item" role="none">
 		<#if name?has_content>
 			<div
-				aria-controls="${namespace}treeItem${id}"
+				aria-controls="${(termDisplayContexts?has_content)?then(namespace + 'treeItem' + id, '')}"
 				aria-expanded="true"
 				class="treeview-link ${cssClassTreeItem}"
 				data-target="#${namespace}treeItem${id}"
@@ -27,6 +27,7 @@
 								<@clay.button
 									aria\-controls="${namespace}treeItem${id}"
 									aria\-expanded="true"
+									aria\-label="${languageUtil.get(locale, 'toggle')}"
 									cssClass="btn btn-monospaced component-expander"
 									data\-target="#${namespace}treeItem${id}"
 									data\-toggle="collapse"
@@ -147,7 +148,7 @@
 					<@treeview_item
 						cssClassTreeItem="tree-item-vocabulary"
 						frequencyVisible=false
-						id=vocabularyName + vocabularyName?index
+						id=vocabularyName?replace("[^\\w]|_", '', 'r') + vocabularyName?index
 						name="${(vocabularyNames?size == 1)?then('', htmlUtil.escape(vocabularyName))}"
 						termDisplayContexts=assetCategoriesSearchFacetDisplayContext.getBucketDisplayContexts(vocabularyName)
 					/>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-23621 - Accessibility issue within Category Facet's Vocabulary Layout

Changes:
- Remove `aria-control` value if tree item has no children and does not toggle visibility of anything
- Add `aria-label` to a toggle button
- For vocabulary names with spaces and special characters, remove the character to avoid bugs and awkwardly named ids like `_com_liferay_portal_search_web_category_facet_portlet_CategoryFacetPortlet_INSTANCE_BoF5udHk7qCe_treeItemVocabulary Name33417`