### PR TITLE
LPD-87409 Respect explicit productionModeEnabled during Elasticsearch config upgrade

### DIFF
--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/upgrade/v1_0_0/ElasticsearchConfigurationUpgradeProcess.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/upgrade/v1_0_0/ElasticsearchConfigurationUpgradeProcess.java
@@ -59,7 +59,19 @@ public class ElasticsearchConfigurationUpgradeProcess extends UpgradeProcess {
 				_log.warn("The operationMode property is no longer supported");
 			}
 
-			properties.put("productionModeEnabled", Boolean.TRUE);
+			Object productionModeEnabled = properties.get(
+				"productionModeEnabled");
+
+			if (productionModeEnabled == null) {
+				properties.put("productionModeEnabled", Boolean.TRUE);
+			}
+			else if (!GetterUtil.getBoolean(productionModeEnabled) &&
+					 _log.isWarnEnabled()) {
+
+				_log.warn(
+					"Preserving existing productionModeEnabled value over " +
+						"operationMode=REMOTE");
+			}
 		}
 
 		Object trackTotalHits = properties.remove("trackTotalHits");

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/upgrade/v1_0_0/ElasticsearchConfigurationUpgradeProcess.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/upgrade/v1_0_0/ElasticsearchConfigurationUpgradeProcess.java
@@ -36,13 +36,9 @@ public class ElasticsearchConfigurationUpgradeProcess extends UpgradeProcess {
 		_configurationUpgradeStepFactory = configurationUpgradeStepFactory;
 	}
 
-	@Override
-	protected void doUpgrade() throws Exception {
-		_upgradeElasticsearchConfiguration();
-		_upgradeElasticsearchConnectionConfigurations();
-	}
+	protected static void updateProperties(
+		Dictionary<String, Object> properties) {
 
-	private void _updateProperties(Dictionary<String, Object> properties) {
 		properties.remove("discoveryZenPingUnicastHostsPort");
 
 		Object embeddedHttpPort = properties.remove("embeddedHttpPort");
@@ -82,6 +78,12 @@ public class ElasticsearchConfigurationUpgradeProcess extends UpgradeProcess {
 		properties.remove("restClientLoggerLevel");
 	}
 
+	@Override
+	protected void doUpgrade() throws Exception {
+		_upgradeElasticsearchConfiguration();
+		_upgradeElasticsearchConnectionConfigurations();
+	}
+
 	private void _upgradeElasticsearchConfiguration() throws Exception {
 		Configuration elasticsearch7configuration =
 			_configurationAdmin.getConfiguration(
@@ -101,7 +103,7 @@ public class ElasticsearchConfigurationUpgradeProcess extends UpgradeProcess {
 						"to the configuration may be required.");
 		}
 
-		_updateProperties(elasticsearch7properties);
+		updateProperties(elasticsearch7properties);
 
 		UpgradeStep upgradeStep =
 			_configurationUpgradeStepFactory.createUpgradeStep(
@@ -118,7 +120,7 @@ public class ElasticsearchConfigurationUpgradeProcess extends UpgradeProcess {
 		Dictionary<String, Object> elasticsearch8properties =
 			elasticsearch8configuration.getProperties();
 
-		_updateProperties(elasticsearch8properties);
+		updateProperties(elasticsearch8properties);
 
 		Enumeration<String> enumeration = elasticsearch7properties.keys();
 

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/upgrade/v1_0_0/ElasticsearchConfigurationUpgradeProcessTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/upgrade/v1_0_0/ElasticsearchConfigurationUpgradeProcessTest.java
@@ -1,0 +1,87 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.elasticsearch8.internal.upgrade.v1_0_0;
+
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Dictionary;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Joshua Cords
+ */
+public class ElasticsearchConfigurationUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testUpdatePropertiesOperationModeEmbedded() {
+		Dictionary<String, Object> properties =
+			HashMapDictionaryBuilder.<String, Object>put(
+				"operationMode", "EMBEDDED"
+			).build();
+
+		ElasticsearchConfigurationUpgradeProcess.updateProperties(properties);
+
+		Assert.assertNull(properties.get("operationMode"));
+		Assert.assertNull(properties.get("productionModeEnabled"));
+	}
+
+	@Test
+	public void testUpdatePropertiesOperationModeRemote() {
+		Dictionary<String, Object> properties =
+			HashMapDictionaryBuilder.<String, Object>put(
+				"operationMode", "REMOTE"
+			).build();
+
+		ElasticsearchConfigurationUpgradeProcess.updateProperties(properties);
+
+		Assert.assertNull(properties.get("operationMode"));
+		Assert.assertEquals(
+			Boolean.TRUE, properties.get("productionModeEnabled"));
+	}
+
+	@Test
+	public void testUpdatePropertiesOperationModeRemoteAndProductionModeDisabled() {
+		Dictionary<String, Object> properties =
+			HashMapDictionaryBuilder.<String, Object>put(
+				"operationMode", "REMOTE"
+			).put(
+				"productionModeEnabled", Boolean.FALSE
+			).build();
+
+		ElasticsearchConfigurationUpgradeProcess.updateProperties(properties);
+
+		Assert.assertNull(properties.get("operationMode"));
+		Assert.assertEquals(
+			Boolean.FALSE, properties.get("productionModeEnabled"));
+	}
+
+	@Test
+	public void testUpdatePropertiesOperationModeRemoteAndProductionModeEnabled() {
+		Dictionary<String, Object> properties =
+			HashMapDictionaryBuilder.<String, Object>put(
+				"operationMode", "REMOTE"
+			).put(
+				"productionModeEnabled", Boolean.TRUE
+			).build();
+
+		ElasticsearchConfigurationUpgradeProcess.updateProperties(properties);
+
+		Assert.assertNull(properties.get("operationMode"));
+		Assert.assertEquals(
+			Boolean.TRUE, properties.get("productionModeEnabled"));
+	}
+
+}


### PR DESCRIPTION
## Summary

[LPD-87409](https://liferay.atlassian.net/browse/LPD-87409) — `ElasticsearchConfigurationUpgradeProcess` unconditionally writes `productionModeEnabled=true` whenever it encounters the legacy `operationMode=REMOTE` property, overwriting any explicit `productionModeEnabled=false` the user had set in their exported `.config`. After upgrading (e.g. 7.3 → 2026.Q1.0) the setting flips against the user's wishes and the ES connection goes down the production-mode path, failing with:

```
ERROR [main][RestClientTransportFactory:71] Unable to connect to [host=http://localhost:9200]
```

## Fix

- Only derive `productionModeEnabled` from `operationMode=REMOTE` when `productionModeEnabled` is not already present in the properties dictionary.
- Warn-log when the preserved value is `false`, so operators can see in upgrade logs that the derived default was intentionally skipped in favor of their explicit setting.

## Why a unit test (and not the existing integration upgrade test)

The existing integration test at `portal-search-elasticsearch8-test/src/testIntegration/.../ElasticsearchConfigurationUpgradeProcessTest` seeds its scenarios by calling `configuration.update(...)` against the live ES8 configuration PID. Writing to that PID activates `ElasticsearchConnectionConfigurationActivationHandler`, which attempts to open a real Elasticsearch connection — something the test environment doesn't provide. Adding an `operationMode=REMOTE` scenario there would fail for infrastructure reasons rather than exercising the upgrade branch under test.

The buggy logic lives entirely in `updateProperties` (formerly `_updateProperties`) — a pure `Dictionary` transform with no OSGi or connector dependency. This PR exposes it as `protected static` and adds a JUnit test under `portal-search-elasticsearch8-impl/src/test/java` that covers all four branches deterministically (`EMBEDDED`, `REMOTE`, `REMOTE + productionModeEnabled=false`, `REMOTE + productionModeEnabled=true`) with zero blast radius.

## Test plan

- [x] \`../gradlew :apps:portal-search-elasticsearch8:portal-search-elasticsearch8-impl:test --tests "*ElasticsearchConfigurationUpgradeProcessTest"\` — all four scenarios pass at HEAD
- [x] Same tests: \`testUpdatePropertiesOperationModeRemoteAndProductionModeDisabled\` fails against the first commit alone (test only, no fix), confirming the regression guard is load-bearing
- [x] \`formatSource\` clean on both touched files