### PR TITLE
LPD-28190: Flaky Functional Test Failures related to - Test User is missing from Users and Organization

### DIFF
--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/UnindexedUserQueueProcessor.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/UnindexedUserQueueProcessor.java
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.users.admin.internal.search;
+
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.util.UnindexedUserQueue;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Gustavo Lima
+ */
+@Component(service = {})
+public class UnindexedUserQueueProcessor {
+
+	@Activate
+	protected void activate() throws SearchException {
+		UnindexedUserQueue unindexedUserQueue =
+			UnindexedUserQueue.getInstance();
+
+		User user = unindexedUserQueue.poll();
+
+		while (user != null) {
+			indexer.reindex(user);
+
+			user = unindexedUserQueue.poll();
+		}
+	}
+
+	@Reference(
+		target = "(indexer.class.name=com.liferay.portal.kernel.model.User)"
+	)
+	protected Indexer<User> indexer;
+
+}

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -186,6 +186,7 @@ import com.liferay.portal.security.pwd.PwdToolkitUtil;
 import com.liferay.portal.security.pwd.RegExpToolkit;
 import com.liferay.portal.service.base.UserLocalServiceBaseImpl;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.util.UnindexedUserQueue;
 import com.liferay.portlet.usersadmin.util.UsersAdminUtil;
 import com.liferay.ratings.kernel.service.RatingsStatsLocalService;
 import com.liferay.social.kernel.model.SocialRelation;
@@ -6567,10 +6568,14 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	}
 
 	protected void reindex(User user) throws SearchException {
-		Indexer<User> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
-			User.class);
+		Indexer<User> indexer = IndexerRegistryUtil.getIndexer(User.class);
 
-		indexer.reindex(user);
+		if (indexer == null) {
+			_unindexedUserQueue.add(user);
+		}
+		else {
+			indexer.reindex(user);
+		}
 	}
 
 	protected User resetFailedLoginAttempts(User user) {
@@ -7620,6 +7625,9 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 	@BeanReference(type = TicketLocalService.class)
 	private TicketLocalService _ticketLocalService;
+
+	private final UnindexedUserQueue _unindexedUserQueue =
+		UnindexedUserQueue.getInstance();
 
 	@BeanReference(type = UserGroupPersistence.class)
 	private UserGroupPersistence _userGroupPersistence;

--- a/portal-impl/src/com/liferay/portal/util/UnindexedUserQueue.java
+++ b/portal-impl/src/com/liferay/portal/util/UnindexedUserQueue.java
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.util;
+
+import com.liferay.portal.kernel.model.User;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * @author Gustavo Lima
+ */
+public final class UnindexedUserQueue {
+
+	public static UnindexedUserQueue getInstance() {
+		if (_unindexedUserQueue == null) {
+			synchronized (UnindexedUserQueue.class) {
+				if (_unindexedUserQueue == null) {
+					_unindexedUserQueue = new UnindexedUserQueue();
+				}
+			}
+		}
+
+		return _unindexedUserQueue;
+	}
+
+	public void add(User user) {
+		_userQueue.add(user);
+	}
+
+	public User poll() {
+		return _userQueue.poll();
+	}
+
+	private static volatile UnindexedUserQueue _unindexedUserQueue;
+
+	private final Queue<User> _userQueue = new ConcurrentLinkedQueue<>();
+
+}


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-28190

**Problem**: When the portal starts with a new database, the process of creating a company involves creating the omniadmin user. However, the omniadmin user is sometimes not being indexed properly.

**Root cause**: The root of the problem appears to be the initialization order of components. The indexing system might not be fully initialized by the time the omniadmin user is created, causing the user to sometimes not to be indexed correctly.

**Solution**: Create a service that has a dependency on the User indexer so when it is activated it can reindex all the user that were not indexed on startup. 


To debug this  issue and understand it better put a breakpoint in https://github.com/liferay/liferay-portal/blob/403926de07a6dbfc35c975e8409cbe354a9aad89/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexerRegistryImpl.java#L151 and https://github.com/liferay/liferay-portal/blob/a2e61dd1f1c6d35b3d3e24003ce1ee56cdabc514/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java#L6571 and debug on portal startup.