### PR TITLE
LPD-39546 portal-search-web/search*.spec.ts [Playwright]

### DIFF
--- a/modules/test/playwright/pages/portal-search-web/SearchPage.ts
+++ b/modules/test/playwright/pages/portal-search-web/SearchPage.ts
@@ -125,7 +125,7 @@ export class SearchPage {
 	}
 
 	async goto() {
-		await this.page.goto('/search');
+		await this.page.goto('/web/guest/search');
 	}
 
 	async openSearchPortletConfiguration(

--- a/modules/test/playwright/pages/portal-search-web/SearchPage.ts
+++ b/modules/test/playwright/pages/portal-search-web/SearchPage.ts
@@ -95,9 +95,13 @@ export class SearchPage {
 			),
 		});
 
-		await categoryPanel.getByText(portletName).click();
+		await categoryPanel.getByText(portletName, {exact: true}).click();
 
-		await categoryPanel.getByRole('button', {name: 'Add Content'}).click();
+		await categoryPanel
+			.locator('li')
+			.filter({hasText: new RegExp(`^${portletName}$`)})
+			.getByLabel('Add Content')
+			.click();
 	}
 
 	async getSearchFacetCheckbox(

--- a/modules/test/playwright/tests/portal-search-web/searchBar.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/searchBar.spec.ts
@@ -26,10 +26,7 @@ export const test = mergeTests(
 );
 
 test.describe('Search Bar with user input', () => {
-	test('Alert does not display on search page @LPD-39110', async ({
-		page,
-		searchPage,
-	}) => {
+	test('Alert does not display on search page @LPD-39110', async ({page}) => {
 		await test.step('Check that an alert with message does not appear', async () => {
 			page.on('dialog', async (dialog) => {
 				dialog.accept();
@@ -49,9 +46,7 @@ test.describe('Search Bar with user input', () => {
 					'/search;%3B%3Cdiv%20id%3D%221%22%3EQuestionable%20Text%3C%2Fdiv%3E'
 			);
 
-			await expect(
-				searchPage.searchBarPortletInMainContent
-			).not.toHaveText(/Questionable Text/);
+			await expect(page.getByText(/Questionable Text/)).toBeNull;
 		});
 	});
 });

--- a/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
@@ -6,15 +6,23 @@
 import {Locator, expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../fixtures/dataApiHelpersTest';
+import {isolatedLayoutTest} from '../../fixtures/isolatedLayoutTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {searchPageTest} from '../../fixtures/searchPageTest';
 import getRandomString from '../../utils/getRandomString';
 
-export const test = mergeTests(loginTest(), searchPageTest, dataApiHelpersTest);
+export const test = mergeTests(
+	isolatedLayoutTest({type: 'portlet'}),
+	loginTest(),
+	searchPageTest,
+	dataApiHelpersTest
+);
 
 test.describe('Category facet configuration for vocabularies', () => {
 	test('Lists 20+ sites available to the user @LPD-33194', async ({
 		apiHelpers,
+		layout,
+		page,
 		searchPage,
 	}) => {
 		const siteName = getRandomString();
@@ -29,12 +37,16 @@ test.describe('Category facet configuration for vocabularies', () => {
 			}
 		});
 
-		await test.step('Navigate to search page', async () => {
-			await searchPage.goto();
+		await test.step('Add search bar and results portlet to new page', async () => {
+			await page.goto('/web/guest' + layout.friendlyURL);
+
+			await searchPage.addPortlet('Search Bar', 'Search');
+			await searchPage.addPortlet('Category Facet', 'Search');
+			await searchPage.addPortlet('Search Results', 'Search');
 		});
 
 		await test.step('Search for keyword "Test"', async () => {
-			await searchPage.searchKeywordInNavBar('test');
+			await searchPage.searchKeywordInMainContent('test');
 
 			await expect(searchPage.searchResultsTotalLabel).toHaveText(
 				/\d+ Results for test/
@@ -72,12 +84,23 @@ test.describe('Clear and retain facet selections', () => {
 	let userTestTestFacetCheckbox: Locator;
 	let lastModifiedPastYearFacetLink: Locator;
 
-	test.beforeEach(async ({searchPage}) => {
-		await searchPage.goto();
+	test.beforeEach(async ({layout, page, searchPage}) => {
+
+		// Add search portlet to a new page
+
+		await page.goto('/web/guest' + layout.friendlyURL);
+
+		await searchPage.addPortlet('Search Bar', 'Search');
+		await searchPage.addPortlet('Folder Facet', 'Search');
+		await searchPage.addPortlet('Type Facet', 'Search');
+		await searchPage.addPortlet('User Facet', 'Search');
+		await searchPage.addPortlet('Modified Facet', 'Search');
+		await searchPage.addPortlet('Search Results', 'Search');
+		await searchPage.addPortlet('Search Options', 'Search');
 
 		// Perform a search
 
-		await searchPage.searchKeywordInNavBar('test');
+		await searchPage.searchKeywordInMainContent('test');
 
 		await expect(searchPage.searchResultsTotalLabel).toHaveText(
 			/\d+ Results for test/
@@ -134,7 +157,7 @@ test.describe('Clear and retain facet selections', () => {
 
 		// Perform new search with different keyword
 
-		await searchPage.searchKeywordInNavBar('png');
+		await searchPage.searchKeywordInMainContent('png');
 
 		await expect(searchPage.searchResultsTotalLabel).toHaveText(
 			/\d+ Results for png/
@@ -157,7 +180,7 @@ test.describe('Clear and retain facet selections', () => {
 
 		// Perform new search with same keyword
 
-		await searchPage.searchKeywordInNavBar('test');
+		await searchPage.searchKeywordInMainContent('test');
 
 		await expect(searchPage.searchResultsTotalLabel).toHaveText(
 			/\d+ Results for test/
@@ -187,7 +210,7 @@ test.describe('Clear and retain facet selections', () => {
 
 		// Perform new search with different keyword
 
-		await searchPage.searchKeywordInNavBar('png');
+		await searchPage.searchKeywordInMainContent('png');
 
 		await expect(searchPage.searchResultsTotalLabel).toHaveText(
 			/\d+ Results for png/
@@ -230,7 +253,7 @@ test.describe('Clear and retain facet selections', () => {
 
 		// Perform new search with empty keyword
 
-		await searchPage.searchKeywordInNavBar('');
+		await searchPage.searchKeywordInMainContent('');
 
 		await expect(searchPage.searchResultsTotalLabel).toHaveText(
 			/\d+ Results for\s+/
@@ -268,7 +291,7 @@ test.describe('Clear and retain facet selections', () => {
 
 		// Perform new search with different keyword
 
-		await searchPage.searchKeywordInNavBar('png');
+		await searchPage.searchKeywordInMainContent('png');
 
 		await expect(searchPage.searchResultsTotalLabel).toHaveText(
 			/\d+ Results for png/

--- a/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
@@ -131,26 +131,6 @@ test.describe('Clear and retain facet selections', () => {
 		await searchPage.selectSearchFacetLink(lastModifiedPastYearFacetLink);
 	});
 
-	test.afterEach(async ({searchPage}) => {
-
-		// Teardown by resetting search options
-
-		await searchPage.searchOptionsConfigurationLink.click();
-
-		await searchPage.selectPortletConfigurationsCheckbox([
-			{
-				label: 'Allow Empty Searches',
-				value: false,
-			},
-			{
-				label: 'Retain Facet Selections Across Searches',
-				value: false,
-			},
-		]);
-
-		await searchPage.savePortletConfiguration();
-	});
-
 	test('Clears facet terms after new keyword search @LPD-19994', async ({
 		searchPage,
 	}) => {

--- a/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
@@ -85,205 +85,206 @@ test.describe('Clear and retain facet selections', () => {
 	let lastModifiedPastYearFacetLink: Locator;
 
 	test.beforeEach(async ({layout, page, searchPage}) => {
+		await test.step('Add search portlet to a new page', async () => {
+			await page.goto('/web/guest' + layout.friendlyURL);
 
-		// Add search portlet to a new page
+			await searchPage.addPortlet('Search Bar', 'Search');
+			await searchPage.addPortlet('Folder Facet', 'Search');
+			await searchPage.addPortlet('Type Facet', 'Search');
+			await searchPage.addPortlet('User Facet', 'Search');
+			await searchPage.addPortlet('Modified Facet', 'Search');
+			await searchPage.addPortlet('Search Results', 'Search');
+			await searchPage.addPortlet('Search Options', 'Search');
+		});
 
-		await page.goto('/web/guest' + layout.friendlyURL);
+		await test.step('Perform new search', async () => {
+			await searchPage.searchKeywordInMainContent('test');
 
-		await searchPage.addPortlet('Search Bar', 'Search');
-		await searchPage.addPortlet('Folder Facet', 'Search');
-		await searchPage.addPortlet('Type Facet', 'Search');
-		await searchPage.addPortlet('User Facet', 'Search');
-		await searchPage.addPortlet('Modified Facet', 'Search');
-		await searchPage.addPortlet('Search Results', 'Search');
-		await searchPage.addPortlet('Search Options', 'Search');
+			await expect(searchPage.searchResultsTotalLabel).toHaveText(
+				/\d+ Results for test/
+			);
+		});
 
-		// Perform a search
+		await test.step('Select facet terms and assert checked', async () => {
+			folderLiferayFacetCheckbox =
+				await searchPage.getSearchFacetCheckbox(
+					'Provided by Liferay',
+					'Folder'
+				);
+			typeDocumentFacetCheckbox = await searchPage.getSearchFacetCheckbox(
+				/Document\s/,
+				'Type'
+			);
+			userTestTestFacetCheckbox = await searchPage.getSearchFacetCheckbox(
+				'Test Test',
+				'User'
+			);
+			lastModifiedPastYearFacetLink = await searchPage.getSearchFacetLink(
+				'Past Year',
+				'Last Modified'
+			);
 
-		await searchPage.searchKeywordInMainContent('test');
-
-		await expect(searchPage.searchResultsTotalLabel).toHaveText(
-			/\d+ Results for test/
-		);
-
-		// Select facet terms and assert checked
-
-		folderLiferayFacetCheckbox = await searchPage.getSearchFacetCheckbox(
-			'Provided by Liferay',
-			'Folder'
-		);
-		typeDocumentFacetCheckbox = await searchPage.getSearchFacetCheckbox(
-			/Document\s/,
-			'Type'
-		);
-		userTestTestFacetCheckbox = await searchPage.getSearchFacetCheckbox(
-			'Test Test',
-			'User'
-		);
-		lastModifiedPastYearFacetLink = await searchPage.getSearchFacetLink(
-			'Past Year',
-			'Last Modified'
-		);
-
-		await searchPage.selectSearchFacetCheckbox(folderLiferayFacetCheckbox);
-		await searchPage.selectSearchFacetCheckbox(typeDocumentFacetCheckbox);
-		await searchPage.selectSearchFacetCheckbox(userTestTestFacetCheckbox);
-		await searchPage.selectSearchFacetLink(lastModifiedPastYearFacetLink);
+			await searchPage.selectSearchFacetCheckbox(
+				folderLiferayFacetCheckbox
+			);
+			await searchPage.selectSearchFacetCheckbox(
+				typeDocumentFacetCheckbox
+			);
+			await searchPage.selectSearchFacetCheckbox(
+				userTestTestFacetCheckbox
+			);
+			await searchPage.selectSearchFacetLink(
+				lastModifiedPastYearFacetLink
+			);
+		});
 	});
 
 	test('Clears facet terms after new keyword search @LPD-19994', async ({
 		searchPage,
 	}) => {
+		await test.step('Perform new search with different keyword', async () => {
+			await searchPage.searchKeywordInMainContent('png');
 
-		// Perform new search with different keyword
+			await expect(searchPage.searchResultsTotalLabel).toHaveText(
+				/\d+ Results for png/
+			);
+		});
 
-		await searchPage.searchKeywordInMainContent('png');
-
-		await expect(searchPage.searchResultsTotalLabel).toHaveText(
-			/\d+ Results for png/
-		);
-
-		// Verify that facet selections are cleared
-
-		await expect(folderLiferayFacetCheckbox).not.toBeChecked();
-		await expect(typeDocumentFacetCheckbox).not.toBeChecked();
-		await expect(userTestTestFacetCheckbox).not.toBeChecked();
-		await expect(lastModifiedPastYearFacetLink).not.toHaveClass(
-			/facet-term-selected/
-		);
+		await test.step('Verify that facet selections are cleared', async () => {
+			await expect(folderLiferayFacetCheckbox).not.toBeChecked();
+			await expect(typeDocumentFacetCheckbox).not.toBeChecked();
+			await expect(userTestTestFacetCheckbox).not.toBeChecked();
+			await expect(lastModifiedPastYearFacetLink).not.toHaveClass(
+				/facet-term-selected/
+			);
+		});
 	});
 
 	test('Retains facet terms if search keyword has not changed @LPD-19994', async ({
-		page,
 		searchPage,
 	}) => {
+		await test.step('Perform new search with same keyword', async () => {
+			await searchPage.searchKeywordInMainContent('test');
 
-		// Perform new search with same keyword
+			await expect(searchPage.searchResultsTotalLabel).toHaveText(
+				/\d+ Results for test/
+			);
+		});
 
-		await searchPage.searchKeywordInMainContent('test');
-
-		await expect(searchPage.searchResultsTotalLabel).toHaveText(
-			/\d+ Results for test/
-		);
-
-		// Verify that facet selections are retained
-
-		await expect(folderLiferayFacetCheckbox).toBeChecked();
-		await expect(typeDocumentFacetCheckbox).toBeChecked();
-		await expect(userTestTestFacetCheckbox).toBeChecked();
-		await expect(lastModifiedPastYearFacetLink).toHaveClass(
-			/facet-term-selected/
-		);
-
-		await page.reload();
+		await test.step('Verify that facet selections are retained', async () => {
+			await expect(folderLiferayFacetCheckbox).toBeChecked();
+			await expect(typeDocumentFacetCheckbox).toBeChecked();
+			await expect(userTestTestFacetCheckbox).toBeChecked();
+			await expect(lastModifiedPastYearFacetLink).toHaveClass(
+				/facet-term-selected/
+			);
+		});
 	});
 
 	test('Retains items per page after new keyword search @LPD-19994', async ({
 		searchPage,
 	}) => {
+		await test.step('Change pagination items per page and page number', async () => {
+			await searchPage.selectPaginationItemsPerPage(4);
 
-		// Change pagination items per page and page number
+			await searchPage.selectPaginationPageNumber(2);
+		});
 
-		await searchPage.selectPaginationItemsPerPage(4);
+		await test.step('Perform new search with different keyword', async () => {
+			await searchPage.searchKeywordInMainContent('png');
 
-		await searchPage.selectPaginationPageNumber(2);
+			await expect(searchPage.searchResultsTotalLabel).toHaveText(
+				/\d+ Results for png/
+			);
+		});
 
-		// Perform new search with different keyword
+		await test.step('Verify that page number is reset but items per page is not', async () => {
+			await expect(
+				searchPage.searchResultsPaginationItemsPerPageToggle
+			).toHaveText(/4 Entries/);
 
-		await searchPage.searchKeywordInMainContent('png');
+			await expect(
+				searchPage.searchResultsPaginationBar.getByText('1').first()
+			).toHaveAttribute('aria-current', 'page');
 
-		await expect(searchPage.searchResultsTotalLabel).toHaveText(
-			/\d+ Results for png/
-		);
-
-		// Verify that page number is reset but items per page is not
-
-		await expect(
-			searchPage.searchResultsPaginationItemsPerPageToggle
-		).toHaveText(/4 Entries/);
-
-		await expect(
-			searchPage.searchResultsPaginationBar.getByText('1').first()
-		).toHaveAttribute('aria-current', 'page');
-
-		await expect(searchPage.searchResultsPaginationDescription).toHaveText(
-			/Showing 1 to 4 of \d+ entries./
-		);
+			await expect(
+				searchPage.searchResultsPaginationDescription
+			).toHaveText(/Showing 1 to 4 of \d+ entries./);
+		});
 	});
 
 	test('Clears facet terms if performing an empty search @LPD-19994', async ({
 		page,
 		searchPage,
 	}) => {
+		await test.step('Configure search options to retain facet selections', async () => {
+			await searchPage.searchOptionsConfigurationLink.click();
 
-		// Configure search options to retain facet selections
+			await searchPage.selectPortletConfigurationsCheckbox([
+				{
+					label: 'Allow Empty Searches',
+					value: true,
+				},
+			]);
 
-		await searchPage.searchOptionsConfigurationLink.click();
+			await searchPage.savePortletConfiguration();
 
-		await searchPage.selectPortletConfigurationsCheckbox([
-			{
-				label: 'Allow Empty Searches',
-				value: true,
-			},
-		]);
+			await page.reload();
+		});
 
-		await searchPage.savePortletConfiguration();
+		//
 
-		await page.reload();
+		await test.step('Perform new search with empty keyword', async () => {
+			await searchPage.searchKeywordInMainContent('');
 
-		// Perform new search with empty keyword
+			await expect(searchPage.searchResultsTotalLabel).toHaveText(
+				/\d+ Results for\s+/
+			);
+		});
 
-		await searchPage.searchKeywordInMainContent('');
-
-		await expect(searchPage.searchResultsTotalLabel).toHaveText(
-			/\d+ Results for\s+/
-		);
-
-		// Verify that facet selections are cleared
-
-		await expect(folderLiferayFacetCheckbox).not.toBeChecked();
-		await expect(typeDocumentFacetCheckbox).not.toBeChecked();
-		await expect(userTestTestFacetCheckbox).not.toBeChecked();
-		await expect(lastModifiedPastYearFacetLink).not.toHaveClass(
-			/facet-term-selected/
-		);
+		await test.step('Verify that facet selections are cleared', async () => {
+			await expect(folderLiferayFacetCheckbox).not.toBeChecked();
+			await expect(typeDocumentFacetCheckbox).not.toBeChecked();
+			await expect(userTestTestFacetCheckbox).not.toBeChecked();
+			await expect(lastModifiedPastYearFacetLink).not.toHaveClass(
+				/facet-term-selected/
+			);
+		});
 	});
 
 	test('Retains facet terms if configured under search options @LPD-19994', async ({
 		page,
 		searchPage,
 	}) => {
+		await test.step('Configure search options to retain facet selections', async () => {
+			await searchPage.searchOptionsConfigurationLink.click();
 
-		// Configure search options to retain facet selections
+			await searchPage.selectPortletConfigurationsCheckbox([
+				{
+					label: 'Retain Facet Selections Across Searches',
+					value: true,
+				},
+			]);
+			await searchPage.savePortletConfiguration();
 
-		await searchPage.searchOptionsConfigurationLink.click();
+			await page.reload();
+		});
 
-		await searchPage.selectPortletConfigurationsCheckbox([
-			{
-				label: 'Retain Facet Selections Across Searches',
-				value: true,
-			},
-		]);
+		await test.step('Perform new search with different keyword', async () => {
+			await searchPage.searchKeywordInMainContent('png');
 
-		await searchPage.savePortletConfiguration();
+			await expect(searchPage.searchResultsTotalLabel).toHaveText(
+				/\d+ Results for png/
+			);
+		});
 
-		await page.reload();
-
-		// Perform new search with different keyword
-
-		await searchPage.searchKeywordInMainContent('png');
-
-		await expect(searchPage.searchResultsTotalLabel).toHaveText(
-			/\d+ Results for png/
-		);
-
-		// Verify that facet selections are retained
-
-		await expect(folderLiferayFacetCheckbox).toBeChecked();
-		await expect(typeDocumentFacetCheckbox).toBeChecked();
-		await expect(userTestTestFacetCheckbox).toBeChecked();
-		await expect(lastModifiedPastYearFacetLink).toHaveClass(
-			/facet-term-selected/
-		);
+		await test.step('Verify that facet selections are retained', async () => {
+			await expect(folderLiferayFacetCheckbox).toBeChecked();
+			await expect(typeDocumentFacetCheckbox).toBeChecked();
+			await expect(userTestTestFacetCheckbox).toBeChecked();
+			await expect(lastModifiedPastYearFacetLink).toHaveClass(
+				/facet-term-selected/
+			);
+		});
 	});
 });


### PR DESCRIPTION
https://issues.liferay.com/browse/LPD-39546 - portal-search-web/search*.spec.ts [Playwright]

Several updates:
- Use `isolatedLayoutTest` in order to keep processes clean (no need to teardown)
- Use `test.step` instead of comments
- I think maybe the playwright issue was that the searchPage.goto was giving a restricted page error on cloud runs, so the path was updated. But having paths to separate pages should also work, and is a good practice in general.