### PR TITLE
LPD-41747 portal-web: Enable FF to view similar results

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/elasticsearch/SimilarResults.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/elasticsearch/SimilarResults.testcase
@@ -16,6 +16,10 @@ definition {
 
 		WikiPortlet.enableWiki();
 
+		task ("Enable dynamic and manual selection") {
+			AssetPublisherPortlet.enableDynamicAndManualSelection();
+		}
+
 		Navigator.openURL();
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-41747 - SimilarResults test failures "Element is not present" [Functional] (search)

Similar results testcase just needs the same updates as https://liferay.atlassian.net/browse/LPD-39785 to enable the deprecated feature flag for asset publisher.