### PR TITLE
LPD-44295 Adapt the UI to fluid design approach for search experiences + tuning

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/add_results_rankings.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/add_results_rankings.jsp
@@ -15,7 +15,8 @@ taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
+<%@ page import="com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil" %><%@
+page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.servlet.SessionErrors" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
@@ -57,6 +58,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "new-ranking"));
 
 <liferay-frontend:edit-form
 	action="<%= addResultsRankingEntryURL %>"
+	fluid='<%= FeatureFlagManagerUtil.isEnabled("LPS-184404") %>'
 	name="addResultRankingsFm"
 >
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/view.jsp
@@ -105,7 +105,10 @@ RankingPortletDisplayContext rankingPortletDisplayContext = (RankingPortletDispl
 	sortingURL="<%= rankingPortletDisplayContext.getSortingURL() %>"
 />
 
-<aui:form cssClass="container-fluid container-fluid-max-xl" method="post" name="fm">
+<clay:container-fluid
+	fullWidth='<%= FeatureFlagManagerUtil.isEnabled("LPS-184404") %>'
+>
+<aui:form method="post" name="fm">
 	<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 
 	<liferay-ui:search-container
@@ -230,3 +233,4 @@ RankingPortletDisplayContext rankingPortletDisplayContext = (RankingPortletDispl
 		/>
 	</liferay-ui:search-container>
 </aui:form>
+</clay:container-fluid>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/view.jsp
@@ -108,129 +108,129 @@ RankingPortletDisplayContext rankingPortletDisplayContext = (RankingPortletDispl
 <clay:container-fluid
 	fullWidth='<%= FeatureFlagManagerUtil.isEnabled("LPS-184404") %>'
 >
-<aui:form method="post" name="fm">
-	<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
+	<aui:form method="post" name="fm">
+		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 
-	<liferay-ui:search-container
-		id="resultsRankingEntries"
-		searchContainer="<%= rankingPortletDisplayContext.getSearchContainer() %>"
-	>
-		<liferay-ui:search-container-row
-			className="com.liferay.portal.search.tuning.rankings.web.internal.display.context.RankingEntryDisplayContext"
-			keyProperty="uid"
-			modelVar="rankingEntryDisplayContextModelVar"
+		<liferay-ui:search-container
+			id="resultsRankingEntries"
+			searchContainer="<%= rankingPortletDisplayContext.getSearchContainer() %>"
 		>
-
-			<%
-			RankingEntryDisplayContext rankingEntryDisplayContext = rankingEntryDisplayContextModelVar;
-			%>
-
-			<portlet:renderURL var="rowURL">
-				<portlet:param name="mvcRenderCommandName" value="/result_rankings/edit_results_rankings" />
-				<portlet:param name="redirect" value="<%= currentURL %>" />
-				<portlet:param name="resultsRankingUid" value="<%= rankingEntryDisplayContext.getUid() %>" />
-				<portlet:param name="aliases" value="<%= rankingEntryDisplayContext.getAliases() %>" />
-				<portlet:param name="companyId" value="<%= String.valueOf(themeDisplay.getCompanyId()) %>" />
-				<portlet:param name="keywords" value="<%= rankingEntryDisplayContext.getKeywords() %>" />
-				<portlet:param name="status" value="<%= rankingEntryDisplayContext.getStatus() %>" />
-			</portlet:renderURL>
-
-			<liferay-ui:search-container-column-text
-				cssClass="table-cell-expand"
-				name="search-query"
+			<liferay-ui:search-container-row
+				className="com.liferay.portal.search.tuning.rankings.web.internal.display.context.RankingEntryDisplayContext"
+				keyProperty="uid"
+				modelVar="rankingEntryDisplayContextModelVar"
 			>
-				<div class="list-group-title">
-					<a href="<%= rowURL %>">
-						<%= HtmlUtil.escape(rankingEntryDisplayContext.getKeywords()) %>
-					</a>
-				</div>
-			</liferay-ui:search-container-column-text>
 
-			<liferay-ui:search-container-column-text
-				cssClass="table-cell-expand"
-				name="aliases"
-			>
-				<div class="list-group-subtext">
-					<%= HtmlUtil.escape(rankingEntryDisplayContext.getAliases()) %>
-				</div>
-			</liferay-ui:search-container-column-text>
+				<%
+				RankingEntryDisplayContext rankingEntryDisplayContext = rankingEntryDisplayContextModelVar;
+				%>
 
-			<liferay-ui:search-container-column-text
-				cssClass="table-cell-expand-smallest table-cell-minw-150"
-				name="pinned-results"
-				value="<%= rankingEntryDisplayContext.getPinnedResultsCount() %>"
-			/>
+				<portlet:renderURL var="rowURL">
+					<portlet:param name="mvcRenderCommandName" value="/result_rankings/edit_results_rankings" />
+					<portlet:param name="redirect" value="<%= currentURL %>" />
+					<portlet:param name="resultsRankingUid" value="<%= rankingEntryDisplayContext.getUid() %>" />
+					<portlet:param name="aliases" value="<%= rankingEntryDisplayContext.getAliases() %>" />
+					<portlet:param name="companyId" value="<%= String.valueOf(themeDisplay.getCompanyId()) %>" />
+					<portlet:param name="keywords" value="<%= rankingEntryDisplayContext.getKeywords() %>" />
+					<portlet:param name="status" value="<%= rankingEntryDisplayContext.getStatus() %>" />
+				</portlet:renderURL>
 
-			<liferay-ui:search-container-column-text
-				cssClass="table-cell-expand-smallest table-cell-minw-150"
-				name="hidden-results"
-				value="<%= rankingEntryDisplayContext.getHiddenResultsCount() %>"
-			/>
+				<liferay-ui:search-container-column-text
+					cssClass="table-cell-expand"
+					name="search-query"
+				>
+					<div class="list-group-title">
+						<a href="<%= rowURL %>">
+							<%= HtmlUtil.escape(rankingEntryDisplayContext.getKeywords()) %>
+						</a>
+					</div>
+				</liferay-ui:search-container-column-text>
 
-			<c:if test='<%= FeatureFlagManagerUtil.isEnabled("LPD-6368") %>'>
+				<liferay-ui:search-container-column-text
+					cssClass="table-cell-expand"
+					name="aliases"
+				>
+					<div class="list-group-subtext">
+						<%= HtmlUtil.escape(rankingEntryDisplayContext.getAliases()) %>
+					</div>
+				</liferay-ui:search-container-column-text>
+
 				<liferay-ui:search-container-column-text
 					cssClass="table-cell-expand-smallest table-cell-minw-150"
-					name="scope"
+					name="pinned-results"
+					value="<%= rankingEntryDisplayContext.getPinnedResultsCount() %>"
+				/>
+
+				<liferay-ui:search-container-column-text
+					cssClass="table-cell-expand-smallest table-cell-minw-150"
+					name="hidden-results"
+					value="<%= rankingEntryDisplayContext.getHiddenResultsCount() %>"
+				/>
+
+				<c:if test='<%= FeatureFlagManagerUtil.isEnabled("LPD-6368") %>'>
+					<liferay-ui:search-container-column-text
+						cssClass="table-cell-expand-smallest table-cell-minw-150"
+						name="scope"
+					>
+						<c:choose>
+							<c:when test="<%= Validator.isNotNull(rankingEntryDisplayContext.getGroupExternalReferenceCode()) %>">
+
+								<%
+								Group group = GroupLocalServiceUtil.fetchGroupByExternalReferenceCode(rankingEntryDisplayContext.getGroupExternalReferenceCode(), themeDisplay.getCompanyId());
+								%>
+
+								<span class="lfr-portal-tooltip" data-title="<%= Validator.isNotNull(group) ? HtmlUtil.escape(group.getDescriptiveName(locale)) : LanguageUtil.get(request, "the-site-associated-with-this-ranking-was-deleted") %>">
+									<liferay-ui:message key="site" />
+								</span>
+							</c:when>
+							<c:when test="<%= Validator.isNotNull(rankingEntryDisplayContext.getSXPBlueprintExternalReferenceCode()) %>">
+
+								<%
+								String sxpBlueprintTitle = rankingEntryDisplayContext.getSXPBlueprintTitle();
+								%>
+
+								<span class="lfr-portal-tooltip" data-title="<%= Validator.isNotNull(sxpBlueprintTitle) ? HtmlUtil.escape(sxpBlueprintTitle) : LanguageUtil.get(request, "the-blueprint-associated-with-this-ranking-was-deleted") %>">
+									<liferay-ui:message key="blueprint" />
+								</span>
+							</c:when>
+							<c:otherwise>
+								<liferay-ui:message key="everything" />
+							</c:otherwise>
+						</c:choose>
+					</liferay-ui:search-container-column-text>
+				</c:if>
+
+				<liferay-ui:search-container-column-text
+					cssClass="table-cell-expand-smallest table-cell-minw-150"
+					name="status"
 				>
 					<c:choose>
-						<c:when test="<%= Validator.isNotNull(rankingEntryDisplayContext.getGroupExternalReferenceCode()) %>">
-
-							<%
-							Group group = GroupLocalServiceUtil.fetchGroupByExternalReferenceCode(rankingEntryDisplayContext.getGroupExternalReferenceCode(), themeDisplay.getCompanyId());
-							%>
-
-							<span class="lfr-portal-tooltip" data-title="<%= Validator.isNotNull(group) ? HtmlUtil.escape(group.getDescriptiveName(locale)) : LanguageUtil.get(request, "the-site-associated-with-this-ranking-was-deleted") %>">
-								<liferay-ui:message key="site" />
-							</span>
-						</c:when>
-						<c:when test="<%= Validator.isNotNull(rankingEntryDisplayContext.getSXPBlueprintExternalReferenceCode()) %>">
-
-							<%
-							String sxpBlueprintTitle = rankingEntryDisplayContext.getSXPBlueprintTitle();
-							%>
-
-							<span class="lfr-portal-tooltip" data-title="<%= Validator.isNotNull(sxpBlueprintTitle) ? HtmlUtil.escape(sxpBlueprintTitle) : LanguageUtil.get(request, "the-blueprint-associated-with-this-ranking-was-deleted") %>">
-								<liferay-ui:message key="blueprint" />
-							</span>
+						<c:when test="<%= Objects.equals(rankingEntryDisplayContext.getStatus(), ResultRankingsConstants.STATUS_NOT_APPLICABLE) %>">
+							<div class="label label-warning">
+								<span class="label-item label-item-expand">
+									<liferay-ui:message key="<%= rankingEntryDisplayContext.getStatus() %>" />
+								</span>
+							</div>
 						</c:when>
 						<c:otherwise>
-							<liferay-ui:message key="everything" />
+							<div class="label <%= Objects.equals(rankingEntryDisplayContext.getStatus(), ResultRankingsConstants.STATUS_ACTIVE) ? "label-success" : "label-secondary" %>">
+								<span class="label-item label-item-expand">
+									<liferay-ui:message key="<%= rankingEntryDisplayContext.getStatus() %>" />
+								</span>
+							</div>
 						</c:otherwise>
 					</c:choose>
 				</liferay-ui:search-container-column-text>
-			</c:if>
 
-			<liferay-ui:search-container-column-text
-				cssClass="table-cell-expand-smallest table-cell-minw-150"
-				name="status"
-			>
-				<c:choose>
-					<c:when test="<%= Objects.equals(rankingEntryDisplayContext.getStatus(), ResultRankingsConstants.STATUS_NOT_APPLICABLE) %>">
-						<div class="label label-warning">
-							<span class="label-item label-item-expand">
-								<liferay-ui:message key="<%= rankingEntryDisplayContext.getStatus() %>" />
-							</span>
-						</div>
-					</c:when>
-					<c:otherwise>
-						<div class="label <%= Objects.equals(rankingEntryDisplayContext.getStatus(), ResultRankingsConstants.STATUS_ACTIVE) ? "label-success" : "label-secondary" %>">
-							<span class="label-item label-item-expand">
-								<liferay-ui:message key="<%= rankingEntryDisplayContext.getStatus() %>" />
-							</span>
-						</div>
-					</c:otherwise>
-				</c:choose>
-			</liferay-ui:search-container-column-text>
+				<liferay-ui:search-container-column-jsp
+					cssClass="entry-action-column"
+					path="/view_results_rankings_entry_action.jsp"
+				/>
+			</liferay-ui:search-container-row>
 
-			<liferay-ui:search-container-column-jsp
-				cssClass="entry-action-column"
-				path="/view_results_rankings_entry_action.jsp"
+			<liferay-ui:search-iterator
+				markupView="lexicon"
 			/>
-		</liferay-ui:search-container-row>
-
-		<liferay-ui:search-iterator
-			markupView="lexicon"
-		/>
-	</liferay-ui:search-container>
-</aui:form>
+		</liferay-ui:search-container>
+	</aui:form>
 </clay:container-fluid>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/edit_synonym_sets.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/edit_synonym_sets.jsp
@@ -12,7 +12,8 @@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
-<%@ page import="com.liferay.portal.search.tuning.synonyms.web.internal.constants.SynonymsPortletKeys" %><%@
+<%@ page import="com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil" %><%@
+page import="com.liferay.portal.search.tuning.synonyms.web.internal.constants.SynonymsPortletKeys" %><%@
 page import="com.liferay.portal.search.tuning.synonyms.web.internal.display.context.EditSynonymSetsDisplayContext" %>
 
 <liferay-frontend:defineObjects />
@@ -33,6 +34,7 @@ portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 
 <liferay-frontend:edit-form
 	action="<%= editSynonymSetURL %>"
+	fluid='<%= FeatureFlagManagerUtil.isEnabled("LPS-184404") %>'
 	name="<%= editSynonymSetsDisplayContext.getFormName() %>"
 >
 	<aui:input name="<%= editSynonymSetsDisplayContext.getInputName() %>" type="hidden" value="" />

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/view.jsp
@@ -13,7 +13,8 @@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
+<%@ page import="com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil" %><%@
+page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.search.tuning.synonyms.web.internal.constants.SynonymsPortletKeys" %><%@
 page import="com.liferay.portal.search.tuning.synonyms.web.internal.display.context.SynonymsDisplayContext" %>
@@ -42,7 +43,10 @@ SynonymsDisplayContext synonymsDisplayContext = (SynonymsDisplayContext)request.
 	<portlet:param name="redirect" value="<%= currentURL %>" />
 </portlet:actionURL>
 
-<aui:form action="<%= deleteSynonymSetActionURL %>" cssClass="container-fluid container-fluid-max-xl" method="post" name="fm">
+<clay:container-fluid
+	fullWidth='<%= FeatureFlagManagerUtil.isEnabled("LPS-184404") %>'
+>
+<aui:form action="<%= deleteSynonymSetActionURL %>" method="post" name="fm">
 	<aui:input name="deletedSynonymSetsString" type="hidden" value="" />
 
 	<liferay-ui:search-container
@@ -77,3 +81,4 @@ SynonymsDisplayContext synonymsDisplayContext = (SynonymsDisplayContext)request.
 		/>
 	</liferay-ui:search-container>
 </aui:form>
+</clay:container-fluid>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/view.jsp
@@ -46,39 +46,39 @@ SynonymsDisplayContext synonymsDisplayContext = (SynonymsDisplayContext)request.
 <clay:container-fluid
 	fullWidth='<%= FeatureFlagManagerUtil.isEnabled("LPS-184404") %>'
 >
-<aui:form action="<%= deleteSynonymSetActionURL %>" method="post" name="fm">
-	<aui:input name="deletedSynonymSetsString" type="hidden" value="" />
+	<aui:form action="<%= deleteSynonymSetActionURL %>" method="post" name="fm">
+		<aui:input name="deletedSynonymSetsString" type="hidden" value="" />
 
-	<liferay-ui:search-container
-		id="synonymSetsEntries"
-		searchContainer="<%= synonymsDisplayContext.getSearchContainer() %>"
-	>
-		<liferay-ui:search-container-row
-			className="com.liferay.portal.search.tuning.synonyms.web.internal.display.context.SynonymSetDisplayContext"
-			keyProperty="synonymSetId"
-			modelVar="synonymSetDisplayContext"
+		<liferay-ui:search-container
+			id="synonymSetsEntries"
+			searchContainer="<%= synonymsDisplayContext.getSearchContainer() %>"
 		>
-			<liferay-ui:search-container-column-text
-				colspan="<%= 2 %>"
-				cssClass="table-cell-expand table-title"
+			<liferay-ui:search-container-row
+				className="com.liferay.portal.search.tuning.synonyms.web.internal.display.context.SynonymSetDisplayContext"
+				keyProperty="synonymSetId"
+				modelVar="synonymSetDisplayContext"
 			>
-				<aui:a href="<%= synonymSetDisplayContext.getEditRenderURL() %>">
-					<%= HtmlUtil.escape(synonymSetDisplayContext.getDisplayedSynonymSet()) %>
-				</aui:a>
-			</liferay-ui:search-container-column-text>
+				<liferay-ui:search-container-column-text
+					colspan="<%= 2 %>"
+					cssClass="table-cell-expand table-title"
+				>
+					<aui:a href="<%= synonymSetDisplayContext.getEditRenderURL() %>">
+						<%= HtmlUtil.escape(synonymSetDisplayContext.getDisplayedSynonymSet()) %>
+					</aui:a>
+				</liferay-ui:search-container-column-text>
 
-			<liferay-ui:search-container-column-text>
-				<clay:dropdown-actions
-					aria-label='<%= LanguageUtil.get(request, "show-actions") %>'
-					dropdownItems="<%= synonymSetDisplayContext.getDropdownItems() %>"
-					propsTransformer="{SynonymSetsDropdownDefaultPropsTransformer} from portal-search-tuning-synonyms-web"
-				/>
-			</liferay-ui:search-container-column-text>
-		</liferay-ui:search-container-row>
+				<liferay-ui:search-container-column-text>
+					<clay:dropdown-actions
+						aria-label='<%= LanguageUtil.get(request, "show-actions") %>'
+						dropdownItems="<%= synonymSetDisplayContext.getDropdownItems() %>"
+						propsTransformer="{SynonymSetsDropdownDefaultPropsTransformer} from portal-search-tuning-synonyms-web"
+					/>
+				</liferay-ui:search-container-column-text>
+			</liferay-ui:search-container-row>
 
-		<liferay-ui:search-iterator
-			markupView="lexicon"
-		/>
-	</liferay-ui:search-container>
-</aui:form>
+			<liferay-ui:search-iterator
+				markupView="lexicon"
+			/>
+		</liferay-ui:search-container>
+	</aui:form>
 </clay:container-fluid>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/view.jsp
@@ -62,9 +62,11 @@ SynonymsDisplayContext synonymsDisplayContext = (SynonymsDisplayContext)request.
 					colspan="<%= 2 %>"
 					cssClass="table-cell-expand table-title"
 				>
-					<aui:a href="<%= synonymSetDisplayContext.getEditRenderURL() %>">
-						<%= HtmlUtil.escape(synonymSetDisplayContext.getDisplayedSynonymSet()) %>
-					</aui:a>
+					<clay:link
+						href="<%= synonymSetDisplayContext.getEditRenderURL() %>"
+						label="<%= HtmlUtil.escape(synonymSetDisplayContext.getDisplayedSynonymSet()) %>"
+						translated="<%= false %>"
+					/>
 				</liferay-ui:search-container-column-text>
 
 				<liferay-ui:search-container-column-text>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PageToolbar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/PageToolbar.js
@@ -109,7 +109,9 @@ export default function PageToolbar({
 				aria-label={Liferay.Language.get('page-toolbar')}
 				light
 			>
-				<ClayLayout.ContainerFluid>
+				<ClayLayout.ContainerFluid
+					size={Liferay?.FeatureFlags?.['LPS-184404'] ? false : 'xl'}
+				>
 					<ClayToolbar.Nav>
 						<ClayToolbar.Item className="border-right c-mr-3 c-pr-3 text-left title-description-toolbar-item">
 							{modalVisible && (
@@ -371,6 +373,9 @@ export default function PageToolbar({
 			{onChangeTab && (
 				<ClayNavigationBar
 					aria-label={Liferay.Language.get('navigation')}
+					fluidSize={
+						Liferay?.FeatureFlags?.['LPS-184404'] ? false : 'xl'
+					}
 					triggerLabel={tabs[tab]}
 				>
 					{Object.keys(tabs).map((tabKey) => (


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-44295 - Adapt the UI to fluid design approach for search experiences + tuning

Adjustments are made behind `LPS-184404` which plans to be removed soon https://liferay.atlassian.net/browse/LPD-5246. All of the changes seem to have to do with the "full width" or ClayLayout size to "false" which makes layouts wider.

I didn't update the frontend-data-set for blueprints + elements, since frontend infra would want to address that in https://liferay.atlassian.net/browse/LPD-22020 😅 

The SF commit didn't make any code changes, everything shifted after wrapping it in a container!

Rankings
<img width="1781" alt="Screenshot 2025-01-09 at 3 46 04 PM" src="https://github.com/user-attachments/assets/5b74da3d-456a-4963-a4ca-9d4ee91e486e" />
<img width="1788" alt="Screenshot 2025-01-09 at 3 47 08 PM" src="https://github.com/user-attachments/assets/eca1083b-3460-458d-aabf-3dc0482981e5" />

Synonyms
<img width="1788" alt="Screenshot 2025-01-09 at 3 50 12 PM" src="https://github.com/user-attachments/assets/100e7c38-0b93-4a89-9460-24147991a2bd" />
<img width="1788" alt="Screenshot 2025-01-09 at 3 50 50 PM" src="https://github.com/user-attachments/assets/9b3fac9f-1e0f-42ff-a8e8-5aca45a60171" />

Blueprint/Element
<img width="1791" alt="Screenshot 2025-01-09 at 3 52 20 PM" src="https://github.com/user-attachments/assets/83b1a19f-8e68-4027-aea8-a06ac8334c8e" />
<img width="1789" alt="Screenshot 2025-01-09 at 3 52 38 PM" src="https://github.com/user-attachments/assets/3f5ac8b6-83aa-41cb-923b-acc32cd499e0" />
