### PR TITLE
LPD-33194 portal-search-web: Add a parameter to avoid missing pagination

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SelectVocabularies.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SelectVocabularies.js
@@ -232,7 +232,7 @@ function SelectVocabularies({
 		setVocabularyTreeLoading(true);
 
 		fetch(
-			'/o/headless-admin-user/v1.0/my-user-account/sites',
+			'/o/headless-admin-user/v1.0/my-user-account/sites?page=0&pageSize=0',
 			CONFIGURATION
 		)
 			.then((response) => response.json())


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-33194 - Not all sites are listed in Category Facet's Select Vocabularies 

If there are 20+ sites, they wouldn't be visible on the Category Facet's Select Vocab list. There was a previous change that was similar for the vocabularies associated with the site.

Similar ticket: https://liferay.atlassian.net/browse/LPS-178336

> Current portal logic, by default limits the headless api calls to 20 when there's no pagination. (see https://github.com/liferay/liferay-portal/blob/43b763b02f23e3ac3c1c8f25ba5c505ec157d0e4/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/PaginationContextProvider.java#L35,L49)
> 
> I've added this parameters to the url in order to avoid the pagination and do not limit it to 20.

Playwright test subtask: https://liferay.atlassian.net/browse/LPD-33427

