### PR TITLE
LPD-57895 Placeholder text as a configuration option for search bar widget

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletPreferences.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletPreferences.java
@@ -20,6 +20,9 @@ public interface SearchBarPortletPreferences {
 	public static final String PREFERENCE_KEY_INCLUDE_ATTACHMENTS =
 		"includeAttachments";
 
+	public static final String PREFERENCE_KEY_INPUT_PLACEHOLDER =
+		"inputPlaceholder";
+
 	public static final String PREFERENCE_KEY_INVISIBLE = "invisible";
 
 	public static final String PREFERENCE_KEY_KEYWORDS_PARAMETER_NAME =
@@ -49,6 +52,8 @@ public interface SearchBarPortletPreferences {
 	public String getDestination();
 
 	public String getFederatedSearchKey();
+
+	public String getInputPlaceholder();
 
 	public String getKeywordsParameterName();
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletPreferencesImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletPreferencesImpl.java
@@ -38,6 +38,13 @@ public class SearchBarPortletPreferencesImpl
 	}
 
 	@Override
+	public String getInputPlaceholder() {
+		return getString(
+			SearchBarPortletPreferences.PREFERENCE_KEY_INPUT_PLACEHOLDER,
+			"search-...");
+	}
+
+	@Override
 	public String getKeywordsParameterName() {
 		return getString(
 			SearchBarPortletPreferences.PREFERENCE_KEY_KEYWORDS_PARAMETER_NAME,

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/SearchBarPortletDisplayContext.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/SearchBarPortletDisplayContext.java
@@ -5,7 +5,11 @@
 
 package com.liferay.portal.search.web.internal.search.bar.portlet.display.context;
 
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.search.web.internal.search.bar.portlet.configuration.SearchBarPortletInstanceConfiguration;
+
+import java.util.Map;
 
 /**
  * @author André de Oliveira
@@ -42,6 +46,49 @@ public class SearchBarPortletDisplayContext {
 
 	public String getPaginationStartParameterName() {
 		return _paginationStartParameterName;
+	}
+
+	public Map<String, Object> getReactData() {
+		return HashMapBuilder.<String, Object>put(
+			"destinationFriendlyURL", getDestinationFriendlyURL()
+		).put(
+			"emptySearchEnabled", isEmptySearchEnabled()
+		).put(
+			"initialKeywords", getKeywords()
+		).put(
+			"inputPlaceholder", getInputPlaceholder()
+		).put(
+			"isDXP", ReleaseInfo.isDXP()
+		).put(
+			"isSearchExperiencesSupported", isSearchExperiencesSupported()
+		).put(
+			"keywordsParameterName", getKeywordsParameterName()
+		).put(
+			"letUserChooseScope", isLetTheUserChooseTheSearchScope()
+		).put(
+			"paginationStartParameterName", getPaginationStartParameterName()
+		).put(
+			"retainFacetSelections", isRetainFacetSelections()
+		).put(
+			"scopeParameterName", getScopeParameterName()
+		).put(
+			"scopeParameterStringCurrentSite",
+			getCurrentSiteSearchScopeParameterString()
+		).put(
+			"scopeParameterStringEverything",
+			getEverythingSearchScopeParameterString()
+		).put(
+			"searchURL", getSearchURL()
+		).put(
+			"selectedEverythingSearchScope", isSelectedEverythingSearchScope()
+		).put(
+			"suggestionsContributorConfiguration",
+			getSuggestionsContributorConfiguration()
+		).put(
+			"suggestionsDisplayThreshold", getSuggestionsDisplayThreshold()
+		).put(
+			"suggestionsURL", getSuggestionsURL()
+		).build();
 	}
 
 	public String getScopeParameterName() {

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactory.java
@@ -150,7 +150,8 @@ public class SearchBarPortletDisplayContextFactory {
 
 		searchBarPortletDisplayContext.setInputPlaceholder(
 			LanguageUtil.get(
-				getHttpServletRequest(_renderRequest), "search-..."));
+				getHttpServletRequest(_renderRequest),
+				searchBarPortletPreferences.getInputPlaceholder()));
 
 		String keywordsParameterName = _getKeywordsParameterName(
 			portletPreferencesLookup,

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -21,6 +21,7 @@ export default function SearchBar({
 	destinationFriendlyURL,
 	emptySearchEnabled,
 	initialKeywords = '',
+	inputPlaceholder = '',
 	isDXP = true,
 	isSearchExperiencesSupported = true,
 	keywordsParameterName = 'q',
@@ -237,7 +238,7 @@ export default function SearchBar({
 					onChange={_handleValueChange}
 					onFocus={_handleFocus}
 					onKeyDown={_handleKeyDown}
-					placeholder={Liferay.Language.get('search-...')}
+					placeholder={inputPlaceholder}
 					title={Liferay.Language.get('search')}
 					type="text"
 					value={inputValue}
@@ -275,7 +276,7 @@ export default function SearchBar({
 							onChange={_handleValueChange}
 							onFocus={_handleFocus}
 							onKeyDown={_handleKeyDown}
-							placeholder={Liferay.Language.get('search-...')}
+							placeholder={inputPlaceholder}
 							type="text"
 							value={inputValue}
 						/>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/configuration.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/configuration.jsp
@@ -88,6 +88,8 @@ String suggestionsContributorConfiguration = StringBundler.concat(StringPool.OPE
 			<aui:input disabled="<%= searchBarPortletDisplayContext.isDisplayWarningIgnoredConfiguration() %>" label="scope-parameter-name" name="<%= PortletPreferencesJspUtil.getInputName(SearchBarPortletPreferences.PREFERENCE_KEY_SCOPE_PARAMETER_NAME) %>" value="<%= searchBarPortletPreferences.getScopeParameterName() %>" />
 
 			<aui:input helpMessage="destination-page-help" label="destination-page" name="<%= PortletPreferencesJspUtil.getInputName(SearchBarPortletPreferences.PREFERENCE_KEY_DESTINATION) %>" value="<%= searchBarPortletPreferences.getDestination() %>" />
+
+			<aui:input label="placeholder-text" name="<%= PortletPreferencesJspUtil.getInputName(SearchBarPortletPreferences.PREFERENCE_KEY_INPUT_PLACEHOLDER) %>" value="<%= searchBarPortletPreferences.getInputPlaceholder() %>" />
 		</liferay-frontend:fieldset>
 
 		<c:if test="<%= searchBarPortletDisplayContext.isSuggestionsEndpointEnabled() %>">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
@@ -89,6 +89,8 @@ SearchBarPortletDisplayContext searchBarPortletDisplayContext = (SearchBarPortle
 									).put(
 										"initialKeywords", searchBarPortletDisplayContext.getKeywords()
 									).put(
+										"inputPlaceholder", searchBarPortletDisplayContext.getInputPlaceholder()
+									).put(
 										"isDXP", ReleaseInfo.isDXP()
 									).put(
 										"isSearchExperiencesSupported", searchBarPortletDisplayContext.isSearchExperiencesSupported()
@@ -128,7 +130,7 @@ SearchBarPortletDisplayContext searchBarPortletDisplayContext = (SearchBarPortle
 							<div class="input-group <%= searchBarPortletDisplayContext.isLetTheUserChooseTheSearchScope() ? "search-bar-scope" : "search-bar-simple" %>">
 								<c:choose>
 									<c:when test="<%= searchBarPortletDisplayContext.isLetTheUserChooseTheSearchScope() %>">
-										<aui:input autocomplete="off" cssClass="search-bar-keywords-input" data-qa-id="searchInput" disabled="<%= true %>" id="<%= randomNamespace + HtmlUtil.escapeAttribute(searchBarPortletDisplayContext.getKeywordsParameterName()) %>" label="" name="<%= HtmlUtil.escapeAttribute(searchBarPortletDisplayContext.getKeywordsParameterName()) %>" placeholder='<%= LanguageUtil.get(request, "search-...") %>' title='<%= LanguageUtil.get(request, "search") %>' type="text" useNamespace="<%= false %>" value="<%= HtmlUtil.escapeAttribute(searchBarPortletDisplayContext.getKeywords()) %>" wrapperCssClass="input-group-item input-group-prepend search-bar-keywords-input-wrapper" />
+										<aui:input autocomplete="off" cssClass="search-bar-keywords-input" data-qa-id="searchInput" disabled="<%= true %>" id="<%= randomNamespace + HtmlUtil.escapeAttribute(searchBarPortletDisplayContext.getKeywordsParameterName()) %>" label="" name="<%= HtmlUtil.escapeAttribute(searchBarPortletDisplayContext.getKeywordsParameterName()) %>" placeholder="<%= searchBarPortletDisplayContext.getInputPlaceholder() %>" title='<%= LanguageUtil.get(request, "search") %>' type="text" useNamespace="<%= false %>" value="<%= HtmlUtil.escapeAttribute(searchBarPortletDisplayContext.getKeywords()) %>" wrapperCssClass="input-group-item input-group-prepend search-bar-keywords-input-wrapper" />
 
 										<aui:select cssClass="search-bar-scope-select" disabled="<%= true %>" id="<%= randomNamespace + HtmlUtil.escapeAttribute(searchBarPortletDisplayContext.getScopeParameterName()) %>" label="" name="<%= HtmlUtil.escapeAttribute(searchBarPortletDisplayContext.getScopeParameterName()) %>" title="scope" useNamespace="<%= false %>" wrapperCssClass="input-group-item input-group-item-shrink input-group-prepend search-bar-search-select-wrapper">
 											<aui:option label="this-site" selected="<%= searchBarPortletDisplayContext.isSelectedCurrentSiteSearchScope() %>" value="<%= searchBarPortletDisplayContext.getCurrentSiteSearchScopeParameterString() %>" />
@@ -151,7 +153,7 @@ SearchBarPortletDisplayContext searchBarPortletDisplayContext = (SearchBarPortle
 									</c:when>
 									<c:otherwise>
 										<div class="input-group-item search-bar-keywords-input-wrapper">
-											<input aria-label="<%= LanguageUtil.get(request, "search") %>" autocomplete="off" class="form-control input-group-inset input-group-inset-after search-bar-keywords-input" data-qa-id="searchInput" disabled="<%= true %>" id="<%= randomNamespace %><%= HtmlUtil.escapeAttribute(searchBarPortletDisplayContext.getKeywordsParameterName()) %>" name="<%= HtmlUtil.escapeAttribute(searchBarPortletDisplayContext.getKeywordsParameterName()) %>" placeholder="<%= LanguageUtil.get(request, "search-...") %>" title="<%= LanguageUtil.get(request, "search") %>" type="text" value="<%= HtmlUtil.escapeAttribute(searchBarPortletDisplayContext.getKeywords()) %>" />
+											<input aria-label="<%= LanguageUtil.get(request, "search") %>" autocomplete="off" class="form-control input-group-inset input-group-inset-after search-bar-keywords-input" data-qa-id="searchInput" disabled="<%= true %>" id="<%= randomNamespace %><%= HtmlUtil.escapeAttribute(searchBarPortletDisplayContext.getKeywordsParameterName()) %>" name="<%= HtmlUtil.escapeAttribute(searchBarPortletDisplayContext.getKeywordsParameterName()) %>" placeholder="<%= searchBarPortletDisplayContext.getInputPlaceholder() %>" title="<%= LanguageUtil.get(request, "search") %>" type="text" value="<%= HtmlUtil.escapeAttribute(searchBarPortletDisplayContext.getKeywords()) %>" />
 
 											<aui:input name="<%= HtmlUtil.escapeAttribute(searchBarPortletDisplayContext.getScopeParameterName()) %>" type="hidden" value="<%= searchBarPortletDisplayContext.getScopeParameterValue() %>" />
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
@@ -22,7 +22,6 @@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
-page import="com.liferay.portal.kernel.util.ReleaseInfo" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.portal.search.web.internal.search.bar.portlet.SearchBarPortlet" %><%@
@@ -81,45 +80,7 @@ SearchBarPortletDisplayContext searchBarPortletDisplayContext = (SearchBarPortle
 						<div id="<portlet:namespace />reactSearchBar">
 							<react:component
 								module="{ReactSearchBar} from portal-search-web/search-bar"
-								props='<%=
-									HashMapBuilder.<String, Object>put(
-										"destinationFriendlyURL", searchBarPortletDisplayContext.getDestinationFriendlyURL()
-									).put(
-										"emptySearchEnabled", searchBarPortletDisplayContext.isEmptySearchEnabled()
-									).put(
-										"initialKeywords", searchBarPortletDisplayContext.getKeywords()
-									).put(
-										"inputPlaceholder", searchBarPortletDisplayContext.getInputPlaceholder()
-									).put(
-										"isDXP", ReleaseInfo.isDXP()
-									).put(
-										"isSearchExperiencesSupported", searchBarPortletDisplayContext.isSearchExperiencesSupported()
-									).put(
-										"keywordsParameterName", searchBarPortletDisplayContext.getKeywordsParameterName()
-									).put(
-										"letUserChooseScope", searchBarPortletDisplayContext.isLetTheUserChooseTheSearchScope()
-									).put(
-										"paginationStartParameterName", searchBarPortletDisplayContext.getPaginationStartParameterName()
-									).put(
-										"retainFacetSelections", searchBarPortletDisplayContext.isRetainFacetSelections()
-									).put(
-										"scopeParameterName", searchBarPortletDisplayContext.getScopeParameterName()
-									).put(
-										"scopeParameterStringCurrentSite", searchBarPortletDisplayContext.getCurrentSiteSearchScopeParameterString()
-									).put(
-										"scopeParameterStringEverything", searchBarPortletDisplayContext.getEverythingSearchScopeParameterString()
-									).put(
-										"searchURL", searchBarPortletDisplayContext.getSearchURL()
-									).put(
-										"selectedEverythingSearchScope", searchBarPortletDisplayContext.isSelectedEverythingSearchScope()
-									).put(
-										"suggestionsContributorConfiguration", searchBarPortletDisplayContext.getSuggestionsContributorConfiguration()
-									).put(
-										"suggestionsDisplayThreshold", searchBarPortletDisplayContext.getSuggestionsDisplayThreshold()
-									).put(
-										"suggestionsURL", searchBarPortletDisplayContext.getSuggestionsURL()
-									).build()
-								%>'
+								props="<%= searchBarPortletDisplayContext.getReactData() %>"
 							/>
 						</div>
 					</c:when>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-57895 - Placeholder text as a configuration option for search bar widget

These changes make it available to change the placeholder text of the searchbar. It is set to `search-...` as default and can accept a text or language key.

'Placeholder text' was added as the last option in display settings:

<img width="900" alt="Screenshot 2025-08-20 at 2 32 56 PM" src="https://github.com/user-attachments/assets/1979db6c-b02c-49ae-acb0-fe6f24cc411b" />

For reference, the search bar portlet already had the `inputPlaceholder` variable that was hard-coded as `search-...`, and the existing example template was using `searchBarPortletDisplayContext.getInputPlaceholder()`, so minimal changes were needed.