### PR TITLE
LPD-86525 search-experiences-service: Use path=null for empty reverse_nested aggregation config

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/aggregation/AggregationWrapperConverter.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/aggregation/AggregationWrapperConverter.java
@@ -1177,7 +1177,8 @@ public class AggregationWrapperConverter {
 	private ReverseNestedAggregation _toReverseNestedAggregation(
 		JSONObject jsonObject, String name) {
 
-		return _aggregations.reverseNested(name, jsonObject.getString("path"));
+		return _aggregations.reverseNested(
+			name, jsonObject.getString("path", null));
 	}
 
 	private SamplerAggregation _toSamplerAggregation(

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/test/java/com/liferay/search/experiences/internal/blueprint/aggregation/AggregationWrapperConverterTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/test/java/com/liferay/search/experiences/internal/blueprint/aggregation/AggregationWrapperConverterTest.java
@@ -1,0 +1,74 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.search.experiences.internal.blueprint.aggregation;
+
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.search.aggregation.bucket.ReverseNestedAggregation;
+import com.liferay.portal.search.internal.aggregation.AggregationsImpl;
+import com.liferay.portal.search.significance.SignificanceHeuristics;
+import com.liferay.portal.search.sort.Sorts;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.search.experiences.internal.blueprint.highlight.HighlightConverter;
+import com.liferay.search.experiences.internal.blueprint.query.QueryConverter;
+import com.liferay.search.experiences.internal.blueprint.script.ScriptConverter;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jason Myatt
+ */
+public class AggregationWrapperConverterTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testReverseNestedAggregationWithoutPath() {
+		ReverseNestedAggregation reverseNestedAggregation =
+			_getReverseNestedAggregation(JSONFactoryUtil.createJSONObject());
+
+		Assert.assertNull(reverseNestedAggregation.getPath());
+	}
+
+	@Test
+	public void testReverseNestedAggregationWithPath() {
+		String path = RandomTestUtil.randomString();
+
+		ReverseNestedAggregation reverseNestedAggregation =
+			_getReverseNestedAggregation(JSONUtil.put("path", path));
+
+		Assert.assertEquals(path, reverseNestedAggregation.getPath());
+	}
+
+	private ReverseNestedAggregation _getReverseNestedAggregation(
+		JSONObject jsonObject) {
+
+		AggregationWrapper aggregationWrapper =
+			_aggregationWrapperConverter.toAggregationWrapper(
+				jsonObject, RandomTestUtil.randomString(), "reverse_nested");
+
+		return (ReverseNestedAggregation)aggregationWrapper.getAggregation();
+	}
+
+	private final AggregationWrapperConverter _aggregationWrapperConverter =
+		new AggregationWrapperConverter(
+			new AggregationsImpl(), Mockito.mock(HighlightConverter.class),
+			Mockito.mock(QueryConverter.class),
+			Mockito.mock(ScriptConverter.class),
+			Mockito.mock(SignificanceHeuristics.class),
+			Mockito.mock(Sorts.class));
+
+}


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-86525

This fixes the case where an empty config for a reverse_nested aggregation in a search blueprint resolves to an empty string for the path attribute, which is the incorrect input to Elasticsearch and breaks the aggregation behavior.
