### PR TITLE
LPP-63633 Add support for List values in SXP parameters

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/util/SXPParameterDataCreatorUtil.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/util/SXPParameterDataCreatorUtil.java
@@ -382,7 +382,16 @@ public class SXPParameterDataCreatorUtil {
 		}
 
 		if (object != null) {
-			return ArrayUtil.toArray(GetterUtil.getIntegerValues(object));
+			int[] fromArray = GetterUtil.getIntegerValues(object);
+
+			if (ArrayUtil.isNotEmpty(fromArray)) {
+				return ArrayUtil.toArray(fromArray);
+			}
+			else if (object instanceof List<?> list) {
+				if (list.stream().allMatch(e -> e instanceof Integer)) {
+					return list.toArray(new Integer[0]);
+				}
+			}
 		}
 
 		if (defaultValue != null) {
@@ -441,7 +450,16 @@ public class SXPParameterDataCreatorUtil {
 		}
 
 		if (object != null) {
-			return ArrayUtil.toArray(GetterUtil.getLongValues(object));
+			long[] fromArray = GetterUtil.getLongValues(object);
+
+			if (ArrayUtil.isNotEmpty(fromArray)) {
+				return ArrayUtil.toArray(fromArray);
+			}
+			else if (object instanceof List<?> list) {
+				if (list.stream().allMatch(e -> e instanceof Long)) {
+					return list.toArray(new Long[0]);
+				}
+			}
 		}
 
 		if (defaultValue != null) {
@@ -494,7 +512,16 @@ public class SXPParameterDataCreatorUtil {
 		String[] defaultValue, Object object) {
 
 		if (object != null) {
-			return GetterUtil.getStringValues(object);
+			String[] fromArray = GetterUtil.getStringValues(object);
+
+			if (ArrayUtil.isNotEmpty(fromArray)) {
+				return fromArray;
+			}
+			else if (object instanceof List<?> list) {
+				if (list.stream().allMatch(e -> e instanceof String)) {
+					return list.toArray(new String[0]);
+				}
+			}
 		}
 
 		if (defaultValue != null) {


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPP-63633

The customer's issue is a misalignment of string array representations between request json -> search experiences code -> Query DSL sent to Elasticsearch.  Adding support for this case in the `search-experiences-service` seemed like the better approach than touching the json deserialization in `portal-kernel`. 