### PR TITLE
LPD-49350 search part of LPD-47718

### DIFF
--- a/modules/apps/asset/asset-list-web/package.json
+++ b/modules/apps/asset/asset-list-web/package.json
@@ -10,6 +10,7 @@
 		"@clayui/tooltip": "3.119.0",
 		"asset-taglib": "*",
 		"classnames": "2.3.1",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "18.2.0",

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/AssetEntryListDropdownDefaultPropsTransformer.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/AssetEntryListDropdownDefaultPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal, openSimpleInputModal} from 'frontend-js-web';
+import {openModal, openSimpleInputModal} from 'frontend-js-components-web';
 
 import openDeleteAssetEntryListModal from './openDeleteAssetEntryListModal';
 

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/AssetListEntryVariationDefaultPropsTransformer.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/AssetListEntryVariationDefaultPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal, openModal} from 'frontend-js-web';
+import {openConfirmModal, openModal} from 'frontend-js-components-web';
 
 const ACTIONS = {
 	deleteAssetListEntryVariation(itemData) {

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/EditAssetListEntryManualDefaultPropsTransformer.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/EditAssetListEntryManualDefaultPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({
 	actions,

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/EmptyResultMessagePropsTransformer.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/EmptyResultMessagePropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSimpleInputModal} from 'frontend-js-web';
+import {openSimpleInputModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({
 	items,

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/InfoCollectionProviderDropdownDefaultPropsTransformer.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/InfoCollectionProviderDropdownDefaultPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
 
 const ACTIONS = {
 	viewInfoCollectionProviderItems(itemData) {

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSimpleInputModal} from 'frontend-js-web';
+import {openSimpleInputModal} from 'frontend-js-components-web';
 
 import openDeleteAssetEntryListModal from './openDeleteAssetEntryListModal';
 

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/ScopeDefaultPropsTransformer.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/ScopeDefaultPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 
 const ACTIONS = {
 	addRow({groupId}, searchContainer, portletNamespace) {

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/Source.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/Source.js
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {openSelectionModal} from 'frontend-js-components-web';
 import {
 	addParams,
 	delegate,
-	openSelectionModal,
 	sub,
 	toggleDisabled,
 	toggleSelectBox,

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/VariationsNav/SortableList.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/VariationsNav/SortableList.js
@@ -4,7 +4,8 @@
  */
 
 import ClayList from '@clayui/list';
-import {openConfirmModal, openToast, sub} from 'frontend-js-web';
+import {openConfirmModal, openToast} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {DndProvider} from 'react-dnd';

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/openDeleteAssetEntryListModal.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/openDeleteAssetEntryListModal.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal, sub} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 
 export default function openDeleteAssetEntryListModal({
 	multiple = false,

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "5a9b05de0db0a1621c332d04a853b80dad145de2",
+	"@generated": "320973d94100bd613a30a8a87978a61d6eaef2bd",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -14,6 +14,9 @@
 		"paths": {
 			"asset-taglib": [
 				"../../../../../../asset-taglib/src/main/resources/META-INF/resources/js/index.js"
+			],
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -37,6 +40,9 @@
 	"references": [
 		{
 			"path": "../../../../../../asset-taglib/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/asset/asset-list-web/test/js/components/VariationsNav.test.js
+++ b/modules/apps/asset/asset-list-web/test/js/components/VariationsNav.test.js
@@ -4,7 +4,7 @@
  */
 
 import {cleanup, fireEvent, render} from '@testing-library/react';
-import {openConfirmModal, openToast} from 'frontend-js-web';
+import {openConfirmModal, openToast} from 'frontend-js-components-web';
 import React from 'react';
 
 import '@testing-library/jest-dom/extend-expect';
@@ -23,9 +23,12 @@ const _getComponent = (props) => {
 	return <VariationsNav {...props} />;
 };
 
-jest.mock('frontend-js-web', () => ({
+jest.mock('frontend-js-components-web', () => ({
 	openConfirmModal: jest.fn(({onConfirm}) => onConfirm(true)),
 	openToast: jest.fn(),
+}));
+
+jest.mock('frontend-js-web', () => ({
 	sub: jest.fn((str) => str),
 }));
 

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/js/IndexActions.js
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/js/IndexActions.js
@@ -8,7 +8,8 @@ import ClayLayout from '@clayui/layout';
 import ClayList from '@clayui/list';
 import {ClayModalProvider, Context as ClayModalContext} from '@clayui/modal';
 import ClayProgressBar from '@clayui/progress-bar';
-import {fetch, localStorage, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch, localStorage} from 'frontend-js-web';
 import React, {
 	useCallback,
 	useContext,

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/utils/initialize_clipboard.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/utils/initialize_clipboard.js
@@ -4,7 +4,7 @@
  */
 
 import ClipboardJS from 'clipboard';
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 
 export default function initializeClipboard({selector}) {
 	const clipboardJS = new ClipboardJS(selector);

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/RankingPortletManagementToolbarPropsTransformer.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/RankingPortletManagementToolbarPropsTransformer.js
@@ -3,11 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {
-	getCheckedCheckboxes,
-	openConfirmModal,
-	postForm,
-} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 export default function propsTransformer({
 	additionalProps: {
 		activateResultsRankingEntryURL,

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsAdd.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsAdd.es.js
@@ -12,8 +12,9 @@ import {
 	FeatureIndicator,
 	LearnMessage,
 	LearnResourcesContext,
+	openSelectionModal,
 } from 'frontend-js-components-web';
-import {navigate, openSelectionModal} from 'frontend-js-web';
+import {navigate} from 'frontend-js-web';
 import React, {useContext, useEffect, useRef, useState} from 'react';
 
 import NamespaceContext from '../NamespaceContext';

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsForm.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsForm.es.js
@@ -6,7 +6,7 @@
 import ClayAlert from '@clayui/alert';
 import ClayLayout from '@clayui/layout';
 import ClayTabs from '@clayui/tabs';
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 import {PropTypes} from 'prop-types';
 import React, {Component} from 'react';
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/shared/ErrorBoundary.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/shared/ErrorBoundary.es.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 import {PropTypes} from 'prop-types';
 import React, {Component} from 'react';
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/package.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/package.json
@@ -5,6 +5,7 @@
 		"@clayui/icon": "3.111.0",
 		"@clayui/layout": "3.111.0",
 		"@clayui/multi-select": "3.127.0",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "18.2.0"

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/js/SynonymSetsDropdownDefaultPropsTransformer.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/js/SynonymSetsDropdownDefaultPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 const ACTIONS = {
 	delete(itemData) {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/js/SynonymsManagementToolbarPropsTransformer.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/js/SynonymsManagementToolbarPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "62ec63fe5de959c0cef721a68b34357aa524a9dc",
+	"@generated": "51bcaabf18e93dbeaa2dfc4ec4f0572e55cac85a",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../../../apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../../../apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../../../apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../../../apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/hooks/useShouldConfirmBeforeNavigate.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/hooks/useShouldConfirmBeforeNavigate.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 import {useEffect} from 'react';
 
 /**

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/ErrorBoundary.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/ErrorBoundary.js
@@ -4,7 +4,7 @@
  */
 
 import ClayEmptyState from '@clayui/empty-state';
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 import React, {Component} from 'react';
 
 import {DEFAULT_ERROR} from '../utils/errorMessages';

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/ItemSelectorInput.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/ItemSelectorInput.js
@@ -6,7 +6,7 @@
 import ClayButton from '@clayui/button';
 import {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 import React from 'react';
 
 function ItemSelectorInput({

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/SiteSelectorInput.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/SiteSelectorInput.js
@@ -6,7 +6,7 @@
 import ClayButton from '@clayui/button';
 import {ClayInput} from '@clayui/form';
 import ClayMultiSelect from '@clayui/multi-select';
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 import React, {useContext, useMemo, useState} from 'react';
 
 import {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/toasts.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/toasts.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openToast, sessionStorage} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {sessionStorage} from 'frontend-js-web';
 
 import {SESSION_IDS} from './sessionStorage';
 


### PR DESCRIPTION
Hi team :wave: 

This PR is part of [LPD-47718](https://liferay.atlassian.net/browse/LPD-47718).

It refactors your code to import `openModal`, `openToast`, etc. from `frontend-js-components-web` instead of `frontend-js-web`.

The final goal is to remove those methods from `frontend-js-web` so that whenever that module is imported the browser doesn't need to pull React and Clay simply because those methods existed there. This will enhance the performance of sites that don't need React or Clay.

Internally, for now, we are only [re-exporting those methods](https://github.com/brianchandotcom/liferay-portal/pull/159020/commits/3c4231e573b72d8775583af87224810fe42de532) from `frontend-js-components-web`, but once all PRs like this one sent to teams are merged, we (Frontend Infra) will send another final PR to move the methods and remove them completely from `frontend-js-web`.

The code in this PR (as well as the one we will send to other teams) has been thoroughly tested in [this PR](https://github.com/liferay-frontend/liferay-portal/pull/4720#) but we want to make sure that it doesn't break anything and that's why we send it to you for review.

The expectations are that you run the tests suites you think apply and if nothing breaks you just simply forward the PR to Brian. 

Also, it would be great if any new code you write that uses those methods imports them from `frontend-js-components-web` instead of `frontend-js-web` so that we don't have to repeat this process again :grimacing: .

For reference, here is the list of moved methods:

1. openAlertModal
2. openCategorySelectionModal
3. openConfirmModal
4. openModal
5. openPortletModal
6. openPortletWindow
7. openSelectionModal
8. openSimpleInputModal
9. openTagSelectionModal
10. openToast