### PR TITLE
LPD-44918 customFilter.spec.ts > Custom filter configuration works as expected on content pages

### DIFF
--- a/modules/test/playwright/tests/portal-search-web/customFilter.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/customFilter.spec.ts
@@ -82,7 +82,10 @@ test.describe('Custom filter configuration works as expected on content pages', 
 		});
 
 		await test.step('Configure custom filter in default experience to return only results that contains Portuguese in the title_en_US field', async () => {
-			await searchPage.openSearchPortletConfiguration('Custom Filter');
+			const widgetId =
+				await pageEditorPage.getFragmentId('Custom Filter');
+
+			await pageEditorPage.clickFragmentOption(widgetId, 'Configuration');
 
 			await searchPage.modalIFrame
 				.getByLabel('Filter Field Set the name of')
@@ -100,7 +103,10 @@ test.describe('Custom filter configuration works as expected on content pages', 
 		});
 
 		await test.step('Configure custom filter in new experience to return only results that contains English in the title_en_US field', async () => {
-			await searchPage.openSearchPortletConfiguration('Custom Filter');
+			const widgetId =
+				await pageEditorPage.getFragmentId('Custom Filter');
+
+			await pageEditorPage.clickFragmentOption(widgetId, 'Configuration');
 
 			await searchPage.modalIFrame
 				.getByLabel('Filter Field Set the name of')

--- a/modules/test/playwright/tests/portal-search-web/customFilter.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/customFilter.spec.ts
@@ -82,10 +82,13 @@ test.describe('Custom filter configuration works as expected on content pages', 
 		});
 
 		await test.step('Configure custom filter in default experience to return only results that contains Portuguese in the title_en_US field', async () => {
-			const widgetId =
+			const customFilterFragmentId =
 				await pageEditorPage.getFragmentId('Custom Filter');
 
-			await pageEditorPage.clickFragmentOption(widgetId, 'Configuration');
+			await pageEditorPage.clickFragmentOption(
+				customFilterFragmentId,
+				'Configuration'
+			);
 
 			await searchPage.modalIFrame
 				.getByLabel('Filter Field Set the name of')
@@ -103,10 +106,13 @@ test.describe('Custom filter configuration works as expected on content pages', 
 		});
 
 		await test.step('Configure custom filter in new experience to return only results that contains English in the title_en_US field', async () => {
-			const widgetId =
+			const customFilterFragmentId =
 				await pageEditorPage.getFragmentId('Custom Filter');
 
-			await pageEditorPage.clickFragmentOption(widgetId, 'Configuration');
+			await pageEditorPage.clickFragmentOption(
+				customFilterFragmentId,
+				'Configuration'
+			);
 
 			await searchPage.modalIFrame
 				.getByLabel('Filter Field Set the name of')


### PR DESCRIPTION
https://issues.liferay.com/browse/LPD-44918 - customFilter.spec.ts > Custom filter configuration works as expected on content pages

Looks like the fragment has its configuration option at a different spot, so changes use `pageEditorPage.clickFragmentOption` now.

Error was: `Error: locator.click: Test timeout of 60000ms exceeded. Call log: - waiting for locator('.portlet-topper').filter({ hasText: 'Custom Filter' }).first().getByLabel('Options') - locator resolved to <button type="button" title="Options" aria-label="Options" aria-haspopup="true" aria-expanded="false" aria-controls="clay-dropdown-menu-30" class="dropdown-toggle component-action portlet-options btn btn-outline-borderless btn-sm btn-outline-secondary">…</button> - attempting click action - waiting for element to be visible, enabled and stable - element is not visible`