### PR TITLE
LPD-44539 Remove inline styles in Search modules due to Content Security Policies

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/display_settings.jspf
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/display_settings.jspf
@@ -32,7 +32,7 @@ for (SearchFacet searchFacet : searchFacets) {
 	>
 		<aui:input label="enabled" name='<%= "preferences--" + searchFacet.getClassName() + "--" %>' type="checkbox" value="<%= searchDisplayContext.isDisplayFacet(searchFacet.getClassName()) %>" />
 
-		<div class="facet-configuration" id="<portlet:namespace /><%= AUIUtil.normalizeId(searchFacet.getClassName()) %>FacetConfiguration" style="margin-left: 40px;">
+		<div class="c-ml-5 facet-configuration" id="<portlet:namespace /><%= AUIUtil.normalizeId(searchFacet.getClassName()) %>FacetConfiguration">
 			<div id="<%= StringUtil.replace(searchFacet.getClassName(), CharPool.PERIOD, CharPool.UNDERLINE) %>">
 
 				<%

--- a/modules/apps/portal-search/portal-search/src/main/resources/com/liferay/portal/search/internal/background/task/display/dependencies/reindex_background_task_progress.ftl
+++ b/modules/apps/portal-search/portal-search/src/main/resources/com/liferay/portal/search/internal/background/task/display/dependencies/reindex_background_task_progress.ftl
@@ -1,9 +1,17 @@
-<#assign percentage = backgroundTaskDisplay.getPercentage() />
+<#assign
+	percentage = backgroundTaskDisplay.getPercentage()
+/>
+
+<style ${nonceAttribute} type="text/css">
+	.percent-${percentage} {
+		width: ${percentage}%;
+	}
+</style>
 
 <div class="background-task-status-in-progress">
 	<div class="progress-group">
 		<div class="progress">
-			<div aria-valuemax="100" aria-valuemin="0" aria-valuenow="${percentage}" class="progress-bar" role="progressbar" style="width: ${percentage}%;"></div>
+			<div aria-valuemax="100" aria-valuemin="0" aria-valuenow="${percentage}" class="progress-bar percent-${percentage}" role="progressbar"></div>
 		</div>
 
 		<div class="progress-group-addon">${percentage}%</div>

--- a/modules/dxp/apps/portal-search-elasticsearch-monitoring/portal-search-elasticsearch-monitoring-web/src/main/resources/META-INF/resources/css/main.css
+++ b/modules/dxp/apps/portal-search-elasticsearch-monitoring/portal-search-elasticsearch-monitoring-web/src/main/resources/META-INF/resources/css/main.css
@@ -8,3 +8,19 @@
 		padding: 10px;
 	}
 }
+
+.portlet-elasticsearch-monitoring {
+	.elasticsearch-monitoring-iframe {
+		bottom: 0px;
+		height: 100%;
+		left: 0px;
+		min-height: 600px;
+		overflow: hidden;
+		overflow-x: hidden;
+		overflow-y: hidden;
+		position: relative;
+		right: 0px;
+		top: 0px;
+		width: 100%;
+	}
+}

--- a/modules/dxp/apps/portal-search-elasticsearch-monitoring/portal-search-elasticsearch-monitoring-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/portal-search-elasticsearch-monitoring/portal-search-elasticsearch-monitoring-web/src/main/resources/META-INF/resources/view.jsp
@@ -12,7 +12,7 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <liferay-theme:defineObjects />
 
-<iframe id="<portlet:namespace />iframe" scrolling="yes" src="<%= application.getContextPath() %>/monitoring-proxy/app/monitoring" style="bottom: 0px; height: 100%; left: 0px; min-height: 600px; overflow: hidden; overflow-x: hidden; overflow-y: hidden; position: relative; right: 0px; top: 0px; width: 100%;"></iframe>
+<iframe class="elasticsearch-monitoring-iframe" id="<portlet:namespace />iframe" scrolling="yes" src="<%= application.getContextPath() %>/monitoring-proxy/app/monitoring"></iframe>
 
 <aui:script use="aui-autosize-iframe">
 	var iframe = A.one('#<portlet:namespace />iframe');


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-44539 - Remove inline styles in Search modules

Directive is from https://liferay.atlassian.net/browse/LPD-43150. To support more restrictive content security policies, the inline styles are to be removed from FTLs/JSPs (nonce should be added to style tags)
- modules/dxp/apps/portal-search-elasticsearch-monitoring/portal-search-elasticsearch-monitoring-web/src/main/resources/META-INF/resources/view.jsp
- modules/apps/portal-search/portal-search/src/main/resources/com/liferay/portal/search/internal/background/task/display/dependencies/reindex_background_task_progress.ftl
- modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/display_settings.jspf
