### PR TITLE
LPD-28532 Vocabularies configured in Category Facets are not updated on Export/Import

### DIFF
--- a/modules/apps/portal-search/portal-search-test/build.gradle
+++ b/modules/apps/portal-search/portal-search-test/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
 	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.component", version: "1.4.0"
 	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	testIntegrationImplementation project(":apps:asset:asset-test-util")
 	testIntegrationImplementation project(":apps:blogs:blogs-api")
 	testIntegrationImplementation project(":apps:blogs:blogs-test-util")
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-api")
@@ -23,8 +24,11 @@ dependencies {
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")
 	testIntegrationImplementation project(":apps:expando:expando-test-util")
+	testIntegrationImplementation project(":apps:export-import:export-import-api")
+	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
 	testIntegrationImplementation project(":apps:journal:journal-api")
 	testIntegrationImplementation project(":apps:journal:journal-test-util")
+	testIntegrationImplementation project(":apps:layout:layout-test-util")
 	testIntegrationImplementation project(":apps:message-boards:message-boards-api")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-instances:portal-instances-api")

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/test/CategoryFacetExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/test/CategoryFacetExportImportPortletPreferencesProcessorTest.java
@@ -1,0 +1,167 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.exportimport.portlet.preferences.processor.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
+import com.liferay.asset.test.util.AssetTestUtil;
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.exportimport.test.util.ExportImportTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.HashMap;
+
+import javax.portlet.PortletPreferences;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Joshua Cords
+ */
+@RunWith(Arquillian.class)
+public class CategoryFacetExportImportPortletPreferencesProcessorTest {
+
+	public static final String CATEGORY_FACET =
+		"com_liferay_portal_search_web_category_facet_portlet_" +
+			"CategoryFacetPortlet";
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		UserTestUtil.setUser(TestPropsValues.getUser());
+
+		_group = GroupTestUtil.addGroup();
+
+		_layout = LayoutTestUtil.addTypePortletLayout(_group.getGroupId());
+
+		LayoutTestUtil.addPortletToLayout(
+			TestPropsValues.getUserId(), _layout, CATEGORY_FACET, "column-1",
+			new HashMap<String, String[]>());
+
+		_portletDataContextExport =
+			ExportImportTestUtil.getExportPortletDataContext(
+				_group.getGroupId());
+
+		_portletDataContextExport.setPlid(_layout.getPlid());
+		_portletDataContextExport.setPortletId(CATEGORY_FACET);
+
+		_portletDataContextImport =
+			ExportImportTestUtil.getImportPortletDataContext(
+				_group.getGroupId());
+
+		_portletDataContextImport.setPlid(_layout.getPlid());
+		_portletDataContextImport.setPortletId(CATEGORY_FACET);
+
+		_portletPreferences =
+			PortletPreferencesFactoryUtil.getStrictPortletSetup(
+				_layout, CATEGORY_FACET);
+
+		_portletPreferences.setValue("selectionStyle", "manual");
+	}
+
+	@Test
+	public void testProcessAssetVocabularyId() throws Exception {
+		AssetVocabulary exportedAssetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId());
+
+		_setCategoryFacetPortletPreferences(exportedAssetVocabulary);
+
+		PortletPreferences exportedPortletPreferences =
+			_exportImportPortletPreferencesProcessor.
+				processExportPortletPreferences(
+					_portletDataContextExport, _portletPreferences);
+
+		String exportedAssetVocabularyId = exportedPortletPreferences.getValue(
+			"vocabularyIds", "");
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				exportedAssetVocabulary.getExternalReferenceCode(),
+				StringPool.POUND, _group.getGroupId(), StringPool.POUND,
+				_group.getExternalReferenceCode()),
+			exportedAssetVocabularyId);
+
+		AssetVocabulary importedAssetVocabulary = _addImportedAssetVocabulary(
+			exportedAssetVocabulary, exportedAssetVocabularyId);
+
+		PortletPreferences importedPortletPreferences =
+			_exportImportPortletPreferencesProcessor.
+				processImportPortletPreferences(
+					_portletDataContextImport, exportedPortletPreferences);
+
+		String importedVocabularyId = importedPortletPreferences.getValue(
+			"vocabularyIds", "");
+
+		Assert.assertEquals(
+			importedAssetVocabulary.getVocabularyId(),
+			GetterUtil.getLong(importedVocabularyId));
+	}
+
+	private AssetVocabulary _addImportedAssetVocabulary(
+			AssetVocabulary assetVocabulary, String exportedAssetVocabularyId)
+		throws Exception {
+
+		AssetVocabularyLocalServiceUtil.deleteVocabulary(
+			assetVocabulary.getVocabularyId());
+
+		assetVocabulary = AssetTestUtil.addVocabulary(_group.getGroupId());
+
+		assetVocabulary.setExternalReferenceCode(
+			exportedAssetVocabularyId.substring(
+				0, exportedAssetVocabularyId.indexOf(CharPool.POUND)));
+
+		return AssetVocabularyLocalServiceUtil.updateAssetVocabulary(
+			assetVocabulary);
+	}
+
+	private void _setCategoryFacetPortletPreferences(
+			AssetVocabulary assetVocabulary)
+		throws Exception {
+
+		_portletPreferences.setValue(
+			"vocabularyIds", String.valueOf(assetVocabulary.getVocabularyId()));
+
+		_portletPreferences.store();
+	}
+
+	@Inject(filter = "javax.portlet.name=" + CATEGORY_FACET)
+	private ExportImportPortletPreferencesProcessor
+		_exportImportPortletPreferencesProcessor;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Layout _layout;
+	private PortletDataContext _portletDataContextExport;
+	private PortletDataContext _portletDataContextImport;
+	private PortletPreferences _portletPreferences;
+
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/CategoryFacetExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/exportimport/portlet/preferences/processor/CategoryFacetExportImportPortletPreferencesProcessor.java
@@ -5,18 +5,252 @@
 
 package com.liferay.portal.search.web.internal.exportimport.portlet.preferences.processor;
 
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.PortletDataException;
+import com.liferay.exportimport.portlet.preferences.processor.Capability;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.exportimport.portlet.preferences.processor.base.BaseExportImportPortletPreferencesProcessor;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.web.internal.category.facet.constants.CategoryFacetPortletKeys;
+import com.liferay.portal.search.web.internal.category.facet.portlet.CategoryFacetPortletPreferences;
+
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+
+import javax.portlet.PortletPreferences;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
- * @author Felipe Lorenz
+ * @author Felipe Lorenz, Joshua Cords
  */
 @Component(
 	property = "javax.portlet.name=" + CategoryFacetPortletKeys.CATEGORY_FACET,
 	service = ExportImportPortletPreferencesProcessor.class
 )
 public class CategoryFacetExportImportPortletPreferencesProcessor
-	extends BaseSearchWidgetsExportImportPortletPreferencesProcessor {
+	extends BaseExportImportPortletPreferencesProcessor {
+
+	@Override
+	public List<Capability> getExportCapabilities() {
+		return ListUtil.fromArray(exportCapability);
+	}
+
+	@Override
+	public List<Capability> getImportCapabilities() {
+		return ListUtil.fromArray(importCapability);
+	}
+
+	@Override
+	public PortletPreferences processExportPortletPreferences(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		try {
+			return _updateExportPortletPreferences(
+				portletDataContext, portletPreferences,
+				portletDataContext.getPortletId());
+		}
+		catch (Exception exception) {
+			throw new PortletDataException(
+				"Unable to update asset categories navigation portlet " +
+					"preferences during export",
+				exception);
+		}
+	}
+
+	@Override
+	public PortletPreferences processImportPortletPreferences(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		try {
+			return _updateImportPortletPreferences(
+				portletDataContext, portletPreferences);
+		}
+		catch (Exception exception) {
+			throw new PortletDataException(
+				"Unable to update asset categories navigation portlet " +
+					"preferences during import",
+				exception);
+		}
+	}
+
+	@Override
+	protected String getExportPortletPreferencesValue(
+			PortletDataContext portletDataContext, Portlet portlet,
+			String className, long primaryKeyLong)
+		throws Exception {
+
+		if (className.equals(AssetVocabulary.class.getName())) {
+			AssetVocabulary assetVocabulary =
+				_assetVocabularyLocalService.fetchAssetVocabulary(
+					primaryKeyLong);
+
+			if (assetVocabulary != null) {
+				String erc = assetVocabulary.getExternalReferenceCode();
+				long groupId = assetVocabulary.getGroupId();
+
+				portletDataContext.addReferenceElement(
+					portlet, portletDataContext.getExportDataRootElement(),
+					assetVocabulary,
+					PortletDataContext.REFERENCE_TYPE_DEPENDENCY, true);
+
+				String groupERC = StringPool.BLANK;
+
+				Group group = _groupLocalService.fetchGroup(groupId);
+
+				if (group != null) {
+					groupERC = group.getExternalReferenceCode();
+				}
+
+				return StringUtil.merge(
+					new Object[] {erc, groupId, groupERC}, StringPool.POUND);
+			}
+		}
+
+		return null;
+	}
+
+	@Override
+	protected Long getImportPortletPreferencesNewValue(
+			PortletDataContext portletDataContext, Class<?> clazz,
+			long companyGroupId, Map<Long, Long> primaryKeys,
+			String portletPreferencesOldValue)
+		throws Exception {
+
+		if (Validator.isNumber(portletPreferencesOldValue)) {
+			long oldPrimaryKey = GetterUtil.getLong(portletPreferencesOldValue);
+
+			return MapUtil.getLong(primaryKeys, oldPrimaryKey, oldPrimaryKey);
+		}
+
+		String className = clazz.getName();
+
+		String[] oldValues = StringUtil.split(
+			portletPreferencesOldValue, StringPool.POUND);
+
+		long groupId = portletDataContext.getScopeGroupId();
+
+		if (oldValues.length > 1) {
+			Map<Long, Long> groupIds =
+				(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+					Group.class);
+
+			groupId = MapUtil.getLong(
+				groupIds, GetterUtil.getLong(oldValues[1]));
+
+			if ((groupId == 0) && (oldValues.length > 2)) {
+				Group group =
+					_groupLocalService.fetchGroupByExternalReferenceCode(
+						oldValues[2], portletDataContext.getCompanyId());
+
+				groupId = group.getGroupId();
+			}
+		}
+
+		if (className.equals(AssetVocabulary.class.getName())) {
+			String erc = oldValues[0];
+
+			AssetVocabulary assetVocabulary =
+				_assetVocabularyLocalService.
+					fetchAssetVocabularyByExternalReferenceCode(erc, groupId);
+
+			if (assetVocabulary != null) {
+				return assetVocabulary.getVocabularyId();
+			}
+		}
+
+		return null;
+	}
+
+	@Reference(target = "(name=PortletDisplayTemplateExporter)")
+	protected Capability exportCapability;
+
+	@Reference(target = "(name=PortletDisplayTemplateImporter)")
+	protected Capability importCapability;
+
+	private PortletPreferences _updateExportPortletPreferences(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences, String portletId)
+		throws Exception {
+
+		Portlet portlet = _portletLocalService.getPortletById(
+			portletDataContext.getCompanyId(), portletId);
+
+		Enumeration<String> enumeration = portletPreferences.getNames();
+
+		while (enumeration.hasMoreElements()) {
+			String name = enumeration.nextElement();
+
+			if (name.equals(
+					CategoryFacetPortletPreferences.
+						PREFERENCE_VOCABULARY_IDS)) {
+
+				updateExportPortletPreferencesClassPKs(
+					portletDataContext, portlet, portletPreferences, name,
+					AssetVocabulary.class.getName());
+			}
+		}
+
+		return portletPreferences;
+	}
+
+	private PortletPreferences _updateImportPortletPreferences(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws Exception {
+
+		Company company = _companyLocalService.getCompanyById(
+			portletDataContext.getCompanyId());
+
+		Group companyGroup = company.getGroup();
+
+		Enumeration<String> enumeration = portletPreferences.getNames();
+
+		while (enumeration.hasMoreElements()) {
+			String name = enumeration.nextElement();
+
+			if (name.equals(
+					CategoryFacetPortletPreferences.
+						PREFERENCE_VOCABULARY_IDS)) {
+
+				updateImportPortletPreferencesClassPKs(
+					portletDataContext, portletPreferences, name,
+					AssetVocabulary.class, companyGroup.getGroupId());
+			}
+		}
+
+		return portletPreferences;
+	}
+
+	@Reference
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private PortletLocalService _portletLocalService;
+
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-28532

Original code fix was reviewed here: https://github.com/liferay-headless/liferay-portal/pull/2107

I made a slight tweak to the logic, removing the conditional for adding the groupIdERC and added a test.

**Author:** @joshuacords
**Reviewer:** DaniSzimko