### PR TITLE
LPD-37525 Blueprints#ViewLinksToLiferayDocumentation

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
@@ -4896,6 +4896,11 @@ definition {
 			key_linkText = "Learn how",
 			locator1 = "Blueprints#DOC_LINK_GENERIC");
 
+		Click(
+			key_linkContext = "portlet-configuration",
+			key_linkText = "Learn how",
+			locator1 = "Blueprints#DOC_LINK_GENERIC");
+
 		SelectWindow(value1 = "Using a Search Blueprint on a Search Page - Liferay Learn");
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPD-37525 - Blueprints#ViewLinksToLiferayDocumentation [Functional]

This just adds additional step to click on link and avoid 403 error.

RCA seems to pass doing this: https://test-1-1.liferay.com/userContent/jobs/root-cause-analysis-tool/builds/14198/jenkins-report.html