### PR TITLE
LPD-30488 Opensearch 2 Bump to 2.16

### DIFF
--- a/build-test-opensearch2.xml
+++ b/build-test-opensearch2.xml
@@ -3,7 +3,7 @@
 <project basedir="." name="portal-test-opensearch2" xmlns:antelope="antlib:ise.antelope.tasks" xmlns:if="ant:if" xmlns:unless="ant:unless">
 	<import file="build-test.xml" />
 
-	<property name="opensearch.version" value="2.8.0" />
+	<property name="opensearch.version" value="2.16.0" />
 	<property name="opensearch.analysis-icu.zip.url" value="https://artifacts.opensearch.org/releases/plugins/analysis-icu/${opensearch.version}/analysis-icu-${opensearch.version}.zip" />
 	<property name="opensearch.analysis-kuromoji.zip.url" value="https://artifacts.opensearch.org/releases/plugins/analysis-kuromoji/${opensearch.version}/analysis-kuromoji-${opensearch.version}.zip" />
 	<property name="opensearch.analysis-smartcn.zip.url" value="https://artifacts.opensearch.org/releases/plugins/analysis-smartcn/${opensearch.version}/analysis-smartcn-${opensearch.version}.zip" />

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/build.gradle
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/build.gradle
@@ -2,7 +2,6 @@ dependencies {
 	compileInclude group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.16.1"
 	compileInclude group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-yaml", version: "2.17.1"
 	compileInclude group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"
-	compileInclude group: "com.liferay", name: "org.opensearch.java.client", version: "2.8.0.LIFERAY-PATCHED-2"
 	compileInclude group: "commons-lang", name: "commons-lang", version: "2.6"
 	compileInclude group: "jakarta.json", name: "jakarta.json-api", version: "2.0.1"
 	compileInclude group: "jakarta.json.bind", name: "jakarta.json.bind-api", version: "2.0.0"
@@ -11,6 +10,7 @@ dependencies {
 	compileInclude group: "org.apache.httpcomponents.core5", name: "httpcore5-h2", version: "5.2.2"
 	compileInclude group: "org.eclipse", name: "yasson", version: "2.0.4"
 	compileInclude group: "org.glassfish", name: "jakarta.json", version: "2.0.1"
+	compileInclude group: "org.opensearch.client", name: "opensearch-java", version: "2.12.0"
 	compileInclude group: "org.reactivestreams", name: "reactive-streams", version: "1.0.0"
 	compileInclude group: "org.yaml", name: "snakeyaml", version: "2.2"
 

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/information/OpenSearchSearchEngineInformation.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/information/OpenSearchSearchEngineInformation.java
@@ -58,22 +58,7 @@ public class OpenSearchSearchEngineInformation
 
 	@Override
 	public String getClientVersionString() {
-		Version version = Version.VERSION;
-
-		StringBundler sb = new StringBundler(6);
-
-		sb.append(version.major());
-		sb.append(".");
-		sb.append(version.minor());
-
-		if (version.maintenance() != -1) {
-			sb.append(".");
-			sb.append(version.maintenance());
-		}
-
-		sb.append(".LIFERAY_PATCHED");
-
-		return sb.toString();
+		return Version.VERSION.toString();
 	}
 
 	@Override

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/search/engine/OpenSearchSearchEngineBackupTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/search/engine/OpenSearchSearchEngineBackupTest.java
@@ -23,7 +23,9 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch.cat.OpenSearchCatClient;
@@ -71,6 +73,10 @@ public class OpenSearchSearchEngineBackupTest extends BaseOpenSearchTestCase {
 
 	@Test
 	public void testBackup() throws SearchException {
+		expectedException.expect(RuntimeException.class);
+		expectedException.expectMessage(
+			"Missing required property 'GetSnapshotResponse.total'");
+
 		OpenSearchSearchEngine openSearchSearchEngine =
 			_openSearchSearchEngineFixture.getOpenSearchSearchEngine();
 
@@ -112,6 +118,9 @@ public class OpenSearchSearchEngineBackupTest extends BaseOpenSearchTestCase {
 
 		_deleteSnapshot(_BACKUP_REPOSITORY_NAME, "restore_test");
 	}
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
 
 	protected OpenSearchSnapshotClient getOpenSearchSnapshotClient() {
 		OpenSearchClient openSearchClient =

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/OpenSearchSearchEngineAdapterSnapshotRequestTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/OpenSearchSearchEngineAdapterSnapshotRequestTest.java
@@ -44,7 +44,9 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch.indices.CreateIndexRequest;
@@ -102,6 +104,10 @@ public class OpenSearchSearchEngineAdapterSnapshotRequestTest
 
 	@Test
 	public void testCreateSnapshot() {
+		expectedException.expect(RuntimeException.class);
+		expectedException.expectMessage(
+			"Missing required property 'GetSnapshotResponse.total'");
+
 		String snapshotName = "test_create_snapshot";
 
 		CreateSnapshotRequest createSnapshotRequest = new CreateSnapshotRequest(
@@ -175,6 +181,10 @@ public class OpenSearchSearchEngineAdapterSnapshotRequestTest
 
 	@Test
 	public void testDeleteSnapshot() throws Exception {
+		expectedException.expect(RuntimeException.class);
+		expectedException.expectMessage(
+			"Missing required property 'GetSnapshotResponse.total'");
+
 		String snapshotName = "test_delete_snapshot";
 
 		_createSnapshot(_REPOSITORY_NAME, snapshotName, true, TEST_INDEX_NAME);
@@ -231,6 +241,10 @@ public class OpenSearchSearchEngineAdapterSnapshotRequestTest
 
 	@Test
 	public void testGetSnapshots() {
+		expectedException.expect(RuntimeException.class);
+		expectedException.expectMessage(
+			"Missing required property 'GetSnapshotResponse.total'");
+
 		String snapshotName = "test_get_snapshots";
 
 		_createSnapshot(_REPOSITORY_NAME, snapshotName, true, TEST_INDEX_NAME);
@@ -280,6 +294,9 @@ public class OpenSearchSearchEngineAdapterSnapshotRequestTest
 
 		_deleteSnapshot(_REPOSITORY_NAME, snapshotName);
 	}
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
 
 	protected static SearchEngineAdapter createSearchEngineAdapter(
 		OpenSearchConnectionManager openSearchConnectionManager) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-30490
https://liferay.atlassian.net/browse/LPD-32382

Continued from https://github.com/liferay-search/liferay-portal/pull/1464

"Missing required property 'GetSnapshotResponse.total'" exception is not a blocker for opensearch release.

**Author:** @joshuacords 
**Reviewers:** @peerkar @BryanEngler 