### PR TITLE
LPD-54435 Search#AssertDefaultSearchResultsDisplayTemplate

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormFields.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormFields.path
@@ -731,6 +731,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>TEXT_MULTILINE_FIELD_EXACT_MATCH</td>
+	<td>//div[@data-field-name='${key_fieldName}']//div[contains(@class,'form-group')]//textarea</td>
+	<td></td>
+</tr>
+<tr>
 	<td></td>
 	<td></td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
@@ -128,7 +128,6 @@ definition {
 	@description = "This is a use case for LPS-160922."
 	@priority = 4
 	test AssertDefaultSearchResultsDisplayTemplate {
-		property portal.acceptance = "quarantine";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
@@ -161,9 +161,10 @@ definition {
 			fieldName = "displayStyleGroupId",
 			fieldValue = ${siteId});
 
-		FormFields.editTextMultiline(
-			fieldName = "displayStyle",
-			fieldValue = "ddmTemplate_${templateKey}");
+		Type(
+			key_fieldName = "displayStyle",
+			locator1 = "FormFields#TEXT_MULTILINE_FIELD_EXACT_MATCH",
+			value1 = "ddmTemplate_${templateKey}");
 
 		PortletEntry.save();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-54435 - Search#AssertDefaultSearchResultsDisplayTemplate

Issue seems to be the new "Display Style External Reference Code" text input was conflicting with the ability to update the default template. This commit adds a new locator in order to identify the accurate input.