### PR TITLE
LPD-87121 Elasticsearch connector is ignoring FieldBoots on MultiMatchQuery

### DIFF
--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/legacy/query/ElasticsearchQueryVisitor.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/legacy/query/ElasticsearchQueryVisitor.java
@@ -266,7 +266,14 @@ public class ElasticsearchQueryVisitor implements QueryVisitor<QueryVariant> {
 		SetterUtil.setNotNullFloatAsDouble(
 			builder::cutoffFrequency, multiMatchQuery.getCutOffFrequency());
 
-		builder.fields(ListUtil.fromCollection(multiMatchQuery.getFields()));
+		List<String> fields = QueryUtil.fieldsBoostsToFieldsWithBoosts(
+			multiMatchQuery.getFieldsBoosts());
+
+		if (fields.isEmpty()) {
+			fields = ListUtil.fromCollection(multiMatchQuery.getFields());
+		}
+
+		builder.fields(fields);
 
 		SetterUtil.setNotBlankString(
 			builder::fuzziness, multiMatchQuery.getFuzziness());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87121

**What is this trying to solve?**
--
The legacy `ElasticsearchQueryVisitor#visitQuery(MultiMatchQuery)` in `portal-search-elasticsearch8-impl` was silently dropping the per-field boosts configured on `com.liferay.portal.kernel.search.generic.MultiMatchQuery`.              
                                                                                                                                                                                                                                              
  On that legacy class, `_fields` (a `Set<String>`) and `_fieldsBoosts` (a `Map<String, Float>`) are independent collections, and the only way to configure per-field boosts is by mutating the map exposed via `getFieldsBoosts()` (there is 
  no `addFieldBoost(...)` nor setter). The visitor, however, was reading `_fields` only:                                                                                                                                                      
                                                                                                                                                                                                                                              
  ```java         
  builder.fields(ListUtil.fromCollection(multiMatchQuery.getFields()));
  ```

  This meant that:

  - Any caller configuring boosts through `multiMatchQuery.getFieldsBoosts().put(...)` would have those boosts silently discarded on the Elasticsearch 8 backend.                                                                             
  - If a caller populated `_fieldsBoosts` without also calling `addFields(...)`, the visitor would send a `multi_match` query with an empty field list, which Elasticsearch rejects.
                                                                                                                                                                                                                                              
  This was also an inconsistency with every other equivalent visitor in the codebase — the non-legacy Elasticsearch 8 visitor, both OpenSearch 2 visitors (legacy and new), and the Solr 8 `BaseQueryVisitor` already honored                 
  `getFieldsBoosts()` via `QueryUtil#fieldsBoostsToFieldsWithBoosts`. 

**How am I fixing it?**
--
  The visitor now first converts `getFieldsBoosts()` into the `"field^boost"` notation via `QueryUtil.fieldsBoostsToFieldsWithBoosts(...)`, and only falls back to `getFields()` when the boosts map is empty:                                
   
  ```java                                                                                                                                                                                                                                     
  List<String> fields = QueryUtil.fieldsBoostsToFieldsWithBoosts(
      multiMatchQuery.getFieldsBoosts());                                                                                                                                                                                                     
   
  if (fields.isEmpty()) {                                                                                                                                                                                                                     
      fields = ListUtil.fromCollection(multiMatchQuery.getFields());
  }                                                                                                                                                                                                                                           
   
  builder.fields(fields);                                                                                                                                                                                                                     
  ```             

  This aligns the legacy Elasticsearch 8 visitor with the approach already used by the OpenSearch 2 legacy visitor and keeps full backwards compatibility: every existing call site in the repository populates `_fields` via `addFields(...)`
   without touching `_fieldsBoosts`, so they hit the fallback branch and behave exactly as before.