### PR TITLE
LPD-34222 portal-search-web: Change initial layout look and feel of search portlets for greater visibility

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/layout/prototype/DefaultSearchLayoutPrototypeCustomizer.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/layout/prototype/DefaultSearchLayoutPrototypeCustomizer.java
@@ -115,7 +115,7 @@ public class DefaultSearchLayoutPrototypeCustomizer
 		DefaultLayoutPrototypesUtil.updatePortletSetup(
 			layout, portletId,
 			HashMapBuilder.put(
-				"portletSetupPortletDecoratorId", "barebone"
+				"portletSetupPortletDecoratorId", "borderless"
 			).build());
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-34222 - Increase visibility of search portlets on widget page

Given that search portlets are configured as "barebone" on the default search page, users would not be able to see what portlets are actually available. Setting it to "borderless" allows some clarity by introducing the header. This change would apply to future search pages.

Search portlets would now look like this after startup:
<img width="1391" alt="Screenshot 2024-08-27 at 10 08 03 AM" src="https://github.com/user-attachments/assets/de42424c-018b-4996-98e0-9957f80b4ffb">
