### PR TITLE
LPD-52329 Apply missing form label for date pickers in search widgets

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/facet/view.jsp
@@ -208,7 +208,7 @@ String aggregationType = customFacetDisplayContext.getAggregationType();
 											id='<%= liferayPortletResponse.getNamespace() + "customRangeFrom" %>'
 											md="6"
 										>
-											<aui:field-wrapper label="from">
+											<aui:field-wrapper label="from" name="fromInput">
 												<liferay-ui:input-date
 													cssClass="custom-range-input-date-from"
 													dayParam="fromDay"
@@ -228,7 +228,7 @@ String aggregationType = customFacetDisplayContext.getAggregationType();
 											id='<%= liferayPortletResponse.getNamespace() + "customRangeTo" %>'
 											md="6"
 										>
-											<aui:field-wrapper label="to">
+											<aui:field-wrapper label="to" name="toInput">
 												<liferay-ui:input-date
 													cssClass="custom-range-input-date-to"
 													dayParam="toDay"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/modified/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/modified/facet/view.jsp
@@ -145,7 +145,7 @@ ModifiedFacetPortletInstanceConfiguration modifiedFacetPortletInstanceConfigurat
 								id='<%= liferayPortletResponse.getNamespace() + "customRangeFrom" %>'
 								md="6"
 							>
-								<aui:field-wrapper label="from">
+								<aui:field-wrapper label="from" name="fromInput">
 									<liferay-ui:input-date
 										cssClass="modified-facet-custom-range-input-date-from"
 										dayParam="fromDay"
@@ -165,7 +165,7 @@ ModifiedFacetPortletInstanceConfiguration modifiedFacetPortletInstanceConfigurat
 								id='<%= liferayPortletResponse.getNamespace() + "customRangeTo" %>'
 								md="6"
 							>
-								<aui:field-wrapper label="to">
+								<aui:field-wrapper label="to" name="toInput">
 									<liferay-ui:input-date
 										cssClass="modified-facet-custom-range-input-date-to"
 										dayParam="toDay"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/custom/facet/portlet/display/template/dependencies/portlet_display_template_checkbox.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/custom/facet/portlet/display/template/dependencies/portlet_display_template_checkbox.ftl
@@ -162,7 +162,10 @@
 				<#if customFacetDisplayContext.getAggregationType() == "dateRange">
 					<div class="${(!customFacetCalendarDisplayContext.isSelected())?then("hide", "")} date-custom-range" id="${namespace}customRange">
 						<div class="col-md-6" id="${namespace}customRangeFrom">
-							<@liferay_aui["field-wrapper"] label="from">
+							<@liferay_aui["field-wrapper"]
+								label="from"
+								name="fromInput"
+							>
 								<@liferay_ui["input-date"]
 									cssClass="custom-range-input-date-from"
 									dayParam="fromDay"
@@ -179,7 +182,10 @@
 						</div>
 
 						<div class="col-md-6" id="${namespace}customRangeTo">
-							<@liferay_aui["field-wrapper"] label="to">
+							<@liferay_aui["field-wrapper"]
+								label="to"
+								name="toInput"
+							>
 								<@liferay_ui["input-date"]
 									cssClass="custom-range-input-date-to"
 									dayParam="toDay"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/custom/facet/portlet/display/template/dependencies/portlet_display_template_compact.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/custom/facet/portlet/display/template/dependencies/portlet_display_template_compact.ftl
@@ -137,7 +137,10 @@
 				<#if customFacetDisplayContext.getAggregationType() == "dateRange">
 					<div class="${(!customFacetCalendarDisplayContext.isSelected())?then("hide", "")} date-custom-range" id="${namespace}customRange">
 						<div class="col-md-6" id="${namespace}customRangeFrom">
-							<@liferay_aui["field-wrapper"] label="from">
+							<@liferay_aui["field-wrapper"]
+								label="from"
+								name="fromInput"
+							>
 								<@liferay_ui["input-date"]
 									cssClass="date-facet-custom-range-input-date-from"
 									dayParam="fromDay"
@@ -154,7 +157,10 @@
 						</div>
 
 						<div class="col-md-6" id="${namespace}customRangeTo">
-							<@liferay_aui["field-wrapper"] label="to">
+							<@liferay_aui["field-wrapper"]
+								label="to"
+								name="toInput"
+							>
 								<@liferay_ui["input-date"]
 									cssClass="date-facet-custom-range-input-date-to"
 									dayParam="toDay"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/custom/facet/portlet/display/template/dependencies/portlet_display_template_label.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/custom/facet/portlet/display/template/dependencies/portlet_display_template_label.ftl
@@ -132,7 +132,10 @@
 			<#if customFacetDisplayContext.getAggregationType() == "dateRange">
 				<div class="${(!customFacetCalendarDisplayContext.isSelected())?then("hide", "")} date-custom-range" id="${namespace}customRange">
 					<div class="col-md-6" id="${namespace}customRangeFrom">
-						<@liferay_aui["field-wrapper"] label="from">
+						<@liferay_aui["field-wrapper"]
+							label="from"
+							name="fromInput"
+						>
 							<@liferay_ui["input-date"]
 								cssClass="date-facet-custom-range-input-date-from"
 								dayParam="fromDay"
@@ -149,7 +152,10 @@
 					</div>
 
 					<div class="col-md-6" id="${namespace}customRangeTo">
-						<@liferay_aui["field-wrapper"] label="to">
+						<@liferay_aui["field-wrapper"]
+							label="to"
+							name="toInput"
+						>
 							<@liferay_ui["input-date"]
 								cssClass="date-facet-custom-range-input-date-to"
 								dayParam="toDay"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/custom/facet/portlet/display/template/dependencies/portlet_display_template_radio.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/custom/facet/portlet/display/template/dependencies/portlet_display_template_radio.ftl
@@ -163,7 +163,10 @@
 				<#if customFacetDisplayContext.getAggregationType() == "dateRange">
 					<div class="${(!customFacetCalendarDisplayContext.isSelected())?then("hide", "")} date-custom-range" id="${namespace}customRange">
 						<div class="col-md-6" id="${namespace}customRangeFrom">
-							<@liferay_aui["field-wrapper"] label="from">
+							<@liferay_aui["field-wrapper"]
+								label="from"
+								name="fromInput"
+							>
 								<@liferay_ui["input-date"]
 									cssClass="date-facet-custom-range-input-date-from"
 									dayParam="fromDay"
@@ -180,7 +183,10 @@
 						</div>
 
 						<div class="col-md-6" id="${namespace}customRangeTo">
-							<@liferay_aui["field-wrapper"] label="to">
+							<@liferay_aui["field-wrapper"]
+								label="to"
+								name="toInput"
+							>
 								<@liferay_ui["input-date"]
 									cssClass="date-facet-custom-range-input-date-to"
 									dayParam="toDay"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/modified/facet/portlet/display/template/dependencies/portlet_display_template_radio.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/modified/facet/portlet/display/template/dependencies/portlet_display_template_radio.ftl
@@ -98,7 +98,10 @@
 
 			<div class="${(!modifiedFacetCalendarDisplayContext.isSelected())?then("hide", "")} modified-custom-range" id="${namespace}customRange">
 				<div class="col-md-6" id="${namespace}customRangeFrom">
-					<@liferay_aui["field-wrapper"] label="from">
+					<@liferay_aui["field-wrapper"]
+						label="from"
+						name="fromInput"
+					>
 						<@liferay_ui["input-date"]
 							cssClass="modified-facet-custom-range-input-date-from"
 							dayParam="fromDay"
@@ -115,7 +118,10 @@
 				</div>
 
 				<div class="col-md-6" id="${namespace}customRangeTo">
-					<@liferay_aui["field-wrapper"] label="to">
+					<@liferay_aui["field-wrapper"]
+						label="to"
+						name="toInput"
+					>
 						<@liferay_ui["input-date"]
 							cssClass="modified-facet-custom-range-input-date-to"
 							dayParam="toDay"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-52329 - Apply missing form label for date pickers in search widgets

For accessibility, the ‘To’ and ‘From’ labels in the Date Picker should reference its respective inputs, by using the correct ‘for’ in the label.

Labels should be notated (example) as `<label class=" control-label" for="_com_liferay_portal_search_web_custom_facet_portlet_CustomFacetPortlet_INSTANCE_agmAU5lDFutw_fromInput">From</label>` to correspond to its input date.

Applied to
- modified facet JSP and FTLs
- custom facet JSP and FTLs (does not apply to general range, just dateRange)