### PR TITLE
LPD-33194 Playwright test to check sites list on category facet configuration

### DIFF
--- a/modules/test/playwright/pages/portal-search-web/SearchPage.ts
+++ b/modules/test/playwright/pages/portal-search-web/SearchPage.ts
@@ -6,6 +6,7 @@
 import {FrameLocator, Locator, Page, expect} from '@playwright/test';
 
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
+import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
 
 export class SearchPage {
 	readonly page: Page;
@@ -125,26 +126,22 @@ export class SearchPage {
 
 	async openSearchPortletConfiguration(
 		portletName: string,
-		order: number = 0
+		index: number = 0
 	) {
+		const portletTopper = this.page
+			.locator('.portlet-topper', {hasText: portletName})
+			.nth(index);
+
 		await this.page
 			.locator('.portlet', {
 				hasText: portletName,
 			})
-			.nth(order)
+			.nth(index)
 			.hover();
 
-		await expect(
-			this.page
-				.locator('.portlet-topper', {hasText: portletName})
-				.nth(order)
-		).toBeVisible();
+		await expect(portletTopper).toBeVisible();
 
-		await this.page
-			.locator('.portlet-topper', {hasText: portletName})
-			.nth(order)
-			.getByLabel('Options')
-			.click();
+		await portletTopper.getByLabel('Options').click();
 
 		await this.configurationMenuItem.click();
 
@@ -153,6 +150,11 @@ export class SearchPage {
 
 	async savePortletConfiguration() {
 		await this.modalIFrame.getByRole('button', {name: 'Save'}).click();
+
+		await waitForSuccessAlert(
+			this.modalIFrame,
+			'Success:You have successfully updated the setup.'
+		);
 
 		await this.modalIFrame.getByRole('button', {name: 'Cancel'}).click();
 	}

--- a/modules/test/playwright/pages/portal-search-web/SearchPage.ts
+++ b/modules/test/playwright/pages/portal-search-web/SearchPage.ts
@@ -123,6 +123,34 @@ export class SearchPage {
 		await this.page.goto('/search');
 	}
 
+	async openSearchPortletConfiguration(
+		portletName: string,
+		order: number = 0
+	) {
+		await this.page
+			.locator('.portlet', {
+				hasText: portletName,
+			})
+			.nth(order)
+			.hover();
+
+		await expect(
+			this.page
+				.locator('.portlet-topper', {hasText: portletName})
+				.nth(order)
+		).toBeVisible();
+
+		await this.page
+			.locator('.portlet-topper', {hasText: portletName})
+			.nth(order)
+			.getByLabel('Options')
+			.click();
+
+		await this.configurationMenuItem.click();
+
+		await expect(this.page.locator('#modalIframe')).toBeVisible();
+	}
+
 	async searchKeywordInMainContent(searchText: string) {
 		await this.searchBarInputInMainContent.fill(searchText);
 

--- a/modules/test/playwright/pages/portal-search-web/SearchPage.ts
+++ b/modules/test/playwright/pages/portal-search-web/SearchPage.ts
@@ -151,6 +151,12 @@ export class SearchPage {
 		await expect(this.page.locator('#modalIframe')).toBeVisible();
 	}
 
+	async savePortletConfiguration() {
+		await this.modalIFrame.getByRole('button', {name: 'Save'}).click();
+
+		await this.modalIFrame.getByRole('button', {name: 'Cancel'}).click();
+	}
+
 	async searchKeywordInMainContent(searchText: string) {
 		await this.searchBarInputInMainContent.fill(searchText);
 
@@ -161,25 +167,6 @@ export class SearchPage {
 		await this.searchBarInputInNavBar.fill(searchText);
 
 		await this.searchBarInputInNavBar.press('Enter');
-	}
-
-	async selectCheckboxPortletConfigurations(
-		options: {label: string; value: boolean}[]
-	) {
-		for (const option of options) {
-			const configurationCheckbox = this.modalIFrame.locator(
-				`xpath=//*[text()[contains(.,'${option.label}')]]//input`
-			);
-
-			await this.selectSearchFacetCheckbox(
-				configurationCheckbox,
-				option.value
-			);
-		}
-
-		await this.modalIFrame.getByRole('button', {name: 'Save'}).click();
-
-		await this.modalIFrame.getByRole('button', {name: 'Cancel'}).click();
 	}
 
 	async selectPaginationItemsPerPage(delta: number) {
@@ -209,14 +196,32 @@ export class SearchPage {
 		).toHaveAttribute('aria-current', 'page');
 	}
 
-	async selectSearchBarInMainContentConfigurations(
+	async selectPortletConfigurationsCheckbox(
 		options: {label: string; value: boolean}[]
 	) {
-		await this.searchBarPortletInMainContent.getByLabel('Options').click();
+		for (const option of options) {
+			const configurationCheckbox = this.modalIFrame.locator(
+				`xpath=//*[text()[contains(.,'${option.label}')]]//input`
+			);
 
-		await this.configurationMenuItem.click();
+			await this.selectSearchFacetCheckbox(
+				configurationCheckbox,
+				option.value
+			);
+		}
+	}
 
-		await this.selectCheckboxPortletConfigurations(options);
+	async selectPortletConfigurationsSelect(
+		options: {label: string; value: string}[]
+	) {
+		for (const option of options) {
+			const configurationSelect = this.modalIFrame.getByLabel(
+				option.label,
+				{exact: true}
+			);
+
+			await configurationSelect.selectOption({label: option.value});
+		}
 	}
 
 	async selectSearchFacetCheckbox(
@@ -251,13 +256,5 @@ export class SearchPage {
 				/facet-term-selected/
 			);
 		}
-	}
-
-	async selectSearchOptionCheckboxConfigurations(
-		options: {label: string; value: boolean}[]
-	) {
-		await this.searchOptionsConfigurationLink.click();
-
-		await this.selectCheckboxPortletConfigurations(options);
 	}
 }

--- a/modules/test/playwright/tests/portal-search-web/searchBar.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/searchBar.spec.ts
@@ -25,7 +25,7 @@ export const test = mergeTests(
 );
 
 test.describe('Search Bar directs to correct page', () => {
-	test('retains impersonation parameter when suggestions is disabled @LPD-17509', async ({
+	test('Retains impersonation parameter when suggestions is disabled @LPD-17509', async ({
 		apiHelpers,
 		layout,
 		page,

--- a/modules/test/playwright/tests/portal-search-web/searchBar.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/searchBar.spec.ts
@@ -49,12 +49,20 @@ test.describe('Search Bar directs to correct page', () => {
 		});
 
 		await test.step('Disable search suggestions for added search bar', async () => {
-			await searchPage.selectSearchBarInMainContentConfigurations([
+			await searchPage.searchBarPortletInMainContent
+				.getByLabel('Options')
+				.click();
+
+			await searchPage.configurationMenuItem.click();
+
+			await searchPage.selectPortletConfigurationsCheckbox([
 				{
 					label: 'Enable Suggestions',
 					value: false,
 				},
 			]);
+
+			await searchPage.savePortletConfiguration();
 		});
 
 		await test.step('Impersonate as the test user', async () => {

--- a/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
@@ -13,7 +13,7 @@ import getRandomString from '../../utils/getRandomString';
 export const test = mergeTests(loginTest(), searchPageTest, dataApiHelpersTest);
 
 test.describe('Category facet configuration for vocabularies', () => {
-	test('lists 20+ sites available to the user @LPD-33194', async ({
+	test('Lists 20+ sites available to the user @LPD-33194', async ({
 		apiHelpers,
 		searchPage,
 	}) => {
@@ -29,15 +29,19 @@ test.describe('Category facet configuration for vocabularies', () => {
 			}
 		});
 
-		await test.step('Open category facet configurations', async () => {
+		await test.step('Navigate to search page', async () => {
 			await searchPage.goto();
+		});
 
+		await test.step('Search for keyword "Test"', async () => {
 			await searchPage.searchKeywordInNavBar('test');
 
 			await expect(searchPage.searchResultsTotalLabel).toHaveText(
 				/\d+ Results for test/
 			);
+		});
 
+		await test.step('Open category facet configurations', async () => {
 			await searchPage.openSearchPortletConfiguration('Category Facet');
 		});
 
@@ -124,7 +128,7 @@ test.describe('Clear and retain facet selections', () => {
 		await searchPage.savePortletConfiguration();
 	});
 
-	test('clears facet terms after new keyword search @LPD-19994', async ({
+	test('Clears facet terms after new keyword search @LPD-19994', async ({
 		searchPage,
 	}) => {
 
@@ -146,7 +150,7 @@ test.describe('Clear and retain facet selections', () => {
 		);
 	});
 
-	test('retains facet terms if search keyword has not changed @LPD-19994', async ({
+	test('Retains facet terms if search keyword has not changed @LPD-19994', async ({
 		page,
 		searchPage,
 	}) => {
@@ -171,7 +175,7 @@ test.describe('Clear and retain facet selections', () => {
 		await page.reload();
 	});
 
-	test('retains items per page after new keyword search @LPD-19994', async ({
+	test('Retains items per page after new keyword search @LPD-19994', async ({
 		searchPage,
 	}) => {
 
@@ -204,7 +208,7 @@ test.describe('Clear and retain facet selections', () => {
 		);
 	});
 
-	test('clears facet terms if performing an empty search @LPD-19994', async ({
+	test('Clears facet terms if performing an empty search @LPD-19994', async ({
 		page,
 		searchPage,
 	}) => {
@@ -242,7 +246,7 @@ test.describe('Clear and retain facet selections', () => {
 		);
 	});
 
-	test('retains facet terms if configured under search options @LPD-19994', async ({
+	test('Retains facet terms if configured under search options @LPD-19994', async ({
 		page,
 		searchPage,
 	}) => {

--- a/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
@@ -108,7 +108,9 @@ test.describe('Clear and retain facet selections', () => {
 
 		// Teardown by resetting search options
 
-		await searchPage.selectSearchOptionCheckboxConfigurations([
+		await searchPage.searchOptionsConfigurationLink.click();
+
+		await searchPage.selectPortletConfigurationsCheckbox([
 			{
 				label: 'Allow Empty Searches',
 				value: false,
@@ -118,6 +120,8 @@ test.describe('Clear and retain facet selections', () => {
 				value: false,
 			},
 		]);
+
+		await searchPage.savePortletConfiguration();
 	});
 
 	test('clears facet terms after new keyword search @LPD-19994', async ({
@@ -207,12 +211,16 @@ test.describe('Clear and retain facet selections', () => {
 
 		// Configure search options to retain facet selections
 
-		await searchPage.selectSearchOptionCheckboxConfigurations([
+		await searchPage.searchOptionsConfigurationLink.click();
+
+		await searchPage.selectPortletConfigurationsCheckbox([
 			{
 				label: 'Allow Empty Searches',
 				value: true,
 			},
 		]);
+
+		await searchPage.savePortletConfiguration();
 
 		await page.reload();
 
@@ -241,12 +249,16 @@ test.describe('Clear and retain facet selections', () => {
 
 		// Configure search options to retain facet selections
 
-		await searchPage.selectSearchOptionCheckboxConfigurations([
+		await searchPage.searchOptionsConfigurationLink.click();
+
+		await searchPage.selectPortletConfigurationsCheckbox([
 			{
 				label: 'Retain Facet Selections Across Searches',
 				value: true,
 			},
 		]);
+
+		await searchPage.savePortletConfiguration();
 
 		await page.reload();
 

--- a/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
@@ -5,10 +5,62 @@
 
 import {Locator, expect, mergeTests} from '@playwright/test';
 
+import {dataApiHelpersTest} from '../../fixtures/dataApiHelpersTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {searchPageTest} from '../../fixtures/searchPageTest';
+import getRandomString from '../../utils/getRandomString';
 
-export const test = mergeTests(loginTest(), searchPageTest);
+export const test = mergeTests(loginTest(), searchPageTest, dataApiHelpersTest);
+
+test.describe('Category facet configuration for vocabularies', () => {
+	test('lists 20+ sites available to the user @LPD-33194', async ({
+		apiHelpers,
+		searchPage,
+	}) => {
+		const siteName = getRandomString();
+
+		await test.step('Create 21 sites to test listing', async () => {
+			for (let count = 0; count < 21; count++) {
+				const newSite = await apiHelpers.headlessSite.createSite({
+					name: `${siteName}-${count}`,
+				});
+
+				apiHelpers.data.push({id: newSite.id, type: 'site'});
+			}
+		});
+
+		await test.step('Open category facet configurations', async () => {
+			await searchPage.goto();
+
+			await searchPage.searchKeywordInMainContent('test');
+
+			await expect(searchPage.searchResultsTotalLabel).toHaveText(
+				/\d+ Results for test/
+			);
+
+			await searchPage.openSearchPortletConfiguration('Category Facet');
+		});
+
+		await test.step('Assert 21 sites are listed in the configuration', async () => {
+			await searchPage.modalIFrame
+				.getByLabel('Select Vocabularies')
+				.click();
+
+			await searchPage.modalIFrame
+				.getByRole('treeitem', {name: 'Global'})
+				.waitFor();
+
+			for (let count = 0; count < 21; count++) {
+				await expect(
+					searchPage.modalIFrame.getByRole('treeitem', {
+						exact: true,
+						name: `${siteName}-${count}`,
+					})
+				).toBeVisible();
+			}
+		});
+	});
+});
 
 test.describe('Clear and retain facet selections', () => {
 	let typeDocumentFacetCheckbox: Locator;

--- a/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
@@ -32,7 +32,7 @@ test.describe('Category facet configuration for vocabularies', () => {
 		await test.step('Open category facet configurations', async () => {
 			await searchPage.goto();
 
-			await searchPage.searchKeywordInMainContent('test');
+			await searchPage.searchKeywordInNavBar('test');
 
 			await expect(searchPage.searchResultsTotalLabel).toHaveText(
 				/\d+ Results for test/


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-33427 - (subtask) Playwright test for LPD-33194

Some notes:
- Some of the test functions seemed a bit too specific now that there's several ways to open configuration modals, so several steps were separated to make them easier to reuse in future tests (like splitting up the open configuration modal, selecting config options, saving config options)
- Added a `selectPortletConfigurationsSelect` + renamed `selectCheckboxPortletConfigurations` to `selectPortletConfigurationsCheckbox` (keeps them alphabetized next to each other 😅 )