### PR TITLE
LPD-65400 Search Bar widget disappears when Search Options and Custom Facet widgets are present

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/facet/view.jsp
@@ -304,6 +304,11 @@ String aggregationType = customFacetDisplayContext.getAggregationType();
 />
 
 <c:if test='<%= customFacetDisplayContext.isShowInputRange() && (aggregationType.equals("dateRange") || aggregationType.equals("range")) %>'>
+	<aui:script>
+		Liferay.destroyComponent('<portlet:namespace />fromInputDatePicker');
+		Liferay.destroyComponent('<portlet:namespace />toInputDatePicker');
+	</aui:script>
+
 	<aui:script use="liferay-search-custom-range-facet">
 		new Liferay.Search.CustomRangeFacet({
 			aggregationType: '<%= customFacetDisplayContext.getAggregationType() %>',

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/modified/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/modified/facet/view.jsp
@@ -209,6 +209,11 @@ ModifiedFacetPortletInstanceConfiguration modifiedFacetPortletInstanceConfigurat
 		module="{FacetUtil} from portal-search-web"
 	/>
 
+	<aui:script>
+		Liferay.destroyComponent('<portlet:namespace />fromInputDatePicker');
+		Liferay.destroyComponent('<portlet:namespace />toInputDatePicker');
+	</aui:script>
+
 	<aui:script use="liferay-search-custom-range-facet">
 		new Liferay.Search.CustomRangeFacet({
 			form: A.one('#<portlet:namespace />fm'),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-65400

### Problem
Search bar disappears and throws console errors when using Custom Facet with Date Range aggregation type.
### Cause
Stale date picker components cause registration conflicts during search refresh.
### Solution
Added cleanup of existing date picker components before creating new instances in view.jsp.