### PR TITLE
LPD-52991 Test failures in Search module due to LPD-51577 pagination update

### DIFF
--- a/modules/test/playwright/pages/portal-search-web/SearchPage.ts
+++ b/modules/test/playwright/pages/portal-search-web/SearchPage.ts
@@ -221,14 +221,14 @@ export class SearchPage {
 			target: this.searchResultsPaginationItemsPerPageDropdown
 				.nth(index)
 				.getByRole('option', {
-					name: `${delta.toString()}  Entries per Page`,
+					name: new RegExp(`${delta}`),
 				}),
 			trigger: this.searchResultsPaginationItemsPerPageToggle.nth(index),
 		});
 
 		await expect(
 			this.searchResultsPaginationItemsPerPageToggle.nth(index)
-		).toHaveText(new RegExp(`${delta.toString()} Entries`));
+		).toHaveText(new RegExp(`${delta} Entries`));
 	}
 
 	async selectPaginationPageNumber(pageNumber: number) {

--- a/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
@@ -7,15 +7,20 @@ import {Locator, expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../fixtures/dataApiHelpersTest';
 import {isolatedLayoutTest} from '../../fixtures/isolatedLayoutTest';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
 import {searchPageTest} from '../../fixtures/searchPageTest';
 import getRandomString from '../../utils/getRandomString';
+import getBasicWebContentStructureId from '../../utils/structured-content/getBasicWebContentStructureId';
 
 export const test = mergeTests(
 	isolatedLayoutTest({type: 'portlet'}),
+	isolatedSiteTest,
 	loginTest(),
 	searchPageTest,
-	dataApiHelpersTest
+	dataApiHelpersTest,
+	pageEditorPagesTest
 );
 
 test.describe('Category facet configuration for vocabularies', () => {
@@ -74,6 +79,86 @@ test.describe('Category facet configuration for vocabularies', () => {
 					})
 				).toBeVisible();
 			}
+		});
+	});
+});
+
+test.describe('Retain items per page in search paginator', () => {
+	test('Retains items per page after new keyword search @LPD-19994', async ({
+		apiHelpers,
+		page,
+		searchPage,
+		site,
+	}) => {
+		let siteLayout: Layout;
+
+		await test.step('Create web content for search results', async () => {
+			const basicWebContentStructureId =
+				await getBasicWebContentStructureId(apiHelpers);
+
+			for (let count = 0; count < 21; count++) {
+				await apiHelpers.jsonWebServicesJournal.addWebContent({
+					ddmStructureId: basicWebContentStructureId,
+					groupId: site.id,
+					titleMap: {en_US: `Test Web Content ${count}`},
+				});
+			}
+		});
+
+		await test.step('Create a portlet page associated to site', async () => {
+			siteLayout = await apiHelpers.jsonWebServicesLayout.addLayout({
+				groupId: site.id,
+				options: {type: 'portlet'},
+				title: getRandomString(),
+			});
+		});
+
+		await test.step('Navigate to the site page', async () => {
+			await page.goto(
+				`/web${site.friendlyUrlPath}${siteLayout.friendlyURL}`
+			);
+		});
+
+		await test.step('Add search bar and results portlet to new page', async () => {
+			await searchPage.addPortlet('Search Bar', 'Search');
+
+			await searchPage.addPortlet('Search Results', 'Search');
+		});
+
+		await test.step('Perform new search', async () => {
+			await searchPage.searchKeywordInMainContent('test');
+
+			await expect(searchPage.searchResultsTotalLabel).toHaveText(
+				/\d+ Results for test/
+			);
+		});
+
+		await test.step('Change pagination items per page and page number', async () => {
+			await searchPage.selectPaginationItemsPerPage(20);
+
+			await searchPage.selectPaginationPageNumber(2);
+		});
+
+		await test.step('Perform new search with different keyword', async () => {
+			await searchPage.searchKeywordInMainContent('web');
+
+			await expect(searchPage.searchResultsTotalLabel).toHaveText(
+				/\d+ Results for web/
+			);
+		});
+
+		await test.step('Verify that page number is reset but items per page is not', async () => {
+			await expect(
+				searchPage.searchResultsPaginationItemsPerPageToggle
+			).toHaveText(/20 Entries/);
+
+			await expect(
+				searchPage.searchResultsPaginationBar.getByText('1').first()
+			).toHaveAttribute('aria-current', 'page');
+
+			await expect(
+				searchPage.searchResultsPaginationDescription
+			).toHaveText(/Showing 1 to 20 of \d+ entries./);
 		});
 	});
 });
@@ -181,38 +266,6 @@ test.describe('Clear and retain facet selections', () => {
 		});
 	});
 
-	test('Retains items per page after new keyword search @LPD-19994', async ({
-		searchPage,
-	}) => {
-		await test.step('Change pagination items per page and page number', async () => {
-			await searchPage.selectPaginationItemsPerPage(4);
-
-			await searchPage.selectPaginationPageNumber(2);
-		});
-
-		await test.step('Perform new search with different keyword', async () => {
-			await searchPage.searchKeywordInMainContent('png');
-
-			await expect(searchPage.searchResultsTotalLabel).toHaveText(
-				/\d+ Results for png/
-			);
-		});
-
-		await test.step('Verify that page number is reset but items per page is not', async () => {
-			await expect(
-				searchPage.searchResultsPaginationItemsPerPageToggle
-			).toHaveText(/4 Entries/);
-
-			await expect(
-				searchPage.searchResultsPaginationBar.getByText('1').first()
-			).toHaveAttribute('aria-current', 'page');
-
-			await expect(
-				searchPage.searchResultsPaginationDescription
-			).toHaveText(/Showing 1 to 4 of \d+ entries./);
-		});
-	});
-
 	test('Clears facet terms if performing an empty search @LPD-19994', async ({
 		page,
 		searchPage,
@@ -231,8 +284,6 @@ test.describe('Clear and retain facet selections', () => {
 
 			await page.reload();
 		});
-
-		//
 
 		await test.step('Perform new search with empty keyword', async () => {
 			await searchPage.searchKeywordInMainContent('');

--- a/modules/test/playwright/tests/portal-search-web/searchResults.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/searchResults.spec.ts
@@ -5,24 +5,59 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
-import {isolatedLayoutTest} from '../../fixtures/isolatedLayoutTest';
+import {dataApiHelpersTest} from '../../fixtures/dataApiHelpersTest';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
 import {searchPageTest} from '../../fixtures/searchPageTest';
+import getRandomString from '../../utils/getRandomString';
+import getBasicWebContentStructureId from '../../utils/structured-content/getBasicWebContentStructureId';
+
 export const test = mergeTests(
-	isolatedLayoutTest({type: 'portlet'}),
+	isolatedSiteTest,
 	loginTest(),
+	dataApiHelpersTest,
+	pageEditorPagesTest,
 	searchPageTest
 );
 
 test.describe('Use two Search Results widgets in the same page', () => {
 	test('Change the pagination delta of a search results widget on a page with two search results widgets @LPD-36512', async ({
-		layout,
+		apiHelpers,
 		page,
 		searchPage,
+		site,
 	}) => {
-		await test.step('Add Search Results and Search Options portlets', async () => {
-			await page.goto('/web/guest' + layout.friendlyURL);
+		let siteLayout: Layout;
 
+		await test.step('Create web content for search results', async () => {
+			const basicWebContentStructureId =
+				await getBasicWebContentStructureId(apiHelpers);
+
+			for (let count = 0; count < 21; count++) {
+				await apiHelpers.jsonWebServicesJournal.addWebContent({
+					ddmStructureId: basicWebContentStructureId,
+					groupId: site.id,
+					titleMap: {en_US: `Test Web Content ${count}`},
+				});
+			}
+		});
+
+		await test.step('Create a portlet page associated to site', async () => {
+			siteLayout = await apiHelpers.jsonWebServicesLayout.addLayout({
+				groupId: site.id,
+				options: {type: 'portlet'},
+				title: getRandomString(),
+			});
+		});
+
+		await test.step('Navigate to the site page', async () => {
+			await page.goto(
+				`/web${site.friendlyUrlPath}${siteLayout.friendlyURL}`
+			);
+		});
+
+		await test.step('Add Search Results and Search Options portlets', async () => {
 			await searchPage.addPortlet('Search Results', 'Search');
 
 			await searchPage.addPortlet('Search Options', 'Search');
@@ -109,17 +144,17 @@ test.describe('Use two Search Results widgets in the same page', () => {
 		await test.step('Check if the pagination delta of a Search Results widget persists when changing that of another widget', async () => {
 			await page.reload();
 
-			await searchPage.selectPaginationItemsPerPage(4);
+			await searchPage.selectPaginationItemsPerPage(40);
 
 			await expect(
 				searchPage.searchResultsPaginationItemsPerPageToggle.nth(1)
 			).toHaveText('20 Entries');
 
-			await searchPage.selectPaginationItemsPerPage(8, 1);
+			await searchPage.selectPaginationItemsPerPage(60, 1);
 
 			await expect(
 				searchPage.searchResultsPaginationItemsPerPageToggle.nth(0)
-			).toHaveText('4 Entries');
+			).toHaveText('40 Entries');
 		});
 
 		await test.step('Remove the federatedSearchKey of one Search Results and Search Options widget', async () => {
@@ -146,20 +181,24 @@ test.describe('Use two Search Results widgets in the same page', () => {
 			await searchPage.savePortletConfiguration();
 		});
 
-		await test.step('Check if the pagination delta of a search results widget persists when changing that of another widget', async () => {
-			await page.goto('/web/guest' + layout.friendlyURL);
+		await test.step('Navigate to the site page', async () => {
+			await page.goto(
+				`/web${site.friendlyUrlPath}${siteLayout.friendlyURL}`
+			);
+		});
 
-			await searchPage.selectPaginationItemsPerPage(40);
+		await test.step('Check if the pagination delta of a search results widget persists when changing that of another widget', async () => {
+			await searchPage.selectPaginationItemsPerPage(60);
 
 			await expect(
 				searchPage.searchResultsPaginationItemsPerPageToggle.nth(1)
 			).toHaveText('20 Entries');
 
-			await searchPage.selectPaginationItemsPerPage(4, 1);
+			await searchPage.selectPaginationItemsPerPage(40, 1);
 
 			await expect(
 				searchPage.searchResultsPaginationItemsPerPageToggle.nth(0)
-			).toHaveText('40 Entries');
+			).toHaveText('60 Entries');
 		});
 	});
 });

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
@@ -93,6 +93,8 @@ definition {
 	@description = "This is a use case for LPS-169035."
 	@priority = 4
 	test AssertCustomSearchResultsDisplayTemplate {
+		property custom.properties = "search.container.page.delta.values=4,20,40,60";
+
 		WidgetTemplates.openWidgetTemplatesAdmin(siteURLKey = "guest");
 
 		WidgetTemplates.addCP(
@@ -289,7 +291,7 @@ definition {
 	@description = "This is a use case for LPS-130227."
 	@priority = 4
 	test AssertPaginationURLforHTTPS {
-		property custom.properties = "redirect.url.domains.allowed=${line.separator}redirect.url.security.mode=domain${line.separator}web.server.host=localhost${line.separator}web.server.https.port=8443${line.separator}web.server.protocol=https${line.separator}feature.flag.LPD-35013=true";
+		property custom.properties = "redirect.url.domains.allowed=${line.separator}redirect.url.security.mode=domain${line.separator}search.container.page.delta.values=4,20,40,60${line.separator}web.server.host=localhost${line.separator}web.server.https.port=8443${line.separator}web.server.protocol=https${line.separator}feature.flag.LPD-35013=true";
 		property portal.ssl.enabled = "true";
 		property search.environment.suite.exclude = "true";
 		property test.liferay.virtual.instance = "false";
@@ -344,7 +346,7 @@ definition {
 	@description = "This is a use case for LPS-89561."
 	@priority = 4
 	test AssertSearchURLWhenModifyingPagination {
-		property custom.properties = "search.container.page.default.delta=10${line.separator}feature.flag.LPD-35013=true";
+		property custom.properties = "search.container.page.default.delta=10${line.separator}search.container.page.delta.values=4,8,20,40,60${line.separator}feature.flag.LPD-35013=true";
 
 		for (var count : list "1,2,3,4,5,6,7,8,9,10,11") {
 			JSONWebcontent.addWebContent(
@@ -1244,6 +1246,8 @@ definition {
 	@description = "This is a use case for LPS-115435."
 	@priority = 3
 	test ModifyPaginationConfigurationProperties {
+		property custom.properties = "search.container.page.delta.values=4,20,40,60";
+
 		for (var count : list "1,2,3,4,5") {
 			JSONWebcontent.addWebContent(
 				content = "WC Content ${count}",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchFacets.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchFacets.testcase
@@ -2760,6 +2760,8 @@ definition {
 	@description = "This is a use case for LPS-185631."
 	@priority = 4
 	test ViewDefaultEmptySearchResultsAndPaginationConfiguration {
+		property custom.properties = "search.container.page.delta.values=4,20,40,60";
+
 		task ("Assert 'Show Default Empty Result Message' and 'Show Default Pagination' are checked by default within the Search Results widget configuration") {
 			SearchPage.openSearchPage();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/elasticsearch/SearchTuningES7.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/elasticsearch/SearchTuningES7.testcase
@@ -218,6 +218,8 @@ definition {
 
 	@priority = 3
 	test AssertResultRankingsMiscUI {
+		property custom.properties = "search.container.page.delta.values=4,20,40,60";
+
 		SearchTuning.openResultRankingsAdmin();
 
 		AssertElementNotPresent(locator1 = "Pagination#PAGINATION_BAR");
@@ -297,7 +299,7 @@ definition {
 
 	@priority = 4
 	test AssertResultRankingsPagination {
-		property custom.properties = "search.container.page.default.delta=5";
+		property custom.properties = "search.container.page.default.delta=5${line.separator}search.container.page.delta.values=4,20,40,60";
 
 		SearchTuning.openResultRankingsAdmin();
 
@@ -541,7 +543,7 @@ definition {
 
 	@priority = 4
 	test AssertSynonymsPagination {
-		property custom.properties = "search.container.page.default.delta=5";
+		property custom.properties = "search.container.page.default.delta=5${line.separator}search.container.page.delta.values=4,20,40,60";
 
 		SearchTuning.openSynonymsAdmin();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
@@ -2155,6 +2155,8 @@ definition {
 
 	@priority = 3
 	test PaginateBlueprintsAdmin {
+		property custom.properties = "search.container.page.delta.values=4,8,20,40,60";
+
 		Blueprints.openBlueprintsAdmin();
 
 		for (var index : list "One,Two,Three,Four,Five") {
@@ -2298,6 +2300,8 @@ definition {
 
 	@priority = 3
 	test PaginateElementsAdmin {
+		property custom.properties = "search.container.page.delta.values=4,8,20,40,60";
+
 		Blueprints.openBlueprintsAdmin();
 
 		Navigator.gotoNavItem(navItem = "Elements");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-52991 - Test failures in Search module due to LPD-51577 pagination update

The default pagination options have changed requiring an update in some of our tests. Most on poshi could be handled by setting some custom properties, but for playwright they were adapted to the increased items per page.

