### PR TITLE
LPD-65518 playwright: Add unique label for config input

### DIFF
--- a/modules/test/playwright/tests/portal-search-web/main/customFilter.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/main/customFilter.spec.ts
@@ -91,11 +91,11 @@ test.describe('Custom filter configuration works as expected on content pages', 
 			);
 
 			await searchPage.modalIFrame
-				.getByLabel('Filter Field')
+				.getByLabel('Filter Field Set the name of')
 				.fill('title_en_US');
 
 			await searchPage.modalIFrame
-				.getByLabel('Filter Value')
+				.getByLabel('Filter Value The value to')
 				.fill('Portuguese');
 
 			await searchPage.savePortletConfiguration();
@@ -115,11 +115,11 @@ test.describe('Custom filter configuration works as expected on content pages', 
 			);
 
 			await searchPage.modalIFrame
-				.getByLabel('Filter Field')
+				.getByLabel('Filter Field Set the name of')
 				.fill('title_en_US');
 
 			await searchPage.modalIFrame
-				.getByLabel('Filter Value')
+				.getByLabel('Filter Value The value to')
 				.fill('English');
 
 			await searchPage.savePortletConfiguration();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-65518 - Failure to assert input customFilter.spec.ts

Label needs to be more specific as the locator finds two possibilities, so this commit just updates the targeted text.