### PR TITLE
LPD-61781 search-experiences-service: during an auto upgrade

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v3_2_0/SXPBlueprintCollectionProviderUpgradeProcess.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v3_2_0/SXPBlueprintCollectionProviderUpgradeProcess.java
@@ -8,15 +8,19 @@ package com.liferay.search.experiences.internal.upgrade.v3_2_0;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * @author Joshua Cords
@@ -26,13 +30,29 @@ public class SXPBlueprintCollectionProviderUpgradeProcess
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
-				"select distinct companyId from PortalPreferenceValue where " +
-					"key_ = 'LPS-129412' and smallValue = 'true'")) {
+		AtomicBoolean foundEnabledFeatureFlag = new AtomicBoolean(false);
 
-			try (ResultSet resultSet = preparedStatement1.executeQuery()) {
-				while (resultSet.next()) {
-					_upgradeSXPBlueprints(resultSet.getLong(1));
+		CompanyLocalServiceUtil.forEachCompanyId(
+			companyId -> {
+				if (FeatureFlagManagerUtil.isEnabled(companyId, "LPS-129412")) {
+					foundEnabledFeatureFlag.set(true);
+
+					_upgradeSXPBlueprints(companyId);
+				}
+			});
+
+		if (!foundEnabledFeatureFlag.get()) {
+			try (PreparedStatement preparedStatement1 =
+					connection.prepareStatement(
+						StringBundler.concat(
+							"select distinct companyId from ",
+							"PortalPreferenceValue where key_ = 'LPS-129412' ",
+							"and smallValue = 'true'"))) {
+
+				try (ResultSet resultSet = preparedStatement1.executeQuery()) {
+					while (resultSet.next()) {
+						_upgradeSXPBlueprints(resultSet.getLong(1));
+					}
 				}
 			}
 		}


### PR DESCRIPTION
FeatureFlagManagerUtil will find all companies which FF are enabled. But during a upgrade using the db-upgrade tool, it will only be able to check if the FF is enabled for all companies through the portal-ext properties. In either case if it found a feature flag then we don't need to run the following database query. The query covers the case where the db-upgrade tool is being used and the Feature Flags were enabled through UI.

https://liferay.atlassian.net/browse/LPD-61781

**Author:** @joshuacords 

Follow up to: https://github.com/brianchandotcom/liferay-portal/pull/164747