### PR TITLE
LPD-61748 SearchBarSuggestions + Missing Search Input CI failures

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
@@ -3075,6 +3075,8 @@ definition {
 	@description = "This is a use case for LPS-193198."
 	@priority = 3
 	test ViewSearchBarVisibility {
+		property test.run.type = "single";
+
 		task ("Configure the embedded search bar to be invisible") {
 			SearchPage.openSearchPage();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchBarSuggestions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchBarSuggestions.testcase
@@ -62,6 +62,8 @@ definition {
 
 	@priority = 4
 	test CanConfigureSearchContributorSize {
+		property test.run.type = "single";
+
 		JSONWebcontent.addWebContent(
 			content = "WC WebContent Content",
 			description = "WC WebContent Description",
@@ -180,6 +182,8 @@ definition {
 
 	@priority = 4
 	test CanViewSearchBarSuggestionsResultDetails {
+		property test.run.type = "single";
+
 		JSONWebcontent.addWebContent(
 			content = "WC WebContent Content",
 			description = "WC WebContent Description",
@@ -227,6 +231,8 @@ definition {
 	@description = "This is a use case for LPS-166050. When using a Blueprint to drive Search Bar suggestions, I can configure a character threshold that applies to this group"
 	@priority = 3
 	test ConfigureBlueprintContributorCharacterThresholds {
+		property test.run.type = "single";
+
 		task ("Add Web Content and Blueprint") {
 			JSONWebcontent.addWebContent(
 				content = "WC WebContent Content",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-61748 - Missing Search Input - SearchBarSuggestions#AssertURLforSuggestionsResults SearchBarSuggestions#CanConfigureSearchContributorSize SearchBarSuggestions#CanCopyPasteInputFields Search#ViewSortedSearchResults

Failing only on CI, due to the way the tests are grouped. In order to address the failures, several tests are marked with `property test.run.type = "single"` to isolate them.