### PR TITLE
LPD-46453 Synonym sets are being viewed as escaped text

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/view.jsp
@@ -15,7 +15,6 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
-page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.search.tuning.synonyms.web.internal.constants.SynonymsPortletKeys" %><%@
 page import="com.liferay.portal.search.tuning.synonyms.web.internal.display.context.SynonymsDisplayContext" %>
 
@@ -64,7 +63,7 @@ SynonymsDisplayContext synonymsDisplayContext = (SynonymsDisplayContext)request.
 				>
 					<clay:link
 						href="<%= synonymSetDisplayContext.getEditRenderURL() %>"
-						label="<%= HtmlUtil.escape(synonymSetDisplayContext.getDisplayedSynonymSet()) %>"
+						label="<%= synonymSetDisplayContext.getDisplayedSynonymSet() %>"
 						translated="<%= false %>"
 					/>
 				</liferay-ui:search-container-column-text>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPD-46453 - Synonym sets are being viewed as escaped text

Recently updated the aui link to be a `<clay:link>`, however synonyms with quotes show up as:
![image](https://github.com/user-attachments/assets/eb4fb2ff-3586-411b-8ec8-9c9e0fdfed85)

