### PR TITLE
LPD-72159 localize object entry content 6

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -116,7 +116,7 @@ public class ObjectEntryModelDocumentContributor
 		fieldArray.addField(field);
 	}
 
-	private void _addLocalizedTitleFields(
+	private void _addTitleFields(
 			Document document, ObjectDefinition objectDefinition,
 			ObjectEntry objectEntry)
 		throws Exception {
@@ -141,6 +141,9 @@ public class ObjectEntryModelDocumentContributor
 			titleObjectField.getI18nObjectFieldName());
 
 		if (MapUtil.isEmpty(localizedValues)) {
+			document.add(
+				new Field("objectEntryTitle", objectEntry.getTitleValue()));
+
 			return;
 		}
 
@@ -454,7 +457,7 @@ public class ObjectEntryModelDocumentContributor
 
 		document.addKeyword("objectEntryId", objectEntry.getObjectEntryId());
 
-		_addLocalizedTitleFields(document, objectDefinition, objectEntry);
+		_addTitleFields(document, objectDefinition, objectEntry);
 
 		ObjectFolder objectFolder = objectDefinition.getObjectFolder();
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -117,8 +117,9 @@ public class ObjectEntryModelDocumentContributor
 	}
 
 	private void _addLocalizedTitleFields(
-		Document document, ObjectDefinition objectDefinition,
-		Map<String, Serializable> values) {
+			Document document, ObjectDefinition objectDefinition,
+			ObjectEntry objectEntry, Map<String, Serializable> values)
+		throws Exception {
 
 		long titleObjectFieldId = objectDefinition.getTitleObjectFieldId();
 
@@ -128,6 +129,9 @@ public class ObjectEntryModelDocumentContributor
 			titleObjectFieldId);
 
 		if ((titleObjectField == null) || !titleObjectField.isLocalized()) {
+			document.add(
+				new Field("objectEntryTitle", objectEntry.getTitleValue()));
+
 			return;
 		}
 
@@ -443,14 +447,13 @@ public class ObjectEntryModelDocumentContributor
 		}
 
 		document.addKeyword("objectEntryId", objectEntry.getObjectEntryId());
-		document.add(
-			new Field("objectEntryTitle", objectEntry.getTitleValue()));
 
 		if (values == null) {
 			values = objectEntry.getIndexedValues();
 		}
 
-		_addLocalizedTitleFields(document, objectDefinition, values);
+		_addLocalizedTitleFields(
+			document, objectDefinition, objectEntry, values);
 
 		ObjectFolder objectFolder = objectDefinition.getObjectFolder();
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -383,10 +383,22 @@ public class ObjectEntryModelDocumentContributor
 				}
 			}
 
-			document.add(
-				new Field(
-					"objectEntryContent",
-					textEmbeddingContentHelper.getNonlocalizedContent()));
+			Map<String, String> localizedContentMap =
+				textEmbeddingContentHelper.getLocalizedContentMap();
+
+			for (Map.Entry<String, String> entry  : localizedContentMap.entrySet()) {
+				document.add(
+					new Field(
+						"objectEntryContent_" + entry.getKey(),
+						entry.getValue()));
+			}
+
+			if (localizedContentMap.isEmpty()) {
+				document.add(
+					new Field(
+						"objectEntryContent",
+						textEmbeddingContentHelper.getNonlocalizedContent()));
+			}
 		}
 
 		document.addKeyword("objectEntryId", objectEntry.getObjectEntryId());

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -14,6 +14,7 @@ import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.entry.util.ObjectEntryValuesUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectEntryFolder;
@@ -113,6 +114,44 @@ public class ObjectEntryModelDocumentContributor
 		field.addField(new Field(valueFieldName, value));
 
 		fieldArray.addField(field);
+	}
+
+	private void _addLocalizedTitleFields(
+		Document document, ObjectDefinition objectDefinition,
+		Map<String, Serializable> values) {
+
+		long titleObjectFieldId = objectDefinition.getTitleObjectFieldId();
+
+		ObjectFieldBag objectFieldBag = objectDefinition.getObjectFieldBag();
+
+		ObjectField titleObjectField = objectFieldBag.getObjectField(
+			titleObjectFieldId);
+
+		if ((titleObjectField == null) || !titleObjectField.isLocalized()) {
+			return;
+		}
+
+		Map<String, Object> localizedValues = (Map<String, Object>)values.get(
+			titleObjectField.getI18nObjectFieldName());
+
+		if (MapUtil.isEmpty(localizedValues)) {
+			return;
+		}
+
+		for (Map.Entry<String, Object> entry : localizedValues.entrySet()) {
+			String languageId = entry.getKey();
+
+			String titleValue = String.valueOf(
+				ObjectEntryValuesUtil.getValue(
+					languageId, titleObjectField, values));
+
+			if (Validator.isBlank(titleValue)) {
+				continue;
+			}
+
+			document.add(
+				new Field("objectEntryTitle_" + languageId, titleValue));
+		}
 	}
 
 	private void _appendToContent(
@@ -386,7 +425,9 @@ public class ObjectEntryModelDocumentContributor
 			Map<String, String> localizedContentMap =
 				textEmbeddingContentHelper.getLocalizedContentMap();
 
-			for (Map.Entry<String, String> entry  : localizedContentMap.entrySet()) {
+			for (Map.Entry<String, String> entry :
+					localizedContentMap.entrySet()) {
+
 				document.add(
 					new Field(
 						"objectEntryContent_" + entry.getKey(),
@@ -404,6 +445,12 @@ public class ObjectEntryModelDocumentContributor
 		document.addKeyword("objectEntryId", objectEntry.getObjectEntryId());
 		document.add(
 			new Field("objectEntryTitle", objectEntry.getTitleValue()));
+
+		if (values == null) {
+			values = objectEntry.getIndexedValues();
+		}
+
+		_addLocalizedTitleFields(document, objectDefinition, values);
 
 		ObjectFolder objectFolder = objectDefinition.getObjectFolder();
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -47,6 +47,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.ml.embedding.text.TextEmbeddingDocumentContributor;
+import com.liferay.portal.search.ml.embedding.text.helper.TextEmbeddingContentHelper;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 
 import java.io.Serializable;
@@ -59,13 +60,11 @@ import java.sql.Types;
 import java.text.Format;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.TreeMap;
 
 /**
  * @author Marco Leo
@@ -117,26 +116,29 @@ public class ObjectEntryModelDocumentContributor
 	}
 
 	private void _appendToContent(
-		ObjectContentHelper objectContentHelper, String locale,
-		String objectFieldName, String valueString) {
+		String locale, String objectFieldName,
+		TextEmbeddingContentHelper<ObjectEntry> textEmbeddingContentHelper,
+		String valueString) {
 
-		if (locale == null) {
-			objectContentHelper.contributeToAll(
-				objectFieldName, ": ", valueString, StringPool.COMMA_AND_SPACE);
+		StringBundler sb = new StringBundler(3);
+
+		sb.append(objectFieldName);
+		sb.append(": ");
+		sb.append(valueString);
+
+		if (locale != null) {
+			textEmbeddingContentHelper.append(locale, sb.toString());
 		}
 		else {
-			objectContentHelper.contributeToLocale(
-				locale, objectFieldName, ": ", valueString,
-				StringPool.COMMA_AND_SPACE);
+			textEmbeddingContentHelper.append(sb.toString());
 		}
 	}
 
 	private void _contribute(
 		Document document, FieldArray fieldArray, String fieldName,
-		Object fieldValue, String locale,
-		ObjectContentHelper objectContentHelper,
-		ObjectDefinition objectDefinition, ObjectEntry objectEntry,
-		ObjectField objectField) {
+		Object fieldValue, String locale, ObjectDefinition objectDefinition,
+		ObjectEntry objectEntry, ObjectField objectField,
+		TextEmbeddingContentHelper<ObjectEntry> textEmbeddingContentHelper) {
 
 		if (!objectField.isIndexed()) {
 			return;
@@ -214,13 +216,13 @@ public class ObjectEntryModelDocumentContributor
 				StringUtil.lowerCase(valueString));
 
 			_appendToContent(
-				objectContentHelper, locale, fieldName, valueString);
+				locale, fieldName, textEmbeddingContentHelper, valueString);
 		}
 		else if (fieldValue instanceof BigDecimal) {
 			_addField(fieldArray, fieldName, "value_double", valueString);
 
 			_appendToContent(
-				objectContentHelper, locale, fieldName, valueString);
+				locale, fieldName, textEmbeddingContentHelper, valueString);
 		}
 		else if (fieldValue instanceof Boolean) {
 			_addField(fieldArray, fieldName, "value_boolean", valueString);
@@ -229,7 +231,7 @@ public class ObjectEntryModelDocumentContributor
 				_translate((Boolean)fieldValue));
 
 			_appendToContent(
-				objectContentHelper, locale, fieldName, valueString);
+				locale, fieldName, textEmbeddingContentHelper, valueString);
 		}
 		else if (fieldValue instanceof Date) {
 			_addField(
@@ -237,26 +239,26 @@ public class ObjectEntryModelDocumentContributor
 				_getDateString(fieldValue));
 
 			_appendToContent(
-				objectContentHelper, locale, fieldName,
+				locale, fieldName, textEmbeddingContentHelper,
 				_getDateString(fieldValue));
 		}
 		else if (fieldValue instanceof Double) {
 			_addField(fieldArray, fieldName, "value_double", valueString);
 
 			_appendToContent(
-				objectContentHelper, locale, fieldName, valueString);
+				locale, fieldName, textEmbeddingContentHelper, valueString);
 		}
 		else if (fieldValue instanceof Integer) {
 			_addField(fieldArray, fieldName, "value_integer", valueString);
 
 			_appendToContent(
-				objectContentHelper, locale, fieldName, valueString);
+				locale, fieldName, textEmbeddingContentHelper, valueString);
 		}
 		else if (fieldValue instanceof Long) {
 			_addField(fieldArray, fieldName, "value_long", valueString);
 
 			_appendToContent(
-				objectContentHelper, locale, fieldName, valueString);
+				locale, fieldName, textEmbeddingContentHelper, valueString);
 		}
 		else if (fieldValue instanceof String) {
 			if (Validator.isBlank(objectField.getIndexedLanguageId())) {
@@ -277,7 +279,7 @@ public class ObjectEntryModelDocumentContributor
 				_getSortableValue(valueString));
 
 			_appendToContent(
-				objectContentHelper, locale, fieldName, valueString);
+				locale, fieldName, textEmbeddingContentHelper, valueString);
 		}
 		else if (fieldValue instanceof byte[]) {
 			_addField(
@@ -341,14 +343,16 @@ public class ObjectEntryModelDocumentContributor
 			objectFields = objectFieldBag.getNonsystemIndexedObjectFields();
 		}
 
-		ObjectContentHelper objectContentHelper = null;
 		Map<String, Serializable> values = null;
+
+		TextEmbeddingContentHelper<ObjectEntry> textEmbeddingContentHelper =
+			new TextEmbeddingContentHelper<>(
+				objectEntry.getCompanyId(), objectEntry.getDefaultLanguageId(),
+				StringPool.COMMA_AND_SPACE, objectEntry, objectFields.size(),
+				_textEmbeddingDocumentContributor);
 
 		if (!objectFields.isEmpty()) {
 			values = objectEntry.getIndexedValues();
-
-			objectContentHelper = new ObjectContentHelper(
-				objectEntry, objectFields, _textEmbeddingDocumentContributor);
 
 			for (ObjectField objectField : objectFields) {
 				if (objectField.isLocalized()) {
@@ -365,25 +369,24 @@ public class ObjectEntryModelDocumentContributor
 
 						_contribute(
 							document, fieldArray, objectField.getName(),
-							entry.getValue(), entry.getKey(),
-							objectContentHelper, objectDefinition, objectEntry,
-							objectField);
+							entry.getValue(), entry.getKey(), objectDefinition,
+							objectEntry, objectField,
+							textEmbeddingContentHelper);
 					}
 				}
 				else {
 					_contribute(
 						document, fieldArray, objectField.getName(),
 						values.get(objectField.getName()), null,
-						objectContentHelper, objectDefinition, objectEntry,
-						objectField);
+						objectDefinition, objectEntry, objectField,
+						textEmbeddingContentHelper);
 				}
 			}
 
-			objectContentHelper.trim();
-
 			document.add(
 				new Field(
-					"objectEntryContent", objectContentHelper.getContent()));
+					"objectEntryContent",
+					textEmbeddingContentHelper.getNonlocalizedContent()));
 		}
 
 		document.addKeyword("objectEntryId", objectEntry.getObjectEntryId());
@@ -445,7 +448,7 @@ public class ObjectEntryModelDocumentContributor
 					values, "r_cmpProjectToCMPTasks_c_cmpProjectId"));
 		}
 
-		_contributeTextEmbeddings(document, objectContentHelper, objectEntry);
+		textEmbeddingContentHelper.contribute(document);
 	}
 
 	private void _contributeFile(Document document, long fileEntryId) {
@@ -490,26 +493,6 @@ public class ObjectEntryModelDocumentContributor
 			rootObjectEntryFolder.getObjectEntryFolderId() ==
 				objectEntryFolderId);
 		document.addKeyword("cms_section", cmsSection);
-	}
-
-	private void _contributeTextEmbeddings(
-		Document document, ObjectContentHelper objectContentHelper,
-		ObjectEntry objectEntry) {
-
-		if (objectContentHelper == null) {
-			return;
-		}
-
-		Map<String, String> localizedContentMap =
-			objectContentHelper.getLocalizedContentMap();
-
-		for (Map.Entry<String, String> localizedContent :
-				localizedContentMap.entrySet()) {
-
-			_textEmbeddingDocumentContributor.contribute(
-				document, localizedContent.getKey(), objectEntry,
-				localizedContent.getValue());
-		}
 	}
 
 	private String _getCMSSection(String externalReferenceCode) {
@@ -699,123 +682,6 @@ public class ObjectEntryModelDocumentContributor
 	private final ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 	private final TextEmbeddingDocumentContributor
 		_textEmbeddingDocumentContributor;
-
-	private static class ObjectContentHelper {
-
-		public void contributeToAll(
-			String s1, String s2, String s3, String s4) {
-
-			_contentSB.append(s1);
-			_contentSB.append(s2);
-			_contentSB.append(s3);
-			_contentSB.append(s4);
-
-			if (_localizedContentSBMap == null) {
-				return;
-			}
-
-			for (StringBundler localizedContentSB :
-					_localizedContentSBMap.values()) {
-
-				localizedContentSB.append(s1);
-				localizedContentSB.append(s2);
-				localizedContentSB.append(s3);
-				localizedContentSB.append(s4);
-			}
-		}
-
-		public void contributeToLocale(
-			String locale, String s1, String s2, String s3, String s4) {
-
-			_contentSB.append(s1);
-			_contentSB.append(s2);
-			_contentSB.append(s3);
-			_contentSB.append(s4);
-
-			if (_localizedContentSBMap == null) {
-				return;
-			}
-
-			StringBundler localizedContentSB = _localizedContentSBMap.get(
-				locale);
-
-			if (localizedContentSB != null) {
-				localizedContentSB.append(s1);
-				localizedContentSB.append(s2);
-				localizedContentSB.append(s3);
-				localizedContentSB.append(s4);
-			}
-		}
-
-		public String getContent() {
-			return _contentSB.toString();
-		}
-
-		public Map<String, String> getLocalizedContentMap() {
-			if (_localizedContentSBMap == null) {
-				return Collections.emptyMap();
-			}
-
-			Map<String, String> localizedContentMap = new TreeMap<>();
-
-			for (Map.Entry<String, StringBundler> localizedContentEntry :
-					_localizedContentSBMap.entrySet()) {
-
-				StringBundler sb = localizedContentEntry.getValue();
-
-				if (sb.index() > 0) {
-					localizedContentMap.put(
-						localizedContentEntry.getKey(), sb.toString());
-				}
-			}
-
-			return localizedContentMap;
-		}
-
-		public void trim() {
-			if (_contentSB.index() > 0) {
-				_contentSB.setIndex(_contentSB.index() - 1);
-			}
-
-			if (_localizedContentSBMap == null) {
-				return;
-			}
-
-			for (StringBundler localizedContentSB :
-					_localizedContentSBMap.values()) {
-
-				if (localizedContentSB.index() > 0) {
-					localizedContentSB.setIndex(localizedContentSB.index() - 1);
-				}
-			}
-		}
-
-		private ObjectContentHelper(
-			ObjectEntry objectEntry, List<ObjectField> objectFields,
-			TextEmbeddingDocumentContributor textEmbeddingDocumentContributor) {
-
-			_contentSB = new StringBundler(objectFields.size() * 4);
-
-			List<String> languageIds =
-				textEmbeddingDocumentContributor.getLanguageIds(objectEntry);
-
-			if (languageIds.isEmpty()) {
-				_localizedContentSBMap = null;
-			}
-			else {
-				_localizedContentSBMap = new TreeMap<>();
-
-				for (String languageId : languageIds) {
-					_localizedContentSBMap.put(
-						languageId, new StringBundler(objectFields.size() * 4));
-				}
-			}
-		}
-
-		private final StringBundler _contentSB;
-		private final Map<String, StringBundler> _localizedContentSBMap;
-
-	}
 
 	private static class ObjectFieldTable extends BaseTable<ObjectFieldTable> {
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -348,6 +348,9 @@ public class ObjectEntryModelDocumentContributor
 			_log.debug("Object entry " + objectEntry);
 		}
 
+		document.addText(
+			"defaultLanguageId", objectEntry.getDefaultLanguageId());
+
 		document.add(
 			new Field(
 				Field.getSortableFieldName(Field.ENTRY_CLASS_PK),
@@ -434,7 +437,8 @@ public class ObjectEntryModelDocumentContributor
 
 				document.add(
 					new Field(
-						"objectEntryContent_" + entry.getKey(),
+						Field.getLocalizedName(
+							entry.getKey(), "objectEntryContent"),
 						entry.getValue()));
 			}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -118,7 +118,7 @@ public class ObjectEntryModelDocumentContributor
 
 	private void _addLocalizedTitleFields(
 			Document document, ObjectDefinition objectDefinition,
-			ObjectEntry objectEntry, Map<String, Serializable> values)
+			ObjectEntry objectEntry)
 		throws Exception {
 
 		long titleObjectFieldId = objectDefinition.getTitleObjectFieldId();
@@ -134,6 +134,8 @@ public class ObjectEntryModelDocumentContributor
 
 			return;
 		}
+
+		Map<String, Serializable> values = objectEntry.getIndexedValues();
 
 		Map<String, Object> localizedValues = (Map<String, Object>)values.get(
 			titleObjectField.getI18nObjectFieldName());
@@ -452,12 +454,7 @@ public class ObjectEntryModelDocumentContributor
 
 		document.addKeyword("objectEntryId", objectEntry.getObjectEntryId());
 
-		if (values == null) {
-			values = objectEntry.getIndexedValues();
-		}
-
-		_addLocalizedTitleFields(
-			document, objectDefinition, objectEntry, values);
+		_addLocalizedTitleFields(document, objectDefinition, objectEntry);
 
 		ObjectFolder objectFolder = objectDefinition.getObjectFolder();
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -33,7 +33,6 @@ import com.liferay.portal.kernel.search.generic.NestedQuery;
 import com.liferay.portal.kernel.search.generic.TermQueryImpl;
 import com.liferay.portal.kernel.search.generic.TermRangeQueryImpl;
 import com.liferay.portal.kernel.search.generic.WildcardQueryImpl;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -132,33 +131,35 @@ public class ObjectEntryKeywordQueryContributor
 
 		queryConfig.addHighlightFieldNames(Field.ENTRY_CLASS_PK);
 
+		boolean hasLocalizedContent = _hasLocalizedContent(objectFields);
+
 		_addLocalizedHighlightFieldNames(
-			objectFields, queryConfig, searchContext);
+			hasLocalizedContent, queryConfig, searchContext);
+
+		String contentField = "objectEntryContent";
+
+		if (hasLocalizedContent) {
+			_addTerm(
+				booleanQuery,
+				Field.getLocalizedName(searchContext.getLocale(), contentField),
+				keywords);
+		}
+		else {
+			_addTerm(booleanQuery, contentField, keywords);
+		}
 
 		String titleField = "objectEntryTitle";
 
-		if (addObjectEntryTitle.get()) {
-			_addTerm(booleanQuery, titleField, keywords);
-			_addTermQueries(
-				booleanQuery,
-				_searchLocalizationHelper.getLocalizedFieldNames(
-					new String[] {titleField}, searchContext),
-				keywords);
-		}
-
-		_addTerm(booleanQuery, "objectEntryContent", keywords);
-		_addTermQueries(
-			booleanQuery,
-			_searchLocalizationHelper.getLocalizedFieldNames(
-				new String[] {"objectEntryContent"}, searchContext),
-			keywords);
+		String localizedTitleFieldName = Field.getLocalizedName(
+			searchContext.getLocale(), titleField);
 
 		if (StringUtil.startsWith(keywords, CharPool.QUOTE) &&
 			StringUtil.endsWith(keywords, CharPool.QUOTE)) {
 
-			try {
-				booleanQuery.addTerm(titleField, keywords, false);
+			_addTerm(booleanQuery, titleField, keywords);
+			_addTerm(booleanQuery, localizedTitleFieldName, keywords);
 
+			try {
 				for (ObjectField objectField : objectFields) {
 					_contribute(
 						objectField, keywords, booleanQuery, searchContext);
@@ -169,6 +170,11 @@ public class ObjectEntryKeywordQueryContributor
 			}
 		}
 		else {
+			if (addObjectEntryTitle.get()) {
+				_addTerm(booleanQuery, titleField, keywords);
+				_addTerm(booleanQuery, localizedTitleFieldName, keywords);
+			}
+
 			for (String token : _tokenizeKeywords(keywords)) {
 				if (addObjectEntryTitle.get() && !Validator.isBlank(token)) {
 					try {
@@ -200,19 +206,12 @@ public class ObjectEntryKeywordQueryContributor
 	}
 
 	private void _addLocalizedHighlightFieldNames(
-		List<ObjectField> objectFields, QueryConfig queryConfig,
+		boolean hasLocalizedContent, QueryConfig queryConfig,
 		SearchContext searchContext) {
 
 		Locale locale = searchContext.getLocale();
 
-		if (locale == null) {
-			queryConfig.addHighlightFieldNames("objectEntryContent");
-			queryConfig.addHighlightFieldNames("objectEntryTitle");
-
-			return;
-		}
-
-		if (_hasLocalizedContent(objectFields)) {
+		if (hasLocalizedContent) {
 			queryConfig.addHighlightFieldNames(
 				"objectEntryContent_" + LocaleUtil.toLanguageId(locale));
 		}
@@ -287,18 +286,6 @@ public class ObjectEntryKeywordQueryContributor
 		}
 		catch (ParseException parseException) {
 			throw new SystemException(parseException);
-		}
-	}
-
-	private void _addTermQueries(
-		BooleanQuery booleanQuery, String[] fieldNames, String value) {
-
-		if (ArrayUtil.isEmpty(fieldNames)) {
-			return;
-		}
-
-		for (String fieldName : fieldNames) {
-			_addTerm(booleanQuery, fieldName, value);
 		}
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.search.generic.NestedQuery;
 import com.liferay.portal.kernel.search.generic.TermQueryImpl;
 import com.liferay.portal.kernel.search.generic.TermRangeQueryImpl;
 import com.liferay.portal.kernel.search.generic.WildcardQueryImpl;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -45,9 +46,11 @@ import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQuery
 import java.io.Serializable;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -131,8 +134,6 @@ public class ObjectEntryKeywordQueryContributor
 
 		queryConfig.addHighlightFieldNames(Field.ENTRY_CLASS_PK);
 
-		boolean localized = _isLocalized(objectFields);
-
 		Locale defaultLocale = LocaleUtil.fromLanguageId(
 			_objectDefinition.getDefaultLanguageId());
 
@@ -141,26 +142,7 @@ public class ObjectEntryKeywordQueryContributor
 		}
 
 		_addLocalizedHighlightFieldNames(
-			defaultLocale, localized, queryConfig, searchContext);
-
-		String contentField = "objectEntryContent";
-
-		if (localized) {
-			_addTerm(
-				booleanQuery,
-				Field.getLocalizedName(searchContext.getLocale(), contentField),
-				keywords);
-
-			if (defaultLocale != null) {
-				_addTerm(
-					booleanQuery,
-					Field.getLocalizedName(defaultLocale, contentField),
-					keywords);
-			}
-		}
-		else {
-			_addTerm(booleanQuery, contentField, keywords);
-		}
+			defaultLocale, queryConfig, searchContext);
 
 		String titleField = "objectEntryTitle";
 
@@ -183,7 +165,8 @@ public class ObjectEntryKeywordQueryContributor
 			try {
 				for (ObjectField objectField : objectFields) {
 					_contribute(
-						objectField, keywords, booleanQuery, searchContext);
+						objectField, keywords, booleanQuery, defaultLocale,
+						searchContext);
 				}
 			}
 			catch (ParseException parseException) {
@@ -221,7 +204,8 @@ public class ObjectEntryKeywordQueryContributor
 				for (ObjectField objectField : objectFields) {
 					try {
 						_contribute(
-							objectField, token, booleanQuery, searchContext);
+							objectField, token, booleanQuery, defaultLocale,
+							searchContext);
 					}
 					catch (ParseException parseException) {
 						throw new SystemException(parseException);
@@ -232,23 +216,19 @@ public class ObjectEntryKeywordQueryContributor
 	}
 
 	private void _addLocalizedHighlightFieldNames(
-		Locale defaultLocale, boolean localized, QueryConfig queryConfig,
+		Locale defaultLocale, QueryConfig queryConfig,
 		SearchContext searchContext) {
 
 		Locale locale = searchContext.getLocale();
 
-		if (localized) {
-			queryConfig.addHighlightFieldNames(
-				Field.getLocalizedName(locale, "objectEntryContent"));
+		queryConfig.addHighlightFieldNames(
+			"nestedFieldArray.value_boolean", "nestedFieldArray.value_keyword",
+			"nestedFieldArray.value_text");
 
-			if (defaultLocale != null) {
-				queryConfig.addHighlightFieldNames(
-					Field.getLocalizedName(
-						defaultLocale, "objectEntryContent"));
-			}
-		}
-		else {
-			queryConfig.addHighlightFieldNames("objectEntryContent");
+		for (String localizedNestedFieldName :
+				_getLocalizedNestedFieldNames(defaultLocale, searchContext)) {
+
+			queryConfig.addHighlightFieldNames(localizedNestedFieldName);
 		}
 
 		long titleObjectFieldId = _objectDefinition.getTitleObjectFieldId();
@@ -326,9 +306,50 @@ public class ObjectEntryKeywordQueryContributor
 		}
 	}
 
+	private void _configureNestedQuery(
+		String[] highlightFieldNames, String innerHitsName,
+		NestedQuery nestedQuery, SearchContext searchContext) {
+
+		if (ArrayUtil.isEmpty(highlightFieldNames)) {
+			return;
+		}
+
+		Set<String> configuredInnerHitsNames =
+			(Set<String>)searchContext.getAttribute(
+				_CONFIGURED_INNER_HITS_NAMES);
+
+		if (configuredInnerHitsNames == null) {
+			configuredInnerHitsNames = new HashSet<>();
+
+			searchContext.setAttribute(
+				_CONFIGURED_INNER_HITS_NAMES,
+				(Serializable)configuredInnerHitsNames);
+		}
+
+		if (!configuredInnerHitsNames.add(innerHitsName)) {
+			return;
+		}
+
+		QueryConfig nestedQueryConfig = nestedQuery.getQueryConfig();
+		QueryConfig queryConfig = searchContext.getQueryConfig();
+
+		nestedQueryConfig.setHighlightEnabled(true);
+		nestedQueryConfig.setHighlightFieldNames(highlightFieldNames);
+		nestedQueryConfig.setHighlightFragmentSize(
+			queryConfig.getHighlightFragmentSize());
+		nestedQueryConfig.setHighlightSnippetSize(
+			queryConfig.getHighlightSnippetSize());
+		nestedQueryConfig.setHighlightRequireFieldMatch(
+			queryConfig.isHighlightRequireFieldMatch());
+		nestedQueryConfig.setLocale(queryConfig.getLocale());
+
+		nestedQuery.setInnerHitsEnabled(true);
+		nestedQuery.setInnerHitsName(innerHitsName);
+	}
+
 	private void _contribute(
 			ObjectField objectField, String token, BooleanQuery booleanQuery,
-			SearchContext searchContext)
+			Locale defaultLocale, SearchContext searchContext)
 		throws ParseException {
 
 		if ((objectField == null) || !objectField.isIndexed()) {
@@ -349,6 +370,7 @@ public class ObjectEntryKeywordQueryContributor
 		}
 
 		BooleanQuery nestedBooleanQuery = new BooleanQueryImpl();
+		String[] highlightFieldNames = null;
 		QueryConfig queryConfig = searchContext.getQueryConfig();
 
 		if (objectField.isIndexedAsKeyword()) {
@@ -363,7 +385,7 @@ public class ObjectEntryKeywordQueryContributor
 				new TermQueryImpl(fieldName, lowerCaseToken),
 				BooleanClauseOccur.SHOULD);
 
-			queryConfig.addHighlightFieldNames(fieldName);
+			highlightFieldNames = new String[] {fieldName};
 		}
 		else if (Objects.equals(
 					objectField.getBusinessType(),
@@ -378,9 +400,8 @@ public class ObjectEntryKeywordQueryContributor
 			String fieldName = "nestedFieldArray.value_text";
 
 			if (objectField.isLocalized()) {
-				String[] localizedFieldNames =
-					_searchLocalizationHelper.getLocalizedFieldNames(
-						new String[] {"nestedFieldArray.value"}, searchContext);
+				String[] localizedFieldNames = _getLocalizedNestedFieldNames(
+					defaultLocale, searchContext);
 
 				BooleanQuery localizedNestedBooleanQuery =
 					new BooleanQueryImpl();
@@ -389,12 +410,12 @@ public class ObjectEntryKeywordQueryContributor
 					localizedNestedBooleanQuery.add(
 						new MatchQuery(localizedFieldName, token),
 						BooleanClauseOccur.SHOULD);
-
-					queryConfig.addHighlightFieldNames(localizedFieldName);
 				}
 
 				nestedBooleanQuery.add(
 					localizedNestedBooleanQuery, BooleanClauseOccur.MUST);
+
+				highlightFieldNames = localizedFieldNames;
 			}
 			else if (Objects.equals(
 						objectField.getIndexedLanguageId(),
@@ -409,7 +430,7 @@ public class ObjectEntryKeywordQueryContributor
 				nestedBooleanQuery.add(
 					new MatchQuery(fieldName, token), BooleanClauseOccur.MUST);
 
-				queryConfig.addHighlightFieldNames(fieldName);
+				highlightFieldNames = new String[] {fieldName};
 			}
 		}
 		else if (Objects.equals(
@@ -447,8 +468,6 @@ public class ObjectEntryKeywordQueryContributor
 				nestedBooleanQuery.add(
 					new TermQueryImpl(fieldName, StringUtil.toLowerCase(token)),
 					BooleanClauseOccur.MUST);
-
-				queryConfig.addHighlightFieldNames(fieldName);
 			}
 		}
 		else if (Objects.equals(
@@ -491,15 +510,43 @@ public class ObjectEntryKeywordQueryContributor
 				booleanClauseOccur = BooleanClauseOccur.MUST;
 			}
 
-			booleanQuery.add(
-				new NestedQuery("nestedFieldArray", nestedBooleanQuery),
-				booleanClauseOccur);
-
 			nestedBooleanQuery.add(
 				new TermQueryImpl(
 					"nestedFieldArray.fieldName", objectField.getName()),
 				BooleanClauseOccur.MUST);
+
+			NestedQuery nestedQuery = new NestedQuery(
+				"nestedFieldArray", nestedBooleanQuery);
+
+			_configureNestedQuery(
+				highlightFieldNames, objectField.getName(), nestedQuery,
+				searchContext);
+
+			booleanQuery.add(nestedQuery, booleanClauseOccur);
 		}
+	}
+
+	private String[] _getLocalizedNestedFieldNames(
+		Locale defaultLocale, SearchContext searchContext) {
+
+		List<String> fieldNames = new ArrayList<>();
+
+		Locale locale = searchContext.getLocale();
+
+		if (locale != null) {
+			fieldNames.add(
+				Field.getLocalizedName(locale, _NESTED_FIELD_ARRAY_VALUE));
+		}
+
+		if ((defaultLocale != null) &&
+			((locale == null) || !locale.equals(defaultLocale))) {
+
+			fieldNames.add(
+				Field.getLocalizedName(
+					defaultLocale, _NESTED_FIELD_ARRAY_VALUE));
+		}
+
+		return fieldNames.toArray(new String[0]);
 	}
 
 	private String _getToken(
@@ -609,6 +656,12 @@ public class ObjectEntryKeywordQueryContributor
 
 		return keywordTokenizer.tokenize(keywords);
 	}
+
+	private static final String _CONFIGURED_INNER_HITS_NAMES =
+		"objectEntryConfiguredInnerHitsNames";
+
+	private static final String _NESTED_FIELD_ARRAY_VALUE =
+		"nestedFieldArray.value";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ObjectEntryKeywordQueryContributor.class);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.search.generic.TermRangeQueryImpl;
 import com.liferay.portal.kernel.search.generic.WildcardQueryImpl;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.localization.SearchLocalizationHelper;
@@ -45,6 +46,7 @@ import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
@@ -126,9 +128,13 @@ public class ObjectEntryKeywordQueryContributor
 		}
 
 		QueryConfig queryConfig = searchContext.getQueryConfig();
-		String titleField = "objectEntryTitle";
 
-		queryConfig.addHighlightFieldNames(Field.ENTRY_CLASS_PK, titleField);
+		queryConfig.addHighlightFieldNames(Field.ENTRY_CLASS_PK);
+
+		_addLocalizedHighlightFieldNames(
+			objectFields, queryConfig, searchContext);
+
+		String titleField = "objectEntryTitle";
 
 		if (StringUtil.startsWith(keywords, CharPool.QUOTE) &&
 			StringUtil.endsWith(keywords, CharPool.QUOTE)) {
@@ -173,6 +179,43 @@ public class ObjectEntryKeywordQueryContributor
 					}
 				}
 			}
+		}
+	}
+
+	private void _addLocalizedHighlightFieldNames(
+		List<ObjectField> objectFields, QueryConfig queryConfig,
+		SearchContext searchContext) {
+
+		Locale locale = searchContext.getLocale();
+
+		if (locale == null) {
+			queryConfig.addHighlightFieldNames("objectEntryContent");
+			queryConfig.addHighlightFieldNames("objectEntryTitle");
+
+			return;
+		}
+
+		if (_hasLocalizedContent(objectFields)) {
+			queryConfig.addHighlightFieldNames(
+				"objectEntryContent_" + LocaleUtil.toLanguageId(locale));
+		}
+		else {
+			queryConfig.addHighlightFieldNames("objectEntryContent");
+		}
+
+		long titleObjectFieldId = _objectDefinition.getTitleObjectFieldId();
+
+		ObjectFieldBag objectFieldBag = _objectDefinition.getObjectFieldBag();
+
+		ObjectField titleObjectField = objectFieldBag.getObjectField(
+			titleObjectFieldId);
+
+		if ((titleObjectField != null) && titleObjectField.isLocalized()) {
+			queryConfig.addHighlightFieldNames(
+				"objectEntryTitle_" + LocaleUtil.toLanguageId(locale));
+		}
+		else {
+			queryConfig.addHighlightFieldNames("objectEntryTitle");
 		}
 	}
 
@@ -428,6 +471,20 @@ public class ObjectEntryKeywordQueryContributor
 		}
 
 		return value;
+	}
+
+	private boolean _hasLocalizedContent(List<ObjectField> objectFields) {
+		if (ListUtil.isEmpty(objectFields)) {
+			return false;
+		}
+
+		for (ObjectField objectField : objectFields) {
+			if ((objectField != null) && objectField.isLocalized()) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private boolean _isValidInput(String token, String type) {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -131,18 +131,32 @@ public class ObjectEntryKeywordQueryContributor
 
 		queryConfig.addHighlightFieldNames(Field.ENTRY_CLASS_PK);
 
-		boolean hasLocalizedContent = _hasLocalizedContent(objectFields);
+		boolean localized = _isLocalized(objectFields);
+
+		Locale defaultLocale = LocaleUtil.fromLanguageId(
+			_objectDefinition.getDefaultLanguageId());
+
+		if (Objects.equals(defaultLocale, searchContext.getLocale())) {
+			defaultLocale = null;
+		}
 
 		_addLocalizedHighlightFieldNames(
-			hasLocalizedContent, queryConfig, searchContext);
+			defaultLocale, localized, queryConfig, searchContext);
 
 		String contentField = "objectEntryContent";
 
-		if (hasLocalizedContent) {
+		if (localized) {
 			_addTerm(
 				booleanQuery,
 				Field.getLocalizedName(searchContext.getLocale(), contentField),
 				keywords);
+
+			if (defaultLocale != null) {
+				_addTerm(
+					booleanQuery,
+					Field.getLocalizedName(defaultLocale, contentField),
+					keywords);
+			}
 		}
 		else {
 			_addTerm(booleanQuery, contentField, keywords);
@@ -150,14 +164,21 @@ public class ObjectEntryKeywordQueryContributor
 
 		String titleField = "objectEntryTitle";
 
+		String defaultLocalizedTitleFieldName = Field.getLocalizedName(
+			defaultLocale, titleField);
 		String localizedTitleFieldName = Field.getLocalizedName(
 			searchContext.getLocale(), titleField);
 
 		if (StringUtil.startsWith(keywords, CharPool.QUOTE) &&
 			StringUtil.endsWith(keywords, CharPool.QUOTE)) {
 
-			_addTerm(booleanQuery, titleField, keywords);
+			if (defaultLocale != null) {
+				_addTerm(
+					booleanQuery, defaultLocalizedTitleFieldName, keywords);
+			}
+
 			_addTerm(booleanQuery, localizedTitleFieldName, keywords);
+			_addTerm(booleanQuery, titleField, keywords);
 
 			try {
 				for (ObjectField objectField : objectFields) {
@@ -171,8 +192,13 @@ public class ObjectEntryKeywordQueryContributor
 		}
 		else {
 			if (addObjectEntryTitle.get()) {
-				_addTerm(booleanQuery, titleField, keywords);
+				if (defaultLocale != null) {
+					_addTerm(
+						booleanQuery, defaultLocalizedTitleFieldName, keywords);
+				}
+
 				_addTerm(booleanQuery, localizedTitleFieldName, keywords);
+				_addTerm(booleanQuery, titleField, keywords);
 			}
 
 			for (String token : _tokenizeKeywords(keywords)) {
@@ -206,14 +232,20 @@ public class ObjectEntryKeywordQueryContributor
 	}
 
 	private void _addLocalizedHighlightFieldNames(
-		boolean hasLocalizedContent, QueryConfig queryConfig,
+		Locale defaultLocale, boolean localized, QueryConfig queryConfig,
 		SearchContext searchContext) {
 
 		Locale locale = searchContext.getLocale();
 
-		if (hasLocalizedContent) {
+		if (localized) {
 			queryConfig.addHighlightFieldNames(
-				"objectEntryContent_" + LocaleUtil.toLanguageId(locale));
+				Field.getLocalizedName(locale, "objectEntryContent"));
+
+			if (defaultLocale != null) {
+				queryConfig.addHighlightFieldNames(
+					Field.getLocalizedName(
+						defaultLocale, "objectEntryContent"));
+			}
 		}
 		else {
 			queryConfig.addHighlightFieldNames("objectEntryContent");
@@ -228,7 +260,12 @@ public class ObjectEntryKeywordQueryContributor
 
 		if ((titleObjectField != null) && titleObjectField.isLocalized()) {
 			queryConfig.addHighlightFieldNames(
-				"objectEntryTitle_" + LocaleUtil.toLanguageId(locale));
+				Field.getLocalizedName(locale, "objectEntryTitle"));
+
+			if (defaultLocale != null) {
+				queryConfig.addHighlightFieldNames(
+					Field.getLocalizedName(defaultLocale, "objectEntryTitle"));
+			}
 		}
 		else {
 			queryConfig.addHighlightFieldNames("objectEntryTitle");
@@ -504,7 +541,7 @@ public class ObjectEntryKeywordQueryContributor
 		return value;
 	}
 
-	private boolean _hasLocalizedContent(List<ObjectField> objectFields) {
+	private boolean _isLocalized(List<ObjectField> objectFields) {
 		if (ListUtil.isEmpty(objectFields)) {
 			return false;
 		}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.search.generic.NestedQuery;
 import com.liferay.portal.kernel.search.generic.TermQueryImpl;
 import com.liferay.portal.kernel.search.generic.TermRangeQueryImpl;
 import com.liferay.portal.kernel.search.generic.WildcardQueryImpl;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -135,6 +136,22 @@ public class ObjectEntryKeywordQueryContributor
 			objectFields, queryConfig, searchContext);
 
 		String titleField = "objectEntryTitle";
+
+		if (addObjectEntryTitle.get()) {
+			_addTerm(booleanQuery, titleField, keywords);
+			_addTermQueries(
+				booleanQuery,
+				_searchLocalizationHelper.getLocalizedFieldNames(
+					new String[] {titleField}, searchContext),
+				keywords);
+		}
+
+		_addTerm(booleanQuery, "objectEntryContent", keywords);
+		_addTermQueries(
+			booleanQuery,
+			_searchLocalizationHelper.getLocalizedFieldNames(
+				new String[] {"objectEntryContent"}, searchContext),
+			keywords);
 
 		if (StringUtil.startsWith(keywords, CharPool.QUOTE) &&
 			StringUtil.endsWith(keywords, CharPool.QUOTE)) {
@@ -256,6 +273,33 @@ public class ObjectEntryKeywordQueryContributor
 			BooleanClauseOccur.MUST);
 
 		return true;
+	}
+
+	private void _addTerm(
+		BooleanQuery booleanQuery, String fieldName, String value) {
+
+		if (Validator.isBlank(fieldName) || Validator.isBlank(value)) {
+			return;
+		}
+
+		try {
+			booleanQuery.addTerm(fieldName, value, false);
+		}
+		catch (ParseException parseException) {
+			throw new SystemException(parseException);
+		}
+	}
+
+	private void _addTermQueries(
+		BooleanQuery booleanQuery, String[] fieldNames, String value) {
+
+		if (ArrayUtil.isEmpty(fieldNames)) {
+			return;
+		}
+
+		for (String fieldName : fieldNames) {
+			_addTerm(booleanQuery, fieldName, value);
+		}
 	}
 
 	private void _contribute(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -302,7 +302,13 @@ public class ObjectEntryKeywordQueryContributor
 			booleanQuery.addTerm(fieldName, value, false);
 		}
 		catch (ParseException parseException) {
-			throw new SystemException(parseException);
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"Unable to add term for field ", fieldName,
+						" and value ", value),
+					parseException);
+			}
 		}
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -385,6 +385,8 @@ public class ObjectEntryKeywordQueryContributor
 				new TermQueryImpl(fieldName, lowerCaseToken),
 				BooleanClauseOccur.SHOULD);
 
+			queryConfig.addHighlightFieldNames(fieldName);
+
 			highlightFieldNames = new String[] {fieldName};
 		}
 		else if (Objects.equals(
@@ -410,6 +412,8 @@ public class ObjectEntryKeywordQueryContributor
 					localizedNestedBooleanQuery.add(
 						new MatchQuery(localizedFieldName, token),
 						BooleanClauseOccur.SHOULD);
+
+					queryConfig.addHighlightFieldNames(localizedFieldName);
 				}
 
 				nestedBooleanQuery.add(
@@ -429,6 +433,8 @@ public class ObjectEntryKeywordQueryContributor
 			if (!objectField.isLocalized()) {
 				nestedBooleanQuery.add(
 					new MatchQuery(fieldName, token), BooleanClauseOccur.MUST);
+
+				queryConfig.addHighlightFieldNames(fieldName);
 
 				highlightFieldNames = new String[] {fieldName};
 			}
@@ -468,6 +474,8 @@ public class ObjectEntryKeywordQueryContributor
 				nestedBooleanQuery.add(
 					new TermQueryImpl(fieldName, StringUtil.toLowerCase(token)),
 					BooleanClauseOccur.MUST);
+
+				queryConfig.addHighlightFieldNames(fieldName);
 			}
 		}
 		else if (Objects.equals(
@@ -546,6 +554,16 @@ public class ObjectEntryKeywordQueryContributor
 					defaultLocale, _NESTED_FIELD_ARRAY_VALUE));
 		}
 
+		if (fieldNames.isEmpty()) {
+			for (Locale availableLocale :
+					_searchLocalizationHelper.getLocales(searchContext)) {
+
+				fieldNames.add(
+					Field.getLocalizedName(
+						availableLocale, _NESTED_FIELD_ARRAY_VALUE));
+			}
+		}
+
 		return fieldNames.toArray(new String[0]);
 	}
 
@@ -586,20 +604,6 @@ public class ObjectEntryKeywordQueryContributor
 		}
 
 		return value;
-	}
-
-	private boolean _isLocalized(List<ObjectField> objectFields) {
-		if (ListUtil.isEmpty(objectFields)) {
-			return false;
-		}
-
-		for (ObjectField objectField : objectFields) {
-			if ((objectField != null) && objectField.isLocalized()) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	private boolean _isValidInput(String token, String type) {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/result/contributor/ObjectEntryModelSummaryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/result/contributor/ObjectEntryModelSummaryContributor.java
@@ -28,10 +28,11 @@ public class ObjectEntryModelSummaryContributor
 	public Summary getSummary(
 		Document document, Locale locale, String snippet) {
 
-		return new Summary(_getTitle(document, locale), _getContent(document));
+		return new Summary(
+			_getTitle(document, locale), _getContent(document, locale));
 	}
 
-	private String _getContent(Document document) {
+	private String _getContent(Document document, Locale locale) {
 		StringBundler sb = new StringBundler();
 
 		Map<String, Field> fields = document.getFields();
@@ -55,6 +56,18 @@ public class ObjectEntryModelSummaryContributor
 		}
 
 		String content = sb.toString();
+
+		if (Validator.isBlank(content)) {
+			String languageId = LanguageUtil.getLanguageId(locale);
+
+			String localizedContent = document.get(
+				"objectEntryContent_" + languageId);
+
+			if (Validator.isNotNull(localizedContent)) {
+				content = StringUtil.shorten(
+					localizedContent, 300, StringPool.TRIPLE_PERIOD);
+			}
+		}
 
 		if (Validator.isBlank(content)) {
 			content = StringUtil.shorten(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/result/contributor/ObjectEntryModelSummaryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/result/contributor/ObjectEntryModelSummaryContributor.java
@@ -5,8 +5,8 @@
 
 package com.liferay.object.internal.search.spi.model.result.contributor;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Summary;
@@ -18,6 +18,7 @@ import java.util.Locale;
 
 /**
  * @author Bryan Engler
+ * @author Joshua Cords
  */
 public class ObjectEntryModelSummaryContributor
 	implements ModelSummaryContributor {
@@ -26,19 +27,26 @@ public class ObjectEntryModelSummaryContributor
 	public Summary getSummary(
 		Document document, Locale locale, String snippet) {
 
+		String defaultLanguageId = document.get("defaultLanguageId");
+
 		return new Summary(
-			_getTitle(document, locale), _getContent(document, locale));
+			_getTitle(defaultLanguageId, document, locale),
+			_getContent(defaultLanguageId, document, locale));
 	}
 
-	private String _getContent(Document document, Locale locale) {
-		String languageId = LanguageUtil.getLanguageId(locale);
+	private String _getContent(
+		String defaultLanguageId, Document document, Locale locale) {
 
-		String content = document.get(
-			"snippet_objectEntryContent_" + languageId);
+		String localizedFieldName = Field.getLocalizedName(
+			locale, _OBJECT_ENTRY_CONTENT);
+
+		String localizedSnippetFieldName = StringBundler.concat(
+			Field.SNIPPET, StringPool.UNDERLINE, localizedFieldName);
+
+		String content = document.get(localizedSnippetFieldName);
 
 		if (Validator.isBlank(content)) {
-			String localizedContent = document.get(
-				"objectEntryContent_" + languageId);
+			String localizedContent = document.get(localizedFieldName);
 
 			if (Validator.isNotNull(localizedContent)) {
 				content = StringUtil.shorten(
@@ -46,12 +54,37 @@ public class ObjectEntryModelSummaryContributor
 			}
 		}
 
-		if (Validator.isBlank(content)) {
-			content = document.get("snippet_objectEntryContent");
+		if (Validator.isBlank(content) &&
+			!Validator.isBlank(defaultLanguageId)) {
+
+			String defaultLocalizedFieldName = Field.getLocalizedName(
+				defaultLanguageId, _OBJECT_ENTRY_CONTENT);
+
+			String defaultLocalizedSnippetFieldName = StringBundler.concat(
+				Field.SNIPPET, StringPool.UNDERLINE, defaultLocalizedFieldName);
+
+			content = document.get(defaultLocalizedSnippetFieldName);
+
+			if (Validator.isBlank(content)) {
+				String localizedContent = document.get(
+					defaultLocalizedFieldName);
+
+				if (Validator.isNotNull(localizedContent)) {
+					content = StringUtil.shorten(
+						localizedContent, 300, StringPool.TRIPLE_PERIOD);
+				}
+			}
 		}
 
 		if (Validator.isBlank(content)) {
-			String nonlocalizedContent = document.get("objectEntryContent");
+			content = document.get(
+				StringBundler.concat(
+					Field.SNIPPET, StringPool.UNDERLINE,
+					_OBJECT_ENTRY_CONTENT));
+		}
+
+		if (Validator.isBlank(content)) {
+			String nonlocalizedContent = document.get(_OBJECT_ENTRY_CONTENT);
 
 			if (Validator.isNotNull(nonlocalizedContent)) {
 				content = StringUtil.shorten(
@@ -62,25 +95,47 @@ public class ObjectEntryModelSummaryContributor
 		return content;
 	}
 
-	private String _getTitle(Document document, Locale locale) {
-		String title = document.get(
-			"snippet_objectEntryTitle_" + LanguageUtil.getLanguageId(locale));
+	private String _getTitle(
+		String defaultLanguageId, Document document, Locale locale) {
+
+		String localizedFieldName = Field.getLocalizedName(
+			locale, _OBJECT_ENTRY_TITLE);
+
+		String localizedSnippetFieldName = StringBundler.concat(
+			Field.SNIPPET, StringPool.UNDERLINE, localizedFieldName);
+
+		String title = document.get(localizedSnippetFieldName);
+
+		if (Validator.isBlank(title)) {
+			title = document.get(localizedFieldName);
+		}
+
+		if (Validator.isBlank(title) && !Validator.isBlank(defaultLanguageId)) {
+			String defaultLocalizedFieldName = Field.getLocalizedName(
+				defaultLanguageId, _OBJECT_ENTRY_TITLE);
+
+			String defaultLocalizedSnippetFieldName = StringBundler.concat(
+				Field.SNIPPET, StringPool.UNDERLINE, defaultLocalizedFieldName);
+
+			title = document.get(defaultLocalizedSnippetFieldName);
+
+			if (Validator.isBlank(title)) {
+				title = document.get(defaultLocalizedFieldName);
+			}
+		}
 
 		if (Validator.isBlank(title)) {
 			title = document.get(
-				"objectEntryTitle_" + LanguageUtil.getLanguageId(locale));
+				StringBundler.concat(
+					Field.SNIPPET, StringPool.UNDERLINE, _OBJECT_ENTRY_TITLE));
 		}
 
 		if (Validator.isBlank(title)) {
-			title = document.get("snippet_objectEntryTitle");
+			title = document.get(_OBJECT_ENTRY_TITLE);
 		}
 
 		if (Validator.isBlank(title)) {
-			title = document.get("objectEntryTitle");
-		}
-
-		if (Validator.isBlank(title)) {
-			title = document.get("snippet_" + Field.ENTRY_CLASS_PK);
+			title = document.get(Field.SNIPPET + Field.ENTRY_CLASS_PK);
 		}
 
 		if (Validator.isBlank(title)) {
@@ -89,5 +144,9 @@ public class ObjectEntryModelSummaryContributor
 
 		return title;
 	}
+
+	private static final String _OBJECT_ENTRY_CONTENT = "objectEntryContent";
+
+	private static final String _OBJECT_ENTRY_TITLE = "objectEntryTitle";
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/result/contributor/ObjectEntryModelSummaryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/result/contributor/ObjectEntryModelSummaryContributor.java
@@ -10,6 +10,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Summary;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.spi.model.result.contributor.ModelSummaryContributor;
@@ -31,68 +32,67 @@ public class ObjectEntryModelSummaryContributor
 
 		return new Summary(
 			_getTitle(defaultLanguageId, document, locale),
-			_getContent(defaultLanguageId, document, locale));
+			_getShortenedContent(defaultLanguageId, document, locale));
 	}
 
 	private String _getContent(
 		String defaultLanguageId, Document document, Locale locale) {
 
-		String localizedFieldName = Field.getLocalizedName(
-			locale, _OBJECT_ENTRY_CONTENT);
+		String content = _getLocalizedNestedFieldSnippet(document, locale);
+
+		if (!Validator.isBlank(content)) {
+			return content;
+		}
+
+		if (!Validator.isBlank(defaultLanguageId)) {
+			content = _getLocalizedNestedFieldSnippet(
+				document, LocaleUtil.fromLanguageId(defaultLanguageId));
+
+			if (!Validator.isBlank(content)) {
+				return content;
+			}
+		}
+
+		content = document.get(
+			Field.getLocalizedName(locale, _OBJECT_ENTRY_CONTENT));
+
+		if (!Validator.isBlank(content)) {
+			return content;
+		}
+
+		if (!Validator.isBlank(defaultLanguageId)) {
+			content = document.get(
+				Field.getLocalizedName(
+					defaultLanguageId, _OBJECT_ENTRY_CONTENT));
+
+			if (!Validator.isBlank(content)) {
+				return content;
+			}
+		}
+
+		return document.get(_OBJECT_ENTRY_CONTENT);
+	}
+
+	private String _getLocalizedNestedFieldSnippet(
+		Document document, Locale locale) {
+
+		if (locale == null) {
+			return StringPool.BLANK;
+		}
 
 		String localizedSnippetFieldName = StringBundler.concat(
-			Field.SNIPPET, StringPool.UNDERLINE, localizedFieldName);
+			Field.SNIPPET, StringPool.UNDERLINE,
+			Field.getLocalizedName(locale, _NESTED_FIELD_ARRAY_VALUE));
 
-		String content = document.get(localizedSnippetFieldName);
+		return document.get(localizedSnippetFieldName);
+	}
 
-		if (Validator.isBlank(content)) {
-			String localizedContent = document.get(localizedFieldName);
+	private String _getShortenedContent(
+		String defaultLanguageId, Document document, Locale locale) {
 
-			if (Validator.isNotNull(localizedContent)) {
-				content = StringUtil.shorten(
-					localizedContent, 300, StringPool.TRIPLE_PERIOD);
-			}
-		}
-
-		if (Validator.isBlank(content) &&
-			!Validator.isBlank(defaultLanguageId)) {
-
-			String defaultLocalizedFieldName = Field.getLocalizedName(
-				defaultLanguageId, _OBJECT_ENTRY_CONTENT);
-
-			String defaultLocalizedSnippetFieldName = StringBundler.concat(
-				Field.SNIPPET, StringPool.UNDERLINE, defaultLocalizedFieldName);
-
-			content = document.get(defaultLocalizedSnippetFieldName);
-
-			if (Validator.isBlank(content)) {
-				String localizedContent = document.get(
-					defaultLocalizedFieldName);
-
-				if (Validator.isNotNull(localizedContent)) {
-					content = StringUtil.shorten(
-						localizedContent, 300, StringPool.TRIPLE_PERIOD);
-				}
-			}
-		}
-
-		if (Validator.isBlank(content)) {
-			content = document.get(
-				StringBundler.concat(
-					Field.SNIPPET, StringPool.UNDERLINE,
-					_OBJECT_ENTRY_CONTENT));
-		}
-
-		if (Validator.isBlank(content)) {
-			String nonlocalizedContent = document.get(_OBJECT_ENTRY_CONTENT);
-
-			if (Validator.isNotNull(nonlocalizedContent)) {
-				content = StringUtil.shorten(
-					nonlocalizedContent, 300, StringPool.TRIPLE_PERIOD);
-			}
-		}
-
-		return content;
+		return StringUtil.shorten(
+			_getContent(defaultLanguageId, document, locale), 300,
+			StringPool.TRIPLE_PERIOD);
 	}
 
 	private String _getTitle(
@@ -144,6 +144,9 @@ public class ObjectEntryModelSummaryContributor
 
 		return title;
 	}
+
+	private static final String _NESTED_FIELD_ARRAY_VALUE =
+		"nestedFieldArray.value";
 
 	private static final String _OBJECT_ENTRY_CONTENT = "objectEntryContent";
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/result/contributor/ObjectEntryModelSummaryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/result/contributor/ObjectEntryModelSummaryContributor.java
@@ -5,7 +5,6 @@
 
 package com.liferay.object.internal.search.spi.model.result.contributor;
 
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.search.Document;
@@ -16,7 +15,6 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.spi.model.result.contributor.ModelSummaryContributor;
 
 import java.util.Locale;
-import java.util.Map;
 
 /**
  * @author Bryan Engler
@@ -33,33 +31,12 @@ public class ObjectEntryModelSummaryContributor
 	}
 
 	private String _getContent(Document document, Locale locale) {
-		StringBundler sb = new StringBundler();
+		String languageId = LanguageUtil.getLanguageId(locale);
 
-		Map<String, Field> fields = document.getFields();
-
-		for (Map.Entry<String, Field> entry : fields.entrySet()) {
-			String fieldName = entry.getKey();
-
-			if (fieldName.startsWith("snippet_nestedFieldArray.value")) {
-				Field field = entry.getValue();
-
-				sb.append(
-					StringUtil.merge(
-						field.getValues(), StringPool.TRIPLE_PERIOD));
-
-				sb.append(StringPool.TRIPLE_PERIOD);
-			}
-		}
-
-		if (sb.index() > 0) {
-			sb.setIndex(sb.index() - 1);
-		}
-
-		String content = sb.toString();
+		String content = document.get(
+			"snippet_objectEntryContent_" + languageId);
 
 		if (Validator.isBlank(content)) {
-			String languageId = LanguageUtil.getLanguageId(locale);
-
 			String localizedContent = document.get(
 				"objectEntryContent_" + languageId);
 
@@ -70,9 +47,16 @@ public class ObjectEntryModelSummaryContributor
 		}
 
 		if (Validator.isBlank(content)) {
-			content = StringUtil.shorten(
-				document.get("objectEntryContent"), 300,
-				StringPool.TRIPLE_PERIOD);
+			content = document.get("snippet_objectEntryContent");
+		}
+
+		if (Validator.isBlank(content)) {
+			String nonlocalizedContent = document.get("objectEntryContent");
+
+			if (Validator.isNotNull(nonlocalizedContent)) {
+				content = StringUtil.shorten(
+					nonlocalizedContent, 300, StringPool.TRIPLE_PERIOD);
+			}
 		}
 
 		return content;

--- a/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributorTest.java
+++ b/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributorTest.java
@@ -18,14 +18,17 @@ import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.generic.NestedQuery;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.search.localization.SearchLocalizationHelper;
 import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQueryContributorHelper;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.util.LocalizationImpl;
 
 import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,6 +46,13 @@ public class ObjectEntryKeywordQueryContributorTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		LocalizationUtil localizationUtil = new LocalizationUtil();
+
+		localizationUtil.setLocalization(new LocalizationImpl());
+	}
 
 	@Test
 	public void testContributeWithCustomObjectDefinition() throws Exception {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryModelDocumentContributorTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryModelDocumentContributorTest.java
@@ -63,15 +63,119 @@ public class ObjectEntryModelDocumentContributorTest {
 
 	@FeatureFlag("LPD-17564")
 	@Test
-	public void testContribute() throws Exception {
+	public void testContributeDateField() throws Exception {
+		ObjectDefinition objectDefinition =
+			_addModifiableSystemObjectDefinition(
+				false, "a" + RandomTestUtil.randomString());
+
+		Date displayDate = new Date();
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			TestPropsValues.getGroupId(), objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				Field.DISPLAY_DATE, displayDate
+			).build());
+
+		Document document = new DocumentImpl();
+
+		ModelDocumentContributor<ObjectEntry>
+			objectEntryModelDocumentContributor =
+				_getObjectEntryModelDocumentContributor(objectDefinition);
+
+		objectEntryModelDocumentContributor.contribute(document, objectEntry);
+
+		Field field = document.getField(Field.DISPLAY_DATE);
+
+		Assert.assertEquals(
+			DateUtil.getDate(displayDate, "yyyyMMddHHmmss", LocaleUtil.US),
+			field.getValue());
+	}
+
+	@Test
+	public void testContributeLocalizedFields() throws Exception {
 		String objectFieldName = "a" + RandomTestUtil.randomString();
+
+		ObjectDefinition objectDefinition =
+			_addModifiableSystemObjectDefinition(true, objectFieldName);
+
+		String englishObjectFieldValue = RandomTestUtil.randomString();
+		String portugueseObjectFieldValue =
+			objectFieldName + RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			TestPropsValues.getGroupId(), objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				objectFieldName, englishObjectFieldValue
+			).put(
+				objectFieldName + "_i18n",
+				HashMapBuilder.<String, Serializable>put(
+					"en_US", englishObjectFieldValue
+				).put(
+					"pt_BR", portugueseObjectFieldValue
+				).build()
+			).build());
+
+		Document document = new DocumentImpl();
+
+		ModelDocumentContributor<ObjectEntry>
+			objectEntryModelDocumentContributor =
+				_getObjectEntryModelDocumentContributor(objectDefinition);
+
+		objectEntryModelDocumentContributor.contribute(document, objectEntry);
+
+		_assertObjectEntryContentField(
+			document, englishObjectFieldValue,
+			Field.getLocalizedName(LocaleUtil.US, "objectEntryContent"),
+			objectFieldName);
+		_assertObjectEntryContentField(
+			document, portugueseObjectFieldValue,
+			Field.getLocalizedName(LocaleUtil.BRAZIL, "objectEntryContent"),
+			objectFieldName);
+
+		Assert.assertNull(document.getField("objectEntryContent"));
+	}
+
+	@Test
+	public void testContributeNonlocalizedFields() throws Exception {
+		String objectFieldName = "a" + RandomTestUtil.randomString();
+
+		ObjectDefinition objectDefinition =
+			_addModifiableSystemObjectDefinition(false, objectFieldName);
+
+		String objectFieldValue = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			TestPropsValues.getGroupId(), objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				objectFieldName, objectFieldValue
+			).build());
+
+		Document document = new DocumentImpl();
+
+		ModelDocumentContributor<ObjectEntry>
+			objectEntryModelDocumentContributor =
+				_getObjectEntryModelDocumentContributor(objectDefinition);
+
+		objectEntryModelDocumentContributor.contribute(document, objectEntry);
+
+		_assertObjectEntryContentField(
+			document, objectFieldValue, "objectEntryContent", objectFieldName);
+
+		Assert.assertNull(
+			document.getField(
+				Field.getLocalizedName(LocaleUtil.US, "objectEntryContent")));
+	}
+
+	private ObjectDefinition _addModifiableSystemObjectDefinition(
+			boolean localized, String objectFieldName)
+		throws Exception {
 
 		ObjectField objectField = ObjectFieldUtil.createObjectField(
 			0, ObjectFieldConstants.BUSINESS_TYPE_TEXT, null,
 			ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
 			RandomTestUtil.randomString(), objectFieldName, false, true);
 
-		objectField.setLocalized(true);
+		objectField.setLocalized(localized);
 
 		ObjectDefinition modifiableSystemObjectDefinition =
 			ObjectDefinitionTestUtil.addModifiableSystemObjectDefinition(
@@ -82,57 +186,23 @@ public class ObjectEntryModelDocumentContributorTest {
 				ObjectDefinitionConstants.SCOPE_SITE, null, 1,
 				Arrays.asList(objectField));
 
-		modifiableSystemObjectDefinition =
-			_objectDefinitionLocalService.publishSystemObjectDefinition(
-				TestPropsValues.getUserId(),
-				modifiableSystemObjectDefinition.getObjectDefinitionId());
+		return _objectDefinitionLocalService.publishSystemObjectDefinition(
+			TestPropsValues.getUserId(),
+			modifiableSystemObjectDefinition.getObjectDefinitionId());
+	}
 
-		Date displayDate = new Date();
-		String objectFieldValue = RandomTestUtil.randomString();
+	private void _assertObjectEntryContentField(
+		Document document, String expectedValue, String fieldName,
+		String objectFieldName) {
 
-		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
-			TestPropsValues.getGroupId(), modifiableSystemObjectDefinition,
-			HashMapBuilder.<String, Serializable>put(
-				Field.DISPLAY_DATE, displayDate
-			).put(
-				objectFieldName, objectFieldValue
-			).put(
-				objectFieldName + "_i18n",
-				HashMapBuilder.<String, Serializable>put(
-					"en_US", objectFieldValue
-				).put(
-					"pt_BR", objectFieldValue + "pt_BR"
-				).build()
-			).build());
-
-		Document document = new DocumentImpl();
-
-		ModelDocumentContributor<ObjectEntry>
-			objectEntryModelDocumentContributor =
-				_getObjectEntryModelDocumentContributor(
-					modifiableSystemObjectDefinition);
-
-		objectEntryModelDocumentContributor.contribute(document, objectEntry);
-
-		Field field = document.getField(Field.DISPLAY_DATE);
-
-		Assert.assertEquals(
-			DateUtil.getDate(displayDate, "yyyyMMddHHmmss", LocaleUtil.US),
-			field.getValue());
-
-		field = document.getField("objectEntryContent");
+		Field field = document.getField(fieldName);
 
 		String value = field.getValue();
 
 		Assert.assertTrue(
 			value,
 			value.contains(
-				StringBundler.concat(objectFieldName, ": ", objectFieldValue)));
-		Assert.assertTrue(
-			value,
-			value.contains(
-				StringBundler.concat(
-					objectFieldName, ": ", objectFieldValue, "pt_BR")));
+				StringBundler.concat(objectFieldName, ": ", expectedValue)));
 	}
 
 	private ModelDocumentContributor<ObjectEntry>

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/search/test/ObjectEntrySearchHighlightTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/search/test/ObjectEntrySearchHighlightTest.java
@@ -16,6 +16,7 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.highlight.HighlightUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -138,9 +139,9 @@ public class ObjectEntrySearchHighlightTest {
 		SearchHit searchHit = _search(
 			LocaleUtil.US, _nonlocalizedObjectDefinition,
 			_nonlocalizedObjectEntry);
-
-		_assertHighlight("objectEntryContent", searchHit);
-		_assertNoLocalizedHighlight("objectEntryContent", searchHit);
+//this might not be expected, do Objects always use the Default Locale for non-localized fields?
+		_assertHighlight(_NESTED_FIELD_ARRAY_VALUE, searchHit);
+		_assertNoLocalizedHighlight(_NESTED_FIELD_ARRAY_VALUE, searchHit);
 	}
 
 	@Test
@@ -311,7 +312,7 @@ public class ObjectEntrySearchHighlightTest {
 	}
 
 	private String _getContentFieldName(Locale locale) {
-		return "objectEntryContent_" + LocaleUtil.toLanguageId(locale);
+		return StringBundler.concat(_NESTED_FIELD_ARRAY_VALUE, StringPool.UNDERLINE, LocaleUtil.toLanguageId(locale));
 	}
 
 	private String _getTitleFieldName(Locale locale) {
@@ -361,6 +362,8 @@ public class ObjectEntrySearchHighlightTest {
 		ObjectEntrySearchHighlightTest._KEYWORD,
 		HighlightUtil.HIGHLIGHT_TAG_CLOSE);
 
+	private static final String _NESTED_FIELD_ARRAY_VALUE =
+			"nestedFieldArray.value";
 	private static final String _KEYWORD = "keyword";
 
 	private static final String _LOCALIZED_CONTENT_FIELD_NAME = "localizedText";

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/search/test/ObjectEntrySearchHighlightTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/search/test/ObjectEntrySearchHighlightTest.java
@@ -1,0 +1,376 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.highlight.HighlightUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.document.Document;
+import com.liferay.portal.search.highlight.HighlightField;
+import com.liferay.portal.search.hits.SearchHit;
+import com.liferay.portal.search.hits.SearchHits;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.search.test.rule.SearchTestRule;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Joshua Cords
+ */
+@RunWith(Arquillian.class)
+public class ObjectEntrySearchHighlightTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_localizedObjectDefinition = _addObjectDefinition(true);
+
+		_localizedObjectEntry = _addObjectEntry(
+			true, _localizedObjectDefinition);
+
+		_nonlocalizedObjectDefinition = _addObjectDefinition(false);
+
+		_nonlocalizedObjectEntry = _addObjectEntry(
+			false, _nonlocalizedObjectDefinition);
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		if (_localizedObjectDefinition != null) {
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				_localizedObjectDefinition);
+		}
+
+		if (_nonlocalizedObjectDefinition != null) {
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				_nonlocalizedObjectDefinition);
+		}
+	}
+
+	@Test
+	public void testLocalizedContent() throws Exception {
+		SearchHit searchHit = _search(
+			LocaleUtil.US, _localizedObjectDefinition, _localizedObjectEntry);
+
+		_assertHighlight(_getContentFieldName(LocaleUtil.US), searchHit);
+
+		searchHit = _search(
+			LocaleUtil.SPAIN, _localizedObjectDefinition,
+			_localizedObjectEntry);
+
+		_assertHighlight(_getContentFieldName(LocaleUtil.SPAIN), searchHit);
+	}
+
+	@Test
+	public void testLocalizedTitle() throws Exception {
+		SearchHit searchHit = _search(
+			LocaleUtil.US, _localizedObjectDefinition, _localizedObjectEntry);
+
+		_assertHighlight(_getTitleFieldName(LocaleUtil.US), searchHit);
+
+		searchHit = _search(
+			LocaleUtil.SPAIN, _localizedObjectDefinition,
+			_localizedObjectEntry);
+
+		_assertHighlight(_getTitleFieldName(LocaleUtil.SPAIN), searchHit);
+	}
+
+	@Test
+	public void testNonlocalizedContent() throws Exception {
+		SearchHit searchHit = _search(
+			LocaleUtil.US, _nonlocalizedObjectDefinition,
+			_nonlocalizedObjectEntry);
+
+		_assertHighlight("objectEntryContent", searchHit);
+		_assertNoLocalizedHighlight("objectEntryContent", searchHit);
+	}
+
+	@Test
+	public void testNonlocalizedTitle() throws Exception {
+		SearchHit searchHit = _search(
+			LocaleUtil.US, _nonlocalizedObjectDefinition,
+			_nonlocalizedObjectEntry);
+
+		_assertHighlight("objectEntryTitle", searchHit);
+		_assertNoLocalizedHighlight("objectEntryTitle", searchHit);
+
+		searchHit = _search(
+			LocaleUtil.SPAIN, _nonlocalizedObjectDefinition,
+			_nonlocalizedObjectEntry);
+
+		_assertHighlight("objectEntryTitle", searchHit);
+		_assertNoLocalizedHighlight("objectEntryTitle", searchHit);
+	}
+
+	@Rule
+	public SearchTestRule searchTestRule = new SearchTestRule();
+
+	@Inject
+	protected Searcher searcher;
+
+	@Inject
+	protected SearchRequestBuilderFactory searchRequestBuilderFactory;
+
+	private static ObjectDefinition _addObjectDefinition(boolean localized)
+		throws Exception {
+
+		String contentFieldLabel = "Nonlocalized Field";
+		String contentFieldName = _NONLOCALIZED_CONTENT_FIELD_NAME;
+		String titleFieldLabel = "Title";
+		String titleFieldName = _NONLOCALIZED_TITLE_FIELD_NAME;
+
+		if (localized) {
+			contentFieldLabel = "Localized Field";
+			contentFieldName = _LOCALIZED_CONTENT_FIELD_NAME;
+			titleFieldLabel = "Localized Title";
+			titleFieldName = _LOCALIZED_TITLE_FIELD_NAME;
+		}
+
+		List<ObjectField> objectFields = new ArrayList<>();
+
+		objectFields.add(
+			_buildTextObjectField(
+				contentFieldLabel, localized, contentFieldName));
+
+		objectFields.add(
+			_buildTextObjectField(titleFieldLabel, localized, titleFieldName));
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(objectFields);
+
+		ObjectField titleObjectField = _objectFieldLocalService.getObjectField(
+			objectDefinition.getObjectDefinitionId(), titleFieldName);
+
+		_objectDefinitionLocalService.updateTitleObjectFieldId(
+			objectDefinition.getObjectDefinitionId(),
+			titleObjectField.getObjectFieldId());
+
+		return _objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId());
+	}
+
+	private static ObjectEntry _addObjectEntry(
+			boolean localizedTitle, ObjectDefinition objectDefinition)
+		throws Exception {
+
+		Map<String, Serializable> values = null;
+
+		if (localizedTitle) {
+			values = HashMapBuilder.<String, Serializable>put(
+				_LOCALIZED_CONTENT_FIELD_NAME + "_i18n",
+				HashMapBuilder.put(
+					LocaleUtil.toLanguageId(LocaleUtil.US),
+					"English content " + _KEYWORD
+				).put(
+					LocaleUtil.toLanguageId(LocaleUtil.SPAIN),
+					"Contenido en español " + _KEYWORD
+				).build()
+			).put(
+				_LOCALIZED_TITLE_FIELD_NAME + "_i18n",
+				HashMapBuilder.put(
+					LocaleUtil.toLanguageId(LocaleUtil.US),
+					"English title with " + _KEYWORD
+				).put(
+					LocaleUtil.toLanguageId(LocaleUtil.SPAIN),
+					"Título en español " + _KEYWORD
+				).build()
+			).build();
+		}
+		else {
+			values = HashMapBuilder.<String, Serializable>put(
+				_NONLOCALIZED_CONTENT_FIELD_NAME, "General content " + _KEYWORD
+			).put(
+				_NONLOCALIZED_TITLE_FIELD_NAME, "General title " + _KEYWORD
+			).build();
+		}
+
+		return _objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null, values, ServiceContextTestUtil.getServiceContext());
+	}
+
+	private static ObjectField _buildTextObjectField(
+		String label, boolean localized, String name) {
+
+		return new TextObjectFieldBuilder(
+		).indexed(
+			true
+		).indexedAsKeyword(
+			false
+		).labelMap(
+			LocalizedMapUtil.getLocalizedMap(label)
+		).localized(
+			localized
+		).name(
+			name
+		).build();
+	}
+
+	private void _assertHighlight(
+		String highlightFieldName, SearchHit searchHit) {
+
+		Map<String, HighlightField> highlightFieldsMap =
+			searchHit.getHighlightFieldsMap();
+
+		HighlightField highlightField = highlightFieldsMap.get(
+			highlightFieldName);
+
+		Assert.assertNotNull(
+			"Missing highlight field " + highlightFieldName, highlightField);
+
+		List<String> fragments = highlightField.getFragments();
+
+		Assert.assertFalse(
+			"Highlight fragments missing for " + highlightFieldName,
+			fragments.isEmpty());
+
+		for (String fragment : fragments) {
+			Assert.assertTrue(
+				"Missing highlight markup in fragment: " + fragment,
+				fragment.contains(_HIGHLIGHTED_RESULT));
+		}
+	}
+
+	private void _assertNoLocalizedHighlight(
+		String fieldName, SearchHit searchHit) {
+
+		Map<String, HighlightField> highlightFieldsMap =
+			searchHit.getHighlightFieldsMap();
+
+		Locale[] locales = {LocaleUtil.US, LocaleUtil.SPAIN};
+
+		for (Locale locale : locales) {
+			String localizedFieldName =
+				fieldName + "_" + LocaleUtil.toLanguageId(locale);
+
+			Assert.assertFalse(
+				"Unexpected localized highlight " + localizedFieldName,
+				highlightFieldsMap.containsKey(localizedFieldName));
+		}
+	}
+
+	private String _getContentFieldName(Locale locale) {
+		return "objectEntryContent_" + LocaleUtil.toLanguageId(locale);
+	}
+
+	private String _getTitleFieldName(Locale locale) {
+		return "objectEntryTitle_" + LocaleUtil.toLanguageId(locale);
+	}
+
+	private SearchHit _search(
+			Locale locale, ObjectDefinition objectDefinition,
+			ObjectEntry objectEntry)
+		throws Exception {
+
+		SearchResponse searchResponse = searcher.search(
+			searchRequestBuilderFactory.builder(
+			).companyId(
+				TestPropsValues.getCompanyId()
+			).entryClassNames(
+				objectDefinition.getClassName()
+			).highlightEnabled(
+				true
+			).locale(
+				locale
+			).queryString(
+				_KEYWORD
+			).size(
+				1
+			).build());
+
+		SearchHits searchHits = searchResponse.getSearchHits();
+
+		List<SearchHit> searchHitList = searchHits.getSearchHits();
+
+		Assert.assertFalse(searchHitList.toString(), searchHitList.isEmpty());
+
+		SearchHit searchHit = searchHitList.get(0);
+
+		Document document = searchHit.getDocument();
+
+		Assert.assertEquals(
+			String.valueOf(objectEntry.getObjectEntryId()),
+			document.getString(Field.ENTRY_CLASS_PK));
+
+		return searchHit;
+	}
+
+	private static final String _HIGHLIGHTED_RESULT = StringBundler.concat(
+		HighlightUtil.HIGHLIGHT_TAG_OPEN,
+		ObjectEntrySearchHighlightTest._KEYWORD,
+		HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+
+	private static final String _KEYWORD = "keyword";
+
+	private static final String _LOCALIZED_CONTENT_FIELD_NAME = "localizedText";
+
+	private static final String _LOCALIZED_TITLE_FIELD_NAME = "localizedTitle";
+
+	private static final String _NONLOCALIZED_CONTENT_FIELD_NAME =
+		"nonlocalizedText";
+
+	private static final String _NONLOCALIZED_TITLE_FIELD_NAME = "title";
+
+	private static ObjectDefinition _localizedObjectDefinition;
+	private static ObjectEntry _localizedObjectEntry;
+	private static ObjectDefinition _nonlocalizedObjectDefinition;
+	private static ObjectEntry _nonlocalizedObjectEntry;
+
+	@Inject
+	private static ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private static ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private static ObjectFieldLocalService _objectFieldLocalService;
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/search/test/ObjectEntrySearchHighlightTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/search/test/ObjectEntrySearchHighlightTest.java
@@ -93,6 +93,19 @@ public class ObjectEntrySearchHighlightTest {
 	}
 
 	@Test
+	public void testDefaultLocaleFallback() throws Exception {
+		SearchHit searchHit = _search(
+			LocaleUtil.HUNGARY, _localizedObjectDefinition,
+			_localizedObjectEntry);
+
+		Locale defaultLocale = LocaleUtil.fromLanguageId(
+			_localizedObjectDefinition.getDefaultLanguageId());
+
+		_assertHighlight(_getContentFieldName(defaultLocale), searchHit);
+		_assertHighlight(_getTitleFieldName(defaultLocale), searchHit);
+	}
+
+	@Test
 	public void testLocalizedContent() throws Exception {
 		SearchHit searchHit = _search(
 			LocaleUtil.US, _localizedObjectDefinition, _localizedObjectEntry);

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/hits/HitsMetadataTranslator.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/hits/HitsMetadataTranslator.java
@@ -8,6 +8,7 @@ package com.liferay.portal.search.elasticsearch8.internal.hits;
 import co.elastic.clients.elasticsearch.core.explain.Explanation;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
+import co.elastic.clients.elasticsearch.core.search.InnerHitsResult;
 import co.elastic.clients.elasticsearch.core.search.TotalHits;
 import co.elastic.clients.json.JsonData;
 
@@ -78,7 +79,7 @@ public class HitsMetadataTranslator {
 		SearchHitBuilder searchHitBuilder = new SearchHitBuilder();
 
 		return searchHitBuilder.addHighlightFields(
-			_translateHighlightFields(hit.highlight())
+			_translateHighlightFields(hit)
 		).addSources(
 			_translateSource(hit.source())
 		).document(
@@ -109,6 +110,48 @@ public class HitsMetadataTranslator {
 		return StringPool.BLANK;
 	}
 
+	private void _populateHighlightFields(
+		Hit<JsonData> hit, List<HighlightField> highlightFields) {
+
+		Map<String, List<String>> highlight = hit.highlight();
+
+		if (highlight != null) {
+			for (Map.Entry<String, List<String>> entry : highlight.entrySet()) {
+				highlightFields.add(
+					new HighlightFieldBuilder(
+					).fragments(
+						entry.getValue()
+					).name(
+						entry.getKey()
+					).build());
+			}
+		}
+
+		Map<String, InnerHitsResult> innerHits = hit.innerHits();
+
+		if ((innerHits == null) || innerHits.isEmpty()) {
+			return;
+		}
+
+		for (InnerHitsResult innerHitsResult : innerHits.values()) {
+			HitsMetadata<JsonData> hitsMetadata = innerHitsResult.hits();
+
+			if (hitsMetadata == null) {
+				continue;
+			}
+
+			List<Hit<JsonData>> hits = hitsMetadata.hits();
+
+			if (hits == null) {
+				continue;
+			}
+
+			for (Hit<JsonData> innerHit : hits) {
+				_populateHighlightFields(innerHit, highlightFields);
+			}
+		}
+	}
+
 	private Document _translateDocument(
 		String alternateUidFieldName, Hit<JsonData> hit) {
 
@@ -128,20 +171,10 @@ public class HitsMetadataTranslator {
 		return documentBuilder.build();
 	}
 
-	private List<HighlightField> _translateHighlightFields(
-		Map<String, List<String>> highlight) {
-
+	private List<HighlightField> _translateHighlightFields(Hit<JsonData> hit) {
 		List<HighlightField> highlightFields = new ArrayList<>();
 
-		for (Map.Entry<String, List<String>> entry : highlight.entrySet()) {
-			highlightFields.add(
-				new HighlightFieldBuilder(
-				).fragments(
-					entry.getValue()
-				).name(
-					entry.getKey()
-				).build());
-		}
+		_populateHighlightFields(hit, highlightFields);
 
 		return highlightFields;
 	}

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/legacy/query/ElasticsearchQueryVisitor.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/legacy/query/ElasticsearchQueryVisitor.java
@@ -20,11 +20,14 @@ import co.elastic.clients.elasticsearch._types.query_dsl.QueryVariant;
 import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.TextQueryType;
 import co.elastic.clients.elasticsearch._types.query_dsl.ZeroTermsQuery;
+import co.elastic.clients.elasticsearch.core.search.Highlight;
+import co.elastic.clients.elasticsearch.core.search.InnerHits;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.QueryTerm;
 import com.liferay.portal.kernel.search.TermQuery;
 import com.liferay.portal.kernel.search.TermRangeQuery;
@@ -43,6 +46,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.elasticsearch8.internal.filter.ElasticsearchFilterVisitor;
+import com.liferay.portal.search.elasticsearch8.internal.highlight.HighlightTranslator;
 import com.liferay.portal.search.elasticsearch8.internal.util.QueryUtil;
 import com.liferay.portal.search.elasticsearch8.internal.util.SetterUtil;
 
@@ -326,6 +330,29 @@ public class ElasticsearchQueryVisitor implements QueryVisitor<QueryVariant> {
 		builder.query(new Query(query.accept(this)));
 
 		builder.scoreMode(ChildScoreMode.Sum);
+
+		if (nestedQuery.isInnerHitsEnabled()) {
+			QueryConfig nestedQueryConfig = nestedQuery.getQueryConfig();
+
+			Highlight highlight = _highlightTranslator.translate(
+				nestedQueryConfig.getHighlightFieldNames(),
+				nestedQueryConfig.getHighlightFragmentSize(),
+				nestedQueryConfig.isHighlightRequireFieldMatch(),
+				nestedQueryConfig.getHighlightSnippetSize());
+
+			if (highlight != null) {
+				InnerHits.Builder innerHitsBuilder = new InnerHits.Builder(
+				).highlight(
+					highlight
+				);
+
+				if (Validator.isNotNull(nestedQuery.getInnerHitsName())) {
+					innerHitsBuilder.name(nestedQuery.getInnerHitsName());
+				}
+
+				builder.innerHits(innerHitsBuilder.build());
+			}
+		}
 
 		return builder.build();
 	}
@@ -647,5 +674,8 @@ public class ElasticsearchQueryVisitor implements QueryVisitor<QueryVariant> {
 		throw new IllegalArgumentException(
 			"Invalid multi match query type " + type);
 	}
+
+	private final HighlightTranslator _highlightTranslator =
+		new HighlightTranslator();
 
 }

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/response/SearchResponseTranslator.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/response/SearchResponseTranslator.java
@@ -13,6 +13,7 @@ import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
 import co.elastic.clients.elasticsearch._types.aggregations.TopHitsAggregate;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
+import co.elastic.clients.elasticsearch.core.search.InnerHitsResult;
 import co.elastic.clients.elasticsearch.core.search.ResponseBody;
 import co.elastic.clients.elasticsearch.core.search.TotalHits;
 import co.elastic.clients.json.JsonData;
@@ -91,6 +92,30 @@ public class SearchResponseTranslator {
 			_statsTranslator.translateResponse(aggregates, _translate(stats)));
 	}
 
+	private void _addInnerHitsSnippets(
+		Document document, Hit<JsonData> hit, Locale locale) {
+
+		Map<String, InnerHitsResult> innerHits = hit.innerHits();
+
+		if (MapUtil.isEmpty(innerHits)) {
+			return;
+		}
+
+		for (InnerHitsResult innerHitsResult : innerHits.values()) {
+			HitsMetadata<JsonData> hitsMetadata = innerHitsResult.hits();
+
+			if ((hitsMetadata == null) ||
+				ListUtil.isEmpty(hitsMetadata.hits())) {
+
+				continue;
+			}
+
+			for (Hit<JsonData> innerHit : hitsMetadata.hits()) {
+				_addSnippets(document, innerHit, locale);
+			}
+		}
+	}
+
 	private void _addSnippets(
 		Document document, Hit<JsonData> hit, Locale locale) {
 
@@ -100,6 +125,8 @@ public class SearchResponseTranslator {
 			hit.highlight(),
 			(fieldName, fragments) -> _addSnippets(
 				document, fieldName, highlights, locale));
+
+		_addInnerHitsSnippets(document, hit, locale);
 	}
 
 	private void _addSnippets(

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/response/SearchResponseTranslator.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/response/SearchResponseTranslator.java
@@ -129,6 +129,7 @@ public class SearchResponseTranslator {
 		_addInnerHitsSnippets(document, hit, locale);
 	}
 
+	//this adds snippets to com.liferay.portal.kernel.search.Documents
 	private void _addSnippets(
 		Document document, String fieldName,
 		Map<String, List<String>> highlights, Locale locale) {

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/hits/HitsMetadataTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/hits/HitsMetadataTranslator.java
@@ -34,6 +34,7 @@ import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.core.explain.Explanation;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.core.search.HitsMetadata;
+import org.opensearch.client.opensearch.core.search.InnerHitsResult;
 import org.opensearch.client.opensearch.core.search.TotalHits;
 
 /**
@@ -76,7 +77,7 @@ public class HitsMetadataTranslator {
 		SearchHitBuilder searchHitBuilder = new SearchHitBuilder();
 
 		return searchHitBuilder.addHighlightFields(
-			_translateHighlightFields(hit.highlight())
+			_translateHighlightFields(hit)
 		).addSources(
 			_translateSource(hit.source())
 		).document(
@@ -126,21 +127,55 @@ public class HitsMetadataTranslator {
 	}
 
 	private List<HighlightField> _translateHighlightFields(
-		Map<String, List<String>> highlight) {
+		Hit<JsonData> hit) {
 
 		List<HighlightField> highlightFields = new ArrayList<>();
 
-		for (Map.Entry<String, List<String>> entry : highlight.entrySet()) {
-			highlightFields.add(
-				new HighlightFieldBuilder(
-				).fragments(
-					entry.getValue()
-				).name(
-					entry.getKey()
-				).build());
-		}
+		_populateHighlightFields(hit, highlightFields);
 
 		return highlightFields;
+	}
+
+	private void _populateHighlightFields(
+		Hit<JsonData> hit, List<HighlightField> highlightFields) {
+
+		Map<String, List<String>> highlight = hit.highlight();
+
+		if (highlight != null) {
+			for (Map.Entry<String, List<String>> entry : highlight.entrySet()) {
+				highlightFields.add(
+					new HighlightFieldBuilder(
+					).fragments(
+						entry.getValue()
+					).name(
+						entry.getKey()
+					).build());
+			}
+		}
+
+		Map<String, InnerHitsResult> innerHits = hit.innerHits();
+
+		if ((innerHits == null) || innerHits.isEmpty()) {
+			return;
+		}
+
+		for (InnerHitsResult innerHitsResult : innerHits.values()) {
+			HitsMetadata<JsonData> hitsMetadata = innerHitsResult.hits();
+
+			if (hitsMetadata == null) {
+				continue;
+			}
+
+			List<Hit<JsonData>> hits = hitsMetadata.hits();
+
+			if (hits == null) {
+				continue;
+			}
+
+			for (Hit<JsonData> innerHit : hits) {
+				_populateHighlightFields(innerHit, highlightFields);
+			}
+		}
 	}
 
 	private Map<String, Object> _translateSource(JsonData jsonData) {

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/legacy/query/OpenSearchQueryVisitor.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/legacy/query/OpenSearchQueryVisitor.java
@@ -9,6 +9,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.QueryTerm;
 import com.liferay.portal.kernel.search.TermQuery;
 import com.liferay.portal.kernel.search.TermRangeQuery;
@@ -23,10 +24,12 @@ import com.liferay.portal.kernel.search.generic.MultiMatchQuery;
 import com.liferay.portal.kernel.search.generic.NestedQuery;
 import com.liferay.portal.kernel.search.generic.StringQuery;
 import com.liferay.portal.kernel.search.query.QueryVisitor;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.opensearch2.internal.filter.OpenSearchFilterVisitor;
+import com.liferay.portal.search.opensearch2.internal.highlight.HighlightTranslator;
 import com.liferay.portal.search.opensearch2.internal.util.QueryUtil;
 import com.liferay.portal.search.opensearch2.internal.util.SetterUtil;
 
@@ -49,6 +52,8 @@ import org.opensearch.client.opensearch._types.query_dsl.QueryVariant;
 import org.opensearch.client.opensearch._types.query_dsl.RangeQuery;
 import org.opensearch.client.opensearch._types.query_dsl.TextQueryType;
 import org.opensearch.client.opensearch._types.query_dsl.ZeroTermsQuery;
+import org.opensearch.client.opensearch.core.search.Highlight;
+import org.opensearch.client.opensearch.core.search.InnerHits;
 
 /**
  * @author André de Oliveira
@@ -329,6 +334,32 @@ public class OpenSearchQueryVisitor implements QueryVisitor<QueryVariant> {
 		builder.query(new Query(query.accept(this)));
 
 		builder.scoreMode(ChildScoreMode.Sum);
+
+		if (nestedQuery.isInnerHitsEnabled()) {
+			QueryConfig nestedQueryConfig = nestedQuery.getQueryConfig();
+
+			Highlight highlight = _highlightTranslator.translate(
+				nestedQueryConfig.getHighlightFieldNames(),
+				nestedQueryConfig.getHighlightFragmentSize(),
+				nestedQueryConfig.isHighlightRequireFieldMatch(),
+				nestedQueryConfig.getHighlightSnippetSize());
+
+			if ((highlight != null) &&
+				ArrayUtil.isNotEmpty(
+					nestedQueryConfig.getHighlightFieldNames())) {
+
+				InnerHits.Builder innerHitsBuilder = new InnerHits.Builder(
+				).highlight(
+					highlight
+				);
+
+				if (Validator.isNotNull(nestedQuery.getInnerHitsName())) {
+					innerHitsBuilder.name(nestedQuery.getInnerHitsName());
+				}
+
+				builder.innerHits(innerHitsBuilder.build());
+			}
+		}
 
 		return builder.build();
 	}
@@ -643,5 +674,8 @@ public class OpenSearchQueryVisitor implements QueryVisitor<QueryVariant> {
 		throw new IllegalArgumentException(
 			"Invalid multi match query type " + type);
 	}
+
+	private static final HighlightTranslator _highlightTranslator =
+		new HighlightTranslator();
 
 }

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/response/SearchResponseTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/response/SearchResponseTranslator.java
@@ -49,6 +49,7 @@ import org.opensearch.client.opensearch._types.aggregations.TopHitsAggregate;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.core.search.HitsMetadata;
+import org.opensearch.client.opensearch.core.search.InnerHitsResult;
 import org.opensearch.client.opensearch.core.search.TotalHits;
 
 /**
@@ -93,6 +94,30 @@ public class SearchResponseTranslator {
 			_statsTranslator.translateResponse(aggregates, _translate(stats)));
 	}
 
+	private void _addInnerHitsSnippets(
+		Document document, Hit<JsonData> hit, Locale locale) {
+
+		Map<String, InnerHitsResult> innerHits = hit.innerHits();
+
+		if (MapUtil.isEmpty(innerHits)) {
+			return;
+		}
+
+		for (InnerHitsResult innerHitsResult : innerHits.values()) {
+			HitsMetadata<JsonData> hitsMetadata = innerHitsResult.hits();
+
+			if ((hitsMetadata == null) ||
+				ListUtil.isEmpty(hitsMetadata.hits())) {
+
+				continue;
+			}
+
+			for (Hit<JsonData> innerHit : hitsMetadata.hits()) {
+				_addSnippets(document, innerHit, locale);
+			}
+		}
+	}
+
 	private void _addSnippets(
 		Document document, Hit<JsonData> hit, Locale locale) {
 
@@ -102,6 +127,8 @@ public class SearchResponseTranslator {
 			hit.highlight(),
 			(fieldName, fragments) -> _addSnippets(
 				document, fieldName, highlights, locale));
+
+		_addInnerHitsSnippets(document, hit, locale);
 	}
 
 	private void _addSnippets(

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/NestedQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/NestedQuery.java
@@ -25,6 +25,10 @@ public class NestedQuery extends BaseQueryImpl {
 		return queryVisitor.visitQuery(this);
 	}
 
+	public String getInnerHitsName() {
+		return _innerHitsName;
+	}
+
 	public String getPath() {
 		return _path;
 	}
@@ -40,6 +44,18 @@ public class NestedQuery extends BaseQueryImpl {
 		}
 
 		return false;
+	}
+
+	public boolean isInnerHitsEnabled() {
+		return _innerHitsEnabled;
+	}
+
+	public void setInnerHitsEnabled(boolean innerHitsEnabled) {
+		_innerHitsEnabled = innerHitsEnabled;
+	}
+
+	public void setInnerHitsName(String innerHitsName) {
+		_innerHitsName = innerHitsName;
 	}
 
 	@Override
@@ -61,6 +77,8 @@ public class NestedQuery extends BaseQueryImpl {
 		return sb.toString();
 	}
 
+	private boolean _innerHitsEnabled;
+	private String _innerHitsName;
 	private final String _path;
 	private final Query _query;
 

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-72159
https://liferay.atlassian.net/browse/LPD-75868

This localizes objectEntryContent and allows highlighting for it.

Still ToDo: Reimplement Shuyang's performance improvements from https://github.com/liferay/liferay-portal/commit/5c34474a1f9a0538d3ec0ca760e31a284df1aff3

Add nested highlight fields based off of their nested fields names instead of all being ...value_en_US.

Hi @BryanEngler,

If you could take a last look at this, in particular the nested array highlight direction and point out anything that looks like it will be a bad idea to support. Thanks!