### PR TITLE
LPD-84891 Display basic OpenSearch connection information in the Search admin when using AWS OpenSearch Service

### DIFF
--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/information/OpenSearchSearchEngineInformation.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/information/OpenSearchSearchEngineInformation.java
@@ -347,8 +347,7 @@ public class OpenSearchSearchEngineInformation
 
 		JsonObject jsonObject = _getNodesInfoJsonObject(openSearchClient);
 
-		String clusterName = GetterUtil.getString(
-			jsonObject.getString("cluster_name", null));
+		String clusterName = jsonObject.getString("cluster_name", StringPool.BLANK);
 
 		connectionInformationBuilder.clusterName(clusterName);
 
@@ -365,11 +364,9 @@ public class OpenSearchSearchEngineInformation
 					nodeInformationBuilderFactory.getNodeInformationBuilder();
 
 				nodeInformationBuilder.name(
-					GetterUtil.getString(
-						nodeJsonObject.getString("name", null)));
+					nodeJsonObject.getString("name", StringPool.BLANK));
 				nodeInformationBuilder.version(
-					GetterUtil.getString(
-						nodeJsonObject.getString("version", null)));
+					nodeJsonObject.getString("version", StringPool.BLANK));
 
 				nodeInformationList.add(nodeInformationBuilder.build());
 			}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/information/OpenSearchSearchEngineInformation.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/information/OpenSearchSearchEngineInformation.java
@@ -10,7 +10,6 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.engine.ConnectionInformation;
@@ -347,7 +346,8 @@ public class OpenSearchSearchEngineInformation
 
 		JsonObject jsonObject = _getNodesInfoJsonObject(openSearchClient);
 
-		String clusterName = jsonObject.getString("cluster_name", StringPool.BLANK);
+		String clusterName = jsonObject.getString(
+			"cluster_name", StringPool.BLANK);
 
 		connectionInformationBuilder.clusterName(clusterName);
 

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/information/OpenSearchSearchEngineInformation.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/information/OpenSearchSearchEngineInformation.java
@@ -28,20 +28,21 @@ import com.liferay.portal.search.opensearch2.internal.configuration.OpenSearchCo
 import com.liferay.portal.search.opensearch2.internal.connection.OpenSearchConnection;
 import com.liferay.portal.search.opensearch2.internal.connection.OpenSearchConnectionManager;
 
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Dictionary;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
+import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.opensearch.OpenSearchClient;
-import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch._types.TimeUnit;
-import org.opensearch.client.opensearch.nodes.NodesInfoRequest;
-import org.opensearch.client.opensearch.nodes.NodesInfoResponse;
-import org.opensearch.client.opensearch.nodes.OpenSearchNodesClient;
-import org.opensearch.client.opensearch.nodes.info.NodeInfo;
+import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.Version;
+import org.opensearch.client.transport.endpoints.SimpleEndpoint;
 
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -320,39 +321,58 @@ public class OpenSearchSearchEngineInformation
 		}
 	}
 
+	private JsonObject _getNodesInfoJsonObject(
+			OpenSearchClient openSearchClient)
+		throws Exception {
+
+		OpenSearchTransport openSearchTransport = openSearchClient._transport();
+
+		JsonValue jsonValue = openSearchTransport.performRequest(
+			null,
+			new SimpleEndpoint<>(
+				nodesInfoEndpointRequest -> "GET", request -> "/_nodes",
+				nodesInfoEndpointRequest -> Collections.singletonMap(
+					"timeout", "10000" + TimeUnit.Milliseconds.jsonValue()),
+				nodesInfoEndpointRequest -> Collections.emptyMap(), false,
+				JsonpDeserializer.jsonValueDeserializer()),
+			null);
+
+		return jsonValue.asJsonObject();
+	}
+
 	private void _setClusterAndNodeInformation(
 			ConnectionInformationBuilder connectionInformationBuilder,
 			OpenSearchClient openSearchClient)
 		throws Exception {
 
-		OpenSearchNodesClient openSearchNodesClient = openSearchClient.nodes();
-
-		NodesInfoResponse nodesInfoResponse = openSearchNodesClient.info(
-			NodesInfoRequest.of(
-				nodesInforequest -> nodesInforequest.timeout(
-					Time.of(
-						time -> time.time(
-							"10000" + TimeUnit.Milliseconds.jsonValue())))));
+		JsonObject jsonObject = _getNodesInfoJsonObject(openSearchClient);
 
 		String clusterName = GetterUtil.getString(
-			nodesInfoResponse.clusterName());
+			jsonObject.getString("cluster_name", null));
 
 		connectionInformationBuilder.clusterName(clusterName);
 
-		Map<String, NodeInfo> nodeInfos = nodesInfoResponse.nodes();
-
 		List<NodeInformation> nodeInformationList = new ArrayList<>();
 
-		for (Map.Entry<String, NodeInfo> entry : nodeInfos.entrySet()) {
-			NodeInfo nodeInfo = entry.getValue();
+		JsonObject nodesJsonObject = jsonObject.getJsonObject("nodes");
 
-			NodeInformationBuilder nodeInformationBuilder =
-				nodeInformationBuilderFactory.getNodeInformationBuilder();
+		if (nodesJsonObject != null) {
+			for (String nodeId : nodesJsonObject.keySet()) {
+				JsonObject nodeJsonObject = nodesJsonObject.getJsonObject(
+					nodeId);
 
-			nodeInformationBuilder.name(nodeInfo.name());
-			nodeInformationBuilder.version(nodeInfo.version());
+				NodeInformationBuilder nodeInformationBuilder =
+					nodeInformationBuilderFactory.getNodeInformationBuilder();
 
-			nodeInformationList.add(nodeInformationBuilder.build());
+				nodeInformationBuilder.name(
+					GetterUtil.getString(
+						nodeJsonObject.getString("name", null)));
+				nodeInformationBuilder.version(
+					GetterUtil.getString(
+						nodeJsonObject.getString("version", null)));
+
+				nodeInformationList.add(nodeInformationBuilder.build());
+			}
 		}
 
 		connectionInformationBuilder.nodeInformationList(nodeInformationList);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84891

**What is this trying to solve?**
--
AWS omits some operating system-related information, possibly for security reasons. This breaks the Opensearch specification regarding required fields in the endpoint `https://opensearch/_nodes`, causing the error: `Missing required property 'NodeOperatingSystemInfo.arch'`

**How am I fixing it?**
--
The way the opensearch2 connector obtains information from node was changed, no longer using native request classes from the opensearch-java library, and we started extracting JSON data manually.

**Note**
--
There was an attempt to use ApiTypeHelper.DANGEROUS_disableRequiredPropertiesCheck(true)* to prevent the suggested change in these PRs, but it didn't work. It seems that it didn't work because ThreadLocal was not synchronized, perhaps due to some OSGI issue.

*https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/8.19/missing-required-property.html (This method is also available in the opensearch-java library)

We followed the same strategy to correct another endpoint: https://github.com/liferay-search/liferay-portal/pull/1857

**How can you verify that it works?**
--
1. Creating an environment that uses AWS Opensearch 2 (Follow the guide https://liferay.atlassian.net/wiki/spaces/ENGSEARCH/pages/4712628357/Guide+Create+test+environment+with+Liferay+DXP+AWS+OpenSearch+Service)
2. Access the Liferay Portal > Control Panel > Search > Connections

**Expected result:**
The page is rendered without errors, and the cluster information and nodes with their respective names and versions are displayed.