### PR TITLE
LPD-23128 LPD-53324 search-experience-service: Remove beta badge for blueprint collection providers

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/info/collection/provider/SXPBlueprintInfoCollectionProvider.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/info/collection/provider/SXPBlueprintInfoCollectionProvider.java
@@ -6,7 +6,6 @@
 package com.liferay.search.experiences.internal.info.collection.provider;
 
 import com.liferay.asset.util.AssetHelper;
-import com.liferay.info.collection.provider.BetaInfoCollectionProvider;
 import com.liferay.info.collection.provider.CollectionQuery;
 import com.liferay.info.collection.provider.FilteredInfoCollectionProvider;
 import com.liferay.info.collection.provider.SingleFormVariationInfoCollectionProvider;
@@ -38,7 +37,7 @@ import java.util.Locale;
  * @author Petteri Karttunen
  */
 public abstract class SXPBlueprintInfoCollectionProvider<T>
-	implements BetaInfoCollectionProvider<T>, FilteredInfoCollectionProvider<T>,
+	implements FilteredInfoCollectionProvider<T>,
 			   SingleFormVariationInfoCollectionProvider<T> {
 
 	public SXPBlueprintInfoCollectionProvider(


### PR DESCRIPTION
[https://liferay.atlassian.net/browse/LPD-53324](https://liferay.atlassian.net/browse/LPD-53324) - Remove Beta Badge from the title of Blueprint Collection Provider instances

Since the view is controlled by checking whether or not the collection provider is an instance of beta [here](https://github.com/liferay-search/liferay-portal/blob/2546c5624924494e42b7d3011fb9bf40c547c2b9/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_info_collection_providers.jsp#L50), it looks like to remove the badge it needs the blueprint collection provider to no longer implement the beta info collection provider.

Tried it out and no longer seeing the badge:
<img width="948" height="491" alt="Screenshot 2025-07-11 at 10 28 14 AM" src="https://github.com/user-attachments/assets/0a56b5f5-4013-4bca-8aa6-38e285999c75" />