### PR TITLE
LPD-41744 Blueprint test setup errors

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
@@ -13,9 +13,9 @@ definition {
 	setUp {
 		TestCase.setUpPortalInstance();
 
-		WikiPortlet.enableWiki();
-
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 	}
 
 	tearDown {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-41744 - Multiple Blueprint tests blocked by TEST_SETUP_ERROR: Element is not present at "//button[@data-qa-id='applicationsMenu']" [Functional] (search)