### PR TITLE
LPD-33329: "Portlet is temporarily unavailable" error appears if you try to filter by a non-existent categoryId via the URL

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/facet/display/context/AssetCategoriesSearchFacetDisplayContextTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/facet/display/context/AssetCategoriesSearchFacetDisplayContextTest.java
@@ -283,6 +283,22 @@ public class AssetCategoriesSearchFacetDisplayContextTest
 	}
 
 	@Test
+	public void testSelectionOfNonexistentTerms() throws Exception {
+		FacetDisplayContext facetDisplayContext = createFacetDisplayContext(
+			RandomTestUtil.randomString());
+
+		List<BucketDisplayContext> bucketDisplayContexts =
+			facetDisplayContext.getBucketDisplayContexts();
+
+		Assert.assertEquals(
+			bucketDisplayContexts.toString(), 0, bucketDisplayContexts.size());
+
+		Assert.assertEquals("0", facetDisplayContext.getParameterValue());
+		Assert.assertFalse(facetDisplayContext.isNothingSelected());
+		Assert.assertFalse(facetDisplayContext.isRenderNothing());
+	}
+
+	@Test
 	public void testUnauthorized() throws Exception {
 		long assetCategoryId = RandomTestUtil.randomLong();
 


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-33329

- Sub-task: https://liferay.atlassian.net/browse/LPD-34712

Follow-up test for this changes https://github.com/brianchandotcom/liferay-portal/pull/153612