### PR TITLE
LPD-28066 Fix searchfacets paginator assertion

### DIFF
--- a/modules/test/playwright/pages/portal-search-web/SearchPage.ts
+++ b/modules/test/playwright/pages/portal-search-web/SearchPage.ts
@@ -102,7 +102,7 @@ export class SearchPage {
 		});
 
 		await expect(this.searchResultsPaginationItemsPerPageToggle).toHaveText(
-			`${delta.toString()} Entries Per Page`
+			new RegExp(`${delta.toString()} Entries`)
 		);
 	}
 

--- a/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
@@ -137,7 +137,7 @@ test.describe('Clear and retain facet selections', () => {
 
 		await expect(
 			searchPage.searchResultsPaginationItemsPerPageToggle
-		).toHaveText('4 Entries Per Page');
+		).toHaveText(/4 Entries/);
 
 		await expect(
 			searchPage.searchResultsPaginationBar.getByText('1').first()


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-28066 - Fix test failure searchFacets.spec.ts 

The wording changed on search-paginator slightly, so these changes replace the expected text with regex so that partial matches will work.