### PR TITLE
LPD-28164 Break terms query when "The number of terms exceeded the allowed maximum"

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/filter/TermsFilterTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/filter/TermsFilterTranslatorImpl.java
@@ -6,9 +6,9 @@
 package com.liferay.portal.search.elasticsearch7.internal.filter;
 
 import com.liferay.portal.kernel.search.filter.TermsFilter;
+import com.liferay.portal.search.elasticsearch7.internal.util.TermsUtil;
 
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -20,7 +20,7 @@ public class TermsFilterTranslatorImpl implements TermsFilterTranslator {
 
 	@Override
 	public QueryBuilder translate(TermsFilter termsFilter) {
-		return QueryBuilders.termsQuery(
+		return TermsUtil.translateTerms(
 			termsFilter.getField(), termsFilter.getValues());
 	}
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/filter/TermsFilterTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/filter/TermsFilterTranslatorImpl.java
@@ -6,7 +6,7 @@
 package com.liferay.portal.search.elasticsearch7.internal.filter;
 
 import com.liferay.portal.kernel.search.filter.TermsFilter;
-import com.liferay.portal.search.elasticsearch7.internal.util.TermsUtil;
+import com.liferay.portal.search.elasticsearch7.internal.util.QueryUtil;
 
 import org.elasticsearch.index.query.QueryBuilder;
 
@@ -20,7 +20,7 @@ public class TermsFilterTranslatorImpl implements TermsFilterTranslator {
 
 	@Override
 	public QueryBuilder translate(TermsFilter termsFilter) {
-		return TermsUtil.translateTerms(
+		return QueryUtil.translateTerms(
 			termsFilter.getField(), termsFilter.getValues());
 	}
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/TermsQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/TermsQueryTranslatorImpl.java
@@ -5,7 +5,7 @@
 
 package com.liferay.portal.search.elasticsearch7.internal.query;
 
-import com.liferay.portal.search.elasticsearch7.internal.util.TermsUtil;
+import com.liferay.portal.search.elasticsearch7.internal.util.QueryUtil;
 import com.liferay.portal.search.query.TermsQuery;
 
 import org.elasticsearch.index.query.QueryBuilder;
@@ -20,7 +20,7 @@ public class TermsQueryTranslatorImpl implements TermsQueryTranslator {
 
 	@Override
 	public QueryBuilder translate(TermsQuery termsQuery) {
-		return TermsUtil.translateTerms(
+		return QueryUtil.translateTerms(
 			termsQuery.getField(), termsQuery.getValues());
 	}
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/TermsQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/TermsQueryTranslatorImpl.java
@@ -5,14 +5,10 @@
 
 package com.liferay.portal.search.elasticsearch7.internal.query;
 
+import com.liferay.portal.search.elasticsearch7.internal.util.TermsUtil;
 import com.liferay.portal.search.query.TermsQuery;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -24,38 +20,8 @@ public class TermsQueryTranslatorImpl implements TermsQueryTranslator {
 
 	@Override
 	public QueryBuilder translate(TermsQuery termsQuery) {
-		String field = termsQuery.getField();
-		String[] terms = termsQuery.getValues();
-
-		if (terms.length <= _MAX_TERMS_COUNT) {
-			return QueryBuilders.termsQuery(field, terms);
-		}
-
-		BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
-
-		List<String> termsList = new ArrayList<>();
-
-		for (String term : terms) {
-			termsList.add(term);
-
-			if (termsList.size() == _MAX_TERMS_COUNT) {
-				boolQueryBuilder.should(
-					QueryBuilders.termsQuery(
-						field, termsList.toArray(new String[0])));
-
-				termsList.clear();
-			}
-		}
-
-		if (!termsList.isEmpty()) {
-			boolQueryBuilder.should(
-				QueryBuilders.termsQuery(
-					field, termsList.toArray(new String[0])));
-		}
-
-		return boolQueryBuilder;
+		return TermsUtil.translateTerms(
+			termsQuery.getField(), termsQuery.getValues());
 	}
-
-	private static final Integer _MAX_TERMS_COUNT = 65536;
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/util/QueryUtil.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/util/QueryUtil.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/util/QueryUtil.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/util/QueryUtil.java
@@ -15,7 +15,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 /**
  * @author Gustavo Lima
  */
-public abstract class TermsUtil {
+public class QueryUtil {
 
 	public static AbstractQueryBuilder<? extends AbstractQueryBuilder<?>>
 		translateTerms(String field, String[] terms) {

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/util/TermsUtil.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/util/TermsUtil.java
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+
+/**
+ * @author Gustavo Lima
+ */
+public abstract class TermsUtil {
+
+	public static AbstractQueryBuilder<? extends AbstractQueryBuilder<?>>
+		translateTerms(String field, String[] terms) {
+
+		if (terms.length <= _MAX_TERMS_COUNT) {
+			return QueryBuilders.termsQuery(field, terms);
+		}
+
+		BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
+
+		List<String> termsList = new ArrayList<>();
+
+		for (String term : terms) {
+			termsList.add(term);
+
+			if (termsList.size() == _MAX_TERMS_COUNT) {
+				boolQueryBuilder.should(
+					QueryBuilders.termsQuery(
+						field, termsList.toArray(new String[0])));
+
+				termsList.clear();
+			}
+		}
+
+		if (!termsList.isEmpty()) {
+			boolQueryBuilder.should(
+				QueryBuilders.termsQuery(
+					field, termsList.toArray(new String[0])));
+		}
+
+		return boolQueryBuilder;
+	}
+
+	private static final Integer _MAX_TERMS_COUNT = 65536;
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/filter/TermsFilterTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/filter/TermsFilterTest.java
@@ -5,13 +5,21 @@
 
 package com.liferay.portal.search.elasticsearch7.internal.filter;
 
+import com.liferay.portal.kernel.search.filter.TermsFilter;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.elasticsearch7.internal.indexing.LiferayElasticsearchIndexingFixtureFactory;
+import com.liferay.portal.search.elasticsearch7.internal.legacy.query.ElasticsearchQueryTranslatorFixture;
+import com.liferay.portal.search.elasticsearch7.internal.util.QueryUtil;
 import com.liferay.portal.search.test.util.filter.BaseTermsFilterTestCase;
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * @author André de Oliveira
@@ -23,9 +31,63 @@ public class TermsFilterTest extends BaseTermsFilterTestCase {
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
 
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+
+		ElasticsearchFilterTranslatorFixture
+			elasticsearchFilterTranslatorFixture =
+				new ElasticsearchFilterTranslatorFixture(
+					new ElasticsearchQueryTranslatorFixture(
+					).getElasticsearchQueryTranslator());
+
+		_elasticsearchFilterTranslator =
+			elasticsearchFilterTranslatorFixture.
+				getElasticsearchFilterTranslator();
+	}
+
+	@Test
+	public void testTranslateTermsFilterExceedingMaxAllowedTerms() {
+		TermsFilter termsFilter = new TermsFilter("groupId");
+
+		ReflectionTestUtil.setFieldValue(
+			_elasticsearchFilterTranslator, "termsFilterTranslator",
+			new TermsFilterTranslatorImpl());
+
+		termsFilter.addValues("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+
+		_setMaxTermsCount(10);
+
+		_assertTermsCount(1, termsFilter);
+
+		_setMaxTermsCount(5);
+
+		_assertTermsCount(2, termsFilter);
+
+		_setMaxTermsCount(3);
+
+		_assertTermsCount(4, termsFilter);
+	}
+
 	@Override
 	protected IndexingFixture createIndexingFixture() throws Exception {
 		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
 	}
+
+	private void _assertTermsCount(int expected, TermsFilter termsFilter) {
+		String queryString = _elasticsearchFilterTranslator.visit(
+			termsFilter
+		).toString();
+
+		Assert.assertEquals(
+			queryString, expected, StringUtil.count(queryString, "terms"));
+	}
+
+	private void _setMaxTermsCount(int maxTermsCount) {
+		ReflectionTestUtil.setFieldValue(
+			QueryUtil.class, "_MAX_TERMS_COUNT", maxTermsCount);
+	}
+
+	private ElasticsearchFilterTranslator _elasticsearchFilterTranslator;
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/filter/TermsFilterTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/filter/TermsFilterTest.java
@@ -11,9 +11,12 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.elasticsearch7.internal.indexing.LiferayElasticsearchIndexingFixtureFactory;
 import com.liferay.portal.search.elasticsearch7.internal.legacy.query.ElasticsearchQueryTranslatorFixture;
 import com.liferay.portal.search.elasticsearch7.internal.util.QueryUtil;
+import com.liferay.portal.search.test.util.IdempotentRetryAssert;
 import com.liferay.portal.search.test.util.filter.BaseTermsFilterTestCase;
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -47,12 +50,10 @@ public class TermsFilterTest extends BaseTermsFilterTestCase {
 	}
 
 	@Test
-	public void testTranslateTermsFilterExceedingMaxAllowedTerms() {
-		TermsFilter termsFilter = new TermsFilter("groupId");
+	public void testTranslateTermsFilterExceedingMaxAllowedTerms()
+		throws Exception {
 
-		ReflectionTestUtil.setFieldValue(
-			_elasticsearchFilterTranslator, "termsFilterTranslator",
-			new TermsFilterTranslatorImpl());
+		TermsFilter termsFilter = new TermsFilter("groupId");
 
 		termsFilter.addValues("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
 
@@ -74,13 +75,20 @@ public class TermsFilterTest extends BaseTermsFilterTestCase {
 		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
 	}
 
-	private void _assertTermsCount(int expected, TermsFilter termsFilter) {
-		String queryString = _elasticsearchFilterTranslator.visit(
-			termsFilter
-		).toString();
+	private void _assertTermsCount(int expected, TermsFilter termsFilter)
+		throws Exception {
 
-		Assert.assertEquals(
-			queryString, expected, StringUtil.count(queryString, "terms"));
+		IdempotentRetryAssert.retryAssert(
+			10, TimeUnit.SECONDS,
+			() -> {
+				String queryString = _elasticsearchFilterTranslator.visit(
+					termsFilter
+				).toString();
+
+				Assert.assertEquals(
+					queryString, expected,
+					StringUtil.count(queryString, "terms"));
+			});
 	}
 
 	private void _setMaxTermsCount(int maxTermsCount) {

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/query/ElasticsearchQueryTranslatorTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/query/ElasticsearchQueryTranslatorTest.java
@@ -7,6 +7,7 @@ package com.liferay.portal.search.elasticsearch7.internal.query;
 
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.elasticsearch7.internal.util.QueryUtil;
 import com.liferay.portal.search.internal.query.BooleanQueryImpl;
 import com.liferay.portal.search.internal.query.CommonTermsQueryImpl;
 import com.liferay.portal.search.internal.query.FuzzyQueryImpl;
@@ -112,24 +113,21 @@ public class ElasticsearchQueryTranslatorTest {
 	public void testTranslateTermsQueryExceedingMaxAllowedTerms() {
 		TermsQuery termsQuery = new TermsQueryImpl("groupId");
 
-		TermsQueryTranslator termsQueryTranslator =
-			new TermsQueryTranslatorImpl();
-
 		ReflectionTestUtil.setFieldValue(
 			_elasticsearchQueryTranslator, "_termsQueryTranslator",
-			termsQueryTranslator);
+			new TermsQueryTranslatorImpl());
 
 		termsQuery.addValues("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
 
-		_setMaxTermsCount(10, termsQueryTranslator);
+		_setMaxTermsCount(10);
 
 		_assertTermsCount(1, termsQuery);
 
-		_setMaxTermsCount(5, termsQueryTranslator);
+		_setMaxTermsCount(5);
 
 		_assertTermsCount(2, termsQuery);
 
-		_setMaxTermsCount(3, termsQueryTranslator);
+		_setMaxTermsCount(3);
 
 		_assertTermsCount(4, termsQuery);
 	}
@@ -154,11 +152,9 @@ public class ElasticsearchQueryTranslatorTest {
 			queryString, expected, StringUtil.count(queryString, "terms"));
 	}
 
-	private void _setMaxTermsCount(
-		int maxTermsCount, TermsQueryTranslator termsQueryTranslator) {
-
+	private void _setMaxTermsCount(int maxTermsCount) {
 		ReflectionTestUtil.setFieldValue(
-			termsQueryTranslator, "_MAX_TERMS_COUNT", maxTermsCount);
+			QueryUtil.class, "_MAX_TERMS_COUNT", maxTermsCount);
 	}
 
 	private static final Float _BOOST = 1.5F;

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/query/ElasticsearchQueryTranslatorTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/query/ElasticsearchQueryTranslatorTest.java
@@ -19,10 +19,12 @@ import com.liferay.portal.search.internal.query.WildcardQueryImpl;
 import com.liferay.portal.search.query.BooleanQuery;
 import com.liferay.portal.search.query.Query;
 import com.liferay.portal.search.query.TermsQuery;
+import com.liferay.portal.search.test.util.IdempotentRetryAssert;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -110,12 +112,10 @@ public class ElasticsearchQueryTranslatorTest {
 	}
 
 	@Test
-	public void testTranslateTermsQueryExceedingMaxAllowedTerms() {
-		TermsQuery termsQuery = new TermsQueryImpl("groupId");
+	public void testTranslateTermsQueryExceedingMaxAllowedTerms()
+		throws Exception {
 
-		ReflectionTestUtil.setFieldValue(
-			_elasticsearchQueryTranslator, "_termsQueryTranslator",
-			new TermsQueryTranslatorImpl());
+		TermsQuery termsQuery = new TermsQueryImpl("groupId");
 
 		termsQuery.addValues("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
 
@@ -143,13 +143,20 @@ public class ElasticsearchQueryTranslatorTest {
 			String.valueOf(queryBuilder.boost()));
 	}
 
-	private void _assertTermsCount(int expected, TermsQuery termsQuery) {
-		String queryString = _elasticsearchQueryTranslator.translate(
-			termsQuery
-		).toString();
+	private void _assertTermsCount(int expected, TermsQuery termsQuery)
+		throws Exception {
 
-		Assert.assertEquals(
-			queryString, expected, StringUtil.count(queryString, "terms"));
+		IdempotentRetryAssert.retryAssert(
+			10, TimeUnit.SECONDS,
+			() -> {
+				String queryString = _elasticsearchQueryTranslator.visit(
+					termsQuery
+				).toString();
+
+				Assert.assertEquals(
+					queryString, expected,
+					StringUtil.count(queryString, "terms"));
+			});
 	}
 
 	private void _setMaxTermsCount(int maxTermsCount) {

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/filter/OpenSearchFilterTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/filter/OpenSearchFilterTranslator.java
@@ -32,7 +32,6 @@ import com.liferay.portal.search.filter.FilterVisitor;
 import com.liferay.portal.search.filter.RangeFilter;
 import com.liferay.portal.search.filter.TermsSetFilter;
 import com.liferay.portal.search.opensearch2.internal.geolocation.GeoTranslator;
-import com.liferay.portal.search.opensearch2.internal.util.ConversionUtil;
 import com.liferay.portal.search.opensearch2.internal.util.QueryUtil;
 import com.liferay.portal.search.opensearch2.internal.util.SetterUtil;
 
@@ -54,8 +53,6 @@ import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
 import org.opensearch.client.opensearch._types.query_dsl.QueryVariant;
 import org.opensearch.client.opensearch._types.query_dsl.RangeQuery;
 import org.opensearch.client.opensearch._types.query_dsl.TermQuery;
-import org.opensearch.client.opensearch._types.query_dsl.TermsQuery;
-import org.opensearch.client.opensearch._types.query_dsl.TermsQueryField;
 import org.opensearch.client.opensearch._types.query_dsl.TermsSetQuery;
 
 import org.osgi.service.component.annotations.Component;
@@ -294,14 +291,8 @@ public class OpenSearchFilterTranslator
 
 	@Override
 	public QueryVariant visit(TermsFilter termsFilter) {
-		return TermsQuery.of(
-			termsQuery -> termsQuery.field(
-				termsFilter.getField()
-			).terms(
-				TermsQueryField.of(
-					termsQueryField -> termsQueryField.value(
-						ConversionUtil.toFieldValues(termsFilter.getValues())))
-			));
+		return QueryUtil.translateTerms(
+			null, termsFilter.getField(), termsFilter.getValues());
 	}
 
 	@Override

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/query/OpenSearchQueryTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/query/OpenSearchQueryTranslator.java
@@ -65,7 +65,6 @@ import com.liferay.portal.search.query.function.CombineFunction;
 import com.liferay.portal.search.query.geolocation.ShapeRelation;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
@@ -990,38 +989,9 @@ public class OpenSearchQueryTranslator
 
 	@Override
 	public QueryVariant visit(TermsQuery termsQuery) {
-		String field = termsQuery.getField();
-		String[] terms = termsQuery.getValues();
-
-		if (terms.length <= _MAX_TERMS_COUNT) {
-			return _translateTermsQuery(termsQuery, field, terms);
-		}
-
-		BoolQuery.Builder builder = QueryBuilders.bool();
-
-		List<String> termsList = new ArrayList<>();
-
-		for (String term : terms) {
-			termsList.add(term);
-
-			if (termsList.size() == _MAX_TERMS_COUNT) {
-				builder.should(
-					_translateTermsQuery(
-						termsQuery, field, termsList.toArray(new String[0])
-					)._toQuery());
-
-				termsList.clear();
-			}
-		}
-
-		if (!termsList.isEmpty()) {
-			builder.should(
-				_translateTermsQuery(
-					termsQuery, field, termsList.toArray(new String[0])
-				)._toQuery());
-		}
-
-		return builder.build();
+		return QueryUtil.translateTerms(
+			termsQuery.getBoost(), termsQuery.getField(),
+			termsQuery.getValues());
 	}
 
 	@Override
@@ -1396,33 +1366,6 @@ public class OpenSearchQueryTranslator
 		throw new IllegalArgumentException(
 			"Invalid shape relation " + shapeRelation);
 	}
-
-	private org.opensearch.client.opensearch._types.query_dsl.TermsQuery
-		_translateTermsQuery(
-			TermsQuery termsQuery, String field, String[] values) {
-
-		org.opensearch.client.opensearch._types.query_dsl.TermsQuery.Builder
-			builder = QueryBuilders.terms();
-
-		SetterUtil.setNotNullFloat(builder::boost, termsQuery.getBoost());
-
-		builder.field(field);
-
-		builder.terms(
-			termsQueryField -> {
-				List<FieldValue> fieldValues = new ArrayList<>();
-
-				ListUtil.isNotEmptyForEach(
-					Arrays.asList(values),
-					value -> fieldValues.add(FieldValue.of(value)));
-
-				return termsQueryField.value(fieldValues);
-			});
-
-		return builder.build();
-	}
-
-	private static final Integer _MAX_TERMS_COUNT = 65536;
 
 	private final GeoTranslator _geoTranslator = new GeoTranslator();
 	private final OpenSearchScoreFunctionTranslator

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/util/QueryUtil.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/util/QueryUtil.java
@@ -5,15 +5,22 @@
 
 package com.liferay.portal.search.opensearch2.internal.util;
 
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
+import org.opensearch.client.opensearch._types.query_dsl.QueryVariant;
 import org.opensearch.client.opensearch._types.query_dsl.RangeQuery;
+import org.opensearch.client.opensearch._types.query_dsl.TermsQuery;
 
 /**
  * @author Petteri Karttunen
@@ -64,5 +71,66 @@ public class QueryUtil {
 			}
 		}
 	}
+
+	public static QueryVariant translateTerms(
+		Float boost, String field, String[] terms) {
+
+		if (terms.length <= _MAX_TERMS_COUNT) {
+			return _getTermsQuery(boost, field, terms);
+		}
+
+		BoolQuery.Builder builder = QueryBuilders.bool();
+
+		List<String> termsList = new ArrayList<>();
+
+		for (String term : terms) {
+			termsList.add(term);
+
+			if (termsList.size() == _MAX_TERMS_COUNT) {
+				builder.should(
+					_getTermsQuery(
+						boost, field, termsList.toArray(new String[0])
+					)._toQuery());
+
+				termsList.clear();
+			}
+		}
+
+		if (!termsList.isEmpty()) {
+			builder.should(
+				_getTermsQuery(
+					boost, field, termsList.toArray(new String[0])
+				)._toQuery());
+		}
+
+		return builder.build();
+	}
+
+	private static TermsQuery _getTermsQuery(
+		Float boost, String field, String[] values) {
+
+		TermsQuery.Builder builder = QueryBuilders.terms();
+
+		if (boost != null) {
+			SetterUtil.setNotNullFloat(builder::boost, boost);
+		}
+
+		builder.field(field);
+
+		builder.terms(
+			termsQueryField -> {
+				List<FieldValue> fieldValues = new ArrayList<>();
+
+				ListUtil.isNotEmptyForEach(
+					Arrays.asList(values),
+					value -> fieldValues.add(FieldValue.of(value)));
+
+				return termsQueryField.value(fieldValues);
+			});
+
+		return builder.build();
+	}
+
+	private static final Integer _MAX_TERMS_COUNT = 65536;
 
 }

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/filter/TermsFilterTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/filter/TermsFilterTest.java
@@ -14,9 +14,12 @@ import com.liferay.portal.search.opensearch2.internal.legacy.query.OpenSearchQue
 import com.liferay.portal.search.opensearch2.internal.util.JsonpUtil;
 import com.liferay.portal.search.opensearch2.internal.util.QueryUtil;
 import com.liferay.portal.search.query.Query;
+import com.liferay.portal.search.test.util.IdempotentRetryAssert;
 import com.liferay.portal.search.test.util.filter.BaseTermsFilterTestCase;
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -49,7 +52,9 @@ public class TermsFilterTest extends BaseTermsFilterTestCase {
 	}
 
 	@Test
-	public void testTranslateTermsFilterExceedingMaxAllowedTerms() {
+	public void testTranslateTermsFilterExceedingMaxAllowedTerms()
+		throws Exception {
+
 		TermsFilter termsFilter = new TermsFilter("groupId");
 
 		termsFilter.addValues("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
@@ -72,10 +77,17 @@ public class TermsFilterTest extends BaseTermsFilterTestCase {
 		return LiferayOpenSearchIndexingFixtureFactory.getInstance();
 	}
 
-	private void _assertTermsCount(int expected, TermsFilter termsFilter) {
-		String jsonp = _toJSONP(termsFilter);
+	private void _assertTermsCount(int expected, TermsFilter termsFilter)
+		throws Exception {
 
-		Assert.assertEquals(jsonp, expected, StringUtil.count(jsonp, "terms"));
+		IdempotentRetryAssert.retryAssert(
+			10, TimeUnit.SECONDS,
+			() -> {
+				String jsonp = _toJSONP(termsFilter);
+
+				Assert.assertEquals(
+					jsonp, expected, StringUtil.count(jsonp, "terms"));
+			});
 	}
 
 	private void _setMaxTermsCount(int maxTermsCount) {

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/filter/TermsFilterTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/filter/TermsFilterTest.java
@@ -5,13 +5,23 @@
 
 package com.liferay.portal.search.opensearch2.internal.filter;
 
+import com.liferay.portal.kernel.search.filter.TermsFilter;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.opensearch2.internal.OpenSearchTestRule;
 import com.liferay.portal.search.opensearch2.internal.indexing.LiferayOpenSearchIndexingFixtureFactory;
+import com.liferay.portal.search.opensearch2.internal.legacy.query.OpenSearchQueryTranslator;
+import com.liferay.portal.search.opensearch2.internal.util.JsonpUtil;
+import com.liferay.portal.search.opensearch2.internal.util.QueryUtil;
+import com.liferay.portal.search.query.Query;
 import com.liferay.portal.search.test.util.filter.BaseTermsFilterTestCase;
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Test;
 
 /**
  * @author André de Oliveira
@@ -26,9 +36,62 @@ public class TermsFilterTest extends BaseTermsFilterTestCase {
 	public static final OpenSearchTestRule openSearchTestRule =
 		OpenSearchTestRule.INSTANCE;
 
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+
+		OpenSearchFilterTranslatorFixture openSearchFilterTranslatorFixture =
+			new OpenSearchFilterTranslatorFixture(
+				new OpenSearchQueryTranslator());
+
+		_openSearchFilterTranslator =
+			openSearchFilterTranslatorFixture.getOpenSearchFilterTranslator();
+	}
+
+	@Test
+	public void testTranslateTermsFilterExceedingMaxAllowedTerms() {
+		TermsFilter termsFilter = new TermsFilter("groupId");
+
+		termsFilter.addValues("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+
+		_setMaxTermsCount(10);
+
+		_assertTermsCount(1, termsFilter);
+
+		_setMaxTermsCount(5);
+
+		_assertTermsCount(2, termsFilter);
+
+		_setMaxTermsCount(3);
+
+		_assertTermsCount(4, termsFilter);
+	}
+
 	@Override
 	protected IndexingFixture createIndexingFixture() throws Exception {
 		return LiferayOpenSearchIndexingFixtureFactory.getInstance();
 	}
+
+	private void _assertTermsCount(int expected, TermsFilter termsFilter) {
+		String jsonp = _toJSONP(termsFilter);
+
+		Assert.assertEquals(jsonp, expected, StringUtil.count(jsonp, "terms"));
+	}
+
+	private void _setMaxTermsCount(int maxTermsCount) {
+		ReflectionTestUtil.setFieldValue(
+			QueryUtil.class, "_MAX_TERMS_COUNT", maxTermsCount);
+	}
+
+	private String _toJSONP(TermsFilter termsFilter) {
+		org.opensearch.client.opensearch._types.query_dsl.Query
+			openSearchQuery =
+				new org.opensearch.client.opensearch._types.query_dsl.Query(
+					_openSearchFilterTranslator.visit(termsFilter));
+
+		return JsonpUtil.toString(openSearchQuery);
+	}
+
+	private OpenSearchFilterTranslator _openSearchFilterTranslator;
 
 }

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/query/OpenSearchQueryTranslatorTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/query/OpenSearchQueryTranslatorTest.java
@@ -22,11 +22,13 @@ import com.liferay.portal.search.opensearch2.internal.util.QueryUtil;
 import com.liferay.portal.search.query.BooleanQuery;
 import com.liferay.portal.search.query.Query;
 import com.liferay.portal.search.query.TermsQuery;
+import com.liferay.portal.search.test.util.IdempotentRetryAssert;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -123,7 +125,9 @@ public class OpenSearchQueryTranslatorTest {
 	}
 
 	@Test
-	public void testTranslateTermsQueryExceedingMaxAllowedTerms() {
+	public void testTranslateTermsQueryExceedingMaxAllowedTerms()
+		throws Exception {
+
 		TermsQuery termsQuery = new TermsQueryImpl("groupId");
 
 		termsQuery.addValues("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
@@ -150,10 +154,17 @@ public class OpenSearchQueryTranslatorTest {
 			jsonp, jsonp.contains("\"boost\":" + String.valueOf(_BOOST)));
 	}
 
-	private void _assertTermsCount(int expected, TermsQuery termsQuery) {
-		String jsonp = _toJSONP(termsQuery);
+	private void _assertTermsCount(int expected, TermsQuery termsQuery)
+		throws Exception {
 
-		Assert.assertEquals(jsonp, expected, StringUtil.count(jsonp, "terms"));
+		IdempotentRetryAssert.retryAssert(
+			10, TimeUnit.SECONDS,
+			() -> {
+				String jsonp = _toJSONP(termsQuery);
+
+				Assert.assertEquals(
+					jsonp, expected, StringUtil.count(jsonp, "terms"));
+			});
 	}
 
 	private void _setMaxTermsCount(int maxTermsCount) {

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/query/OpenSearchQueryTranslatorTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/query/OpenSearchQueryTranslatorTest.java
@@ -18,6 +18,7 @@ import com.liferay.portal.search.internal.query.TermsQueryImpl;
 import com.liferay.portal.search.internal.query.WildcardQueryImpl;
 import com.liferay.portal.search.opensearch2.internal.OpenSearchTestRule;
 import com.liferay.portal.search.opensearch2.internal.util.JsonpUtil;
+import com.liferay.portal.search.opensearch2.internal.util.QueryUtil;
 import com.liferay.portal.search.query.BooleanQuery;
 import com.liferay.portal.search.query.Query;
 import com.liferay.portal.search.query.TermsQuery;
@@ -157,7 +158,7 @@ public class OpenSearchQueryTranslatorTest {
 
 	private void _setMaxTermsCount(int maxTermsCount) {
 		ReflectionTestUtil.setFieldValue(
-			_openSearchQueryTranslator, "_MAX_TERMS_COUNT", maxTermsCount);
+			QueryUtil.class, "_MAX_TERMS_COUNT", maxTermsCount);
 	}
 
 	private String _toJSONP(Query query) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-28164

Sending again a solution for this Error because it was not tested the right way before, now it was tested manually and new tests were added to make sure it works fine.

Basically we had other place where Terms could generate the error.