### PR TITLE
LPD-56454 Add playwright test related to blueprint as a collection provider

### DIFF
--- a/modules/test/playwright/helpers/SearchExperiencesApiHelper.ts
+++ b/modules/test/playwright/helpers/SearchExperiencesApiHelper.ts
@@ -6,7 +6,7 @@
 import {getRandomInt} from '../utils/getRandomInt';
 import {ApiHelpers, DataApiHelpers} from './ApiHelpers';
 
-const DEFAULT_SXP_BLUEPRINT_CONFIGURATION = {
+export const DEFAULT_SXP_BLUEPRINT_CONFIGURATION = {
 	advancedConfiguration: {},
 	aggregationConfiguration: {},
 	generalConfiguration: {

--- a/modules/test/playwright/pages/search-experiences-web/EditSXPBlueprintPage.ts
+++ b/modules/test/playwright/pages/search-experiences-web/EditSXPBlueprintPage.ts
@@ -220,6 +220,65 @@ export class EditSXPBlueprintPage {
 		await selectElement.check();
 	}
 
+	async selectAssetTypes(types: string[]) {
+		await this.selectQuerySettingsRadioProperty('Selected Types');
+
+		await this.querySettings
+			.getByRole('button', {name: 'Select Asset Types'})
+			.click();
+
+		await expect(
+			this.page.getByRole('dialog').getByText('Select Types')
+		).toBeVisible();
+
+		for (const type of types) {
+			await this.page
+				.getByRole('checkbox', {
+					exact: true,
+					name: `Select ${type}`,
+				})
+				.check();
+		}
+
+		await this.page
+			.getByRole('dialog')
+			.getByRole('button', {name: 'Done'})
+			.click();
+
+		for (const type of types) {
+			await expect(
+				this.querySettings.locator('li').getByText(type, {exact: true})
+			).toBeVisible();
+		}
+	}
+
+	async selectAssetSubtypes(subtypes: string[], type: string) {
+		const assetListItem = this.querySettings
+			.locator('li')
+			.filter({hasText: type});
+
+		await assetListItem.getByLabel('Select Subtypes').click();
+
+		await expect(
+			this.page.getByRole('dialog').getByText('Select Subtypes')
+		).toBeVisible();
+
+		for (const subtype of subtypes) {
+			await this.page
+				.getByRole('checkbox', {exact: true, name: `Select ${subtype}`})
+				.check();
+		}
+
+		await this.page
+			.getByRole('dialog')
+			.getByRole('button', {name: 'Done'})
+			.click();
+
+		for (const subtype of subtypes) {
+			await expect(assetListItem).toHaveText(new RegExp(subtype));
+		}
+	}
+
 	async selectClauseContributors(option: {labels: string[]; value: boolean}) {
 
 		// If labels is ['*'], then all contributors are selected

--- a/modules/test/playwright/tests/search-experiences-web/main/sxpBlueprint.spec.ts
+++ b/modules/test/playwright/tests/search-experiences-web/main/sxpBlueprint.spec.ts
@@ -6,12 +6,24 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
 import {searchExperiencesPagesTest} from '../../../fixtures/searchExperiencesPageTest';
+import {DEFAULT_SXP_BLUEPRINT_CONFIGURATION} from '../../../helpers/SearchExperiencesApiHelper';
 import {getRandomInt} from '../../../utils/getRandomInt';
+import getRandomString from '../../../utils/getRandomString';
+import getDataStructureDefinition from '../../journal-web/main/utils/getDataStructureDefinition';
 
 export const test = mergeTests(
 	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPS-129412': {enabled: true}, // Collection Providers for Blueprint
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	pageEditorPagesTest,
 	loginTest(),
 	searchExperiencesPagesTest
 );
@@ -487,6 +499,147 @@ test.describe('Searching in preview with clause contributors is accurate', () =>
 					},
 					{label: 'userName', value: 'test test'},
 				]
+			);
+		});
+	});
+});
+
+test.describe('Blueprint can be registered as a collection provider', () => {
+	test('Setup a blueprint with web content subtype as a collection provider', async ({
+		apiHelpers,
+		editSXPBlueprintPage,
+		page,
+		pageEditorPage,
+		site,
+		sxpBlueprintsAndElementsViewPage,
+	}) => {
+		let layout;
+		let sxpBlueprint: SXPBlueprint;
+
+		const fieldName = `CustomTextField${getRandomInt()}`;
+		const structureName = `WebContentStructure${getRandomInt()}`;
+
+		await test.step('Create a web content structure with a custom text field', async () => {
+			await apiHelpers.dataEngine.createStructure(
+				site.id,
+				getDataStructureDefinition({
+					defaultLanguageId: 'en_US',
+					fields: [
+						{fieldType: 'text', name: fieldName, repeatable: true},
+					],
+					name: structureName,
+				})
+			);
+		});
+
+		await test.step('Create a blueprint with collection provider enabled', async () => {
+			sxpBlueprint =
+				await apiHelpers.searchExperiences.createSXPBlueprint({
+					configuration: {
+						...DEFAULT_SXP_BLUEPRINT_CONFIGURATION,
+						generalConfiguration: {
+							...DEFAULT_SXP_BLUEPRINT_CONFIGURATION.generalConfiguration,
+							collectionProvider: true,
+						},
+					},
+				});
+		});
+
+		await test.step('Navigate to created blueprint', async () => {
+			await sxpBlueprintsAndElementsViewPage.goto();
+
+			await sxpBlueprintsAndElementsViewPage.selectTableLink(
+				sxpBlueprint.title
+			);
+		});
+
+		await test.step('Add the custom web content structure to blueprint subtypes', async () => {
+			await editSXPBlueprintPage.goToQuerySettingsMenuItem();
+
+			await editSXPBlueprintPage.selectQuerySettingsRadioProperty(
+				'Selected Types'
+			);
+
+			await editSXPBlueprintPage.selectAssetTypes([
+				'Web Content Article',
+			]);
+
+			await editSXPBlueprintPage.selectAssetSubtypes(
+				[structureName],
+				'Web Content Article'
+			);
+
+			await editSXPBlueprintPage.saveBlueprint();
+		});
+
+		await test.step('Create a content page with the collection display fragment', async () => {
+			layout = await apiHelpers.headlessDelivery.createSitePage({
+				siteId: site.id,
+				title: getRandomString(),
+			});
+
+			await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+			await pageEditorPage.addFragment(
+				'Content Display',
+				'Collection Display'
+			);
+		});
+
+		await test.step('Select the blueprint as the collection provider', async () => {
+			await pageEditorPage.chooseCollectionDisplayCollection(
+				'Collection Providers',
+				sxpBlueprint.title
+			);
+
+			await pageEditorPage.waitForChangesSaved();
+		});
+
+		await test.step('Add an HTML fragment to the collection display fragment', async () => {
+			await pageEditorPage.addFragment(
+				'Basic Components',
+				'HTML',
+				page.locator('.page-editor__collection-item.empty').first()
+			);
+		});
+
+		await test.step('Open the sidebar to edit HTML fragment', async () => {
+			const htmlFragmentId = await pageEditorPage.getFragmentId('HTML');
+
+			await pageEditorPage.selectEditable(htmlFragmentId, 'element-html');
+		});
+
+		await test.step('Assert the type and subtype are correct (as established from blueprint)', async () => {
+			await expect(
+				page.locator('.page-editor__mapping-panel__type-label', {
+					hasText: /Content Type/,
+				})
+			).toHaveText(/Web Content Article/);
+
+			await expect(
+				page.locator('.page-editor__mapping-panel__type-label', {
+					hasText: /Subtype/,
+				})
+			).toHaveText(new RegExp(structureName));
+		});
+
+		await test.step('Map the custom text field to the HTML fragment', async () => {
+			await page
+				.getByLabel('Field', {exact: true})
+				.selectOption(`DDMStructure_${fieldName}`);
+
+			await pageEditorPage.waitForChangesSaved();
+		});
+
+		await test.step('Check that several basic fields are also available to map', async () => {
+			['Title', 'Description', 'Publish Date', 'Author Name'].forEach(
+				async (field) => {
+					expect(
+						page
+							.getByLabel('Field', {exact: true})
+							.locator('option', {hasText: field})
+					).toBeDefined();
+				}
 			);
 		});
 	});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-56454 - Create test for Field Mappings for Subtypes

Playwright test related to having blueprint as a collection provider, set to searching for a created subtype of Web Content.

Steps include (with FF `LPS-129412` enabled):
1. Create a Web Content Structure “Custom Structure” with a Text field “Custom Text Field”
2. Create a Blueprints which has Selected Types “Web Content” and Subtype “Custom Structure”
3. Create a Content Page
4. Add a Collection Display Fragment to the page and select the new Blueprint as the Collection Provider
5. Add an HTML fragment inside the Collection Display Fragment
6. Open the HTML element and map the Field “Custom Text Field” to it, while doing this also check that some of the basic fields like “Title” are available.