### PR TITLE
LPD-39364 portal-search-web: Add logic to show custom range without reloading

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/facet/view.jsp
@@ -151,8 +151,28 @@ String aggregationType = customFacetDisplayContext.getAggregationType();
 												<aui:script>
 													document.getElementById(
 														'<portlet:namespace /><%= customRangeBucketDisplayContext.getBucketText() %>'
-													).onchange = function (event) {
-														Liferay.Search.FacetUtil.changeSelection(event);
+													).onclick = function (event) {
+														event.preventDefault();
+
+														if (
+															'<%= customFacetDisplayContext.getAggregationType() %>' == 'dateRange'
+														) {
+															Liferay.Search.FacetUtil.changeSelection(event);
+														}
+														else {
+															const customRangeElement = document.getElementById(
+																'<portlet:namespace />customRange'
+															);
+
+															if (customRangeElement.classList.contains('hide')) {
+																customRangeElement.classList.remove('hide');
+															}
+															else {
+																if (Liferay.Search.FacetUtil.isCustomRangeValid(event)) {
+																	Liferay.Search.FacetUtil.changeSelection(event);
+																}
+															}
+														}
 													};
 												</aui:script>
 
@@ -250,6 +270,7 @@ String aggregationType = customFacetDisplayContext.getAggregationType();
 										<clay:button
 											aria-label='<%= LanguageUtil.get(request, "search") %>'
 											cssClass="custom-range-filter-button"
+											disabled="<%= (customFacetDisplayContext.getToParameterValue() == null) || (customFacetDisplayContext.getFromParameterValue() == null) || (Float.parseFloat(customFacetDisplayContext.getToParameterValue()) < Float.parseFloat(customFacetDisplayContext.getFromParameterValue())) %>"
 											displayType="secondary"
 											id='<%= liferayPortletResponse.getNamespace() + "searchCustomRangeButton" %>'
 											label="search"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/FacetUtil.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/FacetUtil.js
@@ -89,46 +89,37 @@ export const FacetUtil = {
 			.map((term) => {
 				const termId = _getTermId(term);
 
-				if (termId === CUSTOM_RANGE_BUCKET_TEXT) {
+				const isCurrentTarget = termId === currentSelectedTermId;
 
-					// For the special case of a range facet, the
-					// termId is 'custom-range' and the parameters are
-					// prefixed with 'from' and 'to'.
-
-					// Set an empty range if a non-custom-range facet
-					// was selected. It should serve as a placeholder to grab
-					// the existing range from the URL parameters.
-
-					if (currentSelectedTermId !== CUSTOM_RANGE_BUCKET_TEXT) {
-						return [];
-					}
-
-					if (
-						form.querySelector('.aggregation-type').value ===
-						'range'
-					) {
-						return [0, 0];
-					}
-
-					// If no min-max values are set, assume it's a date
-					// range, and use the last 24 hours as the default range.
-
-					const endDate = new Date();
-					const startDate = new Date(
-						endDate - 1000 * 60 * 60 * 24 // 24 hours
-					);
-
-					return [
-						startDate.toISOString().split('T')[0],
-						endDate.toISOString().split('T')[0],
-					];
-				}
-				else {
-					return termId;
-				}
+				return this.getSelectedTerm(termId, form, isCurrentTarget);
 			});
 
 		this.selectTerms(form, selectedTerms);
+	},
+
+	changeSelectionForSingleFacet(event) {
+		event.preventDefault();
+
+		const form = event.currentTarget.form;
+
+		if (!form) {
+			return;
+		}
+
+		// Disable checkboxes across all facets to avoid multiple
+		// selections. Only the most recent selection will be added
+		// since the page needs to be reloaded before another selection
+		// can be made.
+
+		const allFacetTerms = document.querySelectorAll(`.${FACET_TERM_CLASS}`);
+
+		allFacetTerms.forEach((term) => {
+			Liferay.Util.toggleDisabled(term, true);
+		});
+
+		const termId = _getTermId(event.currentTarget);
+
+		this.selectTerms(form, [this.getSelectedTerm(termId, form, true)]);
 	},
 
 	clearSelections(event) {
@@ -149,6 +140,67 @@ export const FacetUtil = {
 		inputs.forEach((term) => {
 			Liferay.Util.toggleDisabled(term, false);
 		});
+	},
+
+	getSelectedTerm(termId, form, isCurrentTarget) {
+		if (termId === CUSTOM_RANGE_BUCKET_TEXT) {
+
+			// For the special case of a range facet, the
+			// termId is 'custom-range' and the parameters are
+			// prefixed with 'from' and 'to'. This will return
+			// an array [from, to] for the custom range.
+
+			// If the term is not the current target, apply the
+			// existing range from the URL parameters. This is set
+			// in setURLParameters so use '[]' as a placeholder.
+
+			if (!isCurrentTarget) {
+				return [];
+			}
+
+			// If the term is the current target, use the current
+			// values in the inputs.
+			// General range defaults to [0, 0] if no value is set.
+			// Date range defaults to the last 24 hours if no value is set.
+
+			const fromValue = form.querySelector('[id$=fromInput]').value;
+			const toValue = form.querySelector('[id$=toInput]').value;
+
+			if (form.querySelector('.aggregation-type').value === 'range') {
+				return [fromValue || 0, toValue || 0];
+			}
+
+			let endDate = new Date();
+			let startDate = new Date(
+				endDate - 1000 * 60 * 60 * 24 // 24 hours
+			);
+
+			if (fromValue && toValue) {
+				endDate = new Date(toValue);
+				startDate = new Date(fromValue);
+			}
+
+			return [
+				startDate.toISOString().split('T')[0],
+				endDate.toISOString().split('T')[0],
+			];
+		}
+		else {
+			return termId;
+		}
+	},
+
+	isCustomRangeValid(event) {
+		const form = event.currentTarget.form;
+
+		const fromInputValue = form.querySelector('[id$=fromInput]').value;
+		const toInputValue = form.querySelector('[id$=toInput]').value;
+
+		return (
+			fromInputValue &&
+			toInputValue &&
+			Number(fromInputValue) <= Number(toInputValue)
+		);
 	},
 
 	queryParameterAndUpdateValue(form, search, selections) {

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/custom/facet/portlet/display/template/dependencies/portlet_display_template_checkbox.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/custom/facet/portlet/display/template/dependencies/portlet_display_template_checkbox.ftl
@@ -82,8 +82,24 @@
 								/>
 
 								<@liferay_aui.script>
-									document.getElementById('${namespace}${customRangeBucketDisplayContext.getBucketText()}').onchange = function() {
-										Liferay.Search.FacetUtil.changeSelection(event);
+									document.getElementById('${namespace}${customRangeBucketDisplayContext.getBucketText()}').onclick = function(event) {
+										if ("${customFacetDisplayContext.getAggregationType()}" == "dateRange") {
+											Liferay.Search.FacetUtil.changeSelection(event);
+										}
+										else {
+											event.preventDefault();
+
+											const customRangeElement = document.getElementById('${namespace}customRange');
+
+											if (customRangeElement.classList.contains('hide')) {
+												customRangeElement.classList.remove('hide');
+											}
+											else {
+												if (Liferay.Search.FacetUtil.isCustomRangeValid(event)) {
+													Liferay.Search.FacetUtil.changeSelection(event);
+												}
+											}
+										}
 									}
 								</@liferay_aui.script>
 
@@ -135,6 +151,7 @@
 
 						<@clay["button"]
 							cssClass="custom-range-filter-button"
+							disabled=!customFacetDisplayContext.getToParameterValue()?? || !customFacetDisplayContext.getFromParameterValue()?? || (customFacetDisplayContext.getToParameterValue()?number < customFacetDisplayContext.getFromParameterValue()?number)
 							displayType="secondary"
 							id="${namespace + 'searchCustomRangeButton'}"
 							label="search"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/custom/facet/portlet/display/template/dependencies/portlet_display_template_compact.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/custom/facet/portlet/display/template/dependencies/portlet_display_template_compact.ftl
@@ -60,7 +60,6 @@
 							displayType="link"
 							id="${namespace}${customRangeBucketDisplayContext.getBucketText()}"
 							name="${namespace}${customRangeBucketDisplayContext.getBucketText()}"
-							onClick="Liferay.Search.FacetUtil.changeSelection(event);"
 						>
 							<#if customRangeBucketDisplayContext.isSelected()>
 								<strong><@liferay_ui["message"] key="${htmlUtil.escape(customRangeBucketDisplayContext.getBucketText())}" /></strong>
@@ -74,6 +73,28 @@
 								</small>
 							</#if>
 						</@clay.button>
+
+						<@liferay_aui.script>
+							document.getElementById('${namespace}${customRangeBucketDisplayContext.getBucketText()}').onclick = function(event) {
+								if ("${customFacetDisplayContext.getAggregationType()}" == "dateRange") {
+									Liferay.Search.FacetUtil.changeSelection(event);
+								}
+								else {
+									event.preventDefault();
+
+									const customRangeElement = document.getElementById('${namespace}customRange');
+
+									if (customRangeElement.classList.contains('hide')) {
+										customRangeElement.classList.remove('hide');
+									}
+									else {
+										if (Liferay.Search.FacetUtil.isCustomRangeValid(event)) {
+											Liferay.Search.FacetUtil.changeSelection(event);
+										}
+									}
+								}
+							}
+						</@liferay_aui.script>
 					</li>
 				</#if>
 
@@ -105,6 +126,7 @@
 
 						<@clay["button"]
 							cssClass="custom-range-filter-button"
+							disabled=!customFacetDisplayContext.getToParameterValue()?? || !customFacetDisplayContext.getFromParameterValue()?? || customFacetDisplayContext.getToParameterValue()?number < customFacetDisplayContext.getFromParameterValue()?number
 							displayType="secondary"
 							id="${namespace + 'searchCustomRangeButton'}"
 							label="search"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/custom/facet/portlet/display/template/dependencies/portlet_display_template_label.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/custom/facet/portlet/display/template/dependencies/portlet_display_template_label.ftl
@@ -56,7 +56,6 @@
 					displayType="unstyled"
 					id="${namespace}${customRangeBucketDisplayContext.getBucketText()}"
 					name="${namespace}${customRangeBucketDisplayContext.getBucketText()}"
-					onClick="Liferay.Search.FacetUtil.changeSelection(event);"
 				>
 					<#if customRangeBucketDisplayContext.isSelected()>
 						<strong><@liferay_ui["message"] key="${htmlUtil.escape(customRangeBucketDisplayContext.getBucketText())}" /></strong>
@@ -70,6 +69,28 @@
 						</div>
 					</#if>
 				</@clay.button>
+
+				<@liferay_aui.script>
+					document.getElementById('${namespace}${customRangeBucketDisplayContext.getBucketText()}').onclick = function(event) {
+						if ("${customFacetDisplayContext.getAggregationType()}" == "dateRange") {
+							Liferay.Search.FacetUtil.changeSelection(event);
+						}
+						else {
+							event.preventDefault();
+
+							const customRangeElement = document.getElementById('${namespace}customRange');
+
+							if (customRangeElement.classList.contains('hide')) {
+								customRangeElement.classList.remove('hide');
+							}
+							else {
+								if (Liferay.Search.FacetUtil.isCustomRangeValid(event)) {
+									Liferay.Search.FacetUtil.changeSelection(event);
+								}
+							}
+						}
+					}
+				</@liferay_aui.script>
 			</#if>
 
 			<#if customFacetDisplayContext.getAggregationType() == "range">
@@ -100,6 +121,7 @@
 
 					<@clay["button"]
 						cssClass="custom-range-filter-button"
+						disabled=!customFacetDisplayContext.getToParameterValue()?? || !customFacetDisplayContext.getFromParameterValue()?? || customFacetDisplayContext.getToParameterValue()?number < customFacetDisplayContext.getFromParameterValue()?number
 						displayType="secondary"
 						id="${namespace + 'searchCustomRangeButton'}"
 						label="search"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/custom/facet/portlet/display/template/dependencies/portlet_display_template_radio.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/custom/facet/portlet/display/template/dependencies/portlet_display_template_radio.ftl
@@ -73,6 +73,7 @@
 							<label class="facet-checkbox-label" for="${namespace}${customRangeBucketDisplayContext.getBucketText()}">
 								<input
 									${(customRangeBucketDisplayContext.isSelected())?then("checked", "")}
+									data-term-id="${htmlUtil.escape(customRangeBucketDisplayContext.getBucketText())}"
 									class="custom-control-input facet-term"
 									disabled
 									id="${namespace}${customRangeBucketDisplayContext.getBucketText()}"
@@ -82,8 +83,24 @@
 								/>
 
 								<@liferay_aui.script>
-									document.getElementById('${namespace}${customRangeBucketDisplayContext.getBucketText()}').onchange = function() {
-										window.location.href = "${customRangeBucketDisplayContext.getFilterValue()}";
+									document.getElementById('${namespace}${customRangeBucketDisplayContext.getBucketText()}').onclick = function(event) {
+										if ("${customFacetDisplayContext.getAggregationType()}" == "dateRange") {
+											window.location.href = "${customRangeBucketDisplayContext.getFilterValue()}";
+										}
+										else {
+											event.preventDefault();
+
+											const customRangeElement = document.getElementById('${namespace}customRange');
+
+											if (customRangeElement.classList.contains('hide')) {
+												customRangeElement.classList.remove('hide');
+											}
+											else {
+												if (Liferay.Search.FacetUtil.isCustomRangeValid(event)) {
+													Liferay.Search.FacetUtil.changeSelectionForSingleFacet(event);
+												}
+											}
+										}
 									}
 								</@liferay_aui.script>
 
@@ -135,6 +152,7 @@
 
 						<@clay["button"]
 							cssClass="custom-range-filter-button"
+							disabled=!customFacetDisplayContext.getToParameterValue()?? || !customFacetDisplayContext.getFromParameterValue()?? || customFacetDisplayContext.getToParameterValue()?number < customFacetDisplayContext.getFromParameterValue()?number
 							displayType="secondary"
 							id="${namespace + 'searchCustomRangeButton'}"
 							label="search"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-39364 - With Range Aggregation, clicking on Custom Range unnecessarily triggers a search and reloads the page with no results in the Custom Facet (Dev FF)

Clicking on Custom Range the first time opens the range inputs without needing a page refresh. When the inputs are visible and clicked on it again (with valid values), it will select the custom range.

Short demo: 

https://github.com/user-attachments/assets/0f5bed14-8eaa-4ded-8b33-435ba11ada2c

