### PR TITLE
LPD-85988 OpenSearch connector is generating the multi_match query without fields

### DIFF
--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/legacy/query/OpenSearchQueryVisitor.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/legacy/query/OpenSearchQueryVisitor.java
@@ -267,9 +267,14 @@ public class OpenSearchQueryVisitor implements QueryVisitor<QueryVariant> {
 		SetterUtil.setNotNullFloatAsDouble(
 			builder::cutoffFrequency, multiMatchQuery.getCutOffFrequency());
 
-		builder.fields(
-			QueryUtil.fieldsBoostsToFieldsWithBoosts(
-				multiMatchQuery.getFieldsBoosts()));
+		List<String> fields = QueryUtil.fieldsBoostsToFieldsWithBoosts(
+			multiMatchQuery.getFieldsBoosts());
+
+		if (fields.isEmpty()) {
+			fields = ListUtil.fromCollection(multiMatchQuery.getFields());
+		}
+
+		builder.fields(fields);
 
 		SetterUtil.setNotBlankString(
 			builder::fuzziness, multiMatchQuery.getFuzziness());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85988


**What is this trying to solve?**
--
When performing a product search in Commerce using an Opensearch connector, the search result is inconsistent.

**How am I fixing it?**
--
To add fields to the building, we first use the FieldsBoosts field; if it's not defined, we use only Fields (deprecated field). This is because the legacy `MultiMatchQuery` class is separating the values ​​into distinct fields: `_fields` (deprecated) and `_fieldsBoosts` (new attribute).

**How can you verify that it works?**
--

1. Setup and Use OpenSearch
2. On the Liferay Portal, Go to Control Panel > Commerce > Products and add a product
Name: P1
SKU: add a SKU called kw-1
Publish the product
3. Go to the Products main page again
4. Use the search bar and search for 'boo'
5. Use the search bar and search for 'book'

**Expected result:**
Action 4 and 5 should not return products