### PR TITLE
LPD-39359 LPD-39358 Bugs in custom range

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/facet/configuration.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/facet/configuration.jsp
@@ -186,7 +186,7 @@ JSONArray rangesJSONArray = customFacetPortletPreferences.getRangesJSONArray();
 
 				<liferay-frontend:fieldset
 					collapsible="<%= true %>"
-					cssClass='<%= StringUtil.equals(customFacetPortletPreferences.getOrder(), "rangesConfiguration") ? StringPool.BLANK : "hide" %>'
+					cssClass='<%= StringUtil.equals(customFacetPortletPreferences.getAggregationType(), "terms") ? "hide" : StringPool.BLANK %>'
 					label="ranges-configuration"
 				>
 					<div class="form-text text-weight-normal">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/CustomConfigurationRangeOptions.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/CustomConfigurationRangeOptions.js
@@ -231,36 +231,15 @@ function CustomConfigurationRangeOptions({
 			}
 		};
 
-		const _handlePreferenceKeyOrderChange = (event) => {
-			const currentValue = event.target.value;
-
-			if (currentValue === RANGES_CONFIGURATION_OPTION.VALUE) {
-				enableRangesConfiguration(aggregationTypeElement.value);
-			}
-			else {
-				disableRangesConfiguration();
-			}
-		};
-
 		aggregationTypeElement?.addEventListener(
 			'change',
 			_handleAggregationTypeChange
-		);
-
-		preferenceKeyOrderElement?.addEventListener(
-			'change',
-			_handlePreferenceKeyOrderChange
 		);
 
 		return () => {
 			aggregationTypeElement?.removeEventListener(
 				'change',
 				_handleAggregationTypeChange
-			);
-
-			preferenceKeyOrderElement?.removeEventListener(
-				'change',
-				_handlePreferenceKeyOrderChange
 			);
 		};
 	}, [namespace, onInputSetsChange]);

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/CustomConfigurationRangeOptions.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/CustomConfigurationRangeOptions.js
@@ -247,20 +247,36 @@ function CustomConfigurationRangeOptions({
 	return (
 		<div className="sort-configurations-options">
 			<InputSets>
-				{ranges.map((valueItem, valueIndex) => (
+				{ranges.map((valueItem, valueIndex) => {
+					const {
+						index,
+						isLastItem,
+						key,
+						onInputSetItemDelete,
+						onInputSetItemMove,
+					} = getInputSetItemProps(valueItem, valueIndex);
 
-					// eslint-disable-next-line react/jsx-key
-					<InputSets.Item
-						{...getInputSetItemProps(valueItem, valueIndex)}
-					>
-						<Inputs
-							index={valueIndex}
-							namespace={namespace}
-							onInputSetItemChange={onInputSetItemChange}
-							value={valueItem}
-						/>
-					</InputSets.Item>
-				))}
+					return (
+						<InputSets.Item
+							index={index}
+							isLastItem={isLastItem}
+							key={key}
+							onInputSetItemDelete={
+								ranges.length === 1
+									? null // Forbid deletion of the last item
+									: onInputSetItemDelete
+							}
+							onInputSetItemMove={onInputSetItemMove}
+						>
+							<Inputs
+								index={valueIndex}
+								namespace={namespace}
+								onInputSetItemChange={onInputSetItemChange}
+								value={valueItem}
+							/>
+						</InputSets.Item>
+					);
+				})}
 
 				<ClayButton
 					aria-label={Liferay.Language.get('add-range')}

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/custom_range_facet.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/custom_range_facet.js
@@ -192,8 +192,8 @@ AUI.add(
 					{
 						[rangeRuleName]() {
 							return (
-								instance.fromInputPicker.val() <=
-								instance.toInputPicker.val()
+								Number(instance.fromInputPicker.val()) <=
+								Number(instance.toInputPicker.val())
 							);
 						},
 					},

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/shared/input_sets/Item.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/shared/input_sets/Item.js
@@ -70,8 +70,9 @@ function Item({
 							displayType="secondary"
 							monospaced
 							onClick={
-								!!onInputSetItemDelete &&
-								onInputSetItemDelete(index)
+								onInputSetItemDelete
+									? onInputSetItemDelete(index)
+									: undefined
 							}
 							small
 						>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/shared/input_sets/Item.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/shared/input_sets/Item.js
@@ -66,9 +66,13 @@ function Item({
 							aria-label={Liferay.Language.get('delete')}
 							borderless
 							className="c-ml-2"
+							disabled={!onInputSetItemDelete}
 							displayType="secondary"
 							monospaced
-							onClick={onInputSetItemDelete(index)}
+							onClick={
+								!!onInputSetItemDelete &&
+								onInputSetItemDelete(index)
+							}
 							small
 						>
 							<ClayIcon symbol="trash" />


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-39359 - When selecting Date Range or Range aggregation and Order by Frequency/Valuse ASC/DSC the Ranges Configuration section disappears (Dev FF)
- Remove hiding of "Range Configuration" section if selecting other than "order by range aggregation"

https://liferay.atlassian.net/browse/LPD-39358 - Date Range and Range aggregations with Order by Frequency or Value ASC/DESC, so anything, but not Ranges Configuration fails with Elasticsearch error in Custom Facet (Dev FF)
- With the fix above, now it will default to at least entry in range configuration that is set as required. Option to remove would not be available (added updates to `InputSets.Item` to disable the 'delete' option).

Extra:
- There were some issues with validating on custom ranges, so range input values were converted to numbers first for the validation rule.