### PR TITLE
LPD-89759 Escape input parameter value to eliminate XSS risk

### DIFF
--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/util/ScopeUtil.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/util/ScopeUtil.java
@@ -8,6 +8,7 @@ package com.liferay.portal.search.rest.internal.util;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.search.rest.internal.resource.exception.IllegalScopeParameterException;
 
 import java.util.ArrayList;
@@ -39,7 +40,8 @@ public class ScopeUtil {
 			}
 			catch (NumberFormatException numberFormatException) {
 				throw new IllegalScopeParameterException(
-					"Invalid external reference code or group ID: " + part,
+					"Invalid external reference code or group ID: " +
+						HtmlUtil.escape(part),
 					numberFormatException);
 			}
 		}


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-89759

Response from Suggestions API before the change:
```
{
  "status" : "BAD_REQUEST",
  "title" : "Invalid external reference code or group ID: <script>alert(1737339)</script>",
  "type" : "IllegalScopeParameterException"
}

```
and after:
```
{
  "status" : "BAD_REQUEST",
  "title" : "Invalid external reference code or group ID: &lt;script&gt;alert(1737339)&lt;/script&gt;",
  "type" : "IllegalScopeParameterException"
}
```
