### PR TITLE
LPD-42280 SearchContinuousUpgrade#ViewSearchPortletsConfiguration

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchContinuousUpgrade.testcase
@@ -37,7 +37,7 @@ definition {
 
 			WebContent.addCP(webContentTitle = "WC Title ${count}");
 
-			WebContent.publishWithPermissions();
+			PortletEntry.publish();
 		}
 
 		Navigator.openSpecificURL(url = "http://localhost:8080");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-42280 - SearchContinuousUpgrade#ViewSearchPortletsConfiguration [Functional] (search)

Test is failing with  `com.liferay.poshi.runner.exception.ElementNotFoundPoshiRunnerException: Element is not present at "//button[contains(@class, 'dropdown-item') and contains(text(), 'Publish With Permissions')]"` after changes were made in [LPD-29163](https://liferay.atlassian.net/browse/LPD-29163). Looks like the fix is to use `PortletEntry.publish`, since the publish button does not open a dropdown.