### PR TITLE
LPD-5260 Add Backend Test for IndexerReindexer

### DIFF
--- a/modules/apps/portal-search/portal-search-test/build.gradle
+++ b/modules/apps/portal-search/portal-search-test/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	testImplementation group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	testImplementation project(":apps:calendar:calendar-api")
 	testImplementation project(":apps:portal-search:portal-search")
+	testImplementation project(":apps:portal-search:portal-search-spi")
 	testImplementation project(":apps:portal-search:portal-search-test-util")
 	testImplementation project(":core:osgi-service-tracker-collections")
 	testImplementation project(":core:petra:petra-function")

--- a/modules/apps/portal-search/portal-search-test/src/test/java/com/liferay/portal/search/internal/background/task/ReindexIndexReindexerBackgroundTaskExecutorTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/test/java/com/liferay/portal/search/internal/background/task/ReindexIndexReindexerBackgroundTaskExecutorTest.java
@@ -1,0 +1,120 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.internal.background.task;
+
+import com.liferay.portal.kernel.search.background.task.ReindexStatusMessageSender;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.search.spi.reindexer.IndexReindexer;
+import com.liferay.portal.search.spi.reindexer.IndexReindexerRegistry;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Joshua Cords
+ */
+public class ReindexIndexReindexerBackgroundTaskExecutorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_reindexIndexReindexerBackgroundTaskExecutor =
+			new ReindexIndexReindexerBackgroundTaskExecutor();
+
+		Collection<IndexReindexer> indexReindexers = new ArrayList<>();
+
+		indexReindexers.add(_indexReindexer1);
+		indexReindexers.add(_indexReindexer2);
+
+		Mockito.when(
+			_indexReindexerRegistry.getIndexReindexers()
+		).thenReturn(
+			indexReindexers
+		);
+
+		Mockito.when(
+			_indexReindexerRegistry.getIndexReindexer(Mockito.anyString())
+		).thenReturn(
+			_indexReindexer1
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			_reindexIndexReindexerBackgroundTaskExecutor,
+			"_indexReindexerRegistry", _indexReindexerRegistry);
+		ReflectionTestUtil.setFieldValue(
+			_reindexIndexReindexerBackgroundTaskExecutor,
+			"_reindexStatusMessageSender", _reindexStatusMessageSender);
+	}
+
+	@Test
+	public void testReindexAllClasses() throws Exception {
+		_reindexIndexReindexerBackgroundTaskExecutor.reindex(
+			"", _COMPANY_IDS, _EXECUTION_MODE);
+
+		_verifyIndexerCalledOnceForEachCompany(_indexReindexer1);
+		_verifyIndexerCalledOnceForEachCompany(_indexReindexer2);
+	}
+
+	@Test
+	public void testReindexSingleClass() throws Exception {
+		_reindexIndexReindexerBackgroundTaskExecutor.reindex(
+			"className", _COMPANY_IDS, _EXECUTION_MODE);
+
+		_verifyIndexerCalledOnceForEachCompany(_indexReindexer1);
+
+		Mockito.verify(
+			_indexReindexer2, Mockito.never()
+		).reindex(
+			_COMPANY_IDS[0], _EXECUTION_MODE
+		);
+		Mockito.verify(
+			_indexReindexer2, Mockito.never()
+		).reindex(
+			_COMPANY_IDS[1], _EXECUTION_MODE
+		);
+	}
+
+	private void _verifyIndexerCalledOnceForEachCompany(
+			IndexReindexer indexReindexer)
+		throws Exception {
+
+		for (long companyId : _COMPANY_IDS) {
+			Mockito.verify(
+				indexReindexer
+			).reindex(
+				companyId, _EXECUTION_MODE
+			);
+		}
+	}
+
+	private static final long[] _COMPANY_IDS = {11111L, 22222L};
+
+	private static final String _EXECUTION_MODE = "full";
+
+	private final IndexReindexer _indexReindexer1 = Mockito.mock(
+		IndexReindexer.class);
+	private final IndexReindexer _indexReindexer2 = Mockito.mock(
+		IndexReindexer.class);
+	private final IndexReindexerRegistry _indexReindexerRegistry = Mockito.mock(
+		IndexReindexerRegistry.class);
+	private ReindexIndexReindexerBackgroundTaskExecutor
+		_reindexIndexReindexerBackgroundTaskExecutor;
+	private final ReindexStatusMessageSender _reindexStatusMessageSender =
+		Mockito.mock(ReindexStatusMessageSender.class);
+
+}

--- a/modules/apps/portal-search/portal-search-test/src/test/java/com/liferay/portal/search/internal/background/task/ReindexIndexReindexerBackgroundTaskExecutorTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/test/java/com/liferay/portal/search/internal/background/task/ReindexIndexReindexerBackgroundTaskExecutorTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -11,7 +11,7 @@ import com.liferay.portal.search.spi.reindexer.IndexReindexer;
 import com.liferay.portal.search.spi.reindexer.IndexReindexerRegistry;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 
 import org.junit.Before;
@@ -36,10 +36,8 @@ public class ReindexIndexReindexerBackgroundTaskExecutorTest {
 		_reindexIndexReindexerBackgroundTaskExecutor =
 			new ReindexIndexReindexerBackgroundTaskExecutor();
 
-		Collection<IndexReindexer> indexReindexers = new ArrayList<>();
-
-		indexReindexers.add(_indexReindexer1);
-		indexReindexers.add(_indexReindexer2);
+		Collection<IndexReindexer> indexReindexers = Arrays.asList(
+			_indexReindexer1, _indexReindexer2);
 
 		Mockito.when(
 			_indexReindexerRegistry.getIndexReindexers()
@@ -82,6 +80,7 @@ public class ReindexIndexReindexerBackgroundTaskExecutorTest {
 		).reindex(
 			_COMPANY_IDS[0], _EXECUTION_MODE
 		);
+
 		Mockito.verify(
 			_indexReindexer2, Mockito.never()
 		).reindex(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-5260
Subtask: https://liferay.atlassian.net/browse/LPD-25881

It was difficult to what needed to be tested exactly. From what I could tell https://liferay.atlassian.net/browse/LPS-183661 made logical changes to ReindexIndexReindexerBackgroundTaskExecutor and those are what need to be tested. I don't think the background tasks were part of this so I don't see the need to add testing there.

@gustavolimav, let me know if I'm missing something.

**Author:** @joshuacords 