### PR TITLE
LPD-27992 Fix flakiness for reindex/localized search admin tests

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/elasticsearch/Elasticsearch7.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/elasticsearch/Elasticsearch7.testcase
@@ -705,7 +705,7 @@ definition {
 								"must": [
 									{
 										"match": {
-											"userName": "test test"
+											"screenName": "default-service-account"
 										}
 									},
 									{
@@ -729,13 +729,13 @@ definition {
 		}
 
 		task ("Assert that search results are still returned during the reindex") {
-			SearchPage.openSearchPage(searchTerm = "test");
+			SearchPage.openSearchPage(searchTerm = "tree");
 
 			AssertElementPresent(locator1 = "Search#REINDEX_IN_PROGRESS_INDICATOR");
 
 			SearchResults.viewSearchResults(
-				searchAssetTitle = "Test Test",
-				searchAssetType = "User");
+				searchAssetTitle = "tree.png",
+				searchAssetType = "Document");
 		}
 
 		task ("After the reindex is complete, assert the timestamp value for the 'Test Test' user document has updated in the index") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/elasticsearch/Elasticsearch7.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/elasticsearch/Elasticsearch7.testcase
@@ -743,6 +743,8 @@ definition {
 
 			WaitForElementNotPresent(locator1 = "Search#REINDEX_IN_PROGRESS_INDICATOR");
 
+			SearchPage.openSearchPage();
+
 			var postSyncReindexTimestamp = JSONCurlUtil.get(${curl}, "$.hits.hits[0]._source.timestamp");
 
 			if (${preSyncReindexTimestamp} != ${postSyncReindexTimestamp}) {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
@@ -1093,6 +1093,8 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
+		HeadlessSite.addSite(siteName = "Site Name");
+
 		User.openUsersAdmin();
 
 		User.editDisplaySettingsCP(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-27992 - Search#IsLocalizedInSearchAdmin
https://liferay.atlassian.net/browse/LPD-27123 - Elasticsearch7#ReindexWithSyncExecutionMode

These flakey test fails are related to not being able to see the Test Test user sometimes on startup, so the workarounds have been to:
- Add a site to be able to access user admin menu
- Assert a visible document (tree.png) or the default-service-account user

And also:
- Add a little step before grabbing reindex timestamp