### PR TITLE
LPD-86449 Remove apiHelpers.headlessSite calls for Search

### DIFF
--- a/modules/test/playwright/tests/portal-search-web/main/searchFacets.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/main/searchFacets.spec.ts
@@ -37,13 +37,8 @@ test.describe('Category Facet', () => {
 
 		await test.step('Create 21 sites to test listing', async () => {
 			for (let count = 0; count < 21; count++) {
-				const newSite = await apiHelpers.headlessSite.createSite({
+				await apiHelpers.headlessAdminSite.postSite({
 					name: `${siteName}-${count}`,
-				});
-
-				apiHelpers.data.push({
-					id: newSite.externalReferenceCode,
-					type: 'site',
 				});
 			}
 		});

--- a/modules/test/playwright/tests/search-experiences-web/main/unified_query_builder/scopeSelection.spec.ts
+++ b/modules/test/playwright/tests/search-experiences-web/main/unified_query_builder/scopeSelection.spec.ts
@@ -122,23 +122,13 @@ test.describe('Site Scope', () => {
 	let site2: any;
 
 	test.beforeEach(async ({apiHelpers}) => {
-		site1 = await apiHelpers.headlessSite.createSite({
+		site1 = await apiHelpers.headlessAdminSite.postSite({
 			name: `Site1 ${getRandomInt()}`,
 		});
 
-		site2 = await apiHelpers.headlessSite.createSite({
+		site2 = await apiHelpers.headlessAdminSite.postSite({
 			name: `Site2 ${getRandomInt()}`,
 		});
-	});
-
-	test.afterEach(async ({apiHelpers}) => {
-		if (site1.id) {
-			await apiHelpers.headlessSite.deleteSite(site1.id);
-		}
-
-		if (site2.id) {
-			await apiHelpers.headlessSite.deleteSite(site2.id);
-		}
 	});
 
 	test('Scope selection persists after saving blueprint', async ({


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86449

### Summary
Standardized Playwright tests by replacing legacy `apiHelpers.headlessSite` with `apiHelpers.headlessAdminSite`.

### Site Cleanup
- Automated: Manual `deleteSite` calls were removed when using `dataApiHelpersTest`, as cleanup is now handled automatically through `ApiHelpers.clearData`.
- Manual: Explicit deletion remains for tests using `apiHelpersTest` (which lacks the automatic registry) or where immediate cleanup is required for state validation.

If you encounter any failures or flakiness related to these changes, please let me know.