### PR TITLE
LPD-27132 Assert poshi success message after downloading JSON

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
@@ -895,6 +895,8 @@ definition {
 
 		Click(locator1 = "Link#DOWNLOAD");
 
+		Alert.viewSuccessMessage();
+
 		var outputDir = PropsUtil.get("output.dir.name");
 
 		var fileContent = FileUtil.read("${outputDir}/sxpElement.json");
@@ -964,6 +966,8 @@ definition {
 		SelectFrameTop();
 
 		Click(locator1 = "Link#DOWNLOAD");
+
+		Alert.viewSuccessMessage();
 
 		var outputDir = PropsUtil.get("output.dir.name");
 
@@ -1622,6 +1626,8 @@ definition {
 
 		Click(locator1 = "Link#DOWNLOAD");
 
+		Alert.viewSuccessMessage();
+
 		Blueprints.viewDownloadedContent(
 			fileName = "sxpElement.json",
 			text = "clauses");
@@ -1647,6 +1653,8 @@ definition {
 
 		Click(locator1 = "Link#DOWNLOAD");
 
+		Alert.viewSuccessMessage();
+
 		Blueprints.viewDownloadedContent(
 			fileName = "sxpElement.json",
 			text = "queryConfiguration");
@@ -1668,6 +1676,8 @@ definition {
 
 		Click(locator1 = "Link#DOWNLOAD");
 
+		Alert.viewSuccessMessage();
+
 		Blueprints.viewDownloadedContent(
 			fileName = "raw_response.json",
 			text = "hits");
@@ -1688,6 +1698,8 @@ definition {
 		SelectFrameTop();
 
 		Click(locator1 = "Link#DOWNLOAD");
+
+		Alert.viewSuccessMessage();
 
 		Blueprints.viewDownloadedContent(
 			fileName = "score_explanation.json",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-27132 - Investigate flake functional tests: Blueprints#AssertUsingCopiedElementJSONWithinCustomJSONElement & Blueprints#DownloadElementJSONViaElementsEditPreview & Blueprints#AssertUsingCopiedElementJSONWithinCustomElement

https://liferay.atlassian.net/browse/LPD-29096 - [Integration Test] Investigate Blueprints#DownloadElementJSONViaBlueprintsQueryBuilder 

https://liferay.atlassian.net/browse/LPD-27130 - Investigate flake functional test: Blueprints#DownloadRawResponseViaBlueprintsPreview

Affects tests:
Blueprints#AssertUsingCopiedElementJSONWithinCustomJSONElement 
Blueprints#DownloadElementJSONViaElementsEditPreview
Blueprints#AssertUsingCopiedElementJSONWithinCustomElement
Blueprints#DownloadElementJSONViaBlueprintsQueryBuilder 
Blueprints#DownloadRawResponseViaBlueprintsPreview

These all have to do with flakiness related to downloading JSON (sxpElement.json, raw_response.json, score_explanation.json), which seems to work fine when tested manually. The tests only fail from time to time, so it's hard to say what is actually causing the issues. The tentative fix here is to assert the success message that the JSON is saved, it helps with CI processing that the JSON would be found. 