### PR TITLE
LPD-38605 Make Opensearch and Solr tests run on EE Development Acceptance (master)

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -907,7 +907,7 @@ mariadb.executable=${mariadb.executable}]]></echo>
 					</if>
 
 					<if>
-						<equals arg1="${test.batch.name}" arg2="solr" />
+						<contains string="${test.batch.name}" substring="solr" />
 						<then>
 							<ant antfile="build-test-solr.xml" target="start-solr" />
 

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -7842,6 +7842,8 @@ information. Make sure to commit in all format-javadoc results.
 					</then>
 				</if>
 
+				<property name="test.batch.name" unless:set="test.batch.name" value="${env.TEST_BATCH_NAME}" />
+
 				<condition else="" property="test.arg.opensearch2.unit.tests" value="-Dcom.liferay.portal.search.opensearch2.test.unit.enabled=true">
 					<istrue value="${run.opensearch2.unit.tests}" />
 				</condition>

--- a/modules/apps/portal-search-opensearch2/test.properties
+++ b/modules/apps/portal-search-opensearch2/test.properties
@@ -18,7 +18,7 @@
 
     test.batch.names[relevant][portal-search-opensearch2-java-rule]=\
         modules-integration-postgresql163,\
-        modules-unit
+        modules-unit-opensearch2
 
     #
     # Relevant
@@ -27,7 +27,7 @@
     modules.includes.required.test.batch.class.names.includes[modules-integration-postgresql163][relevant][portal-search-opensearch2-java-rule]=\
         apps/portal-search-opensearch2/**/*Test.java
 
-    modules.includes.required.test.batch.class.names.includes[modules-unit][relevant][portal-search-opensearch2-java-rule]=\
+    modules.includes.required.test.batch.class.names.includes[modules-unit-opensearch2][relevant][portal-search-opensearch2-java-rule]=\
         apps/portal-search-opensearch2/**/*Test.java
 
     test.batch.run.property.query[functional-upgrade-tomcat*-mysql*][relevant][portal-search-opensearch2-functional-rule]=\

--- a/modules/apps/portal-search-solr8/test.properties
+++ b/modules/apps/portal-search-solr8/test.properties
@@ -18,7 +18,7 @@
 
     test.batch.names[relevant][portal-search-solr8-java-rule]=\
         modules-integration-postgresql163,\
-        modules-unit
+        modules-unit-solr
 
     #
     # Relevant
@@ -27,7 +27,7 @@
     modules.includes.required.test.batch.class.names.includes[modules-integration-postgresql163][relevant][portal-search-solr8-java-rule]=\
         apps/portal-search-solr8/**/*Test.java
 
-    modules.includes.required.test.batch.class.names.includes[modules-unit][relevant][portal-search-solr8-java-rule]=\
+    modules.includes.required.test.batch.class.names.includes[modules-unit-solr][relevant][portal-search-solr8-java-rule]=\
         apps/portal-search-solr8/**/*Test.java
 
     test.batch.run.property.query[functional-upgrade-tomcat*-mysql*][relevant][portal-search-solr8-functional-rule]=\

--- a/test.properties
+++ b/test.properties
@@ -924,9 +924,6 @@
         default-modules-unit-rule,\
         default-unit-rule,\
         modules-semantic-versioning-rule,\
-        modules-unit-opensearch2-rule,\
-        modules-unit-remote-elasticsearch-rule,\
-        modules-unit-solr-rule,\
         playwright-compile-rule,\
         playwright-setup-rule,\
         rest-builder-rule,\
@@ -1059,45 +1056,6 @@
     modified.files.includes[modules-semantic-versioning-rule][relevant]=modules/**
 
     test.batch.names[modules-semantic-versioning-rule][relevant]=modules-semantic-versioning
-
-    #
-    # Modules Unit Open Search 2 Rule
-    #
-
-    modified.files.includes[modules-unit-opensearch2-rule][relevant]=\
-        modules/apps/portal-search-opensearch2/**/*.java,\
-        modules/apps/portal-search-opensearch2/**/test/**/*Test.java,\
-        modules/apps/portal-search-opensearch2/**/testIntegration/**/*Test.java
-
-    modules.includes.required.test.batch.class.names.includes[modules-unit-opensearch2-rule][relevant][modules-unit-opensearch2]=modules-unit-opensearch2
-
-    test.batch.names[modules-unit-opensearch2-rule][relevant]=modules-unit-opensearch2
-
-    #
-    # Modules Unit Remote Elasticsearch Rule
-    #
-
-    modified.files.includes[modules-unit-remote-elasticsearch-rule][relevant]=\
-        modules/apps/portal-search-elasticsearch7/**/*.java,\
-        modules/apps/portal-search-elasticsearch7/**/test/**/*Test.java,\
-        modules/apps/portal-search-elasticsearch7/**/testIntegration/**/*Test.java
-
-    modules.includes.required.test.batch.class.names.includes[modules-unit-remote-elasticsearch-rule][relevant][modules-unit-remote-elasticsearch]=modules-unit-remote-elasticsearch
-
-    test.batch.names[modules-unit-remote-elasticsearch-rule][relevant]=modules-unit-remote-elasticsearch
-
-    #
-    # Modules Unit Solr Rule
-    #
-
-    modified.files.includes[modules-unit-solr-rule][relevant]=\
-        modules/apps/portal-search-solr8/**/*.java,\
-        modules/apps/portal-search-solr8/**/test/**/*Test.java,\
-        modules/apps/portal-search-solr8/**/testIntegration/**/*Test.java
-
-    modules.includes.required.test.batch.class.names.includes[modules-unit-solr-rule][relevant][modules-unit-solr]=modules-unit-solr
-
-    test.batch.names[modules-unit-solr-rule][relevant]=modules-unit-solr
 
     #
     # Playwright Compile Rule


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-38605 - Make Opensearch and Solr tests run on EE Development Acceptance (master)

Allows these unit tests to run on relevant after updates to opensearch2 and solr! Before, they were failing with `testRun: Failed to run test on CI` or `Unable to run test on CI`

Relevant test run available here: https://github.com/oliv-yu/liferay-portal/pull/104

@CalumR23
@BryanEngler

🎉 