### PR TITLE
LPD-45175 Search#MasterPageTemplateSearchBarConfigurationIsPropagated

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/SearchPage.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/SearchPage.macro
@@ -317,8 +317,11 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro configureSearchBarWidget(federatedSearchKey = null, scopeParameterName = null, searchScope = null, keywordsParameterName = null, index = null) {
-		if (isSet(index)) {
+	macro configureSearchBarWidget(federatedSearchKey = null, scopeParameterName = null, searchScope = null, keywordsParameterName = null, index = null, isFragment = null) {
+		if (${isFragment} == "true") {
+			SearchPage.gotoSearchBarFragmentOptions(portletOption = "Configuration");
+		}
+		else if (isSet(index)) {
 			SearchPage.gotoSearchBarWidgetOptionsSpecific(
 				index = ${index},
 				portletOption = "Configuration");
@@ -590,6 +593,21 @@ definition {
 		AssertClick(
 			locator1 = "SearchPage#RESULT_TITLE",
 			value1 = ${searchAssetTitle});
+	}
+
+	@summary = "Default summary"
+	macro gotoSearchBarFragmentOptions(portletOption = null) {
+		Click(locator1 = "Search#SEARCH_BAR_WIDGET");
+
+		Click(
+			key_fragmentName = "Search Bar",
+			locator1 = "Fragment#FRAGMENT_HEADER_ELLIPSIS");
+
+		if (isSet(portletOption)) {
+			var key_menuItem = ${portletOption};
+
+			Click(locator1 = "MenuItem#ANY_MENU_ITEM");
+		}
 	}
 
 	@summary = "Default summary"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
@@ -1184,7 +1184,9 @@ definition {
 			portletName = "Search Bar",
 			scope = "Master");
 
-		SearchPage.configureSearchBarWidget(destinationPage = "search");
+		SearchPage.configureSearchBarWidget(
+			destinationPage = "search",
+			isFragment = "true");
 
 		MastersPageTemplates.publishMaster();
 
@@ -1216,7 +1218,9 @@ definition {
 
 		MastersPageTemplatesAdmin.gotoMasters(masterLayoutName = "Custom Master Page Template");
 
-		SearchPage.configureSearchBarWidget(destinationPage = "Test Page Name");
+		SearchPage.configureSearchBarWidget(
+			destinationPage = "Test Page Name",
+			isFragment = "true");
 
 		MastersPageTemplates.propagateChange();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-45175 - Search#MasterPageTemplateSearchBarConfigurationIsPropagated [Functional] (search)

Workflow for selecting configurations has changed a little for fragments on a content page, so a macro was added to address that particular case.

Updated from https://github.com/liferay-search/liferay-portal/pull/1568 😅 (it had an unnecessary locator)