### PR TITLE
LPD-49421 Category Facet Selection Issues

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/category/facet/configuration.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/category/facet/configuration.jsp
@@ -97,7 +97,7 @@ CategoryFacetPortletPreferences categoryFacetPortletPreferences = new CategoryFa
 						).put(
 							"namespace", liferayPortletResponse.getNamespace()
 						).put(
-							"vocabularyERCsInputName", PortletPreferencesJspUtil.getInputName(CategoryFacetPortletPreferences.PREFERENCE_GROUP_VOCABULARY_EXTERNAL_REFERENCE_CODES)
+							"vocabularyExternalReferenceCodesInputName", PortletPreferencesJspUtil.getInputName(CategoryFacetPortletPreferences.PREFERENCE_GROUP_VOCABULARY_EXTERNAL_REFERENCE_CODES)
 						).build()
 					%>'
 				/>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SelectVocabularies.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SelectVocabularies.js
@@ -149,7 +149,7 @@ function VocabularyTree({
 			showExpanderOnHover={false}
 		>
 			{(item) => (
-				<TreeView.Item key={item.id}>
+				<TreeView.Item key={item.externalReferenceCode}>
 					<div className="treeview-link-site-row">
 						<SiteRow
 							name={

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SelectVocabularies.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SelectVocabularies.js
@@ -118,12 +118,12 @@ function VocabularyTree({
 	const _handleSelect = (list, add = true) => {
 		const newList = new Set(selectedKeys);
 
-		list.forEach(({erc}) => {
+		list.forEach(({externalReferenceCode}) => {
 			if (add) {
-				newList.add(erc);
+				newList.add(externalReferenceCode);
 			}
 			else {
-				newList.delete(erc);
+				newList.delete(externalReferenceCode);
 			}
 		});
 
@@ -131,7 +131,7 @@ function VocabularyTree({
 	};
 
 	const _handleToggle = (item) => {
-		_handleSelect([item], !selectedKeys.has(item.erc));
+		_handleSelect([item], !selectedKeys.has(item.externalReferenceCode));
 	};
 
 	if (loading || vocabularyTree === null) {
@@ -164,13 +164,15 @@ function VocabularyTree({
 
 					{item.children?.length ? (
 						<TreeView.Group items={item.children}>
-							{({erc, name}) => (
+							{({externalReferenceCode, name}) => (
 								<TreeView.Item
-									key={erc}
+									key={externalReferenceCode}
 									style={{cursor: 'unset'}}
 								>
 									<ClayCheckbox
-										checked={selectedKeys.has(erc)}
+										checked={selectedKeys.has(
+											externalReferenceCode
+										)}
 										onChange={() => _handleToggle(item)}
 									/>
 
@@ -293,21 +295,19 @@ function SelectVocabularies({
 
 										return true;
 									})
-									.map(
-										({externalReferenceCode, id, name}) => {
-											const erc = `${itemsFilteredForSites[index].externalReferenceCode}&&${externalReferenceCode}`;
+									.map((item) => {
+										const externalReferenceCode = `${itemsFilteredForSites[index].externalReferenceCode}&&${item.externalReferenceCode}`;
 
-											fetchedExternalReferenceCodes.push(
-												erc
-											); // Collect ExternalReferenceCodes to allow deselection of unavailable vocabularies
+										fetchedExternalReferenceCodes.push(
+											externalReferenceCode
+										); // Collect ExternalReferenceCodes to allow deselection of unavailable vocabularies
 
-											return {
-												erc,
-												id: id.toString(),
-												name,
-											};
-										}
-									),
+										return {
+											externalReferenceCode,
+											id: item.id.toString(),
+											name: item.name,
+										};
+									}),
 							}))
 						);
 
@@ -331,9 +331,11 @@ function SelectVocabularies({
 	const _handleDeselectUnavailableVocabularyExternalReferenceCodes = () => {
 		const newList = new Set(selectedKeys);
 
-		unavailableVocabularyExternalReferenceCodes.forEach((erc) => {
-			newList.delete(erc);
-		});
+		unavailableVocabularyExternalReferenceCodes.forEach(
+			(externalReferenceCode) => {
+				newList.delete(externalReferenceCode);
+			}
+		);
 
 		setSelectedKeys(newList);
 	};
@@ -347,8 +349,8 @@ function SelectVocabularies({
 	};
 
 	const _isUnavailableVocabularyExternalReferenceCodesSelected = () =>
-		unavailableVocabularyExternalReferenceCodes.some((erc) =>
-			selectedKeys.has(erc)
+		unavailableVocabularyExternalReferenceCodes.some(
+			(externalReferenceCode) => selectedKeys.has(externalReferenceCode)
 		);
 
 	return (

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SelectVocabularies.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SelectVocabularies.js
@@ -365,7 +365,9 @@ function SelectVocabularies({
 				value={
 					selection === SELECT_OPTIONS.ALL
 						? SELECT_OPTIONS.ALL
-						: Array.from(selectedKeys).toString()
+						: Array.from(selectedKeys)
+								.filter((item) => item.includes('&&')) // Filter out site headers ClayTreeView may select
+								.toString()
 				}
 			/>
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-52612 - Category Facet Selection Issues

Several updates:
- Rename `erc` to `externalReferenceCode`
- Needed to change name for `vocabularyERCsInputName`
- Clay TreeView now selects headers when expanding the tree, simplest workaround would be to filter them out on submission
- Use `externalReferenceCode` for site key (does not cause issues, but good to be consistent)