### PR TITLE
LPD-27983 poshi: Wait for title before asserting description in blueprint localization

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
@@ -3373,6 +3373,10 @@ definition {
 
 		Button.click(button = "Seleccionar");
 
+		WaitForElementPresent(
+			key_blueprintTitle = "Título en Español",
+			locator1 = "Blueprints#BLUEPRINTS_OPTION_WIDGET_TITLE");
+
 		AssertTextEquals(
 			key_blueprintTitle = "Título en Español",
 			locator1 = "Blueprints#BLUEPRINTS_OPTION_WIDGET_TITLE",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-27983 - Blueprints#ViewBlueprintLocalizationWithinBlueprintsOptionsWidget

Error:
`java.lang.Exception: Element is not present at "//tr[contains(.,'Título en Español')]/..//following-sibling::td"`


Small update where the poshi test is asserting the description before it has a chance to load onto the view. This change adds waiting until the description element is present.