### PR TITLE
LPD-54958 Deactivate consistently failing test

### DIFF
--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FacetedSearcherTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FacetedSearcherTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -83,6 +84,7 @@ public class FacetedSearcherTest extends BaseFacetedSearcherTestCase {
 			prefix, Collections.<String, String>emptyMap());
 	}
 
+	@Ignore
 	@Test
 	public void testSearchByQuotedRegexKeywords() throws Exception {
 		Group group = userSearchFixture.addGroup();


### PR DESCRIPTION
Hi team,
This test has been [consistently failing](https://testray.liferay.com/#/project/35392/cases/55306) in the Acceptance and Release test suites.
These tickets are related to the failure:
https://liferay.atlassian.net/browse/LPD-50797
https://liferay.atlassian.net/browse/LPD-50533

Whether these are bugs or test fixes, if these are lower priority tests that will not be fixed in the near future it might be best to deactivate for now so it's not muddying test results or using up CI resources. For more information, please see this [Slack post](https://liferay.slack.com/archives/C0251HKT0K0/p1747027740422599).

If everything looks good, please forward. If not, please let the Release team know in #t-release on Slack. Thanks!