### PR TITLE
LPD-86163 review follow-ups: cover custom facet ADTs and tighten sortParameters

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/facet/display/context/builder/CustomFacetDisplayContextBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/facet/display/context/builder/CustomFacetDisplayContextBuilder.java
@@ -462,9 +462,10 @@ public class CustomFacetDisplayContextBuilder {
 		rangeURL = HttpComponentsUtil.removeParameter(rangeURL, _parameterName);
 		rangeURL = HttpComponentsUtil.setParameter(
 			rangeURL, _parameterName + "From", from);
-
-		return HttpComponentsUtil.setParameter(
+		rangeURL = HttpComponentsUtil.setParameter(
 			rangeURL, _parameterName + "To", to);
+
+		return HttpComponentsUtil.sortParameters(rangeURL);
 	}
 
 	private TermCollector _getCustomRangeTermCollector(boolean selected) {
@@ -501,9 +502,10 @@ public class CustomFacetDisplayContextBuilder {
 		rangeURL = HttpComponentsUtil.removeParameter(rangeURL, _parameterName);
 		rangeURL = HttpComponentsUtil.setParameter(
 			rangeURL, _parameterName + "From", 0);
-
-		return HttpComponentsUtil.setParameter(
+		rangeURL = HttpComponentsUtil.setParameter(
 			rangeURL, _parameterName + "To", 0);
+
+		return HttpComponentsUtil.sortParameters(rangeURL);
 	}
 
 	private long _getDisplayStyleGroupId() {
@@ -545,8 +547,10 @@ public class CustomFacetDisplayContextBuilder {
 			rangeURL, _parameterName + "From");
 		rangeURL = HttpComponentsUtil.removeParameter(
 			rangeURL, _parameterName + "To");
+		rangeURL = HttpComponentsUtil.setParameter(
+			rangeURL, _parameterName, label);
 
-		return HttpComponentsUtil.setParameter(rangeURL, _parameterName, label);
+		return HttpComponentsUtil.sortParameters(rangeURL);
 	}
 
 	private JSONArray _getRangesJSONArray() {
@@ -573,7 +577,7 @@ public class CustomFacetDisplayContextBuilder {
 		termsURL = HttpComponentsUtil.setParameter(
 			termsURL, _parameterName, term);
 
-		return termsURL;
+		return HttpComponentsUtil.sortParameters(termsURL);
 	}
 
 	private boolean _isCustomRangeSelected() {

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/display/context/builder/ModifiedFacetDisplayContextBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/display/context/builder/ModifiedFacetDisplayContextBuilder.java
@@ -328,7 +328,9 @@ public class ModifiedFacetDisplayContextBuilder implements Serializable {
 		rangeURL = HttpComponentsUtil.setParameter(
 			rangeURL, "modifiedFrom", from);
 
-		return HttpComponentsUtil.setParameter(rangeURL, "modifiedTo", to);
+		rangeURL = HttpComponentsUtil.setParameter(rangeURL, "modifiedTo", to);
+
+		return HttpComponentsUtil.sortParameters(rangeURL);
 	}
 
 	private String _getLabeledRangeURL(String label) {
@@ -340,7 +342,9 @@ public class ModifiedFacetDisplayContextBuilder implements Serializable {
 		rangeURL = HttpComponentsUtil.removeParameter(
 			rangeURL, _paginationStartParameterName);
 
-		return HttpComponentsUtil.setParameter(rangeURL, "modified", label);
+		rangeURL = HttpComponentsUtil.setParameter(rangeURL, "modified", label);
+
+		return HttpComponentsUtil.sortParameters(rangeURL);
 	}
 
 	private JSONArray _getRangesJSONArray() {

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/sort/display/context/builder/SortDisplayContextBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/sort/display/context/builder/SortDisplayContextBuilder.java
@@ -238,7 +238,10 @@ public class SortDisplayContextBuilder {
 		String sortURL = HttpComponentsUtil.removeParameter(
 			_currentURL, _parameterName);
 
-		return HttpComponentsUtil.setParameter(sortURL, _parameterName, field);
+		sortURL = HttpComponentsUtil.setParameter(
+			sortURL, _parameterName, field);
+
+		return HttpComponentsUtil.sortParameters(sortURL);
 	}
 
 	private String _currentURL;

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/FacetUtil.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/FacetUtil.js
@@ -225,11 +225,21 @@ export const FacetUtil = {
 			search
 		);
 
-		return search;
+		const searchParams = new URLSearchParams(search);
+
+		searchParams.sort();
+
+		return searchParams.toString();
 	},
 
 	removeAllFacetParameters(queryString) {
 		let search = queryString;
+
+		const hasQuestionMark = search[0] === '?';
+
+		if (hasQuestionMark) {
+			search = search.substr(1);
+		}
 
 		const allForms = document.getElementsByTagName('form');
 
@@ -250,6 +260,10 @@ export const FacetUtil = {
 				selections
 			);
 		});
+
+		if (hasQuestionMark) {
+			search = '?' + search;
+		}
 
 		return search;
 	},
@@ -360,7 +374,7 @@ export const FacetUtil = {
 			}
 		});
 
-		return newParameters;
+		return newParameters.sort();
 	},
 
 	updateQueryString(key, selections, queryString) {

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/custom_range_facet.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/custom_range_facet.js
@@ -326,6 +326,8 @@ AUI.add(
 					parameterArray
 				);
 
+				parameterArray.sort();
+
 				CustomRangeFacetUtil.submitSearch(parameterArray.join('&'));
 			},
 		});

--- a/modules/apps/portal-search/portal-search-web/test/js/FacetUtil.js
+++ b/modules/apps/portal-search/portal-search-web/test/js/FacetUtil.js
@@ -6,204 +6,6 @@
 import {FacetUtil} from '../../src/main/resources/META-INF/resources/js/FacetUtil';
 
 describe('FacetUtil', () => {
-	describe('removeURLParameters()', () => {
-		it('removes the parameter whose name is the given key', () => {
-			const parameters = ['modified=last-24-hours', 'q=test'];
-
-			const newParameters = FacetUtil.removeURLParameters(
-				'modified',
-				parameters
-			);
-
-			expect(newParameters).toEqual(['q=test']);
-		});
-
-		it('does not remove parameters not matching the given key', () => {
-			const parameters = [
-				'modifiedFrom=2018-01-01',
-				'modifiedTo=2018-01-31',
-				'q=test',
-			];
-
-			const newParameters = FacetUtil.removeURLParameters(
-				'modified',
-				parameters
-			);
-
-			expect(newParameters).toEqual([
-				'modifiedFrom=2018-01-01',
-				'modifiedTo=2018-01-31',
-				'q=test',
-			]);
-		});
-
-		it('removes given parameter', () => {
-			const parameters = FacetUtil.removeURLParameters('key', [
-				'key=sel1',
-				'key=sel2',
-			]);
-
-			expect(parameters).toEqual([]);
-		});
-
-		it('preserves other parameters', () => {
-			const parameters = FacetUtil.removeURLParameters('key1', [
-				'key1=sel1',
-				'key2=sel2',
-			]);
-
-			expect(parameters).toEqual(['key2=sel2']);
-		});
-
-		it('preserves key-only parameters', () => {
-			const parameters = FacetUtil.removeURLParameters('key', [
-				'checked',
-				'key=value',
-			]);
-
-			expect(parameters).toEqual(['checked']);
-		});
-
-		it('removes key-only parameters', () => {
-			const parameters = FacetUtil.removeURLParameters('checked', [
-				'checked',
-				'key=value',
-			]);
-
-			expect(parameters).toEqual(['key=value']);
-		});
-	});
-
-	describe('setURLParameter()', () => {
-		it('adds a missing parameter', () => {
-			const url = FacetUtil.setURLParameter(
-				'http://example.com/',
-				'q',
-				'test'
-			);
-
-			expect(url).toBe('http://example.com/?q=test');
-		});
-
-		it('updates an existing parameter', () => {
-			const url = FacetUtil.setURLParameter(
-				'http://example.com/?q=example',
-				'q',
-				'test'
-			);
-
-			expect(url).toBe('http://example.com/?q=test');
-		});
-
-		it('adds a missing parameter with path', () => {
-			const url = FacetUtil.setURLParameter(
-				'http://example.com/path',
-				'q',
-				'test'
-			);
-
-			expect(url).toBe('http://example.com/path?q=test');
-		});
-	});
-
-	describe('setURLParameters()', () => {
-		it('adds new selections', () => {
-			const parameters = FacetUtil.setURLParameters(
-				'key',
-				['sel1', 'sel2'],
-				[]
-			);
-
-			expect(parameters).toEqual(['key=sel1', 'key=sel2']);
-		});
-
-		it('removes old selections', () => {
-			const parameters = FacetUtil.setURLParameters(
-				'key',
-				['sel2', 'sel3'],
-				['key=sel1']
-			);
-
-			expect(parameters).toEqual(['key=sel2', 'key=sel3']);
-		});
-
-		it('preserves other selections', () => {
-			const parameters = FacetUtil.setURLParameters(
-				'key1',
-				['sel1'],
-				['key2=sel2']
-			);
-
-			expect(parameters).toEqual(['key1=sel1', 'key2=sel2']);
-		});
-
-		it('sorts parameters alphabetically', () => {
-			const parameters = FacetUtil.setURLParameters(
-				'paramB',
-				['valB'],
-				['paramC=valC', 'paramA=valA']
-			);
-
-			expect(parameters).toEqual([
-				'paramA=valA',
-				'paramB=valB',
-				'paramC=valC',
-			]);
-		});
-	});
-
-	describe('.updateQueryString()', () => {
-		it('removes old selections', () => {
-			const queryString = FacetUtil.updateQueryString(
-				'key',
-				['sel2', 'sel3'],
-				'?key=sel1'
-			);
-
-			expect(queryString).toEqual('?key=sel2&key=sel3');
-		});
-
-		it('adds new selections', () => {
-			const queryString = FacetUtil.updateQueryString(
-				'key1',
-				['sel1'],
-				'?key2=sel2'
-			);
-
-			expect(queryString).toEqual('?key1=sel1&key2=sel2');
-		});
-
-		it('accepts query string without question mark', () => {
-			const queryString = FacetUtil.updateQueryString(
-				'key1',
-				['sel1'],
-				'key2=sel2'
-			);
-
-			expect(queryString).toEqual('key1=sel1&key2=sel2');
-		});
-
-		it('does not prefix with ampersand', () => {
-			const queryString = FacetUtil.updateQueryString(
-				'key',
-				['sel1', 'sel2'],
-				'?'
-			);
-
-			expect(queryString).toEqual('?key=sel1&key=sel2');
-		});
-
-		it('sorts parameters alphabetically', () => {
-			const queryString = FacetUtil.updateQueryString(
-				'paramB',
-				['valB'],
-				'?paramC=valC&paramA=valA'
-			);
-
-			expect(queryString).toEqual('?paramA=valA&paramB=valB&paramC=valC');
-		});
-	});
-
 	describe('queryParameterAndUpdateValue()', () => {
 		let originalQuerySelector;
 
@@ -243,6 +45,204 @@ describe('FacetUtil', () => {
 			);
 
 			expect(queryString).toEqual('paramA=valA&paramC=valC&q=newQuery');
+		});
+	});
+
+	describe('removeURLParameters()', () => {
+		it('does not remove parameters not matching the given key', () => {
+			const parameters = [
+				'modifiedFrom=2018-01-01',
+				'modifiedTo=2018-01-31',
+				'q=test',
+			];
+
+			const newParameters = FacetUtil.removeURLParameters(
+				'modified',
+				parameters
+			);
+
+			expect(newParameters).toEqual([
+				'modifiedFrom=2018-01-01',
+				'modifiedTo=2018-01-31',
+				'q=test',
+			]);
+		});
+
+		it('preserves other parameters', () => {
+			const parameters = FacetUtil.removeURLParameters('key1', [
+				'key1=sel1',
+				'key2=sel2',
+			]);
+
+			expect(parameters).toEqual(['key2=sel2']);
+		});
+
+		it('preserves key-only parameters', () => {
+			const parameters = FacetUtil.removeURLParameters('key', [
+				'checked',
+				'key=value',
+			]);
+
+			expect(parameters).toEqual(['checked']);
+		});
+
+		it('removes given parameter', () => {
+			const parameters = FacetUtil.removeURLParameters('key', [
+				'key=sel1',
+				'key=sel2',
+			]);
+
+			expect(parameters).toEqual([]);
+		});
+
+		it('removes key-only parameters', () => {
+			const parameters = FacetUtil.removeURLParameters('checked', [
+				'checked',
+				'key=value',
+			]);
+
+			expect(parameters).toEqual(['key=value']);
+		});
+
+		it('removes the parameter whose name is the given key', () => {
+			const parameters = ['modified=last-24-hours', 'q=test'];
+
+			const newParameters = FacetUtil.removeURLParameters(
+				'modified',
+				parameters
+			);
+
+			expect(newParameters).toEqual(['q=test']);
+		});
+	});
+
+	describe('setURLParameter()', () => {
+		it('adds a missing parameter', () => {
+			const url = FacetUtil.setURLParameter(
+				'http://example.com/',
+				'q',
+				'test'
+			);
+
+			expect(url).toBe('http://example.com/?q=test');
+		});
+
+		it('adds a missing parameter with path', () => {
+			const url = FacetUtil.setURLParameter(
+				'http://example.com/path',
+				'q',
+				'test'
+			);
+
+			expect(url).toBe('http://example.com/path?q=test');
+		});
+
+		it('updates an existing parameter', () => {
+			const url = FacetUtil.setURLParameter(
+				'http://example.com/?q=example',
+				'q',
+				'test'
+			);
+
+			expect(url).toBe('http://example.com/?q=test');
+		});
+	});
+
+	describe('setURLParameters()', () => {
+		it('adds new selections', () => {
+			const parameters = FacetUtil.setURLParameters(
+				'key',
+				['sel1', 'sel2'],
+				[]
+			);
+
+			expect(parameters).toEqual(['key=sel1', 'key=sel2']);
+		});
+
+		it('preserves other selections', () => {
+			const parameters = FacetUtil.setURLParameters(
+				'key1',
+				['sel1'],
+				['key2=sel2']
+			);
+
+			expect(parameters).toEqual(['key1=sel1', 'key2=sel2']);
+		});
+
+		it('removes old selections', () => {
+			const parameters = FacetUtil.setURLParameters(
+				'key',
+				['sel2', 'sel3'],
+				['key=sel1']
+			);
+
+			expect(parameters).toEqual(['key=sel2', 'key=sel3']);
+		});
+
+		it('sorts parameters alphabetically', () => {
+			const parameters = FacetUtil.setURLParameters(
+				'paramB',
+				['valB'],
+				['paramC=valC', 'paramA=valA']
+			);
+
+			expect(parameters).toEqual([
+				'paramA=valA',
+				'paramB=valB',
+				'paramC=valC',
+			]);
+		});
+	});
+
+	describe('updateQueryString()', () => {
+		it('accepts query string without question mark', () => {
+			const queryString = FacetUtil.updateQueryString(
+				'key1',
+				['sel1'],
+				'key2=sel2'
+			);
+
+			expect(queryString).toEqual('key1=sel1&key2=sel2');
+		});
+
+		it('adds new selections', () => {
+			const queryString = FacetUtil.updateQueryString(
+				'key1',
+				['sel1'],
+				'?key2=sel2'
+			);
+
+			expect(queryString).toEqual('?key1=sel1&key2=sel2');
+		});
+
+		it('does not prefix with ampersand', () => {
+			const queryString = FacetUtil.updateQueryString(
+				'key',
+				['sel1', 'sel2'],
+				'?'
+			);
+
+			expect(queryString).toEqual('?key=sel1&key=sel2');
+		});
+
+		it('removes old selections', () => {
+			const queryString = FacetUtil.updateQueryString(
+				'key',
+				['sel2', 'sel3'],
+				'?key=sel1'
+			);
+
+			expect(queryString).toEqual('?key=sel2&key=sel3');
+		});
+
+		it('sorts parameters alphabetically', () => {
+			const queryString = FacetUtil.updateQueryString(
+				'paramB',
+				['valB'],
+				'?paramC=valC&paramA=valA'
+			);
+
+			expect(queryString).toEqual('?paramA=valA&paramB=valB&paramC=valC');
 		});
 	});
 });

--- a/modules/apps/portal-search/portal-search-web/test/js/FacetUtil.js
+++ b/modules/apps/portal-search/portal-search-web/test/js/FacetUtil.js
@@ -134,7 +134,21 @@ describe('FacetUtil', () => {
 				['key2=sel2']
 			);
 
-			expect(parameters).toEqual(['key2=sel2', 'key1=sel1']);
+			expect(parameters).toEqual(['key1=sel1', 'key2=sel2']);
+		});
+
+		it('sorts parameters alphabetically', () => {
+			const parameters = FacetUtil.setURLParameters(
+				'paramB',
+				['valB'],
+				['paramC=valC', 'paramA=valA']
+			);
+
+			expect(parameters).toEqual([
+				'paramA=valA',
+				'paramB=valB',
+				'paramC=valC',
+			]);
 		});
 	});
 
@@ -156,7 +170,7 @@ describe('FacetUtil', () => {
 				'?key2=sel2'
 			);
 
-			expect(queryString).toEqual('?key2=sel2&key1=sel1');
+			expect(queryString).toEqual('?key1=sel1&key2=sel2');
 		});
 
 		it('accepts query string without question mark', () => {
@@ -166,7 +180,7 @@ describe('FacetUtil', () => {
 				'key2=sel2'
 			);
 
-			expect(queryString).toEqual('key2=sel2&key1=sel1');
+			expect(queryString).toEqual('key1=sel1&key2=sel2');
 		});
 
 		it('does not prefix with ampersand', () => {
@@ -177,6 +191,58 @@ describe('FacetUtil', () => {
 			);
 
 			expect(queryString).toEqual('?key=sel1&key=sel2');
+		});
+
+		it('sorts parameters alphabetically', () => {
+			const queryString = FacetUtil.updateQueryString(
+				'paramB',
+				['valB'],
+				'?paramC=valC&paramA=valA'
+			);
+
+			expect(queryString).toEqual('?paramA=valA&paramB=valB&paramC=valC');
+		});
+	});
+
+	describe('queryParameterAndUpdateValue()', () => {
+		let originalQuerySelector;
+
+		beforeEach(() => {
+			originalQuerySelector = document.querySelector;
+
+			document.querySelector = (selector) => {
+				if (selector === '#fm input.facet-parameter-name') {
+					return {
+						value: 'q',
+					};
+				}
+
+				if (selector === '#fm input.start-parameter-name') {
+					return {
+						value: 'start',
+					};
+				}
+
+				return null;
+			};
+		});
+
+		afterEach(() => {
+			document.querySelector = originalQuerySelector;
+		});
+
+		it('sorts parameters alphabetically when updating value', () => {
+			const mockForm = {
+				id: 'fm',
+			};
+
+			const queryString = FacetUtil.queryParameterAndUpdateValue(
+				mockForm,
+				'?start=10&paramC=valC&q=initial&paramA=valA',
+				['newQuery']
+			);
+
+			expect(queryString).toEqual('paramA=valA&paramC=valC&q=newQuery');
 		});
 	});
 });

--- a/modules/test/playwright/tests/portal-search-web/main/searchResults.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/main/searchResults.spec.ts
@@ -419,3 +419,123 @@ test.describe('Search Paginator', () => {
 		});
 	});
 });
+
+test.describe('URL Parameters Are Sorted', () => {
+	test('Facet selection, modified range, pagination, and sort links on the page have alphabetically sorted URL parameters @LPD-86163', async ({
+		apiHelpers,
+		page,
+		searchPage,
+		site,
+	}) => {
+		let siteLayout: Layout;
+
+		await test.step('Create web content for search results', async () => {
+			const basicWebContentStructureId =
+				await getBasicWebContentStructureId(apiHelpers);
+
+			for (let count = 0; count < 21; count++) {
+				await apiHelpers.jsonWebServicesJournal.addWebContent({
+					ddmStructureId: basicWebContentStructureId,
+					groupId: site.id,
+					titleMap: {en_US: `Test Web Content ${count}`},
+				});
+			}
+		});
+
+		await test.step('Create a portlet page associated to site', async () => {
+			siteLayout = await apiHelpers.jsonWebServicesLayout.addLayout({
+				groupId: site.id,
+				options: {type: 'portlet'},
+				title: getRandomString(),
+			});
+		});
+
+		await test.step('Navigate to the site page', async () => {
+			await page.goto(
+				`/web${site.friendlyUrlPath}${siteLayout.friendlyURL}`
+			);
+		});
+
+		await test.step('Add search portlets to new page', async () => {
+			await searchPage.addPortlet('Modified Facet', 'Search');
+			await searchPage.addPortlet('Search Bar', 'Search');
+			await searchPage.addPortlet('Search Results', 'Search');
+			await searchPage.addPortlet('Sort', 'Search');
+			await searchPage.addPortlet('Type Facet', 'Search');
+		});
+
+		await test.step('Perform a search', async () => {
+			await searchPage.searchKeywordInMainContent('test');
+
+			await expect(searchPage.searchResultsTotalLabel).toHaveText(
+				/\d+ Results for test/
+			);
+		});
+
+		await test.step('Verify URL parameters are sorted after clicking facet checkbox', async () => {
+			const typeFacetCheckbox = await searchPage.getSearchFacetCheckbox(
+				/Web Content\s/,
+				'Type'
+			);
+
+			await searchPage.selectSearchFacetCheckbox(typeFacetCheckbox);
+
+			const facetKeys = Array.from(
+				new URL(page.url()).searchParams.keys()
+			);
+
+			expect(facetKeys).toEqual([...facetKeys].sort());
+		});
+
+		await test.step('Verify URL parameters are sorted after clicking modified facet link', async () => {
+			const pastYearFacetLink = await searchPage.getSearchFacetLink(
+				'Past Year',
+				'Last Modified'
+			);
+
+			await searchPage.selectSearchFacetLink(pastYearFacetLink);
+
+			const modifiedKeys = Array.from(
+				new URL(page.url()).searchParams.keys()
+			);
+
+			expect(modifiedKeys).toEqual([...modifiedKeys].sort());
+		});
+
+		await test.step('Verify URL parameters are sorted after changing items per page', async () => {
+			await searchPage.selectPaginationItemsPerPage(40);
+
+			const deltaKeys = Array.from(
+				new URL(page.url()).searchParams.keys()
+			);
+
+			expect(deltaKeys).toEqual([...deltaKeys].sort());
+		});
+		
+		await test.step('Verify URL parameters are sorted after clicking pagination page number', async () => {
+			await searchPage.selectPaginationPageNumber(2);
+
+			const paginationKeys = Array.from(
+				new URL(page.url()).searchParams.keys()
+			);
+
+			expect(paginationKeys).toEqual([...paginationKeys].sort());
+		});
+
+		await test.step('Verify URL parameters are sorted after clicking sort option', async () => {
+			const sortPortlet = page.locator('.portlet-sort');
+
+			await sortPortlet
+				.getByRole('button', {name: 'Sort By'})
+				.click();
+
+			await page.getByRole('menuitem', {name: 'Title'}).click();
+
+			const sortKeys = Array.from(
+				new URL(page.url()).searchParams.keys()
+			);
+
+			expect(sortKeys).toEqual([...sortKeys].sort());
+		});
+	});
+});

--- a/portal-kernel/src/com/liferay/portal/kernel/util/HttpComponentsUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/HttpComponentsUtil.java
@@ -986,16 +986,32 @@ public class HttpComponentsUtil {
 	}
 
 	public static String sortParameters(String url) {
-		String queryString = getQueryString(url);
+		if (Validator.isNull(url)) {
+			return url;
+		}
+
+		int pos = url.indexOf(CharPool.QUESTION);
+
+		if (pos == -1) {
+			return url;
+		}
+
+		String[] array = PortalUtil.stripURLAnchor(url, StringPool.POUND);
+
+		url = array[0];
+
+		String anchor = array[1];
+
+		String queryString = url.substring(pos + 1);
 
 		if (Validator.isNull(queryString)) {
-			return url;
+			return url + anchor;
 		}
 
 		String sortedQueryString = parameterMapToString(
 			parameterMapFromString(queryString, true), false);
 
-		return StringUtil.replace(url, queryString, sortedQueryString);
+		return url.substring(0, pos + 1) + sortedQueryString + anchor;
 	}
 
 	private static String _shortenURL(

--- a/portal-kernel/src/com/liferay/portal/kernel/util/HttpComponentsUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/HttpComponentsUtil.java
@@ -31,6 +31,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 /**
  * @author Tina Tian
@@ -626,7 +627,20 @@ public class HttpComponentsUtil {
 	public static Map<String, String[]> parameterMapFromString(
 		String queryString) {
 
-		Map<String, String[]> parameterMap = new LinkedHashMap<>();
+		return parameterMapFromString(queryString, false);
+	}
+
+	public static Map<String, String[]> parameterMapFromString(
+		String queryString, boolean sort) {
+
+		Map<String, String[]> parameterMap = null;
+
+		if (sort) {
+			parameterMap = new TreeMap<>();
+		}
+		else {
+			parameterMap = new LinkedHashMap<>();
+		}
 
 		if (Validator.isNull(queryString)) {
 			return parameterMap;
@@ -969,6 +983,19 @@ public class HttpComponentsUtil {
 		return _shortenURL(
 			url, 0, StringPool.QUESTION, StringPool.AMPERSAND,
 			StringPool.EQUAL);
+	}
+
+	public static String sortParameters(String url) {
+		String queryString = getQueryString(url);
+
+		if (Validator.isNull(queryString)) {
+			return url;
+		}
+
+		String sortedQueryString = parameterMapToString(
+			parameterMapFromString(queryString, true), false);
+
+		return StringUtil.replace(url, queryString, sortedQueryString);
 	}
 
 	private static String _shortenURL(

--- a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
@@ -103,6 +103,8 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 						}
 
 						String curDeltaURL = HttpComponentsUtil.setParameter(url + urlAnchor, namespace + deltaParam, curDelta);
+
+						curDeltaURL = HttpComponentsUtil.sortParameters(curDeltaURL);
 					%>
 
 						<li role="presentation">
@@ -538,7 +540,13 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 <%!
 private String _getHREF(String formName, String curParam, int cur, String jsCall, String url, String urlAnchor) throws Exception {
 	if (Validator.isNotNull(url)) {
-		return HtmlUtil.escapeHREF(HttpComponentsUtil.addParameter(HttpComponentsUtil.removeParameter(url, curParam) + urlAnchor, curParam, cur));
+		url = HttpComponentsUtil.removeParameter(url, curParam);
+
+		url = HttpComponentsUtil.addParameter(url + urlAnchor, curParam, cur);
+
+		url = HttpComponentsUtil.sortParameters(url);
+
+		return HtmlUtil.escapeHREF(url);
 	}
 
 	return "javascript:document." + formName + "." + curParam + ".value = '" + cur + "'; " + jsCall;


### PR DESCRIPTION
Two follow-up commits on top of the existing [LPD-86163](https://liferay.atlassian.net/browse/LPD-86163) work.

## `LPD-86163 portal-search-web: sort URL parameters in custom facet bucket links`

`CustomFacetDisplayContextBuilder` builds URLs in `_getCustomDateRangeURL`, `_getCustomRangeURL`, `_getLabeledRangeURL`, and `_getTermsURL` and stores them on `bucketDisplayContext.setFilterValue(...)`. The default `custom/facet/view.jsp` is checkbox-driven and never renders `filterValue` as `href`, so the stock UI was already correct under the original patch. ADTs / display templates that *do* render `getFilterValue()` as an anchor (the way `modified/facet/view.jsp` does) would still emit unsorted URLs to crawlers.

This commit wraps the four methods' final return with `HttpComponentsUtil.sortParameters(...)`, mirroring the pattern already applied to `ModifiedFacetDisplayContextBuilder._getDateRangeURL` / `_getLabeledRangeURL` in the original patch.

## `LPD-86163 portal-kernel: avoid StringUtil.replace in sortParameters`

The original `sortParameters` body used `StringUtil.replace(url, queryString, sortedQueryString)` — a literal substring replace on the whole URL. If the query span happened to also occur in the path or fragment, the wrong span would be rewritten, and it also incurs an extra URI-parse pass via `getQueryString`. But this should also provide better performance and uses the same process as another method [removeParameter()](https://github.com/liferay/liferay-portal/blob/3cf485523ca75f65abeaf58c3fad9e88c57db36b/portal-kernel/src/com/liferay/portal/kernel/util/HttpComponentsUtil.java#L800-L858).

Rewritten to use the `indexOf('?')` + `PortalUtil.stripURLAnchor` pattern that the rest of this file (`removeParameter`, `_shortenURL`, friendly URL handling) already uses. Drops the path-collision risk and one parse cycle.