### PR TITLE
LPD-56585 NoSuchEntryException and faulty viewURL when searching for a page made with a Content Page Template

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/context/builder/SearchResultSummaryDisplayContextBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/context/builder/SearchResultSummaryDisplayContextBuilder.java
@@ -932,9 +932,13 @@ public class SearchResultSummaryDisplayContextBuilder {
 			ClassName className = _classNameLocalService.getClassName(
 				classNameId);
 
-			_buildViewURL(
-				className.getClassName(), classPK,
-				searchResultSummaryDisplayContext);
+			if (getAssetRendererFactoryByClassName(className.getClassName()) !=
+					null) {
+
+				_buildViewURL(
+					className.getClassName(), classPK,
+					searchResultSummaryDisplayContext);
+			}
 		}
 	}
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/suggestions/spi/BasicSuggestionsContributor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/suggestions/spi/BasicSuggestionsContributor.java
@@ -196,6 +196,9 @@ public class BasicSuggestionsContributor implements SuggestionsContributor {
 					assetRenderer.getSummary(
 						liferayPortletRequest, liferayPortletResponse));
 
+				String assetClassName = entryClassName;
+				long assetClassPK = entryClassPK;
+
 				long classNameId = GetterUtil.getLong(
 					document.getValue(Field.CLASS_NAME_ID));
 				long classPK = GetterUtil.getLong(
@@ -205,21 +208,23 @@ public class BasicSuggestionsContributor implements SuggestionsContributor {
 					ClassName className = _classNameLocalService.getClassName(
 						classNameId);
 
-					suggestionBuilder.attribute(
-						"assetURL",
-						_assetURLViewProvider.getAssetURLView(
-							assetRenderer, assetRendererFactory,
-							className.getClassName(), classPK,
-							liferayPortletRequest, liferayPortletResponse));
+					AssetRendererFactory<?> classNameAssetRendererFactory =
+						AssetRendererFactoryRegistryUtil.
+							getAssetRendererFactoryByClassName(
+								className.getClassName());
+
+					if (classNameAssetRendererFactory != null) {
+						assetClassName = className.getClassName();
+						assetClassPK = classPK;
+					}
 				}
-				else {
-					suggestionBuilder.attribute(
-						"assetURL",
-						_assetURLViewProvider.getAssetURLView(
-							assetRenderer, assetRendererFactory, entryClassName,
-							entryClassPK, liferayPortletRequest,
-							liferayPortletResponse));
-				}
+
+				suggestionBuilder.attribute(
+					"assetURL",
+					_assetURLViewProvider.getAssetURLView(
+						assetRenderer, assetRendererFactory, assetClassName,
+						assetClassPK, liferayPortletRequest,
+						liferayPortletResponse));
 
 				text = assetRenderer.getTitle(locale);
 			}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/suggestions/spi/SXPBlueprintSuggestionsContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/suggestions/spi/SXPBlueprintSuggestionsContributor.java
@@ -380,6 +380,9 @@ public class SXPBlueprintSuggestionsContributor
 		}
 
 		if (includeAssetURL) {
+			String assetClassName = entryClassName;
+			long assetClassPK = entryClassPK;
+
 			long classNameId = GetterUtil.getLong(
 				document.getValue(Field.CLASS_NAME_ID));
 			long classPK = GetterUtil.getLong(
@@ -389,21 +392,23 @@ public class SXPBlueprintSuggestionsContributor
 				ClassName className = _classNameLocalService.getClassName(
 					classNameId);
 
-				suggestionBuilder.attribute(
-					"assetURL",
-					_assetURLViewProvider.getAssetURLView(
-						assetRenderer, assetRendererFactory,
-						className.getClassName(), classPK,
-						liferayPortletRequest, liferayPortletResponse));
+				AssetRendererFactory<?> classNameAssetRendererFactory =
+					AssetRendererFactoryRegistryUtil.
+						getAssetRendererFactoryByClassName(
+							className.getClassName());
+
+				if (classNameAssetRendererFactory != null) {
+					assetClassName = className.getClassName();
+					assetClassPK = classPK;
+				}
 			}
-			else {
-				suggestionBuilder.attribute(
-					"assetURL",
-					_assetURLViewProvider.getAssetURLView(
-						assetRenderer, assetRendererFactory, entryClassName,
-						entryClassPK, liferayPortletRequest,
-						liferayPortletResponse));
-			}
+
+			suggestionBuilder.attribute(
+				"assetURL",
+				_assetURLViewProvider.getAssetURLView(
+					assetRenderer, assetRendererFactory, assetClassName,
+					assetClassPK, liferayPortletRequest,
+					liferayPortletResponse));
 		}
 
 		if (useAssetTitle) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-56585 - NoSuchEntryException and faulty viewURL when searching for a page made with a Content Page Template

Customers have been noticing an error when it is checking for the view URL of the parent class. This can be avoided by first checking if it's an asset inside `_checkViewURL`, and if not, then it defaults to the viewURL given previously.

Error:
```shell
2025-05-29 19:16:46.023 ERROR [http-nio-8080-exec-6][AssetURLViewProviderImpl:102] Unable to get asset view URL for class com.liferay.layout.page.template.model.LayoutPageTemplateEntry with primary key 35204
com.liferay.asset.kernel.exception.NoSuchEntryException: No AssetEntry exists with the key {classNameId=29511, classPK=35204}
	at com.liferay.portlet.asset.service.persistence.impl.AssetEntryPersistenceImpl.findByC_C(AssetEntryPersistenceImpl.java:4060) ~[portal-impl.jar:?]
	at com.liferay.portlet.asset.service.impl.AssetEntryLocalServiceImpl.getEntry(AssetEntryLocalServiceImpl.java:351) ~[portal-impl.jar:?]
``` 

Additional commits were made for to do the same for viewURL in suggestions.

Let me know if this looks fine, thank you!