### PR TITLE
LPD-63760 LPD-61749 Test fixes (search playwright, collections)

### DIFF
--- a/modules/test/playwright/tests/portal-search-web/main/customFilter.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/main/customFilter.spec.ts
@@ -91,11 +91,11 @@ test.describe('Custom filter configuration works as expected on content pages', 
 			);
 
 			await searchPage.modalIFrame
-				.getByLabel('Filter Field Set the name of')
+				.getByLabel('Filter Field')
 				.fill('title_en_US');
 
 			await searchPage.modalIFrame
-				.getByLabel('Filter Value The value to')
+				.getByLabel('Filter Value')
 				.fill('Portuguese');
 
 			await searchPage.savePortletConfiguration();
@@ -115,11 +115,11 @@ test.describe('Custom filter configuration works as expected on content pages', 
 			);
 
 			await searchPage.modalIFrame
-				.getByLabel('Filter Field Set the name of')
+				.getByLabel('Filter Field')
 				.fill('title_en_US');
 
 			await searchPage.modalIFrame
-				.getByLabel('Filter Value The value to')
+				.getByLabel('Filter Value')
 				.fill('English');
 
 			await searchPage.savePortletConfiguration();

--- a/modules/test/playwright/tests/portal-search-web/main/searchResults.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/main/searchResults.spec.ts
@@ -80,7 +80,7 @@ test.describe('Use two Search Results widgets in the same page', () => {
 					value: 'start1',
 				},
 				{
-					label: 'Federated Search Key Enter',
+					label: 'Federated Search Key',
 					value: 'federatedSearchKey1',
 				},
 			]);
@@ -94,7 +94,7 @@ test.describe('Use two Search Results widgets in the same page', () => {
 
 			await searchPage.fillPortletConfigurationsInput([
 				{
-					label: 'Federated Search Key Enter',
+					label: 'Federated Search Key',
 					value: 'federatedSearchKey2',
 				},
 			]);
@@ -113,7 +113,7 @@ test.describe('Use two Search Results widgets in the same page', () => {
 			]);
 			await searchPage.fillPortletConfigurationsInput([
 				{
-					label: 'Federated Search Key Enter',
+					label: 'Federated Search Key',
 					value: 'federatedSearchKey1',
 				},
 			]);
@@ -133,7 +133,7 @@ test.describe('Use two Search Results widgets in the same page', () => {
 			]);
 			await searchPage.fillPortletConfigurationsInput([
 				{
-					label: 'Federated Search Key Enter',
+					label: 'Federated Search Key',
 					value: 'federatedSearchKey2',
 				},
 			]);
@@ -162,7 +162,7 @@ test.describe('Use two Search Results widgets in the same page', () => {
 
 			await searchPage.fillPortletConfigurationsInput([
 				{
-					label: 'Federated Search Key Enter',
+					label: 'Federated Search Key',
 					value: '',
 				},
 			]);
@@ -173,7 +173,7 @@ test.describe('Use two Search Results widgets in the same page', () => {
 
 			await searchPage.fillPortletConfigurationsInput([
 				{
-					label: 'Federated Search Key Enter',
+					label: 'Federated Search Key',
 					value: '',
 				},
 			]);

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/collections/Collections.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/collections/Collections.testcase
@@ -1030,7 +1030,7 @@ definition {
 				groupName = "Test Site Name",
 				operator = "equals",
 				segmentName = "Segment With Test User",
-				text = "Test");
+				text = "test");
 		}
 
 		task ("Create a manual Collection") {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-63760- Failure to assert config input customFilter.spec.ts searchResults.spec.ts
- Test fix by updating the expected label

https://liferay.atlassian.net/browse/LPD-61749 - Collections#UseManualCollectionAtPortlet [Functional]
- Test fix now that screen name for 'test' user is case sensitive