### PR TITLE
LPD-28370 poshi: No need to assert order for one result

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/elasticsearch/SearchTuningES7.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/elasticsearch/SearchTuningES7.testcase
@@ -367,11 +367,6 @@ definition {
 
 		SearchPage.searchEmbedded(searchTerm = "Journal");
 
-		AssertTextNotEquals.assertNotPartialMatch(
-			locator1 = "SearchPage#RESULT_TITLE_SPECIFIC_ORDER",
-			resultOrder = 1,
-			value1 = "Journal 2");
-
 		for (var webContentTitle : list "Article 1,Article 2,Journal 1,Journal 2") {
 			SearchResults.viewSearchResults(
 				searchAssetTitle = ${webContentTitle},


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-28370 - Fix flakey test: SearchTuningES7#AssertResultRankingsWithSynonyms

There is some flakiness when asserting that "Journal 2" is never the first result when searching for "Journal".

Search tuning conditions are:
- Synonym set of "Article" and "Journal"
- Result Ranking of "Article" with no aliases + "Journal 2" is pinned + "Article 2" is hidden

Searching for "Journal" would have results for "Article" and "Journal" due to the synonym set, but order may not always be the same (lack of aliases in the result ranking, equal score among search results). It sounds all right to leave out this condition, as it has been causing flakey results.