### PR TITLE
LPD-50535 search-experiences-web: Fix blueprint editor margin causing scroll

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/edit_sxp_blueprint/_edit_sxp_blueprint.scss
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/css/edit_sxp_blueprint/_edit_sxp_blueprint.scss
@@ -4,8 +4,6 @@
 		padding-top: $pageToolbarHeight + 40px;
 
 		.layout-section-main-shift {
-			margin-left: auto;
-			margin-right: calc(50% - #{$layoutSectionMainMaxWidth} / 2);
 			max-width: $layoutSectionMainMaxWidth;
 			transition: margin-right ease 0.2s;
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-50535 - On smaller screens, scrolling horizontally in SXP Blueprint editor shows gap with Control Menu header

This was found after https://liferay.atlassian.net/browse/LPD-48850 (fluid layout in search). If the blueprint editor gets resized to smaller screen (width below 980px), the `layout-section-main-shift` actually becomes longer than expected, allowing a horizontal scroll and showing a gap with the CM header.

![image](https://github.com/user-attachments/assets/6cdc721b-5202-4fc2-a9dc-e56eb8b0a2ea)

The simplest way to address this seems to remove the calculated margin, which was adding on that extra width. I tried this on Firefox, Chrome, and Safari and it solves the issue without introducing a regression. Also on bigger screens, the editor looks the same.

Let me know if I should make any changes, thank you!