### PR TITLE
LPD-59196 playwright: Update locators for sxpBlueprint.spec

### DIFF
--- a/modules/test/playwright/pages/search-experiences-web/SXPBlueprintsAndElementsViewPage.ts
+++ b/modules/test/playwright/pages/search-experiences-web/SXPBlueprintsAndElementsViewPage.ts
@@ -22,7 +22,7 @@ export class SXPBlueprintsAndElementsViewPage {
 
 	constructor(page: Page) {
 		this.addBlueprintButton = page
-			.getByTestId('management-toolbar')
+			.getByTestId('managementToolbar')
 			.getByLabel('New Search Blueprint');
 		this.addBlueprintElementModal = page.locator('.modal-dialog');
 		this.applicationsMenuPage = new ApplicationsMenuPage(page);

--- a/modules/test/playwright/tests/search-experiences-web/main/sxpBlueprint.spec.ts
+++ b/modules/test/playwright/tests/search-experiences-web/main/sxpBlueprint.spec.ts
@@ -47,6 +47,7 @@ test.describe('Blueprint table fields can toggle visibility', () => {
 		await test.step('Select all blueprint table fields to view', async () => {
 			for (const tableField of tableFieldsList) {
 				const tableFieldMenuItem = page.getByRole('menuitem', {
+					exact: true,
 					name: tableField,
 				});
 
@@ -81,7 +82,8 @@ test.describe('Blueprint table fields can toggle visibility', () => {
 			for (const tableField of tableFieldsList) {
 				await expect(
 					sxpBlueprintsAndElementsViewPage.blueprintElementTable.getByText(
-						tableField
+						tableField,
+						{exact: true}
 					)
 				).toBeVisible();
 			}
@@ -90,6 +92,7 @@ test.describe('Blueprint table fields can toggle visibility', () => {
 		await test.step('Toggle off blueprint table fields', async () => {
 			for (const tableField of tableFieldsList) {
 				const tableFieldMenuItem = page.getByRole('menuitem', {
+					exact: true,
 					name: tableField,
 				});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-59196 - sxpBlueprint.spec > Blueprint table, Created Blueprint [Playwright] (search)

Test fixes related to:
1. `search-experiences-web/main/sxpBlueprint.spec.ts:72:2 › Blueprint table fields can toggle visibility › Deselect blueprint table fields from view Error: expect.toBeVisible: Error: strict mode violation: locator('.fds table').getByText('ID') resolved to 2 elements`
2. `search-experiences-web/main/sxpBlueprint.spec.ts:151:2 › Created blueprint has accurate clause contributors › Newly created blueprint starts with "Enable All" clause contributors @LPD-22974 Test timeout of 60000ms exceeded while running "beforeEach" hook`