### PR TITLE
LPD-87357 Wiki disabled in functional tests

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/WikiPortlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WikiPortlet.macro
@@ -48,6 +48,10 @@ definition {
 			configurationName = "Deprecation",
 			configurationScope = "Virtual Instance Scope");
 
+		if (IsElementNotPresent(locator1 = "FeatureFlag#TOGGLE_ROW", title_row = "Wiki", toggle_state = "")) {
+			Search.searchCP(searchTerm = "Wiki");
+		}
+
 		if (IsElementPresent(locator1 = "FeatureFlag#TOGGLE_ROW", title_row = "Wiki", toggle_state = "Disabled")) {
 			Check.checkToggleSwitch(
 				locator1 = "FeatureFlag#TOGGLE_ROW",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87357 - SearchWiki#SearchWikiPage SearchWiki#SearchXSSAsset ClassicSearch#SearchByAssetAndModifiedRangeFacets [Functional] (search)

Wiki deprecation FF was not getting enabled, as it was pushed to page 2 in the results. This adds a macro to search for the wiki FF.