### PR TITLE
LPD-24244 Semantic Version Error - Search

### DIFF
--- a/modules/apps/portal-search/portal-search-api/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search API
 Bundle-SymbolicName: com.liferay.portal.search.api
-Bundle-Version: 16.0.1
+Bundle-Version: 16.1.0
 Export-Package:\
 	com.liferay.portal.search.aggregation,\
 	com.liferay.portal.search.aggregation.bucket,\

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/constants/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/searcher/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/searcher/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0


### PR DESCRIPTION
The semantic version test is failling in the CI daily routine.
[Here's the log](https://testray.liferay.com/reports/production/logs/2024-04/test-1-27/test-portal-testsuite-upstream(master)/2878/modules-semantic-versioning-jdk8/0/4/jenkins-console.txt.gz?authuser=0)