### PR TITLE
LPD-86209 Add support for List values in Blueprint SXP parameters

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/util/SXPParameterDataCreatorUtil.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/util/SXPParameterDataCreatorUtil.java
@@ -382,17 +382,24 @@ public class SXPParameterDataCreatorUtil {
 		}
 
 		if (object != null) {
-			int[] fromArray = GetterUtil.getIntegerValues(object);
+			int[] intArray = GetterUtil.getIntegerValues(object);
 
-			if (ArrayUtil.isNotEmpty(fromArray)) {
-				return ArrayUtil.toArray(fromArray);
+			if (ArrayUtil.isNotEmpty(intArray)) {
+				return ArrayUtil.toArray(intArray);
 			}
-			else if (object instanceof List<?> list) {
-				if (list.stream(
-					).allMatch(
-						e -> e instanceof Integer
-					)) {
 
+			if (object instanceof List<?> list) {
+				boolean allInteger = true;
+
+				for (Object element : list) {
+					if (!(element instanceof Integer)) {
+						allInteger = false;
+
+						break;
+					}
+				}
+
+				if (allInteger) {
 					return list.toArray(new Integer[0]);
 				}
 			}
@@ -454,17 +461,24 @@ public class SXPParameterDataCreatorUtil {
 		}
 
 		if (object != null) {
-			long[] fromArray = GetterUtil.getLongValues(object);
+			long[] longArray = GetterUtil.getLongValues(object);
 
-			if (ArrayUtil.isNotEmpty(fromArray)) {
-				return ArrayUtil.toArray(fromArray);
+			if (ArrayUtil.isNotEmpty(longArray)) {
+				return ArrayUtil.toArray(longArray);
 			}
-			else if (object instanceof List<?> list) {
-				if (list.stream(
-					).allMatch(
-						e -> e instanceof Long
-					)) {
 
+			if (object instanceof List<?> list) {
+				boolean allLong = true;
+
+				for (Object element : list) {
+					if (!(element instanceof Long)) {
+						allLong = false;
+
+						break;
+					}
+				}
+
+				if (allLong) {
 					return list.toArray(new Long[0]);
 				}
 			}
@@ -520,17 +534,24 @@ public class SXPParameterDataCreatorUtil {
 		String[] defaultValue, Object object) {
 
 		if (object != null) {
-			String[] fromArray = GetterUtil.getStringValues(object);
+			String[] stringArray = GetterUtil.getStringValues(object);
 
-			if (ArrayUtil.isNotEmpty(fromArray)) {
-				return fromArray;
+			if (ArrayUtil.isNotEmpty(stringArray)) {
+				return stringArray;
 			}
-			else if (object instanceof List<?> list) {
-				if (list.stream(
-					).allMatch(
-						e -> e instanceof String
-					)) {
 
+			if (object instanceof List<?> list) {
+				boolean allString = true;
+
+				for (Object element : list) {
+					if (!(element instanceof String)) {
+						allString = false;
+
+						break;
+					}
+				}
+
+				if (allString) {
 					return list.toArray(new String[0]);
 				}
 			}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/util/SXPParameterDataCreatorUtil.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/util/SXPParameterDataCreatorUtil.java
@@ -382,7 +382,16 @@ public class SXPParameterDataCreatorUtil {
 		}
 
 		if (object != null) {
-			return ArrayUtil.toArray(GetterUtil.getIntegerValues(object));
+			int[] fromArray = GetterUtil.getIntegerValues(object);
+
+			if (ArrayUtil.isNotEmpty(fromArray)) {
+				return ArrayUtil.toArray(fromArray);
+			}
+			else if (object instanceof List<?> list) {
+				if (list.stream().allMatch(e -> e instanceof Integer)) {
+					return list.toArray(new Integer[0]);
+				}
+			}
 		}
 
 		if (defaultValue != null) {
@@ -441,7 +450,16 @@ public class SXPParameterDataCreatorUtil {
 		}
 
 		if (object != null) {
-			return ArrayUtil.toArray(GetterUtil.getLongValues(object));
+			long[] fromArray = GetterUtil.getLongValues(object);
+
+			if (ArrayUtil.isNotEmpty(fromArray)) {
+				return ArrayUtil.toArray(fromArray);
+			}
+			else if (object instanceof List<?> list) {
+				if (list.stream().allMatch(e -> e instanceof Long)) {
+					return list.toArray(new Long[0]);
+				}
+			}
 		}
 
 		if (defaultValue != null) {
@@ -494,7 +512,16 @@ public class SXPParameterDataCreatorUtil {
 		String[] defaultValue, Object object) {
 
 		if (object != null) {
-			return GetterUtil.getStringValues(object);
+			String[] fromArray = GetterUtil.getStringValues(object);
+
+			if (ArrayUtil.isNotEmpty(fromArray)) {
+				return fromArray;
+			}
+			else if (object instanceof List<?> list) {
+				if (list.stream().allMatch(e -> e instanceof String)) {
+					return list.toArray(new String[0]);
+				}
+			}
 		}
 
 		if (defaultValue != null) {

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/util/SXPParameterDataCreatorUtil.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/util/SXPParameterDataCreatorUtil.java
@@ -388,7 +388,11 @@ public class SXPParameterDataCreatorUtil {
 				return ArrayUtil.toArray(fromArray);
 			}
 			else if (object instanceof List<?> list) {
-				if (list.stream().allMatch(e -> e instanceof Integer)) {
+				if (list.stream(
+					).allMatch(
+						e -> e instanceof Integer
+					)) {
+
 					return list.toArray(new Integer[0]);
 				}
 			}
@@ -456,7 +460,11 @@ public class SXPParameterDataCreatorUtil {
 				return ArrayUtil.toArray(fromArray);
 			}
 			else if (object instanceof List<?> list) {
-				if (list.stream().allMatch(e -> e instanceof Long)) {
+				if (list.stream(
+					).allMatch(
+						e -> e instanceof Long
+					)) {
+
 					return list.toArray(new Long[0]);
 				}
 			}
@@ -518,7 +526,11 @@ public class SXPParameterDataCreatorUtil {
 				return fromArray;
 			}
 			else if (object instanceof List<?> list) {
-				if (list.stream().allMatch(e -> e instanceof String)) {
+				if (list.stream(
+					).allMatch(
+						e -> e instanceof String
+					)) {
+
 					return list.toArray(new String[0]);
 				}
 			}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/test/java/com/liferay/search/experiences/internal/blueprint/parameter/util/SXPParameterDataCreatorUtilTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/test/java/com/liferay/search/experiences/internal/blueprint/parameter/util/SXPParameterDataCreatorUtilTest.java
@@ -1,0 +1,121 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.search.experiences.internal.blueprint.parameter.util;
+
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.search.experiences.blueprint.parameter.SXPParameter;
+import com.liferay.search.experiences.blueprint.parameter.contributor.SXPParameterContributor;
+import com.liferay.search.experiences.internal.blueprint.parameter.SXPParameterData;
+import com.liferay.search.experiences.rest.dto.v1_0.Configuration;
+import com.liferay.search.experiences.rest.dto.v1_0.Parameter;
+import com.liferay.search.experiences.rest.dto.v1_0.ParameterConfiguration;
+import com.liferay.search.experiences.rest.dto.v1_0.SXPBlueprint;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Jason Myatt
+ */
+public class SXPParameterDataCreatorUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		Map<String, Parameter> parameterMap =
+			HashMapBuilder.<String, Parameter>put(
+				_PARAMETER_NAME,
+				() -> {
+					Parameter parameter = new Parameter();
+
+					parameter.setType(_parameterType);
+
+					return parameter;
+				}
+			).build();
+
+		ParameterConfiguration parameterConfiguration =
+			new ParameterConfiguration();
+
+		parameterConfiguration.setParameters(parameterMap);
+
+		Configuration configuration = new Configuration();
+
+		configuration.setParameterConfiguration(parameterConfiguration);
+
+		_sxpBlueprint.setConfiguration(configuration);
+	}
+
+	@Test
+	public void testCreateWithArrayParameter() {
+		String[] arrayOfStrings = {_PARAMETER_VALUE_1, _PARAMETER_VALUE_2};
+
+		_searchContext.setAttribute(_PARAMETER_NAME, arrayOfStrings);
+
+		_assertParameters();
+	}
+
+	@Test
+	public void testCreateWithListParameter() {
+		List<String> requestAttributes = new ArrayList<>();
+
+		requestAttributes.add(_PARAMETER_VALUE_1);
+
+		requestAttributes.add(_PARAMETER_VALUE_2);
+
+		_searchContext.setAttribute(
+			_PARAMETER_NAME, (Serializable)requestAttributes);
+
+		_assertParameters();
+	}
+
+	private void _assertParameters() {
+		SXPParameterData sxpParameterData = SXPParameterDataCreatorUtil.create(
+			_runtimeException::addSuppressed, _searchContext, _sxpBlueprint,
+			new SXPParameterContributor[0]);
+
+		SXPParameter sxpParameter = sxpParameterData.getSXPParameterByName(
+			_PARAMETER_NAME);
+
+		String[] generatedArray = (String[])sxpParameter.getValue();
+
+		Assert.assertEquals(
+			Arrays.toString(generatedArray), 2, generatedArray.length);
+		Assert.assertEquals(_PARAMETER_VALUE_1, generatedArray[0]);
+		Assert.assertEquals(_PARAMETER_VALUE_2, generatedArray[1]);
+	}
+
+	private static final String _PARAMETER_NAME = RandomTestUtil.randomString();
+
+	private static final String _PARAMETER_VALUE_1 =
+		RandomTestUtil.randomString();
+
+	private static final String _PARAMETER_VALUE_2 =
+		RandomTestUtil.randomString();
+
+	private final Parameter.Type _parameterType = Parameter.Type.STRING_ARRAY;
+	private final RuntimeException _runtimeException = new RuntimeException();
+	private final SearchContext _searchContext = new SearchContext();
+	private final SXPBlueprint _sxpBlueprint = new SXPBlueprint();
+
+}


### PR DESCRIPTION
Fix for https://github.com/brianchandotcom/liferay-portal/pull/173782
Changed: removed usage of java.util.stream.Stream

LPD Ticket: https://liferay.atlassian.net/browse/LPD-86209
LPP Ticket: https://liferay.atlassian.net/browse/LPP-63633

The customer's issue is a misalignment of string array representations between request json -> search experiences code -> Query DSL sent to Elasticsearch. Adding support for this case in the search-experiences-service seemed like the better approach than touching the json deserialization in portal-kernel.