### PR TITLE
LPD-86543 Update Opensearch imports to deploy on 2026.Q1.x

### DIFF
--- a/modules/.releng/dxp/apps/portal-search-opensearch2/app.properties
+++ b/modules/.releng/dxp/apps/portal-search-opensearch2/app.properties
@@ -1,4 +1,4 @@
 app.marketplace.id=233702113
 app.marketplace.title=Liferay Connector to OpenSearch 2
-app.marketplace.version=1.1.0
+app.marketplace.version=2.0.0
 app.portal.build=7413

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/bnd.bnd
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/bnd.bnd
@@ -18,6 +18,8 @@ Import-Package:\
 	\
 	!software.amazon.awssdk.*,\
 	\
+	com.liferay.portal.configuration.module.configuration;version="[0.0.0,9999.0.0)",\
+	com.liferay.portal.kernel.cluster;version="[0.0.0,9999.0.0)",\
 	com.liferay.portal.kernel.exception;version="[0.0.0,9999.0.0)",\
 	com.liferay.portal.kernel.json;version="[0.0.0,9999.0.0)",\
 	com.liferay.portal.kernel.model;version="[0.0.0,9999.0.0)",\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86543

**What is this trying to solve?**
--
To allow the OpenSearch connector to be deployed on Liferay DXP 2026.Q1 versions.

**How am I fixing it?**
--
The minimum version verification restriction for the following modules has been changed:
```
com.liferay.portal.configuration.module.configuration
com.liferay.portal.kernel.cluster
```
**Note**
--
1. I reduced the minimum version restriction following the same strategy as this PR: https://github.com/brianchandotcom/liferay-portal/pull/165771
2. This change does not allow it to be used for versions `2025.Qx` because there are restrictions for other packages.
Examples:
**liferay/dxp:2025.q1.22-lts**
```
Unresolved requirement: Import-Package: com.liferay.portal.configuration.metatype.annotations; version="1.11.0"
```
**liferay/dxp:2025.q4.12** 
```
Unresolved requirement: Import-Package: com.liferay.portal.configuration.metatype.annotations; version="1.11.0"
Unresolved requirement: Import-Package: com.liferay.petra.reflect; version="3.3.0"
```

3. _**This PR already contains the necessary changes to the app.properties file for releasing the OpenSearch connector on the Marketplace.**_

**How can you verify that it works?**
--
1. Setup and Use OpenSearch AWS
2. On the Liferay Portal, Go to Control Panel > Search > Connections
**Expected result:**
It should display the node information
4. On the Liferay Portal, Go to Control Panel > Search > Index Actions
**Expected result:**
The full reindex execution should be completed successfully
