### PR TITLE
LPD-52399 Search suggestions a11y with sr-only container

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -10,7 +10,7 @@ import {ClayInput, ClaySelect} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import getCN from 'classnames';
-import {addParams, fetch, navigate} from 'frontend-js-web';
+import {addParams, fetch, navigate, sub} from 'frontend-js-web';
 import React, {useCallback, useRef, useState} from 'react';
 
 import {FacetUtil} from '../FacetUtil';
@@ -356,6 +356,27 @@ export default function SearchBar({
 
 	return (
 		<ClayAutocomplete className="search-bar-suggestions">
+			<span className="sr-only" role="status">
+				{loading
+					? Liferay.Language.get('loading')
+					: active
+						? suggestionsResponseItems.length
+							? sub(Liferay.Language.get('showing-x-x'), [
+									suggestionsResponseItems.reduce(
+										(accumulator, currentValue) =>
+											accumulator +
+											(currentValue?.suggestions
+												?.length || 0),
+										0
+									),
+									Liferay.Language.get('suggestions'),
+								])
+							: sub(Liferay.Language.get('no-x-were-found'), [
+									Liferay.Language.get('suggestions'),
+								])
+						: ''}
+			</span>
+
 			<ClayInput.Group ref={alignElementRef}>
 				{letUserChooseScope
 					? _renderSearchBarWithScope()


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-52399 - Improve search suggestions accessibility with hidden informational container

Creates a hidden container inside search bar suggestions to provide semantics/feedback, by using `sr-only` class. Suggestions are actually split into groups, so the number of displayed results had to be counted up.

Here's what it looks like with voiceover turned on:
![Screenshot 2025-04-02 at 4 23 20 PM](https://github.com/user-attachments/assets/93d1609d-99cf-4f4d-9131-704427153ab8)
