### PR TITLE
LPP-63635 Add proper default of path=null for empty reverse_nested aggregation config

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/aggregation/AggregationWrapperConverter.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/aggregation/AggregationWrapperConverter.java
@@ -1177,7 +1177,8 @@ public class AggregationWrapperConverter {
 	private ReverseNestedAggregation _toReverseNestedAggregation(
 		JSONObject jsonObject, String name) {
 
-		return _aggregations.reverseNested(name, jsonObject.getString("path"));
+		return _aggregations.reverseNested(
+			name, jsonObject.getString("path", null));
 	}
 
 	private SamplerAggregation _toSamplerAggregation(


### PR DESCRIPTION
Investigation LPP ticket: https://liferay.atlassian.net/browse/LPP-63635

This fixes the case where an empty config for a reverse_nested aggregation in a search blueprint resolves to an empty string for the `path` attribute, which is the incorrect input to Elasticsearch and breaks the aggregation behavior.

Note: If this change passes review and if the LPP issue is confirmed to be a bug, I'll create an LPD and change this commit message accordingly 