### PR TITLE
LPD-90191 Modules Unit Test failures "testRun: :apps:portal-search:portal-search-web:test was not executed"

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortletTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortletTest.java
@@ -277,11 +277,6 @@ public class SearchResultsPortletTest {
 			}
 
 			@Override
-			protected String getCurrentURL(RenderRequest renderRequest) {
-				return RandomTestUtil.randomString();
-			}
-
-			@Override
 			protected HttpServletRequest getHttpServletRequest(
 				RenderRequest renderRequest) {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90191 - Modules Unit Test failures "testRun: :apps:portal-search:portal-search-web:test was not executed" [Integration] (search)

Exception was being thrown in the unit test for trying to override the `getCurrentURL` method, which was recently [deleted](https://github.com/liferay-search/liferay-portal/commit/536405b78425307c297c2a1759de58cd782205c2) from SearchResultsPortlet.java. Fix was just to remove the method from the test.