### PR TITLE
LPD-44959 Search#ViewObjectsSearchResultDetailsDisplayPageTemplate 

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
@@ -2967,10 +2967,6 @@ definition {
 	@description = "This is a use case for LPS-141138."
 	@priority = 4
 	test ViewObjectsSearchResultDetailsDisplayPageTemplate {
-		task ("Enable featured content fragment set") {
-			FragmentsAdmin.enableFeaturedContent();
-		}
-
 		ObjectAdmin.addObjectViaAPI(
 			labelName = "Custom Object",
 			objectName = "CustomObject",
@@ -3033,9 +3029,9 @@ definition {
 		Button.clickSave();
 
 		PageEditor.addFragment(
-			collectionName = "Featured Content",
+			collectionName = "Basic Components",
 			composition = "true",
-			fragmentName = "Banner Center");
+			fragmentName = "Heading");
 
 		PageEditorMapping.mapEditableTextToField(
 			field = "title",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-44959 - Search#ViewObjectsSearchResultDetailsDisplayPageTemplate [Functional] (search)

The advice after featured content has been deprecated is to change the functional test to "use another non deprecated fragment since the logic that you are testing should not depend on the fragment." A basic component to view title should be good enough, since this test is supposed to check that a created object is available in the search results.
