### PR TITLE
LPD-52248 portal-search-admin-web: Pass in unique ID to connection table

### DIFF
--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/connections.jsp
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/connections.jsp
@@ -136,6 +136,7 @@ SearchEngineDisplayContext searchEngineDisplayContext = (SearchEngineDisplayCont
 										<liferay-ui:search-container
 											deltaConfigurable="<%= false %>"
 											headerNames="name,version"
+											id="<%= connectionInformation.getConnectionId() %>"
 											total="<%= nodeInformationList.size() %>"
 										>
 											<liferay-ui:search-container-results


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-52248 - Second active connection on Search Admin page has table view issues

Doing this helps render the multiple connections in connection table in search admin correctly.