### PR TITLE
LPD-24353 LPD-24331 Bugs with a11y and facet terms on search-web templates

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/category/facet/portlet/display/template/dependencies/portlet_display_template_vocabulary.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/category/facet/portlet/display/template/dependencies/portlet_display_template_vocabulary.ftl
@@ -17,8 +17,9 @@
 				data-target="#${namespace}treeItem${id}"
 				data-toggle="collapse"
 				onClick="${namespace}toggleTreeItem('${namespace}treeItem${id}');"
+				onKeyPress="${namespace}toggleTreeItemKeypress(event);"
 				role="treeitem"
-				tabindex="0"
+				tabindex="${(termDisplayContexts?has_content)?then(0, -1)}"
 			>
 				<span class="c-inner" tabindex="-2">
 					<span class="autofit-row">
@@ -184,6 +185,14 @@
 			else {
 				subtreeCategoryTreeElement.classList.add('show');
 			}
+		}
+	}
+
+	function ${namespace}toggleTreeItemKeypress(event) {
+		event.preventDefault();
+
+		if (event.code === 'Enter' || event.code === 'Space') {
+			${namespace}toggleTreeItem(event.target.getAttribute('aria-controls'));
 		}
 	}
 </@>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/user/facet/portlet/display/template/dependencies/portlet_display_template_compact.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/user/facet/portlet/display/template/dependencies/portlet_display_template_compact.ftl
@@ -29,7 +29,7 @@
 					<li class="facet-value">
 						<@clay.button
 							cssClass="btn-unstyled facet-term ${(entry.isSelected())?then('facet-term-selected', 'facet-term-unselected')} term-name"
-							data\-term\-id="${entry.getBucketText()}"
+							data\-term\-id="${entry.getFilterValue()}"
 							disabled="true"
 							displayType="link"
 							onClick="Liferay.Search.FacetUtil.changeSelection(event);"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/user/facet/portlet/display/template/dependencies/portlet_display_template_label.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/user/facet/portlet/display/template/dependencies/portlet_display_template_label.ftl
@@ -28,7 +28,7 @@
 				<#list entries as entry>
 					<@clay.button
 						cssClass="label label-lg facet-term ${(entry.isSelected())?then('label-primary facet-term-selected', 'label-secondary facet-term-unselected')} term-name"
-						data\-term\-id="${entry.getBucketText()}"
+						data\-term\-id="${entry.getFilterValue()}"
 						disabled="true"
 						displayType="unstyled"
 						onClick="Liferay.Search.FacetUtil.changeSelection(event);"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-24353 - Accessibility error on Category Facet's Vocab Layout template
- Address a11y issue how user can tabulate between checkbox and description
- Add keypress function to toggle the tree item with keyboard

https://liferay.atlassian.net/browse/LPD-24331 - User facet template (compact, label) is not filtering properly due to incorrect data term id
- Not sure if anyone ever noticed, but the user facet templates for compact and label were filtering by the name but not the ID, so just a short update to change it to the filter value 😓 
