### PR TITLE
LPD-25453 Fix Playwright test portal-search-web/searchFacets

### DIFF
--- a/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
@@ -91,6 +91,7 @@ test.describe('Clear and retain facet selections', () => {
 	});
 
 	test('retains facet terms if search keyword has not changed @LPD-19994', async ({
+		page,
 		searchPage,
 	}) => {
 
@@ -110,6 +111,8 @@ test.describe('Clear and retain facet selections', () => {
 		await expect(lastModifiedPastYearFacetLink).toHaveClass(
 			/facet-term-selected/
 		);
+
+		await page.reload();
 	});
 
 	test('retains items per page after new keyword search @LPD-19994', async ({

--- a/modules/test/playwright/tests/portal-search-web/test.properties
+++ b/modules/test/playwright/tests/portal-search-web/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Web Search


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-25453 - Fix Playwright test portal-search-web/searchFacets.spec.ts

Search facet is having difficulties detecting the Search Configurations link when viewing page after the same keyword is searched. It only happens in one of the tests (the same teardown steps happen in all five of the tests), but it works after adding a refresh.

Also including test.properties to assign component name, so it's clear search team is involved.