### PR TITLE
LPD-75963 Localize and highlight Object entries in search

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectEntrySearchConstants.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectEntrySearchConstants.java
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.constants;
+
+/**
+ * @author Joshua Cords
+ */
+public class ObjectEntrySearchConstants {
+
+	public static final String DEFAULT_LANGUAGE_ID = "defaultLanguageId";
+
+	public static final String NESTED_FIELD_ARRAY = "nestedFieldArray";
+
+	public static final String NESTED_FIELD_ARRAY_FIELD_NAME =
+		"nestedFieldArray.fieldName";
+
+	public static final String NESTED_FIELD_ARRAY_VALUE =
+		"nestedFieldArray.value";
+
+	public static final String NESTED_FIELD_ARRAY_VALUE_BOOLEAN =
+		"nestedFieldArray.value_boolean";
+
+	public static final String NESTED_FIELD_ARRAY_VALUE_DATE =
+		"nestedFieldArray.value_date";
+
+	public static final String NESTED_FIELD_ARRAY_VALUE_DOUBLE =
+		"nestedFieldArray.value_double";
+
+	public static final String NESTED_FIELD_ARRAY_VALUE_INTEGER =
+		"nestedFieldArray.value_integer";
+
+	public static final String NESTED_FIELD_ARRAY_VALUE_KEYWORD =
+		"nestedFieldArray.value_keyword";
+
+	public static final String NESTED_FIELD_ARRAY_VALUE_LONG =
+		"nestedFieldArray.value_long";
+
+	public static final String NESTED_FIELD_ARRAY_VALUE_TEXT =
+		"nestedFieldArray.value_text";
+
+	public static final String OBJECT_ENTRY_CONTENT = "objectEntryContent";
+
+	public static final String OBJECT_ENTRY_TITLE = "objectEntryTitle";
+
+}

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectEntrySearchConstants.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectEntrySearchConstants.java
@@ -20,6 +20,9 @@ public class ObjectEntrySearchConstants {
 	public static final String NESTED_FIELD_ARRAY_VALUE =
 		"nestedFieldArray.value";
 
+	public static final String NESTED_FIELD_ARRAY_VALUE_BINARY =
+		"nestedFieldArray.value_binary";
+
 	public static final String NESTED_FIELD_ARRAY_VALUE_BOOLEAN =
 		"nestedFieldArray.value_boolean";
 
@@ -34,6 +37,9 @@ public class ObjectEntrySearchConstants {
 
 	public static final String NESTED_FIELD_ARRAY_VALUE_KEYWORD =
 		"nestedFieldArray.value_keyword";
+
+	public static final String NESTED_FIELD_ARRAY_VALUE_KEYWORD_LOWERCASE =
+		"nestedFieldArray.value_keyword_lowercase";
 
 	public static final String NESTED_FIELD_ARRAY_VALUE_LONG =
 		"nestedFieldArray.value_long";

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -18,6 +18,7 @@ import com.liferay.object.comment.ObjectEntryComment;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectEntrySearchConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
@@ -3220,18 +3221,22 @@ public class DefaultObjectEntryManagerImpl
 		for (Map.Entry<String, String> entry : aggregationTerms.entrySet()) {
 			String value = entry.getValue();
 
-			if (!value.startsWith("nestedFieldArray")) {
+			if (!value.startsWith(
+					ObjectEntrySearchConstants.NESTED_FIELD_ARRAY)) {
+
 				continue;
 			}
 
 			NestedAggregation nestedAggregation = aggregations.nested(
-				entry.getKey(), "nestedFieldArray");
+				entry.getKey(), ObjectEntrySearchConstants.NESTED_FIELD_ARRAY);
 
 			String[] valueParts = value.split(StringPool.POUND);
 
 			FilterAggregation filterAggregation = aggregations.filter(
 				"filterAggregation",
-				QueriesUtil.term("nestedFieldArray.fieldName", valueParts[1]));
+				QueriesUtil.term(
+					ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_FIELD_NAME,
+					valueParts[1]));
 
 			filterAggregation.addChildAggregation(
 				aggregations.terms(entry.getKey(), valueParts[0]));

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -57,6 +57,7 @@ import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectEntrySearchConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.constants.ObjectFieldValidationConstants;
 import com.liferay.object.constants.ObjectFilterConstants;
@@ -6808,7 +6809,11 @@ public class DefaultObjectEntryManagerImplTest
 
 		JSONObject objectEntryContentJSONObject =
 			JSONFactoryUtil.createJSONObject(
-				"{" + document.getString("objectEntryContent") + "}");
+				StringBundler.concat(
+					"{",
+					document.getString(
+						ObjectEntrySearchConstants.OBJECT_ENTRY_CONTENT),
+					"}"));
 
 		for (ObjectField objectField :
 				objectFieldLocalService.getObjectFields(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -379,10 +379,22 @@ public class ObjectEntryModelDocumentContributor
 				}
 			}
 
-			document.add(
-				new Field(
-					"objectEntryContent",
-					textEmbeddingContentHelper.getNonlocalizedContent()));
+			Map<String, String> localizedContentMap =
+				textEmbeddingContentHelper.getLocalizedContentMap();
+
+			for (Map.Entry<String, String> entry  : localizedContentMap.entrySet()) {
+				document.add(
+					new Field(
+						"objectEntryContent_" + entry.getKey(),
+						entry.getValue()));
+			}
+
+			if (localizedContentMap.isEmpty()) {
+				document.add(
+					new Field(
+						"objectEntryContent",
+						textEmbeddingContentHelper.getNonlocalizedContent()));
+			}
 		}
 
 		document.addKeyword("objectEntryId", objectEntry.getObjectEntryId());

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -118,7 +118,7 @@ public class ObjectEntryModelDocumentContributor
 
 	private void _addLocalizedTitleFields(
 			Document document, ObjectDefinition objectDefinition,
-			ObjectEntry objectEntry, Map<String, Serializable> values)
+			ObjectEntry objectEntry)
 		throws Exception {
 
 		long titleObjectFieldId = objectDefinition.getTitleObjectFieldId();
@@ -134,6 +134,8 @@ public class ObjectEntryModelDocumentContributor
 
 			return;
 		}
+
+		Map<String, Serializable> values = objectEntry.getIndexedValues();
 
 		Map<String, Object> localizedValues = (Map<String, Object>)values.get(
 			titleObjectField.getI18nObjectFieldName());
@@ -444,12 +446,7 @@ public class ObjectEntryModelDocumentContributor
 
 		document.addKeyword("objectEntryId", objectEntry.getObjectEntryId());
 
-		if (values == null) {
-			values = objectEntry.getIndexedValues();
-		}
-
-		_addLocalizedTitleFields(
-			document, objectDefinition, objectEntry, values);
+		_addLocalizedTitleFields(document, objectDefinition, objectEntry);
 
 		ObjectFolder objectFolder = objectDefinition.getObjectFolder();
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -13,6 +13,7 @@ import com.liferay.document.library.kernel.model.DLFileEntryTable;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectEntrySearchConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.entry.util.ObjectEntryValuesUtil;
 import com.liferay.object.model.ObjectDefinition;
@@ -130,7 +131,9 @@ public class ObjectEntryModelDocumentContributor
 
 		if ((titleObjectField == null) || !titleObjectField.isLocalized()) {
 			document.add(
-				new Field("objectEntryTitle", objectEntry.getTitleValue()));
+				new Field(
+					ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE,
+					objectEntry.getTitleValue()));
 
 			return;
 		}
@@ -142,7 +145,9 @@ public class ObjectEntryModelDocumentContributor
 
 		if (MapUtil.isEmpty(localizedValues)) {
 			document.add(
-				new Field("objectEntryTitle", objectEntry.getTitleValue()));
+				new Field(
+					ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE,
+					objectEntry.getTitleValue()));
 
 			return;
 		}
@@ -159,7 +164,11 @@ public class ObjectEntryModelDocumentContributor
 			}
 
 			document.add(
-				new Field("objectEntryTitle_" + languageId, titleValue));
+				new Field(
+					Field.getLocalizedName(
+						languageId,
+						ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE),
+					titleValue));
 		}
 	}
 
@@ -350,7 +359,8 @@ public class ObjectEntryModelDocumentContributor
 		}
 
 		document.addText(
-			"defaultLanguageId", objectEntry.getDefaultLanguageId());
+			ObjectEntrySearchConstants.DEFAULT_LANGUAGE_ID,
+			objectEntry.getDefaultLanguageId());
 
 		document.add(
 			new Field(
@@ -358,10 +368,11 @@ public class ObjectEntryModelDocumentContributor
 				document.get(Field.ENTRY_CLASS_PK)));
 
 		FieldArray fieldArray = (FieldArray)document.getField(
-			"nestedFieldArray");
+			ObjectEntrySearchConstants.NESTED_FIELD_ARRAY);
 
 		if (fieldArray == null) {
-			fieldArray = new FieldArray("nestedFieldArray");
+			fieldArray = new FieldArray(
+				ObjectEntrySearchConstants.NESTED_FIELD_ARRAY);
 
 			document.add(fieldArray);
 		}
@@ -440,14 +451,15 @@ public class ObjectEntryModelDocumentContributor
 				document.add(
 					new Field(
 						Field.getLocalizedName(
-							entry.getKey(), "objectEntryContent"),
+							entry.getKey(),
+							ObjectEntrySearchConstants.OBJECT_ENTRY_CONTENT),
 						entry.getValue()));
 			}
 
 			if (localizedContentMap.isEmpty()) {
 				document.add(
 					new Field(
-						"objectEntryContent",
+						ObjectEntrySearchConstants.OBJECT_ENTRY_CONTENT,
 						textEmbeddingContentHelper.getNonlocalizedContent()));
 			}
 		}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -14,6 +14,7 @@ import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.entry.util.ObjectEntryValuesUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectEntryFolder;
@@ -113,6 +114,44 @@ public class ObjectEntryModelDocumentContributor
 		field.addField(new Field(valueFieldName, value));
 
 		fieldArray.addField(field);
+	}
+
+	private void _addLocalizedTitleFields(
+		Document document, ObjectDefinition objectDefinition,
+		Map<String, Serializable> values) {
+
+		long titleObjectFieldId = objectDefinition.getTitleObjectFieldId();
+
+		ObjectFieldBag objectFieldBag = objectDefinition.getObjectFieldBag();
+
+		ObjectField titleObjectField = objectFieldBag.getObjectField(
+			titleObjectFieldId);
+
+		if ((titleObjectField == null) || !titleObjectField.isLocalized()) {
+			return;
+		}
+
+		Map<String, Object> localizedValues = (Map<String, Object>)values.get(
+			titleObjectField.getI18nObjectFieldName());
+
+		if (MapUtil.isEmpty(localizedValues)) {
+			return;
+		}
+
+		for (Map.Entry<String, Object> entry : localizedValues.entrySet()) {
+			String languageId = entry.getKey();
+
+			String titleValue = String.valueOf(
+				ObjectEntryValuesUtil.getValue(
+					languageId, titleObjectField, values));
+
+			if (Validator.isBlank(titleValue)) {
+				continue;
+			}
+
+			document.add(
+				new Field("objectEntryTitle_" + languageId, titleValue));
+		}
 	}
 
 	private void _appendToContent(
@@ -382,7 +421,9 @@ public class ObjectEntryModelDocumentContributor
 			Map<String, String> localizedContentMap =
 				textEmbeddingContentHelper.getLocalizedContentMap();
 
-			for (Map.Entry<String, String> entry  : localizedContentMap.entrySet()) {
+			for (Map.Entry<String, String> entry :
+					localizedContentMap.entrySet()) {
+
 				document.add(
 					new Field(
 						"objectEntryContent_" + entry.getKey(),
@@ -400,6 +441,12 @@ public class ObjectEntryModelDocumentContributor
 		document.addKeyword("objectEntryId", objectEntry.getObjectEntryId());
 		document.add(
 			new Field("objectEntryTitle", objectEntry.getTitleValue()));
+
+		if (values == null) {
+			values = objectEntry.getIndexedValues();
+		}
+
+		_addLocalizedTitleFields(document, objectDefinition, values);
 
 		ObjectFolder objectFolder = objectDefinition.getObjectFolder();
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -349,6 +349,9 @@ public class ObjectEntryModelDocumentContributor
 			_log.debug("Object entry " + objectEntry);
 		}
 
+		document.addText(
+			"defaultLanguageId", objectEntry.getDefaultLanguageId());
+
 		document.add(
 			new Field(
 				Field.getSortableFieldName(Field.ENTRY_CLASS_PK),
@@ -435,7 +438,8 @@ public class ObjectEntryModelDocumentContributor
 
 				document.add(
 					new Field(
-						"objectEntryContent_" + entry.getKey(),
+						Field.getLocalizedName(
+							entry.getKey(), "objectEntryContent"),
 						entry.getValue()));
 			}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -116,7 +116,7 @@ public class ObjectEntryModelDocumentContributor
 		fieldArray.addField(field);
 	}
 
-	private void _addLocalizedTitleFields(
+	private void _addTitleFields(
 			Document document, ObjectDefinition objectDefinition,
 			ObjectEntry objectEntry)
 		throws Exception {
@@ -141,6 +141,9 @@ public class ObjectEntryModelDocumentContributor
 			titleObjectField.getI18nObjectFieldName());
 
 		if (MapUtil.isEmpty(localizedValues)) {
+			document.add(
+				new Field("objectEntryTitle", objectEntry.getTitleValue()));
+
 			return;
 		}
 
@@ -446,7 +449,7 @@ public class ObjectEntryModelDocumentContributor
 
 		document.addKeyword("objectEntryId", objectEntry.getObjectEntryId());
 
-		_addLocalizedTitleFields(document, objectDefinition, objectEntry);
+		_addTitleFields(document, objectDefinition, objectEntry);
 
 		ObjectFolder objectFolder = objectDefinition.getObjectFolder();
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -47,6 +47,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.ml.embedding.text.TextEmbeddingDocumentContributor;
+import com.liferay.portal.search.ml.embedding.text.helper.TextEmbeddingContentHelper;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 
 import java.io.Serializable;
@@ -59,13 +60,11 @@ import java.sql.Types;
 import java.text.Format;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.TreeMap;
 
 /**
  * @author Marco Leo
@@ -117,26 +116,25 @@ public class ObjectEntryModelDocumentContributor
 	}
 
 	private void _appendToContent(
-		ObjectContentHelper objectContentHelper, String locale,
-		String objectFieldName, String valueString) {
+		String locale, String objectFieldName,
+		TextEmbeddingContentHelper<ObjectEntry> textEmbeddingContentHelper,
+		String valueString) {
 
-		if (locale == null) {
-			objectContentHelper.contributeToAll(
-				objectFieldName, ": ", valueString, StringPool.COMMA_AND_SPACE);
+		if (locale != null) {
+			textEmbeddingContentHelper.append(
+				locale, objectFieldName, ": ", valueString);
 		}
 		else {
-			objectContentHelper.contributeToLocale(
-				locale, objectFieldName, ": ", valueString,
-				StringPool.COMMA_AND_SPACE);
+			textEmbeddingContentHelper.append(
+				objectFieldName, ": ", valueString);
 		}
 	}
 
 	private void _contribute(
 		Document document, FieldArray fieldArray, String fieldName,
-		Object fieldValue, String locale,
-		ObjectContentHelper objectContentHelper,
-		ObjectDefinition objectDefinition, ObjectEntry objectEntry,
-		ObjectField objectField) {
+		Object fieldValue, String locale, ObjectDefinition objectDefinition,
+		ObjectEntry objectEntry, ObjectField objectField,
+		TextEmbeddingContentHelper<ObjectEntry> textEmbeddingContentHelper) {
 
 		if (!objectField.isIndexed()) {
 			return;
@@ -214,13 +212,13 @@ public class ObjectEntryModelDocumentContributor
 				StringUtil.lowerCase(valueString));
 
 			_appendToContent(
-				objectContentHelper, locale, fieldName, valueString);
+				locale, fieldName, textEmbeddingContentHelper, valueString);
 		}
 		else if (fieldValue instanceof BigDecimal) {
 			_addField(fieldArray, fieldName, "value_double", valueString);
 
 			_appendToContent(
-				objectContentHelper, locale, fieldName, valueString);
+				locale, fieldName, textEmbeddingContentHelper, valueString);
 		}
 		else if (fieldValue instanceof Boolean) {
 			_addField(fieldArray, fieldName, "value_boolean", valueString);
@@ -229,7 +227,7 @@ public class ObjectEntryModelDocumentContributor
 				_translate((Boolean)fieldValue));
 
 			_appendToContent(
-				objectContentHelper, locale, fieldName, valueString);
+				locale, fieldName, textEmbeddingContentHelper, valueString);
 		}
 		else if (fieldValue instanceof Date) {
 			_addField(
@@ -237,26 +235,26 @@ public class ObjectEntryModelDocumentContributor
 				_getDateString(fieldValue));
 
 			_appendToContent(
-				objectContentHelper, locale, fieldName,
+				locale, fieldName, textEmbeddingContentHelper,
 				_getDateString(fieldValue));
 		}
 		else if (fieldValue instanceof Double) {
 			_addField(fieldArray, fieldName, "value_double", valueString);
 
 			_appendToContent(
-				objectContentHelper, locale, fieldName, valueString);
+				locale, fieldName, textEmbeddingContentHelper, valueString);
 		}
 		else if (fieldValue instanceof Integer) {
 			_addField(fieldArray, fieldName, "value_integer", valueString);
 
 			_appendToContent(
-				objectContentHelper, locale, fieldName, valueString);
+				locale, fieldName, textEmbeddingContentHelper, valueString);
 		}
 		else if (fieldValue instanceof Long) {
 			_addField(fieldArray, fieldName, "value_long", valueString);
 
 			_appendToContent(
-				objectContentHelper, locale, fieldName, valueString);
+				locale, fieldName, textEmbeddingContentHelper, valueString);
 		}
 		else if (fieldValue instanceof String) {
 			if (Validator.isBlank(objectField.getIndexedLanguageId())) {
@@ -277,7 +275,7 @@ public class ObjectEntryModelDocumentContributor
 				_getSortableValue(valueString));
 
 			_appendToContent(
-				objectContentHelper, locale, fieldName, valueString);
+				locale, fieldName, textEmbeddingContentHelper, valueString);
 		}
 		else if (fieldValue instanceof byte[]) {
 			_addField(
@@ -341,14 +339,16 @@ public class ObjectEntryModelDocumentContributor
 			objectFields = objectFieldBag.getNonsystemIndexedObjectFields();
 		}
 
-		ObjectContentHelper objectContentHelper = null;
 		Map<String, Serializable> values = null;
+
+		TextEmbeddingContentHelper<ObjectEntry> textEmbeddingContentHelper =
+			new TextEmbeddingContentHelper<>(
+				objectEntry.getCompanyId(), objectEntry.getDefaultLanguageId(),
+				StringPool.COMMA_AND_SPACE, objectEntry, objectFields.size(),
+				_textEmbeddingDocumentContributor);
 
 		if (!objectFields.isEmpty()) {
 			values = objectEntry.getIndexedValues();
-
-			objectContentHelper = new ObjectContentHelper(
-				objectEntry, objectFields, _textEmbeddingDocumentContributor);
 
 			for (ObjectField objectField : objectFields) {
 				if (objectField.isLocalized()) {
@@ -365,25 +365,24 @@ public class ObjectEntryModelDocumentContributor
 
 						_contribute(
 							document, fieldArray, objectField.getName(),
-							entry.getValue(), entry.getKey(),
-							objectContentHelper, objectDefinition, objectEntry,
-							objectField);
+							entry.getValue(), entry.getKey(), objectDefinition,
+							objectEntry, objectField,
+							textEmbeddingContentHelper);
 					}
 				}
 				else {
 					_contribute(
 						document, fieldArray, objectField.getName(),
 						values.get(objectField.getName()), null,
-						objectContentHelper, objectDefinition, objectEntry,
-						objectField);
+						objectDefinition, objectEntry, objectField,
+						textEmbeddingContentHelper);
 				}
 			}
 
-			objectContentHelper.trim();
-
 			document.add(
 				new Field(
-					"objectEntryContent", objectContentHelper.getContent()));
+					"objectEntryContent",
+					textEmbeddingContentHelper.getNonlocalizedContent()));
 		}
 
 		document.addKeyword("objectEntryId", objectEntry.getObjectEntryId());
@@ -448,7 +447,7 @@ public class ObjectEntryModelDocumentContributor
 					values, "r_cmpProjectToCMPTasks_c_cmpProjectId"));
 		}
 
-		_contributeTextEmbeddings(document, objectContentHelper, objectEntry);
+		textEmbeddingContentHelper.contribute(document);
 	}
 
 	private void _contributeFile(Document document, long fileEntryId) {
@@ -493,26 +492,6 @@ public class ObjectEntryModelDocumentContributor
 			rootObjectEntryFolder.getObjectEntryFolderId() ==
 				objectEntryFolderId);
 		document.addKeyword("cms_section", cmsSection);
-	}
-
-	private void _contributeTextEmbeddings(
-		Document document, ObjectContentHelper objectContentHelper,
-		ObjectEntry objectEntry) {
-
-		if (objectContentHelper == null) {
-			return;
-		}
-
-		Map<String, String> localizedContentMap =
-			objectContentHelper.getLocalizedContentMap();
-
-		for (Map.Entry<String, String> localizedContent :
-				localizedContentMap.entrySet()) {
-
-			_textEmbeddingDocumentContributor.contribute(
-				document, localizedContent.getKey(), objectEntry,
-				localizedContent.getValue());
-		}
 	}
 
 	private String _getCMSSection(String externalReferenceCode) {
@@ -702,123 +681,6 @@ public class ObjectEntryModelDocumentContributor
 	private final ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 	private final TextEmbeddingDocumentContributor
 		_textEmbeddingDocumentContributor;
-
-	private static class ObjectContentHelper {
-
-		public void contributeToAll(
-			String s1, String s2, String s3, String s4) {
-
-			_contentSB.append(s1);
-			_contentSB.append(s2);
-			_contentSB.append(s3);
-			_contentSB.append(s4);
-
-			if (_localizedContentSBMap == null) {
-				return;
-			}
-
-			for (StringBundler localizedContentSB :
-					_localizedContentSBMap.values()) {
-
-				localizedContentSB.append(s1);
-				localizedContentSB.append(s2);
-				localizedContentSB.append(s3);
-				localizedContentSB.append(s4);
-			}
-		}
-
-		public void contributeToLocale(
-			String locale, String s1, String s2, String s3, String s4) {
-
-			_contentSB.append(s1);
-			_contentSB.append(s2);
-			_contentSB.append(s3);
-			_contentSB.append(s4);
-
-			if (_localizedContentSBMap == null) {
-				return;
-			}
-
-			StringBundler localizedContentSB = _localizedContentSBMap.get(
-				locale);
-
-			if (localizedContentSB != null) {
-				localizedContentSB.append(s1);
-				localizedContentSB.append(s2);
-				localizedContentSB.append(s3);
-				localizedContentSB.append(s4);
-			}
-		}
-
-		public String getContent() {
-			return _contentSB.toString();
-		}
-
-		public Map<String, String> getLocalizedContentMap() {
-			if (_localizedContentSBMap == null) {
-				return Collections.emptyMap();
-			}
-
-			Map<String, String> localizedContentMap = new TreeMap<>();
-
-			for (Map.Entry<String, StringBundler> localizedContentEntry :
-					_localizedContentSBMap.entrySet()) {
-
-				StringBundler sb = localizedContentEntry.getValue();
-
-				if (sb.index() > 0) {
-					localizedContentMap.put(
-						localizedContentEntry.getKey(), sb.toString());
-				}
-			}
-
-			return localizedContentMap;
-		}
-
-		public void trim() {
-			if (_contentSB.index() > 0) {
-				_contentSB.setIndex(_contentSB.index() - 1);
-			}
-
-			if (_localizedContentSBMap == null) {
-				return;
-			}
-
-			for (StringBundler localizedContentSB :
-					_localizedContentSBMap.values()) {
-
-				if (localizedContentSB.index() > 0) {
-					localizedContentSB.setIndex(localizedContentSB.index() - 1);
-				}
-			}
-		}
-
-		private ObjectContentHelper(
-			ObjectEntry objectEntry, List<ObjectField> objectFields,
-			TextEmbeddingDocumentContributor textEmbeddingDocumentContributor) {
-
-			_contentSB = new StringBundler(objectFields.size() * 4);
-
-			List<String> languageIds =
-				textEmbeddingDocumentContributor.getLanguageIds(objectEntry);
-
-			if (languageIds.isEmpty()) {
-				_localizedContentSBMap = null;
-			}
-			else {
-				_localizedContentSBMap = new TreeMap<>();
-
-				for (String languageId : languageIds) {
-					_localizedContentSBMap.put(
-						languageId, new StringBundler(objectFields.size() * 4));
-				}
-			}
-		}
-
-		private final StringBundler _contentSB;
-		private final Map<String, StringBundler> _localizedContentSBMap;
-
-	}
 
 	private static class ObjectFieldTable extends BaseTable<ObjectFieldTable> {
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -117,8 +117,9 @@ public class ObjectEntryModelDocumentContributor
 	}
 
 	private void _addLocalizedTitleFields(
-		Document document, ObjectDefinition objectDefinition,
-		Map<String, Serializable> values) {
+			Document document, ObjectDefinition objectDefinition,
+			ObjectEntry objectEntry, Map<String, Serializable> values)
+		throws Exception {
 
 		long titleObjectFieldId = objectDefinition.getTitleObjectFieldId();
 
@@ -128,6 +129,9 @@ public class ObjectEntryModelDocumentContributor
 			titleObjectFieldId);
 
 		if ((titleObjectField == null) || !titleObjectField.isLocalized()) {
+			document.add(
+				new Field("objectEntryTitle", objectEntry.getTitleValue()));
+
 			return;
 		}
 
@@ -439,14 +443,13 @@ public class ObjectEntryModelDocumentContributor
 		}
 
 		document.addKeyword("objectEntryId", objectEntry.getObjectEntryId());
-		document.add(
-			new Field("objectEntryTitle", objectEntry.getTitleValue()));
 
 		if (values == null) {
 			values = objectEntry.getIndexedValues();
 		}
 
-		_addLocalizedTitleFields(document, objectDefinition, values);
+		_addLocalizedTitleFields(
+			document, objectDefinition, objectEntry, values);
 
 		ObjectFolder objectFolder = objectDefinition.getObjectFolder();
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -395,7 +395,8 @@ public class ObjectEntryModelDocumentContributor
 		TextEmbeddingContentHelper<ObjectEntry> textEmbeddingContentHelper =
 			new TextEmbeddingContentHelper<>(
 				objectEntry.getCompanyId(), objectEntry.getDefaultLanguageId(),
-				StringPool.COMMA_AND_SPACE, objectEntry, objectFields.size(),
+				StringPool.COMMA_AND_SPACE, objectEntry,
+				(objectFields.size() * 4) - 1,
 				_textEmbeddingDocumentContributor);
 
 		if (!objectFields.isEmpty()) {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryHighlightFieldNamesQueryConfigContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryHighlightFieldNamesQueryConfigContributor.java
@@ -5,6 +5,7 @@
 
 package com.liferay.object.internal.search.spi.model.query.contributor;
 
+import com.liferay.object.constants.ObjectEntrySearchConstants;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.search.localization.SearchLocalizationHelper;
@@ -26,15 +27,20 @@ public class ObjectEntryHighlightFieldNamesQueryConfigContributor
 	@Override
 	public String[] getHighlightFieldNames(SearchContext searchContext) {
 		String[] fieldNames = {
-			"entryClassPK", "nestedFieldArray.value_boolean",
-			"nestedFieldArray.value_keyword", "nestedFieldArray.value_text",
-			"objectEntryTitle"
+			"entryClassPK",
+			ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_BOOLEAN,
+			ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_KEYWORD,
+			ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_TEXT,
+			ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE
 		};
 
 		return ArrayUtil.append(
 			fieldNames,
 			_searchLocalizationHelper.getLocalizedFieldNames(
-				new String[] {"nestedFieldArray.value"}, searchContext));
+				new String[] {
+					ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE
+				},
+				searchContext));
 	}
 
 	@Reference

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryHighlightFieldNamesQueryConfigContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryHighlightFieldNamesQueryConfigContributor.java
@@ -6,6 +6,7 @@
 package com.liferay.object.internal.search.spi.model.query.contributor;
 
 import com.liferay.object.constants.ObjectEntrySearchConstants;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.search.localization.SearchLocalizationHelper;
@@ -27,7 +28,7 @@ public class ObjectEntryHighlightFieldNamesQueryConfigContributor
 	@Override
 	public String[] getHighlightFieldNames(SearchContext searchContext) {
 		String[] fieldNames = {
-			"entryClassPK",
+			Field.ENTRY_CLASS_PK,
 			ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_BOOLEAN,
 			ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_KEYWORD,
 			ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_TEXT,

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -130,19 +130,33 @@ public class ObjectEntryKeywordQueryContributor
 
 		queryConfig.addHighlightFieldNames(Field.ENTRY_CLASS_PK);
 
+		Locale defaultLocale = LocaleUtil.fromLanguageId(
+			_objectDefinition.getDefaultLanguageId());
+
+		if (Objects.equals(defaultLocale, searchContext.getLocale())) {
+			defaultLocale = null;
+		}
+
 		_addLocalizedHighlightFieldNames(
-			objectFields, queryConfig, searchContext);
+			defaultLocale, objectFields, queryConfig, searchContext);
 
 		String titleField = "objectEntryTitle";
 
+		String defaultLocalizedTitleFieldName = Field.getLocalizedName(
+			defaultLocale, titleField);
 		String localizedTitleFieldName = Field.getLocalizedName(
 			searchContext.getLocale(), titleField);
 
 		if (StringUtil.startsWith(keywords, CharPool.QUOTE) &&
 			StringUtil.endsWith(keywords, CharPool.QUOTE)) {
 
-			_addTerm(booleanQuery, titleField, keywords);
+			if (defaultLocale != null) {
+				_addTerm(
+					booleanQuery, defaultLocalizedTitleFieldName, keywords);
+			}
+
 			_addTerm(booleanQuery, localizedTitleFieldName, keywords);
+			_addTerm(booleanQuery, titleField, keywords);
 
 			try {
 				for (ObjectField objectField : objectFields) {
@@ -156,8 +170,13 @@ public class ObjectEntryKeywordQueryContributor
 		}
 		else {
 			if (addObjectEntryTitle.get()) {
-				_addTerm(booleanQuery, titleField, keywords);
+				if (defaultLocale != null) {
+					_addTerm(
+						booleanQuery, defaultLocalizedTitleFieldName, keywords);
+				}
+
 				_addTerm(booleanQuery, localizedTitleFieldName, keywords);
+				_addTerm(booleanQuery, titleField, keywords);
 			}
 
 			for (String token : _tokenizeKeywords(keywords)) {
@@ -185,21 +204,20 @@ public class ObjectEntryKeywordQueryContributor
 	}
 
 	private void _addLocalizedHighlightFieldNames(
-		List<ObjectField> objectFields, QueryConfig queryConfig,
-		SearchContext searchContext) {
+		Locale defaultLocale, List<ObjectField> objectFields,
+		QueryConfig queryConfig, SearchContext searchContext) {
 
 		Locale locale = searchContext.getLocale();
 
-		if (locale == null) {
-			queryConfig.addHighlightFieldNames("objectEntryContent");
-			queryConfig.addHighlightFieldNames("objectEntryTitle");
-
-			return;
-		}
-
-		if (_hasLocalizedContent(objectFields)) {
+		if (_isLocalized(objectFields)) {
 			queryConfig.addHighlightFieldNames(
-				"objectEntryContent_" + LocaleUtil.toLanguageId(locale));
+				Field.getLocalizedName(locale, "objectEntryContent"));
+
+			if (defaultLocale != null) {
+				queryConfig.addHighlightFieldNames(
+					Field.getLocalizedName(
+						defaultLocale, "objectEntryContent"));
+			}
 		}
 		else {
 			queryConfig.addHighlightFieldNames("objectEntryContent");
@@ -214,7 +232,12 @@ public class ObjectEntryKeywordQueryContributor
 
 		if ((titleObjectField != null) && titleObjectField.isLocalized()) {
 			queryConfig.addHighlightFieldNames(
-				"objectEntryTitle_" + LocaleUtil.toLanguageId(locale));
+				Field.getLocalizedName(locale, "objectEntryTitle"));
+
+			if (defaultLocale != null) {
+				queryConfig.addHighlightFieldNames(
+					Field.getLocalizedName(defaultLocale, "objectEntryTitle"));
+			}
 		}
 		else {
 			queryConfig.addHighlightFieldNames("objectEntryTitle");
@@ -488,7 +511,7 @@ public class ObjectEntryKeywordQueryContributor
 		return value;
 	}
 
-	private boolean _hasLocalizedContent(List<ObjectField> objectFields) {
+	private boolean _isLocalized(List<ObjectField> objectFields) {
 		if (ListUtil.isEmpty(objectFields)) {
 			return false;
 		}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -295,7 +295,13 @@ public class ObjectEntryKeywordQueryContributor
 			booleanQuery.addTerm(fieldName, value, false);
 		}
 		catch (ParseException parseException) {
-			throw new SystemException(parseException);
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"Unable to add term for field ", fieldName,
+						" and value ", value),
+					parseException);
+			}
 		}
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -132,8 +132,6 @@ public class ObjectEntryKeywordQueryContributor
 
 		QueryConfig queryConfig = searchContext.getQueryConfig();
 
-		String titleField = ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE;
-
 		Locale defaultLocale = LocaleUtil.fromLanguageId(
 			_objectDefinition.getDefaultLanguageId());
 
@@ -144,14 +142,15 @@ public class ObjectEntryKeywordQueryContributor
 		}
 		else {
 			defaultLocalizedTitleFieldName = Field.getLocalizedName(
-				defaultLocale, titleField);
+				defaultLocale, ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE);
 		}
 
 		String localizedTitleFieldName = null;
 
 		if (Validator.isNotNull(searchContext.getLocale())) {
 			localizedTitleFieldName = Field.getLocalizedName(
-				searchContext.getLocale(), titleField);
+				searchContext.getLocale(),
+				ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE);
 		}
 
 		_addLocalizedHighlightFieldNames(
@@ -169,7 +168,9 @@ public class ObjectEntryKeywordQueryContributor
 				_addTerm(booleanQuery, localizedTitleFieldName, keywords);
 			}
 
-			_addTerm(booleanQuery, titleField, keywords);
+			_addTerm(
+				booleanQuery, ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE,
+				keywords);
 
 			try {
 				for (ObjectField objectField : objectFields) {
@@ -193,7 +194,9 @@ public class ObjectEntryKeywordQueryContributor
 					_addTerm(booleanQuery, localizedTitleFieldName, keywords);
 				}
 
-				_addTerm(booleanQuery, titleField, keywords);
+				_addTerm(
+					booleanQuery, ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE,
+					keywords);
 			}
 
 			for (String token : _tokenizeKeywords(keywords)) {
@@ -203,7 +206,9 @@ public class ObjectEntryKeywordQueryContributor
 						BooleanClauseOccur.SHOULD);
 
 					booleanQuery.add(
-						new WildcardQuery(titleField, token + StringPool.STAR),
+						new WildcardQuery(
+							ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE,
+							token + StringPool.STAR),
 						BooleanClauseOccur.SHOULD);
 				}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -131,8 +131,6 @@ public class ObjectEntryKeywordQueryContributor
 
 		QueryConfig queryConfig = searchContext.getQueryConfig();
 
-		queryConfig.addHighlightFieldNames(Field.ENTRY_CLASS_PK);
-
 		Locale defaultLocale = LocaleUtil.fromLanguageId(
 			_objectDefinition.getDefaultLanguageId());
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -131,22 +131,30 @@ public class ObjectEntryKeywordQueryContributor
 
 		QueryConfig queryConfig = searchContext.getQueryConfig();
 
+		String titleField = "objectEntryTitle";
+
 		Locale defaultLocale = LocaleUtil.fromLanguageId(
 			_objectDefinition.getDefaultLanguageId());
+
+		String defaultLocalizedTitleFieldName = null;
 
 		if (Objects.equals(defaultLocale, searchContext.getLocale())) {
 			defaultLocale = null;
 		}
+		else {
+			defaultLocalizedTitleFieldName = Field.getLocalizedName(
+				defaultLocale, titleField);
+		}
+
+		String localizedTitleFieldName = null;
+
+		if (Validator.isNotNull(searchContext.getLocale())) {
+			localizedTitleFieldName = Field.getLocalizedName(
+				searchContext.getLocale(), titleField);
+		}
 
 		_addLocalizedHighlightFieldNames(
 			defaultLocale, queryConfig, searchContext);
-
-		String titleField = "objectEntryTitle";
-
-		String defaultLocalizedTitleFieldName = Field.getLocalizedName(
-			defaultLocale, titleField);
-		String localizedTitleFieldName = Field.getLocalizedName(
-			searchContext.getLocale(), titleField);
 
 		if (StringUtil.startsWith(keywords, CharPool.QUOTE) &&
 			StringUtil.endsWith(keywords, CharPool.QUOTE)) {
@@ -156,7 +164,10 @@ public class ObjectEntryKeywordQueryContributor
 					booleanQuery, defaultLocalizedTitleFieldName, keywords);
 			}
 
-			_addTerm(booleanQuery, localizedTitleFieldName, keywords);
+			if (Validator.isNotNull(searchContext.getLocale())) {
+				_addTerm(booleanQuery, localizedTitleFieldName, keywords);
+			}
+
 			_addTerm(booleanQuery, titleField, keywords);
 
 			try {
@@ -177,7 +188,10 @@ public class ObjectEntryKeywordQueryContributor
 						booleanQuery, defaultLocalizedTitleFieldName, keywords);
 				}
 
-				_addTerm(booleanQuery, localizedTitleFieldName, keywords);
+				if (Validator.isNotNull(searchContext.getLocale())) {
+					_addTerm(booleanQuery, localizedTitleFieldName, keywords);
+				}
+
 				_addTerm(booleanQuery, titleField, keywords);
 			}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.search.TermQuery;
 import com.liferay.portal.kernel.search.TermRangeQuery;
 import com.liferay.portal.kernel.search.WildcardQuery;
 import com.liferay.portal.kernel.search.facet.util.RangeParserUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -44,9 +45,11 @@ import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQuery
 import java.io.Serializable;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -138,7 +141,7 @@ public class ObjectEntryKeywordQueryContributor
 		}
 
 		_addLocalizedHighlightFieldNames(
-			defaultLocale, objectFields, queryConfig, searchContext);
+			defaultLocale, queryConfig, searchContext);
 
 		String titleField = "objectEntryTitle";
 
@@ -161,7 +164,8 @@ public class ObjectEntryKeywordQueryContributor
 			try {
 				for (ObjectField objectField : objectFields) {
 					_contribute(
-						objectField, keywords, booleanQuery, searchContext);
+						objectField, keywords, booleanQuery, defaultLocale,
+						searchContext);
 				}
 			}
 			catch (ParseException parseException) {
@@ -193,7 +197,8 @@ public class ObjectEntryKeywordQueryContributor
 				for (ObjectField objectField : objectFields) {
 					try {
 						_contribute(
-							objectField, token, booleanQuery, searchContext);
+							objectField, token, booleanQuery, defaultLocale,
+							searchContext);
 					}
 					catch (ParseException parseException) {
 						throw new SystemException(parseException);
@@ -204,23 +209,19 @@ public class ObjectEntryKeywordQueryContributor
 	}
 
 	private void _addLocalizedHighlightFieldNames(
-		Locale defaultLocale, List<ObjectField> objectFields,
-		QueryConfig queryConfig, SearchContext searchContext) {
+		Locale defaultLocale, QueryConfig queryConfig,
+		SearchContext searchContext) {
 
 		Locale locale = searchContext.getLocale();
 
-		if (_isLocalized(objectFields)) {
-			queryConfig.addHighlightFieldNames(
-				Field.getLocalizedName(locale, "objectEntryContent"));
+		queryConfig.addHighlightFieldNames(
+			"nestedFieldArray.value_boolean", "nestedFieldArray.value_keyword",
+			"nestedFieldArray.value_text");
 
-			if (defaultLocale != null) {
-				queryConfig.addHighlightFieldNames(
-					Field.getLocalizedName(
-						defaultLocale, "objectEntryContent"));
-			}
-		}
-		else {
-			queryConfig.addHighlightFieldNames("objectEntryContent");
+		for (String localizedNestedFieldName :
+				_getLocalizedNestedFieldNames(defaultLocale, searchContext)) {
+
+			queryConfig.addHighlightFieldNames(localizedNestedFieldName);
 		}
 
 		long titleObjectFieldId = _objectDefinition.getTitleObjectFieldId();
@@ -298,9 +299,50 @@ public class ObjectEntryKeywordQueryContributor
 		}
 	}
 
+	private void _configureNestedQuery(
+		String[] highlightFieldNames, String innerHitsName,
+		NestedQuery nestedQuery, SearchContext searchContext) {
+
+		if (ArrayUtil.isEmpty(highlightFieldNames)) {
+			return;
+		}
+
+		Set<String> configuredInnerHitsNames =
+			(Set<String>)searchContext.getAttribute(
+				_CONFIGURED_INNER_HITS_NAMES);
+
+		if (configuredInnerHitsNames == null) {
+			configuredInnerHitsNames = new HashSet<>();
+
+			searchContext.setAttribute(
+				_CONFIGURED_INNER_HITS_NAMES,
+				(Serializable)configuredInnerHitsNames);
+		}
+
+		if (!configuredInnerHitsNames.add(innerHitsName)) {
+			return;
+		}
+
+		QueryConfig nestedQueryConfig = nestedQuery.getQueryConfig();
+		QueryConfig queryConfig = searchContext.getQueryConfig();
+
+		nestedQueryConfig.setHighlightEnabled(true);
+		nestedQueryConfig.setHighlightFieldNames(highlightFieldNames);
+		nestedQueryConfig.setHighlightFragmentSize(
+			queryConfig.getHighlightFragmentSize());
+		nestedQueryConfig.setHighlightSnippetSize(
+			queryConfig.getHighlightSnippetSize());
+		nestedQueryConfig.setHighlightRequireFieldMatch(
+			queryConfig.isHighlightRequireFieldMatch());
+		nestedQueryConfig.setLocale(queryConfig.getLocale());
+
+		nestedQuery.setInnerHitsEnabled(true);
+		nestedQuery.setInnerHitsName(innerHitsName);
+	}
+
 	private void _contribute(
 			ObjectField objectField, String token, BooleanQuery booleanQuery,
-			SearchContext searchContext)
+			Locale defaultLocale, SearchContext searchContext)
 		throws ParseException {
 
 		if ((objectField == null) || !objectField.isIndexed()) {
@@ -321,6 +363,7 @@ public class ObjectEntryKeywordQueryContributor
 		}
 
 		BooleanQuery nestedBooleanQuery = new BooleanQuery();
+		String[] highlightFieldNames = null;
 		QueryConfig queryConfig = searchContext.getQueryConfig();
 
 		if (objectField.isIndexedAsKeyword()) {
@@ -335,6 +378,8 @@ public class ObjectEntryKeywordQueryContributor
 				BooleanClauseOccur.SHOULD);
 
 			queryConfig.addHighlightFieldNames(fieldName);
+
+			highlightFieldNames = new String[] {fieldName};
 		}
 		else if (Objects.equals(
 					objectField.getBusinessType(),
@@ -349,9 +394,8 @@ public class ObjectEntryKeywordQueryContributor
 			String fieldName = "nestedFieldArray.value_text";
 
 			if (objectField.isLocalized()) {
-				String[] localizedFieldNames =
-					_searchLocalizationHelper.getLocalizedFieldNames(
-						new String[] {"nestedFieldArray.value"}, searchContext);
+				String[] localizedFieldNames = _getLocalizedNestedFieldNames(
+					defaultLocale, searchContext);
 
 				BooleanQuery localizedNestedBooleanQuery = new BooleanQuery();
 
@@ -365,6 +409,8 @@ public class ObjectEntryKeywordQueryContributor
 
 				nestedBooleanQuery.add(
 					localizedNestedBooleanQuery, BooleanClauseOccur.MUST);
+
+				highlightFieldNames = localizedFieldNames;
 			}
 			else if (Objects.equals(
 						objectField.getIndexedLanguageId(),
@@ -380,6 +426,8 @@ public class ObjectEntryKeywordQueryContributor
 					new MatchQuery(fieldName, token), BooleanClauseOccur.MUST);
 
 				queryConfig.addHighlightFieldNames(fieldName);
+
+				highlightFieldNames = new String[] {fieldName};
 			}
 		}
 		else if (Objects.equals(
@@ -461,15 +509,53 @@ public class ObjectEntryKeywordQueryContributor
 				booleanClauseOccur = BooleanClauseOccur.MUST;
 			}
 
-			booleanQuery.add(
-				new NestedQuery("nestedFieldArray", nestedBooleanQuery),
-				booleanClauseOccur);
-
 			nestedBooleanQuery.add(
 				new TermQuery(
 					"nestedFieldArray.fieldName", objectField.getName()),
 				BooleanClauseOccur.MUST);
+
+			NestedQuery nestedQuery = new NestedQuery(
+				"nestedFieldArray", nestedBooleanQuery);
+
+			_configureNestedQuery(
+				highlightFieldNames, objectField.getName(), nestedQuery,
+				searchContext);
+
+			booleanQuery.add(nestedQuery, booleanClauseOccur);
 		}
+	}
+
+	private String[] _getLocalizedNestedFieldNames(
+		Locale defaultLocale, SearchContext searchContext) {
+
+		List<String> fieldNames = new ArrayList<>();
+
+		Locale locale = searchContext.getLocale();
+
+		if (locale != null) {
+			fieldNames.add(
+				Field.getLocalizedName(locale, _NESTED_FIELD_ARRAY_VALUE));
+		}
+
+		if ((defaultLocale != null) &&
+			((locale == null) || !locale.equals(defaultLocale))) {
+
+			fieldNames.add(
+				Field.getLocalizedName(
+					defaultLocale, _NESTED_FIELD_ARRAY_VALUE));
+		}
+
+		if (fieldNames.isEmpty()) {
+			for (Locale availableLocale :
+					_searchLocalizationHelper.getLocales(searchContext)) {
+
+				fieldNames.add(
+					Field.getLocalizedName(
+						availableLocale, _NESTED_FIELD_ARRAY_VALUE));
+			}
+		}
+
+		return fieldNames.toArray(new String[0]);
 	}
 
 	private String _getToken(
@@ -509,20 +595,6 @@ public class ObjectEntryKeywordQueryContributor
 		}
 
 		return value;
-	}
-
-	private boolean _isLocalized(List<ObjectField> objectFields) {
-		if (ListUtil.isEmpty(objectFields)) {
-			return false;
-		}
-
-		for (ObjectField objectField : objectFields) {
-			if ((objectField != null) && objectField.isLocalized()) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	private boolean _isValidInput(String token, String type) {
@@ -579,6 +651,12 @@ public class ObjectEntryKeywordQueryContributor
 
 		return keywordTokenizer.tokenize(keywords);
 	}
+
+	private static final String _CONFIGURED_INNER_HITS_NAMES =
+		"objectEntryConfiguredInnerHitsNames";
+
+	private static final String _NESTED_FIELD_ARRAY_VALUE =
+		"nestedFieldArray.value";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ObjectEntryKeywordQueryContributor.class);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -135,12 +135,16 @@ public class ObjectEntryKeywordQueryContributor
 
 		String titleField = "objectEntryTitle";
 
+		String localizedTitleFieldName = Field.getLocalizedName(
+			searchContext.getLocale(), titleField);
+
 		if (StringUtil.startsWith(keywords, CharPool.QUOTE) &&
 			StringUtil.endsWith(keywords, CharPool.QUOTE)) {
 
-			try {
-				booleanQuery.addTerm(titleField, keywords, false);
+			_addTerm(booleanQuery, titleField, keywords);
+			_addTerm(booleanQuery, localizedTitleFieldName, keywords);
 
+			try {
 				for (ObjectField objectField : objectFields) {
 					_contribute(
 						objectField, keywords, booleanQuery, searchContext);
@@ -151,6 +155,11 @@ public class ObjectEntryKeywordQueryContributor
 			}
 		}
 		else {
+			if (addObjectEntryTitle.get()) {
+				_addTerm(booleanQuery, titleField, keywords);
+				_addTerm(booleanQuery, localizedTitleFieldName, keywords);
+			}
+
 			for (String token : _tokenizeKeywords(keywords)) {
 				if (addObjectEntryTitle.get() && !Validator.isBlank(token)) {
 					booleanQuery.add(
@@ -249,6 +258,21 @@ public class ObjectEntryKeywordQueryContributor
 			BooleanClauseOccur.MUST);
 
 		return true;
+	}
+
+	private void _addTerm(
+		BooleanQuery booleanQuery, String fieldName, String value) {
+
+		if (Validator.isBlank(fieldName) || Validator.isBlank(value)) {
+			return;
+		}
+
+		try {
+			booleanQuery.addTerm(fieldName, value, false);
+		}
+		catch (ParseException parseException) {
+			throw new SystemException(parseException);
+		}
 	}
 
 	private void _contribute(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -421,9 +421,6 @@ public class ObjectEntryKeywordQueryContributor
 					 objectField.getDBType(),
 					 ObjectFieldConstants.DB_TYPE_STRING)) {
 
-			String fieldName =
-				ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_TEXT;
-
 			if (objectField.isLocalized()) {
 				String[] localizedFieldNames = _getLocalizedNestedFieldNames(
 					defaultLocale, searchContext);
@@ -443,16 +440,12 @@ public class ObjectEntryKeywordQueryContributor
 
 				highlightFieldNames = localizedFieldNames;
 			}
-			else if (Objects.equals(
-						objectField.getIndexedLanguageId(),
-						searchContext.getLanguageId())) {
-
-				fieldName = StringBundler.concat(
+			else {
+				String fieldName = StringBundler.concat(
 					ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE,
-					StringPool.UNDERLINE, objectField.getIndexedLanguageId());
-			}
+					StringPool.UNDERLINE,
+					_objectDefinition.getDefaultLanguageId());
 
-			if (!objectField.isLocalized()) {
 				nestedBooleanQuery.add(
 					new MatchQuery(fieldName, token), BooleanClauseOccur.MUST);
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -5,6 +5,7 @@
 
 package com.liferay.object.internal.search.spi.model.query.contributor;
 
+import com.liferay.object.constants.ObjectEntrySearchConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
@@ -131,7 +132,7 @@ public class ObjectEntryKeywordQueryContributor
 
 		QueryConfig queryConfig = searchContext.getQueryConfig();
 
-		String titleField = "objectEntryTitle";
+		String titleField = ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE;
 
 		Locale defaultLocale = LocaleUtil.fromLanguageId(
 			_objectDefinition.getDefaultLanguageId());
@@ -227,8 +228,9 @@ public class ObjectEntryKeywordQueryContributor
 		Locale locale = searchContext.getLocale();
 
 		queryConfig.addHighlightFieldNames(
-			"nestedFieldArray.value_boolean", "nestedFieldArray.value_keyword",
-			"nestedFieldArray.value_text");
+			ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_BOOLEAN,
+			ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_KEYWORD,
+			ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_TEXT);
 
 		for (String localizedNestedFieldName :
 				_getLocalizedNestedFieldNames(defaultLocale, searchContext)) {
@@ -245,15 +247,19 @@ public class ObjectEntryKeywordQueryContributor
 
 		if ((titleObjectField != null) && titleObjectField.isLocalized()) {
 			queryConfig.addHighlightFieldNames(
-				Field.getLocalizedName(locale, "objectEntryTitle"));
+				Field.getLocalizedName(
+					locale, ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE));
 
 			if (defaultLocale != null) {
 				queryConfig.addHighlightFieldNames(
-					Field.getLocalizedName(defaultLocale, "objectEntryTitle"));
+					Field.getLocalizedName(
+						defaultLocale,
+						ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE));
 			}
 		}
 		else {
-			queryConfig.addHighlightFieldNames("objectEntryTitle");
+			queryConfig.addHighlightFieldNames(
+				ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE);
 		}
 	}
 
@@ -385,7 +391,8 @@ public class ObjectEntryKeywordQueryContributor
 		QueryConfig queryConfig = searchContext.getQueryConfig();
 
 		if (objectField.isIndexedAsKeyword()) {
-			String fieldName = "nestedFieldArray.value_keyword";
+			String fieldName =
+				ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_KEYWORD;
 			String lowerCaseToken = StringUtil.toLowerCase(token);
 
 			nestedBooleanQuery.add(
@@ -409,7 +416,8 @@ public class ObjectEntryKeywordQueryContributor
 					 objectField.getDBType(),
 					 ObjectFieldConstants.DB_TYPE_STRING)) {
 
-			String fieldName = "nestedFieldArray.value_text";
+			String fieldName =
+				ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_TEXT;
 
 			if (objectField.isLocalized()) {
 				String[] localizedFieldNames = _getLocalizedNestedFieldNames(
@@ -434,9 +442,9 @@ public class ObjectEntryKeywordQueryContributor
 						objectField.getIndexedLanguageId(),
 						searchContext.getLanguageId())) {
 
-				fieldName =
-					"nestedFieldArray.value_" +
-						objectField.getIndexedLanguageId();
+				fieldName = StringBundler.concat(
+					ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE,
+					StringPool.UNDERLINE, objectField.getIndexedLanguageId());
 			}
 
 			if (!objectField.isLocalized()) {
@@ -453,8 +461,8 @@ public class ObjectEntryKeywordQueryContributor
 					ObjectFieldConstants.DB_TYPE_BIG_DECIMAL)) {
 
 			_addNumericClause(
-				"nestedFieldArray.value_double", nestedBooleanQuery,
-				objectField, token);
+				ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_DOUBLE,
+				nestedBooleanQuery, objectField, token);
 		}
 		else if (Objects.equals(
 					objectField.getDBType(),
@@ -471,12 +479,14 @@ public class ObjectEntryKeywordQueryContributor
 			if (StringUtil.equalsIgnoreCase(token, "false") ||
 				StringUtil.equalsIgnoreCase(token, "true")) {
 
-				fieldName = "nestedFieldArray.value_boolean";
+				fieldName =
+					ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_BOOLEAN;
 			}
 			else if (StringUtil.equalsIgnoreCase(token, "no") ||
 					 StringUtil.equalsIgnoreCase(token, "yes")) {
 
-				fieldName = "nestedFieldArray.value_keyword";
+				fieldName =
+					ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_KEYWORD;
 			}
 
 			if (fieldName != null) {
@@ -492,32 +502,32 @@ public class ObjectEntryKeywordQueryContributor
 					ObjectFieldConstants.DB_TYPE_DATE)) {
 
 			_addNumericClause(
-				"nestedFieldArray.value_date", nestedBooleanQuery, objectField,
-				token);
+				ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_DATE,
+				nestedBooleanQuery, objectField, token);
 		}
 		else if (Objects.equals(
 					objectField.getDBType(),
 					ObjectFieldConstants.DB_TYPE_DOUBLE)) {
 
 			_addNumericClause(
-				"nestedFieldArray.value_double", nestedBooleanQuery,
-				objectField, token);
+				ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_DOUBLE,
+				nestedBooleanQuery, objectField, token);
 		}
 		else if (Objects.equals(
 					objectField.getDBType(),
 					ObjectFieldConstants.DB_TYPE_INTEGER)) {
 
 			_addNumericClause(
-				"nestedFieldArray.value_integer", nestedBooleanQuery,
-				objectField, token);
+				ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_INTEGER,
+				nestedBooleanQuery, objectField, token);
 		}
 		else if (Objects.equals(
 					objectField.getDBType(),
 					ObjectFieldConstants.DB_TYPE_LONG)) {
 
 			_addNumericClause(
-				"nestedFieldArray.value_long", nestedBooleanQuery, objectField,
-				token);
+				ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_LONG,
+				nestedBooleanQuery, objectField, token);
 		}
 
 		if (nestedBooleanQuery.hasClauses()) {
@@ -529,11 +539,13 @@ public class ObjectEntryKeywordQueryContributor
 
 			nestedBooleanQuery.add(
 				new TermQuery(
-					"nestedFieldArray.fieldName", objectField.getName()),
+					ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_FIELD_NAME,
+					objectField.getName()),
 				BooleanClauseOccur.MUST);
 
 			NestedQuery nestedQuery = new NestedQuery(
-				"nestedFieldArray", nestedBooleanQuery);
+				ObjectEntrySearchConstants.NESTED_FIELD_ARRAY,
+				nestedBooleanQuery);
 
 			_configureNestedQuery(
 				highlightFieldNames, objectField.getName(), nestedQuery,
@@ -552,7 +564,9 @@ public class ObjectEntryKeywordQueryContributor
 
 		if (locale != null) {
 			fieldNames.add(
-				Field.getLocalizedName(locale, _NESTED_FIELD_ARRAY_VALUE));
+				Field.getLocalizedName(
+					locale,
+					ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE));
 		}
 
 		if ((defaultLocale != null) &&
@@ -560,7 +574,8 @@ public class ObjectEntryKeywordQueryContributor
 
 			fieldNames.add(
 				Field.getLocalizedName(
-					defaultLocale, _NESTED_FIELD_ARRAY_VALUE));
+					defaultLocale,
+					ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE));
 		}
 
 		if (fieldNames.isEmpty()) {
@@ -569,7 +584,8 @@ public class ObjectEntryKeywordQueryContributor
 
 				fieldNames.add(
 					Field.getLocalizedName(
-						availableLocale, _NESTED_FIELD_ARRAY_VALUE));
+						availableLocale,
+						ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE));
 			}
 		}
 
@@ -672,9 +688,6 @@ public class ObjectEntryKeywordQueryContributor
 
 	private static final String _CONFIGURED_INNER_HITS_NAMES =
 		"objectEntryConfiguredInnerHitsNames";
-
-	private static final String _NESTED_FIELD_ARRAY_VALUE =
-		"nestedFieldArray.value";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ObjectEntryKeywordQueryContributor.class);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.search.WildcardQuery;
 import com.liferay.portal.kernel.search.facet.util.RangeParserUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.localization.SearchLocalizationHelper;
@@ -44,6 +45,7 @@ import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
@@ -125,9 +127,13 @@ public class ObjectEntryKeywordQueryContributor
 		}
 
 		QueryConfig queryConfig = searchContext.getQueryConfig();
-		String titleField = "objectEntryTitle";
 
-		queryConfig.addHighlightFieldNames(Field.ENTRY_CLASS_PK, titleField);
+		queryConfig.addHighlightFieldNames(Field.ENTRY_CLASS_PK);
+
+		_addLocalizedHighlightFieldNames(
+			objectFields, queryConfig, searchContext);
+
+		String titleField = "objectEntryTitle";
 
 		if (StringUtil.startsWith(keywords, CharPool.QUOTE) &&
 			StringUtil.endsWith(keywords, CharPool.QUOTE)) {
@@ -166,6 +172,43 @@ public class ObjectEntryKeywordQueryContributor
 					}
 				}
 			}
+		}
+	}
+
+	private void _addLocalizedHighlightFieldNames(
+		List<ObjectField> objectFields, QueryConfig queryConfig,
+		SearchContext searchContext) {
+
+		Locale locale = searchContext.getLocale();
+
+		if (locale == null) {
+			queryConfig.addHighlightFieldNames("objectEntryContent");
+			queryConfig.addHighlightFieldNames("objectEntryTitle");
+
+			return;
+		}
+
+		if (_hasLocalizedContent(objectFields)) {
+			queryConfig.addHighlightFieldNames(
+				"objectEntryContent_" + LocaleUtil.toLanguageId(locale));
+		}
+		else {
+			queryConfig.addHighlightFieldNames("objectEntryContent");
+		}
+
+		long titleObjectFieldId = _objectDefinition.getTitleObjectFieldId();
+
+		ObjectFieldBag objectFieldBag = _objectDefinition.getObjectFieldBag();
+
+		ObjectField titleObjectField = objectFieldBag.getObjectField(
+			titleObjectFieldId);
+
+		if ((titleObjectField != null) && titleObjectField.isLocalized()) {
+			queryConfig.addHighlightFieldNames(
+				"objectEntryTitle_" + LocaleUtil.toLanguageId(locale));
+		}
+		else {
+			queryConfig.addHighlightFieldNames("objectEntryTitle");
 		}
 	}
 
@@ -419,6 +462,20 @@ public class ObjectEntryKeywordQueryContributor
 		}
 
 		return value;
+	}
+
+	private boolean _hasLocalizedContent(List<ObjectField> objectFields) {
+		if (ListUtil.isEmpty(objectFields)) {
+			return false;
+		}
+
+		for (ObjectField objectField : objectFields) {
+			if ((objectField != null) && objectField.isLocalized()) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private boolean _isValidInput(String token, String type) {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/result/contributor/ObjectEntryModelSummaryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/result/contributor/ObjectEntryModelSummaryContributor.java
@@ -28,10 +28,11 @@ public class ObjectEntryModelSummaryContributor
 	public Summary getSummary(
 		Document document, Locale locale, String snippet) {
 
-		return new Summary(_getTitle(document, locale), _getContent(document));
+		return new Summary(
+			_getTitle(document, locale), _getContent(document, locale));
 	}
 
-	private String _getContent(Document document) {
+	private String _getContent(Document document, Locale locale) {
 		StringBundler sb = new StringBundler();
 
 		Map<String, Field> fields = document.getFields();
@@ -55,6 +56,18 @@ public class ObjectEntryModelSummaryContributor
 		}
 
 		String content = sb.toString();
+
+		if (Validator.isBlank(content)) {
+			String languageId = LanguageUtil.getLanguageId(locale);
+
+			String localizedContent = document.get(
+				"objectEntryContent_" + languageId);
+
+			if (Validator.isNotNull(localizedContent)) {
+				content = StringUtil.shorten(
+					localizedContent, 300, StringPool.TRIPLE_PERIOD);
+			}
+		}
 
 		if (Validator.isBlank(content)) {
 			content = StringUtil.shorten(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/result/contributor/ObjectEntryModelSummaryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/result/contributor/ObjectEntryModelSummaryContributor.java
@@ -5,8 +5,8 @@
 
 package com.liferay.object.internal.search.spi.model.result.contributor;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Summary;
@@ -18,6 +18,7 @@ import java.util.Locale;
 
 /**
  * @author Bryan Engler
+ * @author Joshua Cords
  */
 public class ObjectEntryModelSummaryContributor
 	implements ModelSummaryContributor {
@@ -26,19 +27,26 @@ public class ObjectEntryModelSummaryContributor
 	public Summary getSummary(
 		Document document, Locale locale, String snippet) {
 
+		String defaultLanguageId = document.get("defaultLanguageId");
+
 		return new Summary(
-			_getTitle(document, locale), _getContent(document, locale));
+			_getTitle(defaultLanguageId, document, locale),
+			_getContent(defaultLanguageId, document, locale));
 	}
 
-	private String _getContent(Document document, Locale locale) {
-		String languageId = LanguageUtil.getLanguageId(locale);
+	private String _getContent(
+		String defaultLanguageId, Document document, Locale locale) {
 
-		String content = document.get(
-			"snippet_objectEntryContent_" + languageId);
+		String localizedFieldName = Field.getLocalizedName(
+			locale, _OBJECT_ENTRY_CONTENT);
+
+		String localizedSnippetFieldName = StringBundler.concat(
+			Field.SNIPPET, StringPool.UNDERLINE, localizedFieldName);
+
+		String content = document.get(localizedSnippetFieldName);
 
 		if (Validator.isBlank(content)) {
-			String localizedContent = document.get(
-				"objectEntryContent_" + languageId);
+			String localizedContent = document.get(localizedFieldName);
 
 			if (Validator.isNotNull(localizedContent)) {
 				content = StringUtil.shorten(
@@ -46,12 +54,37 @@ public class ObjectEntryModelSummaryContributor
 			}
 		}
 
-		if (Validator.isBlank(content)) {
-			content = document.get("snippet_objectEntryContent");
+		if (Validator.isBlank(content) &&
+			!Validator.isBlank(defaultLanguageId)) {
+
+			String defaultLocalizedFieldName = Field.getLocalizedName(
+				defaultLanguageId, _OBJECT_ENTRY_CONTENT);
+
+			String defaultLocalizedSnippetFieldName = StringBundler.concat(
+				Field.SNIPPET, StringPool.UNDERLINE, defaultLocalizedFieldName);
+
+			content = document.get(defaultLocalizedSnippetFieldName);
+
+			if (Validator.isBlank(content)) {
+				String localizedContent = document.get(
+					defaultLocalizedFieldName);
+
+				if (Validator.isNotNull(localizedContent)) {
+					content = StringUtil.shorten(
+						localizedContent, 300, StringPool.TRIPLE_PERIOD);
+				}
+			}
 		}
 
 		if (Validator.isBlank(content)) {
-			String nonlocalizedContent = document.get("objectEntryContent");
+			content = document.get(
+				StringBundler.concat(
+					Field.SNIPPET, StringPool.UNDERLINE,
+					_OBJECT_ENTRY_CONTENT));
+		}
+
+		if (Validator.isBlank(content)) {
+			String nonlocalizedContent = document.get(_OBJECT_ENTRY_CONTENT);
 
 			if (Validator.isNotNull(nonlocalizedContent)) {
 				content = StringUtil.shorten(
@@ -62,25 +95,47 @@ public class ObjectEntryModelSummaryContributor
 		return content;
 	}
 
-	private String _getTitle(Document document, Locale locale) {
-		String title = document.get(
-			"snippet_objectEntryTitle_" + LanguageUtil.getLanguageId(locale));
+	private String _getTitle(
+		String defaultLanguageId, Document document, Locale locale) {
+
+		String localizedFieldName = Field.getLocalizedName(
+			locale, _OBJECT_ENTRY_TITLE);
+
+		String localizedSnippetFieldName = StringBundler.concat(
+			Field.SNIPPET, StringPool.UNDERLINE, localizedFieldName);
+
+		String title = document.get(localizedSnippetFieldName);
+
+		if (Validator.isBlank(title)) {
+			title = document.get(localizedFieldName);
+		}
+
+		if (Validator.isBlank(title) && !Validator.isBlank(defaultLanguageId)) {
+			String defaultLocalizedFieldName = Field.getLocalizedName(
+				defaultLanguageId, _OBJECT_ENTRY_TITLE);
+
+			String defaultLocalizedSnippetFieldName = StringBundler.concat(
+				Field.SNIPPET, StringPool.UNDERLINE, defaultLocalizedFieldName);
+
+			title = document.get(defaultLocalizedSnippetFieldName);
+
+			if (Validator.isBlank(title)) {
+				title = document.get(defaultLocalizedFieldName);
+			}
+		}
 
 		if (Validator.isBlank(title)) {
 			title = document.get(
-				"objectEntryTitle_" + LanguageUtil.getLanguageId(locale));
+				StringBundler.concat(
+					Field.SNIPPET, StringPool.UNDERLINE, _OBJECT_ENTRY_TITLE));
 		}
 
 		if (Validator.isBlank(title)) {
-			title = document.get("snippet_objectEntryTitle");
+			title = document.get(_OBJECT_ENTRY_TITLE);
 		}
 
 		if (Validator.isBlank(title)) {
-			title = document.get("objectEntryTitle");
-		}
-
-		if (Validator.isBlank(title)) {
-			title = document.get("snippet_" + Field.ENTRY_CLASS_PK);
+			title = document.get(Field.SNIPPET + Field.ENTRY_CLASS_PK);
 		}
 
 		if (Validator.isBlank(title)) {
@@ -89,5 +144,9 @@ public class ObjectEntryModelSummaryContributor
 
 		return title;
 	}
+
+	private static final String _OBJECT_ENTRY_CONTENT = "objectEntryContent";
+
+	private static final String _OBJECT_ENTRY_TITLE = "objectEntryTitle";
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/result/contributor/ObjectEntryModelSummaryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/result/contributor/ObjectEntryModelSummaryContributor.java
@@ -5,6 +5,7 @@
 
 package com.liferay.object.internal.search.spi.model.result.contributor;
 
+import com.liferay.object.constants.ObjectEntrySearchConstants;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Document;
@@ -27,7 +28,8 @@ public class ObjectEntryModelSummaryContributor
 	public Summary getSummary(
 		Document document, Locale locale, String snippet) {
 
-		String defaultLanguageId = document.get("defaultLanguageId");
+		String defaultLanguageId = document.get(
+			ObjectEntrySearchConstants.DEFAULT_LANGUAGE_ID);
 
 		Summary summary = new Summary(
 			_getTitle(defaultLanguageId, document, locale),
@@ -57,7 +59,8 @@ public class ObjectEntryModelSummaryContributor
 		}
 
 		content = document.get(
-			Field.getLocalizedName(locale, _OBJECT_ENTRY_CONTENT));
+			Field.getLocalizedName(
+				locale, ObjectEntrySearchConstants.OBJECT_ENTRY_CONTENT));
 
 		if (!Validator.isBlank(content)) {
 			return content;
@@ -66,14 +69,15 @@ public class ObjectEntryModelSummaryContributor
 		if (!Validator.isBlank(defaultLanguageId)) {
 			content = document.get(
 				Field.getLocalizedName(
-					defaultLanguageId, _OBJECT_ENTRY_CONTENT));
+					defaultLanguageId,
+					ObjectEntrySearchConstants.OBJECT_ENTRY_CONTENT));
 
 			if (!Validator.isBlank(content)) {
 				return content;
 			}
 		}
 
-		return document.get(_OBJECT_ENTRY_CONTENT);
+		return document.get(ObjectEntrySearchConstants.OBJECT_ENTRY_CONTENT);
 	}
 
 	private String _getLocalizedNestedFieldSnippet(
@@ -85,7 +89,8 @@ public class ObjectEntryModelSummaryContributor
 
 		String localizedSnippetFieldName = StringBundler.concat(
 			Field.SNIPPET, StringPool.UNDERLINE,
-			Field.getLocalizedName(locale, _NESTED_FIELD_ARRAY_VALUE));
+			Field.getLocalizedName(
+				locale, ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE));
 
 		return document.get(localizedSnippetFieldName);
 	}
@@ -94,7 +99,7 @@ public class ObjectEntryModelSummaryContributor
 		String defaultLanguageId, Document document, Locale locale) {
 
 		String localizedFieldName = Field.getLocalizedName(
-			locale, _OBJECT_ENTRY_TITLE);
+			locale, ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE);
 
 		String localizedSnippetFieldName = StringBundler.concat(
 			Field.SNIPPET, StringPool.UNDERLINE, localizedFieldName);
@@ -107,7 +112,8 @@ public class ObjectEntryModelSummaryContributor
 
 		if (Validator.isBlank(title) && !Validator.isBlank(defaultLanguageId)) {
 			String defaultLocalizedFieldName = Field.getLocalizedName(
-				defaultLanguageId, _OBJECT_ENTRY_TITLE);
+				defaultLanguageId,
+				ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE);
 
 			String defaultLocalizedSnippetFieldName = StringBundler.concat(
 				Field.SNIPPET, StringPool.UNDERLINE, defaultLocalizedFieldName);
@@ -122,11 +128,12 @@ public class ObjectEntryModelSummaryContributor
 		if (Validator.isBlank(title)) {
 			title = document.get(
 				StringBundler.concat(
-					Field.SNIPPET, StringPool.UNDERLINE, _OBJECT_ENTRY_TITLE));
+					Field.SNIPPET, StringPool.UNDERLINE,
+					ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE));
 		}
 
 		if (Validator.isBlank(title)) {
-			title = document.get(_OBJECT_ENTRY_TITLE);
+			title = document.get(ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE);
 		}
 
 		if (Validator.isBlank(title)) {
@@ -139,12 +146,5 @@ public class ObjectEntryModelSummaryContributor
 
 		return title;
 	}
-
-	private static final String _NESTED_FIELD_ARRAY_VALUE =
-		"nestedFieldArray.value";
-
-	private static final String _OBJECT_ENTRY_CONTENT = "objectEntryContent";
-
-	private static final String _OBJECT_ENTRY_TITLE = "objectEntryTitle";
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/result/contributor/ObjectEntryModelSummaryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/result/contributor/ObjectEntryModelSummaryContributor.java
@@ -10,7 +10,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Summary;
-import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.spi.model.result.contributor.ModelSummaryContributor;
 
@@ -29,70 +29,65 @@ public class ObjectEntryModelSummaryContributor
 
 		String defaultLanguageId = document.get("defaultLanguageId");
 
-		return new Summary(
+		Summary summary = new Summary(
 			_getTitle(defaultLanguageId, document, locale),
 			_getContent(defaultLanguageId, document, locale));
+
+		summary.setMaxContentLength(200);
+
+		return summary;
 	}
 
 	private String _getContent(
 		String defaultLanguageId, Document document, Locale locale) {
 
-		String localizedFieldName = Field.getLocalizedName(
-			locale, _OBJECT_ENTRY_CONTENT);
+		String content = _getLocalizedNestedFieldSnippet(document, locale);
+
+		if (!Validator.isBlank(content)) {
+			return content;
+		}
+
+		if (!Validator.isBlank(defaultLanguageId)) {
+			content = _getLocalizedNestedFieldSnippet(
+				document, LocaleUtil.fromLanguageId(defaultLanguageId));
+
+			if (!Validator.isBlank(content)) {
+				return content;
+			}
+		}
+
+		content = document.get(
+			Field.getLocalizedName(locale, _OBJECT_ENTRY_CONTENT));
+
+		if (!Validator.isBlank(content)) {
+			return content;
+		}
+
+		if (!Validator.isBlank(defaultLanguageId)) {
+			content = document.get(
+				Field.getLocalizedName(
+					defaultLanguageId, _OBJECT_ENTRY_CONTENT));
+
+			if (!Validator.isBlank(content)) {
+				return content;
+			}
+		}
+
+		return document.get(_OBJECT_ENTRY_CONTENT);
+	}
+
+	private String _getLocalizedNestedFieldSnippet(
+		Document document, Locale locale) {
+
+		if (locale == null) {
+			return StringPool.BLANK;
+		}
 
 		String localizedSnippetFieldName = StringBundler.concat(
-			Field.SNIPPET, StringPool.UNDERLINE, localizedFieldName);
+			Field.SNIPPET, StringPool.UNDERLINE,
+			Field.getLocalizedName(locale, _NESTED_FIELD_ARRAY_VALUE));
 
-		String content = document.get(localizedSnippetFieldName);
-
-		if (Validator.isBlank(content)) {
-			String localizedContent = document.get(localizedFieldName);
-
-			if (Validator.isNotNull(localizedContent)) {
-				content = StringUtil.shorten(
-					localizedContent, 300, StringPool.TRIPLE_PERIOD);
-			}
-		}
-
-		if (Validator.isBlank(content) &&
-			!Validator.isBlank(defaultLanguageId)) {
-
-			String defaultLocalizedFieldName = Field.getLocalizedName(
-				defaultLanguageId, _OBJECT_ENTRY_CONTENT);
-
-			String defaultLocalizedSnippetFieldName = StringBundler.concat(
-				Field.SNIPPET, StringPool.UNDERLINE, defaultLocalizedFieldName);
-
-			content = document.get(defaultLocalizedSnippetFieldName);
-
-			if (Validator.isBlank(content)) {
-				String localizedContent = document.get(
-					defaultLocalizedFieldName);
-
-				if (Validator.isNotNull(localizedContent)) {
-					content = StringUtil.shorten(
-						localizedContent, 300, StringPool.TRIPLE_PERIOD);
-				}
-			}
-		}
-
-		if (Validator.isBlank(content)) {
-			content = document.get(
-				StringBundler.concat(
-					Field.SNIPPET, StringPool.UNDERLINE,
-					_OBJECT_ENTRY_CONTENT));
-		}
-
-		if (Validator.isBlank(content)) {
-			String nonlocalizedContent = document.get(_OBJECT_ENTRY_CONTENT);
-
-			if (Validator.isNotNull(nonlocalizedContent)) {
-				content = StringUtil.shorten(
-					nonlocalizedContent, 300, StringPool.TRIPLE_PERIOD);
-			}
-		}
-
-		return content;
+		return document.get(localizedSnippetFieldName);
 	}
 
 	private String _getTitle(
@@ -144,6 +139,9 @@ public class ObjectEntryModelSummaryContributor
 
 		return title;
 	}
+
+	private static final String _NESTED_FIELD_ARRAY_VALUE =
+		"nestedFieldArray.value";
 
 	private static final String _OBJECT_ENTRY_CONTENT = "objectEntryContent";
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/result/contributor/ObjectEntryModelSummaryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/result/contributor/ObjectEntryModelSummaryContributor.java
@@ -5,7 +5,6 @@
 
 package com.liferay.object.internal.search.spi.model.result.contributor;
 
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.search.Document;
@@ -16,7 +15,6 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.spi.model.result.contributor.ModelSummaryContributor;
 
 import java.util.Locale;
-import java.util.Map;
 
 /**
  * @author Bryan Engler
@@ -33,33 +31,12 @@ public class ObjectEntryModelSummaryContributor
 	}
 
 	private String _getContent(Document document, Locale locale) {
-		StringBundler sb = new StringBundler();
+		String languageId = LanguageUtil.getLanguageId(locale);
 
-		Map<String, Field> fields = document.getFields();
-
-		for (Map.Entry<String, Field> entry : fields.entrySet()) {
-			String fieldName = entry.getKey();
-
-			if (fieldName.startsWith("snippet_nestedFieldArray.value")) {
-				Field field = entry.getValue();
-
-				sb.append(
-					StringUtil.merge(
-						field.getValues(), StringPool.TRIPLE_PERIOD));
-
-				sb.append(StringPool.TRIPLE_PERIOD);
-			}
-		}
-
-		if (sb.index() > 0) {
-			sb.setIndex(sb.index() - 1);
-		}
-
-		String content = sb.toString();
+		String content = document.get(
+			"snippet_objectEntryContent_" + languageId);
 
 		if (Validator.isBlank(content)) {
-			String languageId = LanguageUtil.getLanguageId(locale);
-
 			String localizedContent = document.get(
 				"objectEntryContent_" + languageId);
 
@@ -70,9 +47,16 @@ public class ObjectEntryModelSummaryContributor
 		}
 
 		if (Validator.isBlank(content)) {
-			content = StringUtil.shorten(
-				document.get("objectEntryContent"), 300,
-				StringPool.TRIPLE_PERIOD);
+			content = document.get("snippet_objectEntryContent");
+		}
+
+		if (Validator.isBlank(content)) {
+			String nonlocalizedContent = document.get("objectEntryContent");
+
+			if (Validator.isNotNull(nonlocalizedContent)) {
+				content = StringUtil.shorten(
+					nonlocalizedContent, 300, StringPool.TRIPLE_PERIOD);
+			}
 		}
 
 		return content;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/result/contributor/ObjectEntryModelSummaryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/result/contributor/ObjectEntryModelSummaryContributor.java
@@ -137,7 +137,9 @@ public class ObjectEntryModelSummaryContributor
 		}
 
 		if (Validator.isBlank(title)) {
-			title = document.get(Field.SNIPPET + Field.ENTRY_CLASS_PK);
+			title = document.get(
+				StringBundler.concat(
+					Field.SNIPPET, StringPool.UNDERLINE, Field.ENTRY_CLASS_PK));
 		}
 
 		if (Validator.isBlank(title)) {

--- a/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributorTest.java
+++ b/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributorTest.java
@@ -18,14 +18,17 @@ import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.search.localization.SearchLocalizationHelper;
 import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQueryContributorHelper;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.util.LocalizationImpl;
 
 import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,6 +46,13 @@ public class ObjectEntryKeywordQueryContributorTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		LocalizationUtil localizationUtil = new LocalizationUtil();
+
+		localizationUtil.setLocalization(new LocalizationImpl());
+	}
 
 	@Test
 	public void testContributeWithCustomObjectDefinition() throws Exception {

--- a/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributorTest.java
+++ b/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributorTest.java
@@ -11,21 +11,28 @@ import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.bag.ObjectFieldBag;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectViewLocalService;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.MatchQuery;
 import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
+import com.liferay.portal.language.LanguageImpl;
 import com.liferay.portal.search.localization.SearchLocalizationHelper;
 import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQueryContributorHelper;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.util.LocalizationImpl;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -49,6 +56,10 @@ public class ObjectEntryKeywordQueryContributorTest {
 
 	@Before
 	public void setUp() {
+		LanguageUtil languageUtil = new LanguageUtil();
+
+		languageUtil.setLanguage(new LanguageImpl());
+
 		LocalizationUtil localizationUtil = new LocalizationUtil();
 
 		localizationUtil.setLocalization(new LocalizationImpl());
@@ -115,16 +126,79 @@ public class ObjectEntryKeywordQueryContributorTest {
 		Assert.assertEquals(1, _countNestedQueries(queries));
 	}
 
-	private SearchContext _buildSearchContext() {
+	@Test
+	public void testContributeWithNonlocalizedField() throws Exception {
+		ObjectDefinition objectDefinition = _mockObjectDefinition(false);
+
+		Mockito.when(
+			objectDefinition.getDefaultLanguageId()
+		).thenReturn(
+			"en_US"
+		);
+
+		_mockObjectFields(objectDefinition.getObjectFieldBag());
+
+		ArgumentCaptor<Query> argumentCaptor = ArgumentCaptor.forClass(
+			Query.class);
+
+		BooleanQuery booleanQuery = _mockBooleanQuery(argumentCaptor);
+
+		ObjectEntryKeywordQueryContributor contributor =
+			_createObjectEntryKeywordQueryContributor(objectDefinition);
+
+		contributor.contribute(
+			RandomTestUtil.randomString(), booleanQuery,
+			_mockKeywordQueryContributorHelper(LocaleUtil.SPAIN));
+
+		Set<String> matchQueryFields = new HashSet<>();
+
+		for (Query query : argumentCaptor.getAllValues()) {
+			if (query instanceof NestedQuery) {
+				NestedQuery nestedQuery = (NestedQuery)query;
+
+				_collectMatchQueryFields(
+					nestedQuery.getQuery(), matchQueryFields);
+			}
+		}
+
+		Assert.assertTrue(
+			"Expected " + matchQueryFields +
+				" to contain nestedFieldArray.value_en_US",
+			matchQueryFields.contains("nestedFieldArray.value_en_US"));
+		Assert.assertFalse(
+			"Expected " + matchQueryFields +
+				" not to contain nestedFieldArray.value_text",
+			matchQueryFields.contains("nestedFieldArray.value_text"));
+	}
+
+	private SearchContext _buildSearchContext(Locale locale) {
 		SearchContext searchContext = new SearchContext();
 
 		searchContext.setAndSearch(false);
 		searchContext.setAttribute("searchByObjectView", Boolean.FALSE);
-		searchContext.setLocale(LocaleUtil.US);
+		searchContext.setLocale(locale);
 
 		searchContext.getQueryConfig();
 
 		return searchContext;
+	}
+
+	private void _collectMatchQueryFields(
+		Query query, Set<String> matchQueryFields) {
+
+		if (query instanceof MatchQuery) {
+			MatchQuery matchQuery = (MatchQuery)query;
+
+			matchQueryFields.add(matchQuery.getField());
+		}
+		else if (query instanceof BooleanQuery) {
+			BooleanQuery booleanQuery = (BooleanQuery)query;
+
+			for (BooleanClause<Query> booleanClause : booleanQuery.clauses()) {
+				_collectMatchQueryFields(
+					booleanClause.getClause(), matchQueryFields);
+			}
+		}
 	}
 
 	private int _countNestedQueries(List<Query> queries) {
@@ -177,13 +251,19 @@ public class ObjectEntryKeywordQueryContributorTest {
 	}
 
 	private KeywordQueryContributorHelper _mockKeywordQueryContributorHelper() {
+		return _mockKeywordQueryContributorHelper(LocaleUtil.US);
+	}
+
+	private KeywordQueryContributorHelper _mockKeywordQueryContributorHelper(
+		Locale locale) {
+
 		KeywordQueryContributorHelper helper = Mockito.mock(
 			KeywordQueryContributorHelper.class);
 
 		Mockito.when(
 			helper.getSearchContext()
 		).thenReturn(
-			_buildSearchContext()
+			_buildSearchContext(locale)
 		);
 
 		return helper;

--- a/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributorTest.java
+++ b/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributorTest.java
@@ -5,16 +5,19 @@
 
 package com.liferay.object.internal.search.spi.model.query.contributor;
 
+import com.liferay.object.constants.ObjectEntrySearchConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.bag.ObjectFieldBag;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectViewLocalService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.MatchQuery;
 import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
@@ -161,14 +164,21 @@ public class ObjectEntryKeywordQueryContributorTest {
 			}
 		}
 
+		String localizedNestedFieldArrayValue = Field.getLocalizedName(
+			LocaleUtil.US, ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE);
+
 		Assert.assertTrue(
-			"Expected " + matchQueryFields +
-				" to contain nestedFieldArray.value_en_US",
-			matchQueryFields.contains("nestedFieldArray.value_en_US"));
+			StringBundler.concat(
+				"Expected ", matchQueryFields, " to contain ",
+				localizedNestedFieldArrayValue),
+			matchQueryFields.contains(localizedNestedFieldArrayValue));
+
 		Assert.assertFalse(
-			"Expected " + matchQueryFields +
-				" not to contain nestedFieldArray.value_text",
-			matchQueryFields.contains("nestedFieldArray.value_text"));
+			StringBundler.concat(
+				"Expected ", matchQueryFields, " not to contain ",
+				ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_TEXT),
+			matchQueryFields.contains(
+				ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_TEXT));
 	}
 
 	private SearchContext _buildSearchContext(Locale locale) {

--- a/modules/apps/object/object-storage-salesforce/src/main/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/SalesforceObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-storage-salesforce/src/main/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/SalesforceObjectEntryManagerImpl.java
@@ -10,6 +10,7 @@ import com.liferay.account.model.AccountEntryModel;
 import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.object.constants.ObjectActionKeys;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectEntrySearchConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
@@ -308,7 +309,10 @@ public class SalesforceObjectEntryManagerImpl
 		for (Sort sort : sorts) {
 			String fieldName = sort.getFieldName();
 
-			if (fieldName.startsWith("nestedFieldArray.")) {
+			if (fieldName.startsWith(
+					ObjectEntrySearchConstants.NESTED_FIELD_ARRAY +
+						StringPool.PERIOD)) {
+
 				String[] parts = StringUtil.split(
 					sort.getFieldName(), StringPool.POUND);
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryModelDocumentContributorTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryModelDocumentContributorTest.java
@@ -63,15 +63,119 @@ public class ObjectEntryModelDocumentContributorTest {
 
 	@FeatureFlag("LPD-17564")
 	@Test
-	public void testContribute() throws Exception {
+	public void testContributeDateField() throws Exception {
+		ObjectDefinition objectDefinition =
+			_addModifiableSystemObjectDefinition(
+				false, "a" + RandomTestUtil.randomString());
+
+		Date displayDate = new Date();
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			TestPropsValues.getGroupId(), objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				Field.DISPLAY_DATE, displayDate
+			).build());
+
+		Document document = new DocumentImpl();
+
+		ModelDocumentContributor<ObjectEntry>
+			objectEntryModelDocumentContributor =
+				_getObjectEntryModelDocumentContributor(objectDefinition);
+
+		objectEntryModelDocumentContributor.contribute(document, objectEntry);
+
+		Field field = document.getField(Field.DISPLAY_DATE);
+
+		Assert.assertEquals(
+			DateUtil.getDate(displayDate, "yyyyMMddHHmmss", LocaleUtil.US),
+			field.getValue());
+	}
+
+	@Test
+	public void testContributeLocalizedFields() throws Exception {
 		String objectFieldName = "a" + RandomTestUtil.randomString();
+
+		ObjectDefinition objectDefinition =
+			_addModifiableSystemObjectDefinition(true, objectFieldName);
+
+		String englishObjectFieldValue = RandomTestUtil.randomString();
+		String portugueseObjectFieldValue =
+			objectFieldName + RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			TestPropsValues.getGroupId(), objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				objectFieldName, englishObjectFieldValue
+			).put(
+				objectFieldName + "_i18n",
+				HashMapBuilder.<String, Serializable>put(
+					"en_US", englishObjectFieldValue
+				).put(
+					"pt_BR", portugueseObjectFieldValue
+				).build()
+			).build());
+
+		Document document = new DocumentImpl();
+
+		ModelDocumentContributor<ObjectEntry>
+			objectEntryModelDocumentContributor =
+				_getObjectEntryModelDocumentContributor(objectDefinition);
+
+		objectEntryModelDocumentContributor.contribute(document, objectEntry);
+
+		_assertObjectEntryContentField(
+			document, englishObjectFieldValue,
+			Field.getLocalizedName(LocaleUtil.US, "objectEntryContent"),
+			objectFieldName);
+		_assertObjectEntryContentField(
+			document, portugueseObjectFieldValue,
+			Field.getLocalizedName(LocaleUtil.BRAZIL, "objectEntryContent"),
+			objectFieldName);
+
+		Assert.assertNull(document.getField("objectEntryContent"));
+	}
+
+	@Test
+	public void testContributeNonlocalizedFields() throws Exception {
+		String objectFieldName = "a" + RandomTestUtil.randomString();
+
+		ObjectDefinition objectDefinition =
+			_addModifiableSystemObjectDefinition(false, objectFieldName);
+
+		String objectFieldValue = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			TestPropsValues.getGroupId(), objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				objectFieldName, objectFieldValue
+			).build());
+
+		Document document = new DocumentImpl();
+
+		ModelDocumentContributor<ObjectEntry>
+			objectEntryModelDocumentContributor =
+				_getObjectEntryModelDocumentContributor(objectDefinition);
+
+		objectEntryModelDocumentContributor.contribute(document, objectEntry);
+
+		_assertObjectEntryContentField(
+			document, objectFieldValue, "objectEntryContent", objectFieldName);
+
+		Assert.assertNull(
+			document.getField(
+				Field.getLocalizedName(LocaleUtil.US, "objectEntryContent")));
+	}
+
+	private ObjectDefinition _addModifiableSystemObjectDefinition(
+			boolean localized, String objectFieldName)
+		throws Exception {
 
 		ObjectField objectField = ObjectFieldUtil.createObjectField(
 			0, ObjectFieldConstants.BUSINESS_TYPE_TEXT, null,
 			ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
 			RandomTestUtil.randomString(), objectFieldName, false, true);
 
-		objectField.setLocalized(true);
+		objectField.setLocalized(localized);
 
 		ObjectDefinition modifiableSystemObjectDefinition =
 			ObjectDefinitionTestUtil.addModifiableSystemObjectDefinition(
@@ -82,57 +186,23 @@ public class ObjectEntryModelDocumentContributorTest {
 				ObjectDefinitionConstants.SCOPE_SITE, null, 1,
 				Arrays.asList(objectField));
 
-		modifiableSystemObjectDefinition =
-			_objectDefinitionLocalService.publishSystemObjectDefinition(
-				TestPropsValues.getUserId(),
-				modifiableSystemObjectDefinition.getObjectDefinitionId());
+		return _objectDefinitionLocalService.publishSystemObjectDefinition(
+			TestPropsValues.getUserId(),
+			modifiableSystemObjectDefinition.getObjectDefinitionId());
+	}
 
-		Date displayDate = new Date();
-		String objectFieldValue = RandomTestUtil.randomString();
+	private void _assertObjectEntryContentField(
+		Document document, String expectedValue, String fieldName,
+		String objectFieldName) {
 
-		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
-			TestPropsValues.getGroupId(), modifiableSystemObjectDefinition,
-			HashMapBuilder.<String, Serializable>put(
-				Field.DISPLAY_DATE, displayDate
-			).put(
-				objectFieldName, objectFieldValue
-			).put(
-				objectFieldName + "_i18n",
-				HashMapBuilder.<String, Serializable>put(
-					"en_US", objectFieldValue
-				).put(
-					"pt_BR", objectFieldValue + "pt_BR"
-				).build()
-			).build());
-
-		Document document = new DocumentImpl();
-
-		ModelDocumentContributor<ObjectEntry>
-			objectEntryModelDocumentContributor =
-				_getObjectEntryModelDocumentContributor(
-					modifiableSystemObjectDefinition);
-
-		objectEntryModelDocumentContributor.contribute(document, objectEntry);
-
-		Field field = document.getField(Field.DISPLAY_DATE);
-
-		Assert.assertEquals(
-			DateUtil.getDate(displayDate, "yyyyMMddHHmmss", LocaleUtil.US),
-			field.getValue());
-
-		field = document.getField("objectEntryContent");
+		Field field = document.getField(fieldName);
 
 		String value = field.getValue();
 
 		Assert.assertTrue(
 			value,
 			value.contains(
-				StringBundler.concat(objectFieldName, ": ", objectFieldValue)));
-		Assert.assertTrue(
-			value,
-			value.contains(
-				StringBundler.concat(
-					objectFieldName, ": ", objectFieldValue, "pt_BR")));
+				StringBundler.concat(objectFieldName, ": ", expectedValue)));
 	}
 
 	private ModelDocumentContributor<ObjectEntry>

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryModelDocumentContributorTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryModelDocumentContributorTest.java
@@ -7,6 +7,7 @@ package com.liferay.object.internal.search.spi.model.index.contributor.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectEntrySearchConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
@@ -125,14 +126,18 @@ public class ObjectEntryModelDocumentContributorTest {
 
 		_assertObjectEntryContentField(
 			document, englishObjectFieldValue,
-			Field.getLocalizedName(LocaleUtil.US, "objectEntryContent"),
+			Field.getLocalizedName(
+				LocaleUtil.US, ObjectEntrySearchConstants.OBJECT_ENTRY_CONTENT),
 			objectFieldName);
 		_assertObjectEntryContentField(
 			document, portugueseObjectFieldValue,
-			Field.getLocalizedName(LocaleUtil.BRAZIL, "objectEntryContent"),
+			Field.getLocalizedName(
+				LocaleUtil.BRAZIL,
+				ObjectEntrySearchConstants.OBJECT_ENTRY_CONTENT),
 			objectFieldName);
 
-		Assert.assertNull(document.getField("objectEntryContent"));
+		Assert.assertNull(
+			document.getField(ObjectEntrySearchConstants.OBJECT_ENTRY_CONTENT));
 	}
 
 	@Test
@@ -159,11 +164,14 @@ public class ObjectEntryModelDocumentContributorTest {
 		objectEntryModelDocumentContributor.contribute(document, objectEntry);
 
 		_assertObjectEntryContentField(
-			document, objectFieldValue, "objectEntryContent", objectFieldName);
+			document, objectFieldValue,
+			ObjectEntrySearchConstants.OBJECT_ENTRY_CONTENT, objectFieldName);
 
 		Assert.assertNull(
 			document.getField(
-				Field.getLocalizedName(LocaleUtil.US, "objectEntryContent")));
+				Field.getLocalizedName(
+					LocaleUtil.US,
+					ObjectEntrySearchConstants.OBJECT_ENTRY_CONTENT)));
 	}
 
 	private ObjectDefinition _addModifiableSystemObjectDefinition(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/search/test/ObjectEntrySearchHighlightTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/search/test/ObjectEntrySearchHighlightTest.java
@@ -94,6 +94,19 @@ public class ObjectEntrySearchHighlightTest {
 	}
 
 	@Test
+	public void testDefaultLocaleFallback() throws Exception {
+		SearchHit searchHit = _search(
+			LocaleUtil.HUNGARY, _localizedObjectDefinition,
+			_localizedObjectEntry);
+
+		Locale defaultLocale = LocaleUtil.fromLanguageId(
+			_localizedObjectDefinition.getDefaultLanguageId());
+
+		_assertHighlight(_getContentFieldName(defaultLocale), searchHit);
+		_assertHighlight(_getTitleFieldName(defaultLocale), searchHit);
+	}
+
+	@Test
 	public void testLocalizedContent() throws Exception {
 		SearchHit searchHit = _search(
 			LocaleUtil.US, _localizedObjectDefinition, _localizedObjectEntry);

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/search/test/ObjectEntrySearchHighlightTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/search/test/ObjectEntrySearchHighlightTest.java
@@ -1,0 +1,384 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.highlight.HighlightUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.document.Document;
+import com.liferay.portal.search.highlight.HighlightField;
+import com.liferay.portal.search.hits.SearchHit;
+import com.liferay.portal.search.hits.SearchHits;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.search.test.rule.SearchTestRule;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Joshua Cords
+ */
+@RunWith(Arquillian.class)
+public class ObjectEntrySearchHighlightTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_localizedObjectDefinition = _addObjectDefinition(true);
+
+		_localizedObjectEntry = _addObjectEntry(
+			true, _localizedObjectDefinition);
+
+		_nonlocalizedObjectDefinition = _addObjectDefinition(false);
+
+		_nonlocalizedObjectEntry = _addObjectEntry(
+			false, _nonlocalizedObjectDefinition);
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		if (_localizedObjectDefinition != null) {
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				_localizedObjectDefinition);
+		}
+
+		if (_nonlocalizedObjectDefinition != null) {
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				_nonlocalizedObjectDefinition);
+		}
+	}
+
+	@Test
+	public void testLocalizedContent() throws Exception {
+		SearchHit searchHit = _search(
+			LocaleUtil.US, _localizedObjectDefinition, _localizedObjectEntry);
+
+		_assertHighlight(_getContentFieldName(LocaleUtil.US), searchHit);
+
+		searchHit = _search(
+			LocaleUtil.SPAIN, _localizedObjectDefinition,
+			_localizedObjectEntry);
+
+		_assertHighlight(_getContentFieldName(LocaleUtil.SPAIN), searchHit);
+	}
+
+	@Test
+	public void testLocalizedTitle() throws Exception {
+		SearchHit searchHit = _search(
+			LocaleUtil.US, _localizedObjectDefinition, _localizedObjectEntry);
+
+		_assertHighlight(_getTitleFieldName(LocaleUtil.US), searchHit);
+
+		searchHit = _search(
+			LocaleUtil.SPAIN, _localizedObjectDefinition,
+			_localizedObjectEntry);
+
+		_assertHighlight(_getTitleFieldName(LocaleUtil.SPAIN), searchHit);
+	}
+
+	@Test
+	public void testNonlocalizedContent() throws Exception {
+		SearchHit searchHit = _search(
+			LocaleUtil.US, _nonlocalizedObjectDefinition,
+			_nonlocalizedObjectEntry);
+
+		Locale defaultLocale = LocaleUtil.fromLanguageId(
+			_localizedObjectDefinition.getDefaultLanguageId());
+
+		_assertHighlight(_getContentFieldName(defaultLocale), searchHit);
+	}
+
+	@Test
+	public void testNonlocalizedTitle() throws Exception {
+		SearchHit searchHit = _search(
+			LocaleUtil.US, _nonlocalizedObjectDefinition,
+			_nonlocalizedObjectEntry);
+
+		_assertHighlight("objectEntryTitle", searchHit);
+		_assertNoLocalizedHighlight("objectEntryTitle", searchHit);
+
+		searchHit = _search(
+			LocaleUtil.SPAIN, _nonlocalizedObjectDefinition,
+			_nonlocalizedObjectEntry);
+
+		_assertHighlight("objectEntryTitle", searchHit);
+		_assertNoLocalizedHighlight("objectEntryTitle", searchHit);
+	}
+
+	@Rule
+	public SearchTestRule searchTestRule = new SearchTestRule();
+
+	@Inject
+	protected Searcher searcher;
+
+	@Inject
+	protected SearchRequestBuilderFactory searchRequestBuilderFactory;
+
+	private static ObjectDefinition _addObjectDefinition(boolean localized)
+		throws Exception {
+
+		String contentFieldLabel = "Nonlocalized Field";
+		String contentFieldName = _NONLOCALIZED_CONTENT_FIELD_NAME;
+		String titleFieldLabel = "Title";
+		String titleFieldName = _NONLOCALIZED_TITLE_FIELD_NAME;
+
+		if (localized) {
+			contentFieldLabel = "Localized Field";
+			contentFieldName = _LOCALIZED_CONTENT_FIELD_NAME;
+			titleFieldLabel = "Localized Title";
+			titleFieldName = _LOCALIZED_TITLE_FIELD_NAME;
+		}
+
+		List<ObjectField> objectFields = new ArrayList<>();
+
+		objectFields.add(
+			_buildTextObjectField(
+				contentFieldLabel, localized, contentFieldName));
+
+		objectFields.add(
+			_buildTextObjectField(titleFieldLabel, localized, titleFieldName));
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(objectFields);
+
+		ObjectField titleObjectField = _objectFieldLocalService.getObjectField(
+			objectDefinition.getObjectDefinitionId(), titleFieldName);
+
+		_objectDefinitionLocalService.updateTitleObjectFieldId(
+			objectDefinition.getObjectDefinitionId(),
+			titleObjectField.getObjectFieldId());
+
+		return _objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId());
+	}
+
+	private static ObjectEntry _addObjectEntry(
+			boolean localizedTitle, ObjectDefinition objectDefinition)
+		throws Exception {
+
+		Map<String, Serializable> values = null;
+
+		if (localizedTitle) {
+			values = HashMapBuilder.<String, Serializable>put(
+				_LOCALIZED_CONTENT_FIELD_NAME + "_i18n",
+				HashMapBuilder.put(
+					LocaleUtil.toLanguageId(LocaleUtil.US),
+					"English content " + _KEYWORD
+				).put(
+					LocaleUtil.toLanguageId(LocaleUtil.SPAIN),
+					"Contenido en español " + _KEYWORD
+				).build()
+			).put(
+				_LOCALIZED_TITLE_FIELD_NAME + "_i18n",
+				HashMapBuilder.put(
+					LocaleUtil.toLanguageId(LocaleUtil.US),
+					"English title with " + _KEYWORD
+				).put(
+					LocaleUtil.toLanguageId(LocaleUtil.SPAIN),
+					"Título en español " + _KEYWORD
+				).build()
+			).build();
+		}
+		else {
+			values = HashMapBuilder.<String, Serializable>put(
+				_NONLOCALIZED_CONTENT_FIELD_NAME, "General content " + _KEYWORD
+			).put(
+				_NONLOCALIZED_TITLE_FIELD_NAME, "General title " + _KEYWORD
+			).build();
+		}
+
+		return _objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null, values, ServiceContextTestUtil.getServiceContext());
+	}
+
+	private static ObjectField _buildTextObjectField(
+		String label, boolean localized, String name) {
+
+		return new TextObjectFieldBuilder(
+		).indexed(
+			true
+		).indexedAsKeyword(
+			false
+		).labelMap(
+			LocalizedMapUtil.getLocalizedMap(label)
+		).localized(
+			localized
+		).name(
+			name
+		).build();
+	}
+
+	private void _assertHighlight(
+		String highlightFieldName, SearchHit searchHit) {
+
+		Map<String, HighlightField> highlightFieldsMap =
+			searchHit.getHighlightFieldsMap();
+
+		HighlightField highlightField = highlightFieldsMap.get(
+			highlightFieldName);
+
+		Assert.assertNotNull(
+			"Missing highlight field " + highlightFieldName, highlightField);
+
+		List<String> fragments = highlightField.getFragments();
+
+		Assert.assertFalse(
+			"Highlight fragments missing for " + highlightFieldName,
+			fragments.isEmpty());
+
+		for (String fragment : fragments) {
+			Assert.assertTrue(
+				"Missing highlight markup in fragment: " + fragment,
+				fragment.contains(_HIGHLIGHTED_RESULT));
+		}
+	}
+
+	private void _assertNoLocalizedHighlight(
+		String fieldName, SearchHit searchHit) {
+
+		Map<String, HighlightField> highlightFieldsMap =
+			searchHit.getHighlightFieldsMap();
+
+		Locale[] locales = {LocaleUtil.US, LocaleUtil.SPAIN};
+
+		for (Locale locale : locales) {
+			String localizedFieldName =
+				fieldName + "_" + LocaleUtil.toLanguageId(locale);
+
+			Assert.assertFalse(
+				"Unexpected localized highlight " + localizedFieldName,
+				highlightFieldsMap.containsKey(localizedFieldName));
+		}
+	}
+
+	private String _getContentFieldName(Locale locale) {
+		return StringBundler.concat(
+			_NESTED_FIELD_ARRAY_VALUE, StringPool.UNDERLINE,
+			LocaleUtil.toLanguageId(locale));
+	}
+
+	private String _getTitleFieldName(Locale locale) {
+		return "objectEntryTitle_" + LocaleUtil.toLanguageId(locale);
+	}
+
+	private SearchHit _search(
+			Locale locale, ObjectDefinition objectDefinition,
+			ObjectEntry objectEntry)
+		throws Exception {
+
+		SearchResponse searchResponse = searcher.search(
+			searchRequestBuilderFactory.builder(
+			).companyId(
+				TestPropsValues.getCompanyId()
+			).entryClassNames(
+				objectDefinition.getClassName()
+			).highlightEnabled(
+				true
+			).locale(
+				locale
+			).queryString(
+				_KEYWORD
+			).size(
+				1
+			).build());
+
+		SearchHits searchHits = searchResponse.getSearchHits();
+
+		List<SearchHit> searchHitList = searchHits.getSearchHits();
+
+		Assert.assertFalse(searchHitList.toString(), searchHitList.isEmpty());
+
+		SearchHit searchHit = searchHitList.get(0);
+
+		Document document = searchHit.getDocument();
+
+		Assert.assertEquals(
+			String.valueOf(objectEntry.getObjectEntryId()),
+			document.getString(Field.ENTRY_CLASS_PK));
+
+		return searchHit;
+	}
+
+	private static final String _HIGHLIGHTED_RESULT = StringBundler.concat(
+		HighlightUtil.HIGHLIGHT_TAG_OPEN,
+		ObjectEntrySearchHighlightTest._KEYWORD,
+		HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+
+	private static final String _KEYWORD = "keyword";
+
+	private static final String _LOCALIZED_CONTENT_FIELD_NAME = "localizedText";
+
+	private static final String _LOCALIZED_TITLE_FIELD_NAME = "localizedTitle";
+
+	private static final String _NESTED_FIELD_ARRAY_VALUE =
+		"nestedFieldArray.value";
+
+	private static final String _NONLOCALIZED_CONTENT_FIELD_NAME =
+		"nonlocalizedText";
+
+	private static final String _NONLOCALIZED_TITLE_FIELD_NAME = "title";
+
+	private static ObjectDefinition _localizedObjectDefinition;
+	private static ObjectEntry _localizedObjectEntry;
+	private static ObjectDefinition _nonlocalizedObjectDefinition;
+	private static ObjectEntry _nonlocalizedObjectEntry;
+
+	@Inject
+	private static ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private static ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private static ObjectFieldLocalService _objectFieldLocalService;
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/search/test/ObjectEntrySearchHighlightTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/search/test/ObjectEntrySearchHighlightTest.java
@@ -7,6 +7,7 @@ package com.liferay.object.search.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectEntrySearchConstants;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
@@ -16,7 +17,6 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.highlight.HighlightUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -152,15 +152,19 @@ public class ObjectEntrySearchHighlightTest {
 			LocaleUtil.US, _nonlocalizedObjectDefinition,
 			_nonlocalizedObjectEntry);
 
-		_assertHighlight("objectEntryTitle", searchHit);
-		_assertNoLocalizedHighlight("objectEntryTitle", searchHit);
+		_assertHighlight(
+			ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE, searchHit);
+		_assertNoLocalizedHighlight(
+			ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE, searchHit);
 
 		searchHit = _search(
 			LocaleUtil.SPAIN, _nonlocalizedObjectDefinition,
 			_nonlocalizedObjectEntry);
 
-		_assertHighlight("objectEntryTitle", searchHit);
-		_assertNoLocalizedHighlight("objectEntryTitle", searchHit);
+		_assertHighlight(
+			ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE, searchHit);
+		_assertNoLocalizedHighlight(
+			ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE, searchHit);
 	}
 
 	@Rule
@@ -314,13 +318,13 @@ public class ObjectEntrySearchHighlightTest {
 	}
 
 	private String _getContentFieldName(Locale locale) {
-		return StringBundler.concat(
-			_NESTED_FIELD_ARRAY_VALUE, StringPool.UNDERLINE,
-			LocaleUtil.toLanguageId(locale));
+		return Field.getLocalizedName(
+			locale, ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE);
 	}
 
 	private String _getTitleFieldName(Locale locale) {
-		return "objectEntryTitle_" + LocaleUtil.toLanguageId(locale);
+		return Field.getLocalizedName(
+			locale, ObjectEntrySearchConstants.OBJECT_ENTRY_TITLE);
 	}
 
 	private SearchHit _search(
@@ -371,9 +375,6 @@ public class ObjectEntrySearchHighlightTest {
 	private static final String _LOCALIZED_CONTENT_FIELD_NAME = "localizedText";
 
 	private static final String _LOCALIZED_TITLE_FIELD_NAME = "localizedTitle";
-
-	private static final String _NESTED_FIELD_ARRAY_VALUE =
-		"nestedFieldArray.value";
 
 	private static final String _NONLOCALIZED_CONTENT_FIELD_NAME =
 		"nonlocalizedText";

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/collection/provider/ObjectEntrySingleFormVariationInfoCollectionProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/collection/provider/ObjectEntrySingleFormVariationInfoCollectionProvider.java
@@ -531,7 +531,8 @@ public class ObjectEntrySingleFormVariationInfoCollectionProvider
 					objectField.getDBType(),
 					ObjectFieldConstants.DB_TYPE_STRING)) {
 
-			return "nestedFieldArray.value_keyword_lowercase";
+			return ObjectEntrySearchConstants.
+				NESTED_FIELD_ARRAY_VALUE_KEYWORD_LOWERCASE;
 		}
 
 		return "";

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/collection/provider/ObjectEntrySingleFormVariationInfoCollectionProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/collection/provider/ObjectEntrySingleFormVariationInfoCollectionProvider.java
@@ -35,6 +35,7 @@ import com.liferay.info.pagination.InfoPage;
 import com.liferay.info.pagination.Pagination;
 import com.liferay.list.type.service.ListTypeEntryLocalService;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectEntrySearchConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectLayoutBoxConstants;
 import com.liferay.object.info.collection.provider.util.ObjectEntryInfoCollectionProviderUtil;
@@ -402,11 +403,15 @@ public class ObjectEntrySingleFormVariationInfoCollectionProvider
 				new TermQuery(_getFieldName(objectField), entry.getValue()[0]),
 				BooleanClauseOccur.MUST);
 			nestedBooleanQuery.add(
-				new TermQuery("nestedFieldArray.fieldName", entry.getKey()),
+				new TermQuery(
+					ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_FIELD_NAME,
+					entry.getKey()),
 				BooleanClauseOccur.MUST);
 
 			booleanQuery.add(
-				new NestedQuery("nestedFieldArray", nestedBooleanQuery),
+				new NestedQuery(
+					ObjectEntrySearchConstants.NESTED_FIELD_ARRAY,
+					nestedBooleanQuery),
 				BooleanClauseOccur.MUST);
 		}
 
@@ -520,7 +525,7 @@ public class ObjectEntrySingleFormVariationInfoCollectionProvider
 				objectField.getDBType(),
 				ObjectFieldConstants.DB_TYPE_BOOLEAN)) {
 
-			return "nestedFieldArray.value_boolean";
+			return ObjectEntrySearchConstants.NESTED_FIELD_ARRAY_VALUE_BOOLEAN;
 		}
 		else if (Objects.equals(
 					objectField.getDBType(),

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/hits/HitsMetadataTranslator.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/hits/HitsMetadataTranslator.java
@@ -8,6 +8,7 @@ package com.liferay.portal.search.elasticsearch8.internal.hits;
 import co.elastic.clients.elasticsearch.core.explain.Explanation;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
+import co.elastic.clients.elasticsearch.core.search.InnerHitsResult;
 import co.elastic.clients.elasticsearch.core.search.TotalHits;
 import co.elastic.clients.json.JsonData;
 
@@ -78,7 +79,7 @@ public class HitsMetadataTranslator {
 		SearchHitBuilder searchHitBuilder = new SearchHitBuilder();
 
 		return searchHitBuilder.addHighlightFields(
-			_translateHighlightFields(hit.highlight())
+			_translateHighlightFields(hit)
 		).addSources(
 			_translateSource(hit.source())
 		).document(
@@ -109,6 +110,48 @@ public class HitsMetadataTranslator {
 		return StringPool.BLANK;
 	}
 
+	private void _populateHighlightFields(
+		Hit<JsonData> hit, List<HighlightField> highlightFields) {
+
+		Map<String, List<String>> highlight = hit.highlight();
+
+		if (highlight != null) {
+			for (Map.Entry<String, List<String>> entry : highlight.entrySet()) {
+				highlightFields.add(
+					new HighlightFieldBuilder(
+					).fragments(
+						entry.getValue()
+					).name(
+						entry.getKey()
+					).build());
+			}
+		}
+
+		Map<String, InnerHitsResult> innerHits = hit.innerHits();
+
+		if ((innerHits == null) || innerHits.isEmpty()) {
+			return;
+		}
+
+		for (InnerHitsResult innerHitsResult : innerHits.values()) {
+			HitsMetadata<JsonData> hitsMetadata = innerHitsResult.hits();
+
+			if (hitsMetadata == null) {
+				continue;
+			}
+
+			List<Hit<JsonData>> hits = hitsMetadata.hits();
+
+			if (hits == null) {
+				continue;
+			}
+
+			for (Hit<JsonData> innerHit : hits) {
+				_populateHighlightFields(innerHit, highlightFields);
+			}
+		}
+	}
+
 	private Document _translateDocument(
 		String alternateUidFieldName, Hit<JsonData> hit) {
 
@@ -128,20 +171,10 @@ public class HitsMetadataTranslator {
 		return documentBuilder.build();
 	}
 
-	private List<HighlightField> _translateHighlightFields(
-		Map<String, List<String>> highlight) {
-
+	private List<HighlightField> _translateHighlightFields(Hit<JsonData> hit) {
 		List<HighlightField> highlightFields = new ArrayList<>();
 
-		for (Map.Entry<String, List<String>> entry : highlight.entrySet()) {
-			highlightFields.add(
-				new HighlightFieldBuilder(
-				).fragments(
-					entry.getValue()
-				).name(
-					entry.getKey()
-				).build());
-		}
+		_populateHighlightFields(hit, highlightFields);
 
 		return highlightFields;
 	}

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/legacy/query/ElasticsearchQueryVisitor.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/legacy/query/ElasticsearchQueryVisitor.java
@@ -20,6 +20,8 @@ import co.elastic.clients.elasticsearch._types.query_dsl.QueryVariant;
 import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.TextQueryType;
 import co.elastic.clients.elasticsearch._types.query_dsl.ZeroTermsQuery;
+import co.elastic.clients.elasticsearch.core.search.Highlight;
+import co.elastic.clients.elasticsearch.core.search.InnerHits;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.BooleanClause;
@@ -32,6 +34,7 @@ import com.liferay.portal.kernel.search.MatchQuery;
 import com.liferay.portal.kernel.search.MoreLikeThisQuery;
 import com.liferay.portal.kernel.search.MultiMatchQuery;
 import com.liferay.portal.kernel.search.NestedQuery;
+import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.QueryTerm;
 import com.liferay.portal.kernel.search.StringQuery;
 import com.liferay.portal.kernel.search.TermQuery;
@@ -39,10 +42,12 @@ import com.liferay.portal.kernel.search.TermRangeQuery;
 import com.liferay.portal.kernel.search.WildcardQuery;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.query.QueryVisitor;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.elasticsearch8.internal.filter.ElasticsearchFilterVisitor;
+import com.liferay.portal.search.elasticsearch8.internal.highlight.HighlightTranslator;
 import com.liferay.portal.search.elasticsearch8.internal.util.QueryUtil;
 import com.liferay.portal.search.elasticsearch8.internal.util.SetterUtil;
 
@@ -333,6 +338,32 @@ public class ElasticsearchQueryVisitor implements QueryVisitor<QueryVariant> {
 		builder.query(new Query(query.accept(this)));
 
 		builder.scoreMode(ChildScoreMode.Sum);
+
+		if (nestedQuery.isInnerHitsEnabled()) {
+			QueryConfig nestedQueryConfig = nestedQuery.getQueryConfig();
+
+			Highlight highlight = _highlightTranslator.translate(
+				nestedQueryConfig.getHighlightFieldNames(),
+				nestedQueryConfig.getHighlightFragmentSize(),
+				nestedQueryConfig.isHighlightRequireFieldMatch(),
+				nestedQueryConfig.getHighlightSnippetSize());
+
+			if ((highlight != null) &&
+				ArrayUtil.isNotEmpty(
+					nestedQueryConfig.getHighlightFieldNames())) {
+
+				InnerHits.Builder innerHitsBuilder = new InnerHits.Builder(
+				).highlight(
+					highlight
+				);
+
+				if (Validator.isNotNull(nestedQuery.getInnerHitsName())) {
+					innerHitsBuilder.name(nestedQuery.getInnerHitsName());
+				}
+
+				builder.innerHits(innerHitsBuilder.build());
+			}
+		}
 
 		return builder.build();
 	}
@@ -654,5 +685,8 @@ public class ElasticsearchQueryVisitor implements QueryVisitor<QueryVariant> {
 		throw new IllegalArgumentException(
 			"Invalid multi match query type " + type);
 	}
+
+	private static final HighlightTranslator _highlightTranslator =
+		new HighlightTranslator();
 
 }

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/response/SearchResponseTranslator.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/response/SearchResponseTranslator.java
@@ -13,6 +13,7 @@ import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
 import co.elastic.clients.elasticsearch._types.aggregations.TopHitsAggregate;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
+import co.elastic.clients.elasticsearch.core.search.InnerHitsResult;
 import co.elastic.clients.elasticsearch.core.search.ResponseBody;
 import co.elastic.clients.elasticsearch.core.search.TotalHits;
 import co.elastic.clients.json.JsonData;
@@ -91,6 +92,30 @@ public class SearchResponseTranslator {
 			_statsTranslator.translateResponse(aggregates, _translate(stats)));
 	}
 
+	private void _addInnerHitsSnippets(
+		Document document, Hit<JsonData> hit, Locale locale) {
+
+		Map<String, InnerHitsResult> innerHits = hit.innerHits();
+
+		if (MapUtil.isEmpty(innerHits)) {
+			return;
+		}
+
+		for (InnerHitsResult innerHitsResult : innerHits.values()) {
+			HitsMetadata<JsonData> hitsMetadata = innerHitsResult.hits();
+
+			if ((hitsMetadata == null) ||
+				ListUtil.isEmpty(hitsMetadata.hits())) {
+
+				continue;
+			}
+
+			for (Hit<JsonData> innerHit : hitsMetadata.hits()) {
+				_addSnippets(document, innerHit, locale);
+			}
+		}
+	}
+
 	private void _addSnippets(
 		Document document, Hit<JsonData> hit, Locale locale) {
 
@@ -100,6 +125,8 @@ public class SearchResponseTranslator {
 			hit.highlight(),
 			(fieldName, fragments) -> _addSnippets(
 				document, fieldName, highlights, locale));
+
+		_addInnerHitsSnippets(document, hit, locale);
 	}
 
 	private void _addSnippets(

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/response/SearchResponseTranslator.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/response/SearchResponseTranslator.java
@@ -150,11 +150,18 @@ public class SearchResponseTranslator {
 			return;
 		}
 
-		document.add(
-			new Field(
-				StringBundler.concat(
-					Field.SNIPPET, StringPool.UNDERLINE, snippetFieldName),
-				StringUtil.merge(fragments, StringPool.TRIPLE_PERIOD)));
+		String snippetName = StringBundler.concat(
+			Field.SNIPPET, StringPool.UNDERLINE, snippetFieldName);
+		String snippetValue = StringUtil.merge(
+			fragments, StringPool.TRIPLE_PERIOD);
+
+		if (document.getField(snippetName) != null) {
+			snippetValue = StringBundler.concat(
+				document.get(snippetName), StringPool.TRIPLE_PERIOD,
+				snippetValue);
+		}
+
+		document.add(new Field(snippetName, snippetValue));
 	}
 
 	private FacetCollector _getFacetCollector(

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/hits/HitsMetadataTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/hits/HitsMetadataTranslator.java
@@ -34,6 +34,7 @@ import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.core.explain.Explanation;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.core.search.HitsMetadata;
+import org.opensearch.client.opensearch.core.search.InnerHitsResult;
 import org.opensearch.client.opensearch.core.search.TotalHits;
 
 /**
@@ -76,7 +77,7 @@ public class HitsMetadataTranslator {
 		SearchHitBuilder searchHitBuilder = new SearchHitBuilder();
 
 		return searchHitBuilder.addHighlightFields(
-			_translateHighlightFields(hit.highlight())
+			_translateHighlightFields(hit)
 		).addSources(
 			_translateSource(hit.source())
 		).document(
@@ -106,6 +107,48 @@ public class HitsMetadataTranslator {
 		return StringPool.BLANK;
 	}
 
+	private void _populateHighlightFields(
+		Hit<JsonData> hit, List<HighlightField> highlightFields) {
+
+		Map<String, List<String>> highlight = hit.highlight();
+
+		if (highlight != null) {
+			for (Map.Entry<String, List<String>> entry : highlight.entrySet()) {
+				highlightFields.add(
+					new HighlightFieldBuilder(
+					).fragments(
+						entry.getValue()
+					).name(
+						entry.getKey()
+					).build());
+			}
+		}
+
+		Map<String, InnerHitsResult> innerHits = hit.innerHits();
+
+		if ((innerHits == null) || innerHits.isEmpty()) {
+			return;
+		}
+
+		for (InnerHitsResult innerHitsResult : innerHits.values()) {
+			HitsMetadata<JsonData> hitsMetadata = innerHitsResult.hits();
+
+			if (hitsMetadata == null) {
+				continue;
+			}
+
+			List<Hit<JsonData>> hits = hitsMetadata.hits();
+
+			if (hits == null) {
+				continue;
+			}
+
+			for (Hit<JsonData> innerHit : hits) {
+				_populateHighlightFields(innerHit, highlightFields);
+			}
+		}
+	}
+
 	private Document _translateDocument(
 		String alternateUidFieldName, Hit<JsonData> hit) {
 
@@ -125,20 +168,10 @@ public class HitsMetadataTranslator {
 		return documentBuilder.build();
 	}
 
-	private List<HighlightField> _translateHighlightFields(
-		Map<String, List<String>> highlight) {
-
+	private List<HighlightField> _translateHighlightFields(Hit<JsonData> hit) {
 		List<HighlightField> highlightFields = new ArrayList<>();
 
-		for (Map.Entry<String, List<String>> entry : highlight.entrySet()) {
-			highlightFields.add(
-				new HighlightFieldBuilder(
-				).fragments(
-					entry.getValue()
-				).name(
-					entry.getKey()
-				).build());
-		}
+		_populateHighlightFields(hit, highlightFields);
 
 		return highlightFields;
 	}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/legacy/query/OpenSearchQueryVisitor.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/legacy/query/OpenSearchQueryVisitor.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.search.MatchQuery;
 import com.liferay.portal.kernel.search.MoreLikeThisQuery;
 import com.liferay.portal.kernel.search.MultiMatchQuery;
 import com.liferay.portal.kernel.search.NestedQuery;
+import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.QueryTerm;
 import com.liferay.portal.kernel.search.StringQuery;
 import com.liferay.portal.kernel.search.TermQuery;
@@ -23,10 +24,12 @@ import com.liferay.portal.kernel.search.TermRangeQuery;
 import com.liferay.portal.kernel.search.WildcardQuery;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.query.QueryVisitor;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.opensearch2.internal.filter.OpenSearchFilterVisitor;
+import com.liferay.portal.search.opensearch2.internal.highlight.HighlightTranslator;
 import com.liferay.portal.search.opensearch2.internal.util.QueryUtil;
 import com.liferay.portal.search.opensearch2.internal.util.SetterUtil;
 
@@ -49,6 +52,8 @@ import org.opensearch.client.opensearch._types.query_dsl.QueryVariant;
 import org.opensearch.client.opensearch._types.query_dsl.RangeQuery;
 import org.opensearch.client.opensearch._types.query_dsl.TextQueryType;
 import org.opensearch.client.opensearch._types.query_dsl.ZeroTermsQuery;
+import org.opensearch.client.opensearch.core.search.Highlight;
+import org.opensearch.client.opensearch.core.search.InnerHits;
 
 /**
  * @author André de Oliveira
@@ -334,6 +339,32 @@ public class OpenSearchQueryVisitor implements QueryVisitor<QueryVariant> {
 		builder.query(new Query(query.accept(this)));
 
 		builder.scoreMode(ChildScoreMode.Sum);
+
+		if (nestedQuery.isInnerHitsEnabled()) {
+			QueryConfig nestedQueryConfig = nestedQuery.getQueryConfig();
+
+			Highlight highlight = _highlightTranslator.translate(
+				nestedQueryConfig.getHighlightFieldNames(),
+				nestedQueryConfig.getHighlightFragmentSize(),
+				nestedQueryConfig.isHighlightRequireFieldMatch(),
+				nestedQueryConfig.getHighlightSnippetSize());
+
+			if ((highlight != null) &&
+				ArrayUtil.isNotEmpty(
+					nestedQueryConfig.getHighlightFieldNames())) {
+
+				InnerHits.Builder innerHitsBuilder = new InnerHits.Builder(
+				).highlight(
+					highlight
+				);
+
+				if (Validator.isNotNull(nestedQuery.getInnerHitsName())) {
+					innerHitsBuilder.name(nestedQuery.getInnerHitsName());
+				}
+
+				builder.innerHits(innerHitsBuilder.build());
+			}
+		}
 
 		return builder.build();
 	}
@@ -648,5 +679,8 @@ public class OpenSearchQueryVisitor implements QueryVisitor<QueryVariant> {
 		throw new IllegalArgumentException(
 			"Invalid multi match query type " + type);
 	}
+
+	private static final HighlightTranslator _highlightTranslator =
+		new HighlightTranslator();
 
 }

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/response/SearchResponseTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/response/SearchResponseTranslator.java
@@ -152,11 +152,18 @@ public class SearchResponseTranslator {
 			return;
 		}
 
-		document.add(
-			new Field(
-				StringBundler.concat(
-					Field.SNIPPET, StringPool.UNDERLINE, snippetFieldName),
-				StringUtil.merge(fragments, StringPool.TRIPLE_PERIOD)));
+		String snippetName = StringBundler.concat(
+			Field.SNIPPET, StringPool.UNDERLINE, snippetFieldName);
+		String snippetValue = StringUtil.merge(
+			fragments, StringPool.TRIPLE_PERIOD);
+
+		if (document.getField(snippetName) != null) {
+			snippetValue = StringBundler.concat(
+				document.get(snippetName), StringPool.TRIPLE_PERIOD,
+				snippetValue);
+		}
+
+		document.add(new Field(snippetName, snippetValue));
 	}
 
 	private FacetCollector _getFacetCollector(

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/response/SearchResponseTranslator.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/response/SearchResponseTranslator.java
@@ -49,6 +49,7 @@ import org.opensearch.client.opensearch._types.aggregations.TopHitsAggregate;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.core.search.HitsMetadata;
+import org.opensearch.client.opensearch.core.search.InnerHitsResult;
 import org.opensearch.client.opensearch.core.search.TotalHits;
 
 /**
@@ -93,6 +94,30 @@ public class SearchResponseTranslator {
 			_statsTranslator.translateResponse(aggregates, _translate(stats)));
 	}
 
+	private void _addInnerHitsSnippets(
+		Document document, Hit<JsonData> hit, Locale locale) {
+
+		Map<String, InnerHitsResult> innerHits = hit.innerHits();
+
+		if (MapUtil.isEmpty(innerHits)) {
+			return;
+		}
+
+		for (InnerHitsResult innerHitsResult : innerHits.values()) {
+			HitsMetadata<JsonData> hitsMetadata = innerHitsResult.hits();
+
+			if ((hitsMetadata == null) ||
+				ListUtil.isEmpty(hitsMetadata.hits())) {
+
+				continue;
+			}
+
+			for (Hit<JsonData> innerHit : hitsMetadata.hits()) {
+				_addSnippets(document, innerHit, locale);
+			}
+		}
+	}
+
 	private void _addSnippets(
 		Document document, Hit<JsonData> hit, Locale locale) {
 
@@ -102,6 +127,8 @@ public class SearchResponseTranslator {
 			hit.highlight(),
 			(fieldName, fragments) -> _addSnippets(
 				document, fieldName, highlights, locale));
+
+		_addInnerHitsSnippets(document, hit, locale);
 	}
 
 	private void _addSnippets(

--- a/modules/apps/portal-search/portal-search-api/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search API
 Bundle-SymbolicName: com.liferay.portal.search.api
-Bundle-Version: 22.1.1
+Bundle-Version: 22.2.0
 Export-Package:\
 	com.liferay.portal.search.aggregation,\
 	com.liferay.portal.search.aggregation.bucket,\

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/ml/embedding/text/helper/TextEmbeddingContentHelper.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/ml/embedding/text/helper/TextEmbeddingContentHelper.java
@@ -31,7 +31,7 @@ public class TextEmbeddingContentHelper<T extends BaseModel<T>> {
 		_size = size;
 		_textEmbeddingDocumentContributor = textEmbeddingDocumentContributor;
 
-		_nonlocalizedContentSB = new StringBundler((size * 2) - 1);
+		_nonlocalizedContentSB = new StringBundler((size * 4) - 1);
 	}
 
 	public void append(String value) {
@@ -44,6 +44,18 @@ public class TextEmbeddingContentHelper<T extends BaseModel<T>> {
 
 	public void append(String languageId, String value) {
 		_append(_getLocalizedContentSB(languageId), value);
+	}
+
+	public void append(String s1, String s2, String s3) {
+		_append(_nonlocalizedContentSB, s1, s2, s3);
+
+		for (StringBundler localizedContentSB : _localizedContentSBs.values()) {
+			_append(localizedContentSB, s1, s2, s3);
+		}
+	}
+
+	public void append(String languageId, String s1, String s2, String s3) {
+		_append(_getLocalizedContentSB(languageId), s1, s2, s3);
 	}
 
 	public void contribute(Document document) {
@@ -116,6 +128,20 @@ public class TextEmbeddingContentHelper<T extends BaseModel<T>> {
 		}
 
 		sb.append(value);
+	}
+
+	private void _append(StringBundler sb, String s1, String s2, String s3) {
+		if (sb == null) {
+			return;
+		}
+
+		if (sb.length() > 0) {
+			sb.append(_delimiter);
+		}
+
+		sb.append(s1);
+		sb.append(s2);
+		sb.append(s3);
 	}
 
 	private StringBundler _getLocalizedContentSB(String languageId) {

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/ml/embedding/text/helper/TextEmbeddingContentHelper.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/ml/embedding/text/helper/TextEmbeddingContentHelper.java
@@ -31,7 +31,7 @@ public class TextEmbeddingContentHelper<T extends BaseModel<T>> {
 		_size = size;
 		_textEmbeddingDocumentContributor = textEmbeddingDocumentContributor;
 
-		_nonlocalizedContentSB = new StringBundler((size * 4) - 1);
+		_nonlocalizedContentSB = new StringBundler(size);
 	}
 
 	public void append(String value) {

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/ml/embedding/text/helper/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/ml/embedding/text/helper/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingJSONBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingJSONBuilder.java
@@ -11,6 +11,7 @@ import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.object.constants.ObjectEntrySearchConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.petra.string.StringBundler;
@@ -350,7 +351,8 @@ public class RankingJSONBuilder {
 		String content = sb.toString();
 
 		if (Validator.isBlank(content)) {
-			content = _document.getString("objectEntryContent");
+			content = _document.getString(
+				ObjectEntrySearchConstants.OBJECT_ENTRY_CONTENT);
 		}
 
 		return content;

--- a/portal-kernel/src/com/liferay/portal/kernel/search/NestedQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/NestedQuery.java
@@ -23,6 +23,10 @@ public class NestedQuery extends Query {
 		return queryVisitor.visitQuery(this);
 	}
 
+	public String getInnerHitsName() {
+		return _innerHitsName;
+	}
+
 	public String getPath() {
 		return _path;
 	}
@@ -38,6 +42,18 @@ public class NestedQuery extends Query {
 		}
 
 		return false;
+	}
+
+	public boolean isInnerHitsEnabled() {
+		return _innerHitsEnabled;
+	}
+
+	public void setInnerHitsEnabled(boolean innerHitsEnabled) {
+		_innerHitsEnabled = innerHitsEnabled;
+	}
+
+	public void setInnerHitsName(String innerHitsName) {
+		_innerHitsName = innerHitsName;
 	}
 
 	@Override
@@ -59,6 +75,8 @@ public class NestedQuery extends Query {
 		return sb.toString();
 	}
 
+	private boolean _innerHitsEnabled;
+	private String _innerHitsName;
 	private final String _path;
 	private final Query _query;
 


### PR DESCRIPTION
## Summary

Adds two related capabilities to Object entry search:

- **Localized indexing & retrieval** of Object entry titles and content (LPD-72159, LPD-75874).
- **Search-result highlighting** for Object entries, including nested-field-array contents (LPD-75868).

Tracked under: [LPD-73798](https://liferay.atlassian.net/browse/LPD-73798) Improve CMS 2.0 Support & Interoperability with Search Features.
- [LPD-75963](https://liferay.atlassian.net/browse/LPD-75963) Improve localized search behavior and display for CMS and Objects
- [LPD-75868](https://liferay.atlassian.net/browse/LPD-75868) Highlight associated search text in summary of CMS (Object) in search results

## [LPD-75963](https://liferay.atlassian.net/browse/LPD-75963) Improve localized: ([LPD-72159](https://liferay.atlassian.net/browse/LPD-72159), [LPD-75874](https://liferay.atlassian.net/browse/LPD-75874))

- **Indexes per-locale title and content fields.** Localized text fields are indexed under locale-suffixed keys (`objectEntryTitle_<locale>` and `nestedFieldArray.value_<locale>`) in addition to the default-locale value. Non-localized fields keep their existing keys.
- **When searching, retrieves content for the search context's locale**, falling back to the Object definition's default locale when the search locale has no value (mirrors current Journal Article behavior).
- **Avoids duplicate non-localized title indexing** when the title field is itself localized — only the localized variants are stored.
- ** Preserved [performance improvement from core](https://github.com/liferay/liferay-portal/commit/5c34474a1f9a0538d3ec0ca760e31a284df1aff3) by having `TextEmbeddingContentHelper` gain fixed-arity `append` overloads** so the indexing hot path doesn't allocate a `StringBundler` per field.

Files of note:
- `modules/apps/object/object-service/.../ObjectEntryModelDocumentContributor.java` — title and content indexing.
- `modules/apps/object/object-service/.../ObjectEntryModelSummaryContributor.java` — content retrieval with locale fallback when displaying results.
- `modules/apps/portal-search/portal-search-api/.../TextEmbeddingContentHelper.java` — fixed-arity append.

## Highlighting ([LPD-75868](https://liferay.atlassian.net/browse/LPD-75868))

- **Highlights localized title and content matches** at the search-result level for Object entries.
- **Highlights `nestedFieldArray.*` fields** via inner hits — Object fields live under `nestedFieldArray.value_*`, so nested queries need inner-hit configuration to surface highlights.
- **Default-locale fallback for highlighting** when the search-locale field has no match for search results.
- **Concatenates snippet fragments** rather than overwriting when multiple highlights resolve to the same destination field, using `StringPool.TRIPLE_PERIOD` as delimiter. This is necessary because the nestedFieldArray subfields are all named the same.
- **`ObjectEntryModelSummaryContributor`** surfaces highlighted snippets via `Summary.setMaxContentLength` rather than manual truncation. This prevents the highlight tag from being cut by truncation.

Portal Kernel + connector wiring:
- Adds `innerHits` configuration to `NestedQuery` in `portal-kernel` to allow highlighting of innerHits.
- Both Elasticsearch 8 and OpenSearch 2 connectors translate inner-hit highlights via `HitsMetadataTranslator` and surface them in `SearchResponseTranslator._addInnerHitsSnippets`.
- Both connectors' `SearchResponseTranslator._addSnippets` now concatenate when a destination snippet field already exists.

Files of note:
- `portal-kernel/.../NestedQuery.java`
- `modules/apps/portal-search-elasticsearch8/.../HitsMetadataTranslator.java`, `.../SearchResponseTranslator.java`, `.../ElasticsearchQueryVisitor.java`
- `modules/apps/portal-search-opensearch2/.../HitsMetadataTranslator.java`, `.../SearchResponseTranslator.java`, `.../OpenSearchQueryVisitor.java`
- `modules/apps/object/object-service/.../ObjectEntryKeywordQueryContributor.java` — query construction with highlight field configuration.
- `modules/apps/object/object-service/.../ObjectEntryModelSummaryContributor.java` — summary contributor that surfaces snippets.

## Test plan

- [x] `ObjectEntrySearchHighlightTest` (integration) passes for localized and non-localized Object definitions across the configured locales.
- [x] `ObjectEntryModelDocumentContributorTest`  (integration) passes for localized and non-localized fields.
- [x] Manual: index a localized Object entry, search in `en_US` then switch to `es_ES`; confirm the title and snippet display in the active locale and fall back to the default locale when the active locale has no value.
- [x] Manual: search for a keyword that matches an Object entry's content; confirm a highlighted snippet is returned in search results.
- [x] Manual: Create a object with multiple content fields that contain a search term. Search for that keyword; confirm a highlighted snippet is returned in search results from both content fields.

See screenshots and steps here: https://liferay.atlassian.net/browse/LPD-73798?focusedCommentId=5050538
And indexed fields changes here: https://liferay.atlassian.net/browse/LPD-73798?focusedCommentId=5050546

## Updates since #1884

Replaces #1884 — same branch (head `f068aef`), reopened so the diff is clean against current `master`. Below is a summary of changes made on the branch in response to @rodrigoguedes's review feedback.

### Addressed
- **Unified Object search constants.** Introduced `com.liferay.object.constants.ObjectEntrySearchConstants` (`NESTED_FIELD_ARRAY[_VALUE/_*]`, `OBJECT_ENTRY_CONTENT`, `OBJECT_ENTRY_TITLE`, `DEFAULT_LANGUAGE_ID`) and replaced the duplicated local constants and string literals across `ObjectEntryKeywordQueryContributor`, `ObjectEntryModelSummaryContributor`, `ObjectEntryHighlightFieldNamesQueryConfigContributor`, and `ObjectEntryModelDocumentContributor`.
- **`ElasticsearchQueryVisitor` mirrors OpenSearch.** `HighlightTranslator` is now a `private static final` field, matching the OpenSearch pattern.
- **Inner-hits guard parity.** ES `HitsMetadataTranslator` now uses `(highlight != null) && ArrayUtil.isNotEmpty(nestedQueryConfig.getHighlightFieldNames())`, mirroring the OS implementation.
- **`TextEmbeddingContentHelper` sizing.** Dropped the internal `(size * 4) - 1` multiplier so the helper consistently uses `_size`; the caller (`ObjectEntryModelDocumentContributor`) now pre-calculates the exact size and passes it in.
- **Localized title field guards.** In `ObjectEntryKeywordQueryContributor`, `defaultLocalizedTitleFieldName` is declared next to the `defaultLocale` normalization and only initialized in the `else` branch, and `localizedTitleFieldName` / its `_addTerm` calls are gated on `Validator.isNotNull(searchContext.getLocale())` to avoid emitting `objectEntryTitle_null` queries.
- **Non-localized field searches against the default locale.** Non-localized `nestedFieldArray` fields are now searched against `value_<defaultLanguageId>` (the actually-indexed key) instead of `value_text`, with a new test covering this path.
- **`Field.ENTRY_CLASS_PK` no longer added to highlight fields.**

### Not changed (with reasoning)
- **`setMaxContentLength(200)` magic number.** All existing `ModelSummaryContributor` implementations use `200`; not introducing a constant just for this contributor.
- **Duplicated `document.add(...)` fallback in `_addTitleFields`.** Kept as two early returns — the duplication is a single line and the fast-return form is intentional for the indexing hot path.
- **Localized title fallback indexing the non-localized key.** The case (`titleObjectField.isLocalized()` true but `localizedValues` empty) is not reachable in practice, so no change.
