### PR TITLE
LPD-91437 Enrich /search OpenAPI metadata for LLM context

### DIFF
--- a/modules/apps/portal-search/portal-search-rest-api/src/main/java/com/liferay/portal/search/rest/dto/v1_0/FacetConfiguration.java
+++ b/modules/apps/portal-search/portal-search-rest-api/src/main/java/com/liferay/portal/search/rest/dto/v1_0/FacetConfiguration.java
@@ -35,7 +35,10 @@ import java.util.function.Supplier;
  * @generated
  */
 @Generated("")
-@GraphQLName("FacetConfiguration")
+@GraphQLName(
+	description = "Configuration for a single facet aggregation. Each entry describes a facet to compute alongside the search results. The processed facet term buckets appear in the response's `searchFacets` map, where each entry's key is the `aggregationName` you chose for that facet configuration and each value is an array of term-bucket objects with `displayName` (locale-dependent label), `term` (raw term value), and `frequency` (count of matching documents).",
+	value = "FacetConfiguration"
+)
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "FacetConfiguration")
 public class FacetConfiguration implements Serializable {
@@ -49,7 +52,7 @@ public class FacetConfiguration implements Serializable {
 	}
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The name of the aggregation."
+		description = "Unique name for the aggregation. Required to distinguish between instances of the same facet type (instances that share the same name property)."
 	)
 	public String getAggregationName() {
 		if (_aggregationNameSupplier != null) {
@@ -84,7 +87,9 @@ public class FacetConfiguration implements Serializable {
 		};
 	}
 
-	@GraphQLField(description = "The name of the aggregation.")
+	@GraphQLField(
+		description = "Unique name for the aggregation. Required to distinguish between instances of the same facet type (instances that share the same name property)."
+	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String aggregationName;
 
@@ -92,7 +97,7 @@ public class FacetConfiguration implements Serializable {
 	private Supplier<String> _aggregationNameSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "Additional attributes for the facet."
+		description = "Additional attributes required by some facets. The custom, date-range, and nested facets require a String attribute called `field` to set the field to aggregate results by. The date-range facet also requires a `format` String (such as yyyyMMddHHmmss) and a `ranges` array of objects, each with a `label` String (display name) and a `range` String in the format `[fromDate TO toDate]` (for example, `[20240101000000 TO 20240131235959]` matching the chosen `format`). The nested facet requires `filterField`, `filterValue`, and `path` String attributes. The vocabulary facet requires a String array of asset vocabulary IDs as `vocabularyIds` (discoverable via `GET /o/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies`). Omitting required attributes for a given facet type causes the facet to be silently ignored - the request still succeeds but no aggregation appears in the response."
 	)
 	@Valid
 	public Map<String, Object> getAttributes() {
@@ -129,7 +134,9 @@ public class FacetConfiguration implements Serializable {
 		};
 	}
 
-	@GraphQLField(description = "Additional attributes for the facet.")
+	@GraphQLField(
+		description = "Additional attributes required by some facets. The custom, date-range, and nested facets require a String attribute called `field` to set the field to aggregate results by. The date-range facet also requires a `format` String (such as yyyyMMddHHmmss) and a `ranges` array of objects, each with a `label` String (display name) and a `range` String in the format `[fromDate TO toDate]` (for example, `[20240101000000 TO 20240131235959]` matching the chosen `format`). The nested facet requires `filterField`, `filterValue`, and `path` String attributes. The vocabulary facet requires a String array of asset vocabulary IDs as `vocabularyIds` (discoverable via `GET /o/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies`). Omitting required attributes for a given facet type causes the facet to be silently ignored - the request still succeeds but no aggregation appears in the response."
+	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, Object> attributes;
 
@@ -137,7 +144,7 @@ public class FacetConfiguration implements Serializable {
 	private Supplier<Map<String, Object>> _attributesSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "Frequency threshold for showing the terms."
+		description = "Minimum frequency required for terms to appear in the list of facet terms."
 	)
 	public Integer getFrequencyThreshold() {
 		if (_frequencyThresholdSupplier != null) {
@@ -172,7 +179,9 @@ public class FacetConfiguration implements Serializable {
 		};
 	}
 
-	@GraphQLField(description = "Frequency threshold for showing the terms.")
+	@GraphQLField(
+		description = "Minimum frequency required for terms to appear in the list of facet terms."
+	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer frequencyThreshold;
 
@@ -180,7 +189,7 @@ public class FacetConfiguration implements Serializable {
 	private Supplier<Integer> _frequencyThresholdSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "Maximum number of terms to be shown."
+		description = "Maximum number of facet terms to display, regardless of how many matching terms are found for the facet."
 	)
 	public Integer getMaxTerms() {
 		if (_maxTermsSupplier != null) {
@@ -215,7 +224,9 @@ public class FacetConfiguration implements Serializable {
 		};
 	}
 
-	@GraphQLField(description = "Maximum number of terms to be shown.")
+	@GraphQLField(
+		description = "Maximum number of facet terms to display, regardless of how many matching terms are found for the facet."
+	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer maxTerms;
 
@@ -223,7 +234,7 @@ public class FacetConfiguration implements Serializable {
 	private Supplier<Integer> _maxTermsSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The name of the facet."
+		description = "Type of facet. Supported values are category, custom, date-range, folder, nested, site, tag, type, vocabulary, and user. The custom facet uses top-level index fields only; Object and Web Content Structure fields are indexed as nested fields, so use the nested facet for those entities. The server gracefully ignores unrecognized values - passing an unknown facet type does not return a 500 error; the facet is simply skipped."
 	)
 	public String getName() {
 		if (_nameSupplier != null) {
@@ -256,7 +267,9 @@ public class FacetConfiguration implements Serializable {
 		};
 	}
 
-	@GraphQLField(description = "The name of the facet.")
+	@GraphQLField(
+		description = "Type of facet. Supported values are category, custom, date-range, folder, nested, site, tag, type, vocabulary, and user. The custom facet uses top-level index fields only; Object and Web Content Structure fields are indexed as nested fields, so use the nested facet for those entities. The server gracefully ignores unrecognized values - passing an unknown facet type does not return a 500 error; the facet is simply skipped."
+	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String name;
 
@@ -264,7 +277,7 @@ public class FacetConfiguration implements Serializable {
 	private Supplier<String> _nameSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The values / selections to be filtered by."
+		description = "Post-filter the results by selecting values. Equivalent to clicking facet terms in the facet widget."
 	)
 	@Valid
 	public Object[] getValues() {
@@ -300,7 +313,9 @@ public class FacetConfiguration implements Serializable {
 		};
 	}
 
-	@GraphQLField(description = "The values / selections to be filtered by.")
+	@GraphQLField(
+		description = "Post-filter the results by selecting values. Equivalent to clicking facet terms in the facet widget."
+	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Object[] values;
 
@@ -529,4 +544,4 @@ public class FacetConfiguration implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1184929358
+// LIFERAY-REST-BUILDER-HASH:-1718221196

--- a/modules/apps/portal-search/portal-search-rest-api/src/main/java/com/liferay/portal/search/rest/dto/v1_0/SearchRequestBody.java
+++ b/modules/apps/portal-search/portal-search-rest-api/src/main/java/com/liferay/portal/search/rest/dto/v1_0/SearchRequestBody.java
@@ -35,7 +35,10 @@ import java.util.function.Supplier;
  * @generated
  */
 @Generated("")
-@GraphQLName("SearchRequestBody")
+@GraphQLName(
+	description = "Request body for POST /search. Carries search context attributes (including blueprint selection and empty-search behavior) and any facet aggregations to be returned alongside the results.",
+	value = "SearchRequestBody"
+)
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "SearchRequestBody")
 public class SearchRequestBody implements Serializable {
@@ -48,7 +51,9 @@ public class SearchRequestBody implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(SearchRequestBody.class, json);
 	}
 
-	@io.swagger.v3.oas.annotations.media.Schema
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "Custom search context attributes. Recognized keys are search.empty.search (set to true to return results when the search parameter is omitted from the request - equivalent to the emptySearch GET query parameter), search.experiences.blueprint.external.reference.code (External Reference Code of a Search Blueprint controlling the query and configuration - preferred over passing the blueprint ID; Search Blueprints require DXP Enterprise-tier with the Liferay Enterprise Search (LES) add-on subscription), search.experiences.blueprint.id (ID of a Search Blueprint - prefer search.experiences.blueprint.external.reference.code when available), search.experiences.ip.address (overrides the auto-detected client IP for geolocation-aware blueprint elements such as IP-based boosting or region targeting; defaults to the actual HTTP request's client IP when omitted; LES-only since the consumers ship with Search Experiences), search.experiences.scope.group.id (set when the blueprint contains elements that require a group context, such as 'Limit Search to the Current Site', 'Boost Contents in a Category for a User Segment', or 'Staging Aware'), and any other key prefixed with search.experiences. (dynamic parameters declared in the blueprint's Parameter Configuration - see https://learn.liferay.com/w/dxp/search/liferay-enterprise-search/search-blueprints/search-blueprints-configuration-reference#parameter-configuration for more information)."
+	)
 	@Valid
 	public Map<String, Object> getAttributes() {
 		if (_attributesSupplier != null) {
@@ -84,14 +89,18 @@ public class SearchRequestBody implements Serializable {
 		};
 	}
 
-	@GraphQLField
+	@GraphQLField(
+		description = "Custom search context attributes. Recognized keys are search.empty.search (set to true to return results when the search parameter is omitted from the request - equivalent to the emptySearch GET query parameter), search.experiences.blueprint.external.reference.code (External Reference Code of a Search Blueprint controlling the query and configuration - preferred over passing the blueprint ID; Search Blueprints require DXP Enterprise-tier with the Liferay Enterprise Search (LES) add-on subscription), search.experiences.blueprint.id (ID of a Search Blueprint - prefer search.experiences.blueprint.external.reference.code when available), search.experiences.ip.address (overrides the auto-detected client IP for geolocation-aware blueprint elements such as IP-based boosting or region targeting; defaults to the actual HTTP request's client IP when omitted; LES-only since the consumers ship with Search Experiences), search.experiences.scope.group.id (set when the blueprint contains elements that require a group context, such as 'Limit Search to the Current Site', 'Boost Contents in a Category for a User Segment', or 'Staging Aware'), and any other key prefixed with search.experiences. (dynamic parameters declared in the blueprint's Parameter Configuration - see https://learn.liferay.com/w/dxp/search/liferay-enterprise-search/search-blueprints/search-blueprints-configuration-reference#parameter-configuration for more information)."
+	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, Object> attributes;
 
 	@JsonIgnore
 	private Supplier<Map<String, Object>> _attributesSupplier;
 
-	@io.swagger.v3.oas.annotations.media.Schema
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "Facet aggregation configurations to apply to the search. Each entry describes a facet to compute alongside the results. The processed facet term buckets appear in the response's `searchFacets` field - a map keyed by `aggregationName`, where each value is an array of term-bucket objects with `displayName` (locale-dependent label), `term` (raw term value), and `frequency` (count of matching documents). Only present on POST responses when `facetConfigurations` are provided."
+	)
 	@Valid
 	public FacetConfiguration[] getFacetConfigurations() {
 		if (_facetConfigurationsSupplier != null) {
@@ -129,7 +138,9 @@ public class SearchRequestBody implements Serializable {
 		};
 	}
 
-	@GraphQLField
+	@GraphQLField(
+		description = "Facet aggregation configurations to apply to the search. Each entry describes a facet to compute alongside the results. The processed facet term buckets appear in the response's `searchFacets` field - a map keyed by `aggregationName`, where each value is an array of term-bucket objects with `displayName` (locale-dependent label), `term` (raw term value), and `frequency` (count of matching documents). Only present on POST responses when `facetConfigurations` are provided."
+	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected FacetConfiguration[] facetConfigurations;
 
@@ -298,4 +309,4 @@ public class SearchRequestBody implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-808178220
+// LIFERAY-REST-BUILDER-HASH:-1072940298

--- a/modules/apps/portal-search/portal-search-rest-api/src/main/java/com/liferay/portal/search/rest/dto/v1_0/SearchResult.java
+++ b/modules/apps/portal-search/portal-search-rest-api/src/main/java/com/liferay/portal/search/rest/dto/v1_0/SearchResult.java
@@ -40,7 +40,10 @@ import java.util.function.Supplier;
  * @generated
  */
 @Generated("")
-@GraphQLName("SearchResult")
+@GraphQLName(
+	description = "A single search hit returned by GET /search and POST /search. The properties below appear on every result; the embedded property carries asset-specific payload and so its shape varies by entryClassName.",
+	value = "SearchResult"
+)
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "SearchResult")
 public class SearchResult implements Serializable {
@@ -53,7 +56,9 @@ public class SearchResult implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(SearchResult.class, json);
 	}
 
-	@io.swagger.v3.oas.annotations.media.Schema
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "Map of HATEOAS-style action descriptors keyed by action name (such as view, update, delete). Each action contains metadata like the HTTP method, URL, and required permission. Only actions the requesting user is permitted to perform are returned. Read-only - populated by the API, ignored on requests."
+	)
 	@Valid
 	public Map<String, Map<String, String>> getActions() {
 		if (_actionsSupplier != null) {
@@ -89,7 +94,9 @@ public class SearchResult implements Serializable {
 		};
 	}
 
-	@GraphQLField
+	@GraphQLField(
+		description = "Map of HATEOAS-style action descriptors keyed by action name (such as view, update, delete). Each action contains metadata like the HTTP method, URL, and required permission. Only actions the requesting user is permitted to perform are returned. Read-only - populated by the API, ignored on requests."
+	)
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
@@ -183,7 +190,7 @@ public class SearchResult implements Serializable {
 	private Supplier<Date> _dateModifiedSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The time when the item should next be reviewed."
+		description = "The date when the content item is scheduled for editorial review. Part of the Liferay content lifecycle; populated by Web Content Article and other content types that support a review workflow. May be null when no review date is set for the item."
 	)
 	public Date getDateReview() {
 		if (_dateReviewSupplier != null) {
@@ -219,7 +226,7 @@ public class SearchResult implements Serializable {
 	}
 
 	@GraphQLField(
-		description = "The time when the item should next be reviewed."
+		description = "The date when the content item is scheduled for editorial review. Part of the Liferay content lifecycle; populated by Web Content Article and other content types that support a review workflow. May be null when no review date is set for the item."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date dateReview;
@@ -228,7 +235,7 @@ public class SearchResult implements Serializable {
 	private Supplier<Date> _dateReviewSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The item's description."
+		description = "Free-text description of the item. Locale-dependent on the 'Accept-Language' request header where applicable."
 	)
 	public String getDescription() {
 		if (_descriptionSupplier != null) {
@@ -263,14 +270,18 @@ public class SearchResult implements Serializable {
 		};
 	}
 
-	@GraphQLField(description = "The item's description.")
+	@GraphQLField(
+		description = "Free-text description of the item. Locale-dependent on the 'Accept-Language' request header where applicable."
+	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String description;
 
 	@JsonIgnore
 	private Supplier<String> _descriptionSupplier;
 
-	@io.swagger.v3.oas.annotations.media.Schema
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "Asset-specific nested data. The shape depends on entryClassName - blog entries include authorName and assetTagNames, documents include extension and size, custom Objects include their declared fields, and so on. Populated only when nestedFields=embedded is requested."
+	)
 	@Valid
 	public Object getEmbedded() {
 		if (_embeddedSupplier != null) {
@@ -305,7 +316,9 @@ public class SearchResult implements Serializable {
 		};
 	}
 
-	@GraphQLField
+	@GraphQLField(
+		description = "Asset-specific nested data. The shape depends on entryClassName - blog entries include authorName and assetTagNames, documents include extension and size, custom Objects include their declared fields, and so on. Populated only when nestedFields=embedded is requested."
+	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Object embedded;
 
@@ -313,7 +326,7 @@ public class SearchResult implements Serializable {
 	private Supplier<Object> _embeddedSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The object entry class name."
+		description = "Fully-qualified class name of the indexed entity (for example, com.liferay.blogs.model.BlogsEntry for a blog entry, com.liferay.journal.model.JournalArticle for a Web Content Article). This value can be used directly as input to the entryClassNames query parameter in subsequent /search requests to narrow searches to that type."
 	)
 	public String getEntryClassName() {
 		if (_entryClassNameSupplier != null) {
@@ -348,7 +361,9 @@ public class SearchResult implements Serializable {
 		};
 	}
 
-	@GraphQLField(description = "The object entry class name.")
+	@GraphQLField(
+		description = "Fully-qualified class name of the indexed entity (for example, com.liferay.blogs.model.BlogsEntry for a blog entry, com.liferay.journal.model.JournalArticle for a Web Content Article). This value can be used directly as input to the entryClassNames query parameter in subsequent /search requests to narrow searches to that type."
+	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String entryClassName;
 
@@ -356,7 +371,7 @@ public class SearchResult implements Serializable {
 	private Supplier<String> _entryClassNameSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The link to the embedded item."
+		description = "The headless REST API URL to fetch the full entity. Can be called directly, or the response is included automatically when nestedFields=embedded is set."
 	)
 	public String getItemURL() {
 		if (_itemURLSupplier != null) {
@@ -391,7 +406,9 @@ public class SearchResult implements Serializable {
 		};
 	}
 
-	@GraphQLField(description = "The link to the embedded item.")
+	@GraphQLField(
+		description = "The headless REST API URL to fetch the full entity. Can be called directly, or the response is included automatically when nestedFields=embedded is set."
+	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String itemURL;
 
@@ -399,7 +416,7 @@ public class SearchResult implements Serializable {
 	private Supplier<String> _itemURLSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The item's score."
+		description = "Relevance score assigned by the search engine. Higher values indicate stronger relevance to the query. Typical values fall in the range 0.0 to ~10.0 depending on query complexity and blueprint configuration. Useful for threshold filtering (e.g., dropping results below a chosen score) or custom result ranking logic (combining `score` with other signals)."
 	)
 	@Valid
 	public Float getScore() {
@@ -433,7 +450,9 @@ public class SearchResult implements Serializable {
 		};
 	}
 
-	@GraphQLField(description = "The item's score.")
+	@GraphQLField(
+		description = "Relevance score assigned by the search engine. Higher values indicate stronger relevance to the query. Typical values fall in the range 0.0 to ~10.0 depending on query complexity and blueprint configuration. Useful for threshold filtering (e.g., dropping results below a chosen score) or custom result ranking logic (combining `score` with other signals)."
+	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Float score;
 
@@ -441,7 +460,7 @@ public class SearchResult implements Serializable {
 	private Supplier<Float> _scoreSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The item's title."
+		description = "Title of the item. Locale-dependent on the 'Accept-Language' request header where applicable."
 	)
 	public String getTitle() {
 		if (_titleSupplier != null) {
@@ -476,7 +495,9 @@ public class SearchResult implements Serializable {
 		};
 	}
 
-	@GraphQLField(description = "The item's title.")
+	@GraphQLField(
+		description = "Title of the item. Locale-dependent on the 'Accept-Language' request header where applicable."
+	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String title;
 
@@ -773,4 +794,4 @@ public class SearchResult implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-733302728
+// LIFERAY-REST-BUILDER-HASH:-1629867030

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
@@ -274,9 +274,10 @@ paths:
     "/search":
         get:
             description:
-                "Use this API to search for matching content, products and other indexed data. Use the POST /search API
-                if you also want facets (aggregations) to be returned or you need to specify additional search context
-                attributes for your blueprint. Refer to
+                "Use this API to search for matching content, products and other indexed data. Choose GET when
+                query-string parameters are sufficient; choose POST /search when you need request body features such as
+                `facetConfigurations` (faceted aggregations), Search Blueprint context attributes
+                (`search.experiences.*`), or other request-body-only constructs. Refer to
                 https://learn.liferay.com/w/dxp/integration/headless-apis/search-apis/search-api-basics for more
                 information."
             operationId: getSearchPage
@@ -366,8 +367,11 @@ paths:
                         (the date the entry was modified in OData Edm.Date format YYYY-MM-DD), datePublish (the date the
                         entry was published in OData Edm.Date format YYYY-MM-DD), dateReview (the date the entry should
                         be reviewed in OData Edm.Date format YYYY-MM-DD), keywords (Asset tag names), and title (Asset
-                        title on the locale specified by the 'Accept-Language' request header). Web content articles
-                        (JournalArticle) cannot be filtered by status. See
+                        title on the locale specified by the 'Accept-Language' request header). Supported operators are
+                        `eq`, `ne`, `gt`, `ge`, `lt`, `le`; multi-value collections use `any()`/`all()` (for example,
+                        `groupIds/any(g:g eq 20121)`). Web content articles (JournalArticle) cannot be filtered by
+                        status - for those, limit by site using `scope`/`groupIds` instead, which returns only approved
+                        items by default. See
                         https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
                         for more information on the standard API query parameters. For more robust filtering options,
                         use Search Blueprints (available on DXP Enterprise-tier with Liferay Enterprise Search (LES)
@@ -390,7 +394,7 @@ paths:
                         type: string
                 -   in: query
                     description:
-                        Specify which page to return out of all the pages available. See
+                        Specify which page to return out of all the pages available. Defaults to 1. See
                         https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
                         for more information.
                     example: 1
@@ -400,7 +404,7 @@ paths:
                         type: integer
                 -   in: query
                     description:
-                        Specify how many items you want per page. See
+                        Specify how many items you want per page. Defaults to 20. See
                         https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
                         for more information.
                     example: 20
@@ -421,7 +425,7 @@ paths:
                     description:
                         Specify a list of Site, Asset Library, or Space IDs or External Reference Codes (ERCs) to
                         search. You can mix IDs and ERCs in the same request.
-                    example: "20121"
+                    example: 20121,L_GUEST
                     name: scope
                     required: false
                     schema:
@@ -436,15 +440,15 @@ paths:
                         type: string
                 -   in: query
                     description:
-                        Sort results by ascending or descending order. Supported fields are dateCreated (the date the
-                        entry was created in OData Edm.Date format YYYY-MM-DD), dateDisplay (the date the entry was
-                        displayed in OData Edm.Date format YYYY-MM-DD), dateExpiration (the date the entry expires in
-                        OData Edm.Date format YYYY-MM-DD), dateModified (the date the entry was modified in OData
-                        Edm.Date format YYYY-MM-DD), datePublish (the date the entry was published in OData Edm.Date
-                        format YYYY-MM-DD), dateReview (the date the entry should be reviewed in OData Edm.Date format
-                        YYYY-MM-DD), keywords (Asset tag names - corresponding search index field is
-                        assetTagNames.lowercase), and title (Asset title on the locale specified by the
-                        'Accept-Language' request header - corresponding search index field is
+                        Sort results by ascending or descending order. Use format `field:asc` or `field:desc`. Supported
+                        fields are dateCreated (the date the entry was created in OData Edm.Date format YYYY-MM-DD),
+                        dateDisplay (the date the entry was displayed in OData Edm.Date format YYYY-MM-DD),
+                        dateExpiration (the date the entry expires in OData Edm.Date format YYYY-MM-DD), dateModified
+                        (the date the entry was modified in OData Edm.Date format YYYY-MM-DD), datePublish (the date the
+                        entry was published in OData Edm.Date format YYYY-MM-DD), dateReview (the date the entry should
+                        be reviewed in OData Edm.Date format YYYY-MM-DD), keywords (Asset tag names - corresponding
+                        search index field is assetTagNames.lowercase), and title (Asset title on the locale specified
+                        by the 'Accept-Language' request header - corresponding search index field is
                         localized_title_[locale].keyword_lowercase where 'locale' is a language ID like 'en_US').
                         Defaults to order by relevance score descending. See
                         https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
@@ -474,9 +478,9 @@ paths:
             tags: ["SearchResult"]
         post:
             description:
-                "Use this API to search for matching content, products and other indexed data. Use the available request
-                body attributes to request facets (aggregations) to be also returned or to specify additional search
-                context attributes for your blueprint. Refer to
+                "Use this API to search for matching content, products and other indexed data. Choose POST over GET when
+                you need request body features such as facets (aggregations) via `facetConfigurations`, Search Blueprint
+                context attributes (`search.experiences.*`), or other request-body-only constructs. Refer to
                 https://learn.liferay.com/w/dxp/integration/headless-apis/search-apis/search-api-basics for more
                 information."
             operationId: postSearchPage
@@ -544,8 +548,11 @@ paths:
                         (the date the entry was modified in OData Edm.Date format YYYY-MM-DD), datePublish (the date the
                         entry was published in OData Edm.Date format YYYY-MM-DD), dateReview (the date the entry should
                         be reviewed in OData Edm.Date format YYYY-MM-DD), keywords (Asset tag names), and title (Asset
-                        title on the locale specified by the 'Accept-Language' request header). Web content articles
-                        (JournalArticle) cannot be filtered by status. See
+                        title on the locale specified by the 'Accept-Language' request header). Supported operators are
+                        `eq`, `ne`, `gt`, `ge`, `lt`, `le`; multi-value collections use `any()`/`all()` (for example,
+                        `groupIds/any(g:g eq 20121)`). Web content articles (JournalArticle) cannot be filtered by
+                        status - for those, limit by site using `scope`/`groupIds` instead, which returns only approved
+                        items by default. See
                         https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
                         for more information on the standard API query parameters. For more robust filtering options,
                         use Search Blueprints (available on DXP Enterprise-tier with Liferay Enterprise Search (LES)
@@ -568,7 +575,7 @@ paths:
                         type: string
                 -   in: query
                     description:
-                        Specify which page to return out of all the pages available. See
+                        Specify which page to return out of all the pages available. Defaults to 1. See
                         https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
                         for more information.
                     example: 1
@@ -578,7 +585,7 @@ paths:
                         type: integer
                 -   in: query
                     description:
-                        Specify how many items you want per page. See
+                        Specify how many items you want per page. Defaults to 20. See
                         https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
                         for more information.
                     example: 20
@@ -599,7 +606,7 @@ paths:
                     description:
                         Specify a list of Site, Asset Library, or Space IDs or External Reference Codes (ERCs) to
                         search. You can mix IDs and ERCs in the same request.
-                    example: "20121"
+                    example: 20121,L_GUEST
                     name: scope
                     required: false
                     schema:
@@ -614,15 +621,15 @@ paths:
                         type: string
                 -   in: query
                     description:
-                        Sort results by ascending or descending order. Supported fields are dateCreated (the date the
-                        entry was created in OData Edm.Date format YYYY-MM-DD), dateDisplay (the date the entry was
-                        displayed in OData Edm.Date format YYYY-MM-DD), dateExpiration (the date the entry expires in
-                        OData Edm.Date format YYYY-MM-DD), dateModified (the date the entry was modified in OData
-                        Edm.Date format YYYY-MM-DD), datePublish (the date the entry was published in OData Edm.Date
-                        format YYYY-MM-DD), dateReview (the date the entry should be reviewed in OData Edm.Date format
-                        YYYY-MM-DD), keywords (Asset tag names - corresponding search index field is
-                        assetTagNames.lowercase), and title (Asset title on the locale specified by the
-                        'Accept-Language' request header - corresponding search index field is
+                        Sort results by ascending or descending order. Use format `field:asc` or `field:desc`. Supported
+                        fields are dateCreated (the date the entry was created in OData Edm.Date format YYYY-MM-DD),
+                        dateDisplay (the date the entry was displayed in OData Edm.Date format YYYY-MM-DD),
+                        dateExpiration (the date the entry expires in OData Edm.Date format YYYY-MM-DD), dateModified
+                        (the date the entry was modified in OData Edm.Date format YYYY-MM-DD), datePublish (the date the
+                        entry was published in OData Edm.Date format YYYY-MM-DD), dateReview (the date the entry should
+                        be reviewed in OData Edm.Date format YYYY-MM-DD), keywords (Asset tag names - corresponding
+                        search index field is assetTagNames.lowercase), and title (Asset title on the locale specified
+                        by the 'Accept-Language' request header - corresponding search index field is
                         localized_title_[locale].keyword_lowercase where 'locale' is a language ID like 'en_US').
                         Defaults to order by relevance score descending. See
                         https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
@@ -112,12 +112,47 @@ components:
                     type: array
             type: object
         SearchResult:
+            description:
+                A single search hit returned by GET /search and POST /search. The properties below appear on every
+                result; the embedded property carries asset-specific payload and so its shape varies by entryClassName.
+            example:
+                actions:
+                    update:
+                        href: /o/headless-delivery/v1.0/blog-posting/12345
+                        method: PUT
+                        permissionName: UPDATE
+                    view:
+                        href: /o/headless-delivery/v1.0/blog-posting/12345
+                        method: GET
+                        permissionName: VIEW
+                dateCreated: 2025-08-15T14:32:00Z
+                dateModified: 2025-09-20T09:18:45Z
+                dateReview: 2026-08-15T14:32:00Z
+                description:
+                    A short summary of the blog entry describing the topic.
+                embedded:
+                    assetTagNames:
+                        -   release
+                        -   announcement
+                    authorName: Jane Doe
+                    categoryNames:
+                        -   Product News
+                    groupId: "20121"
+                entryClassName: com.liferay.blogs.model.BlogsEntry
+                itemURL: /web/sites/marketing/-/blogs/release-notes-7.4
+                score: 1.42
+                title: Release Notes for Liferay 7.4
             properties:
                 actions:
                     additionalProperties:
                         additionalProperties:
                             type: string
                         type: object
+                    description:
+                        Map of HATEOAS-style action descriptors keyed by action name (such as view, update, delete).
+                        Each action contains metadata like the HTTP method, URL, and required permission. Only actions
+                        the requesting user is permitted to perform are returned. Read-only - populated by the API,
+                        ignored on requests.
                     readOnly: true
                     type: object
                 dateCreated:
@@ -137,27 +172,36 @@ components:
                     type: string
                 description:
                     description:
-                        The item's description.
+                        Free-text description of the item. Locale-dependent on the 'Accept-Language' request header where applicable.
                     type: string
                 embedded:
+                    description:
+                        Asset-specific nested data. The shape depends on entryClassName - blog entries include
+                        authorName and assetTagNames, documents include extension and size, custom Objects include their
+                        declared fields, and so on. Populated only when nestedFields=embedded is requested.
                     type: object
                 entryClassName:
                     description:
-                        The object entry class name.
+                        Fully-qualified class name of the indexed entity (for example,
+                        com.liferay.blogs.model.BlogsEntry for a blog entry, com.liferay.journal.model.JournalArticle
+                        for a Web Content Article).
                     type: string
                 itemURL:
                     description:
-                        The link to the embedded item.
+                        Friendly URL where the item can be viewed in the portal. May be relative or absolute depending
+                        on configuration.
                     format: uri
                     type: string
                 score:
                     description:
-                        The item's score.
+                        Relevance score assigned by the search engine. Higher values indicate stronger relevance to the
+                        query. Typical values fall in the range 0.0 to ~10.0 depending on query complexity and blueprint
+                        configuration.
                     format: float
                     type: number
                 title:
                     description:
-                        The item's title.
+                        Title of the item. Locale-dependent on the 'Accept-Language' request header where applicable.
                     type: string
         Suggestion:
             properties:

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
@@ -28,43 +28,85 @@ components:
                 expectedDimensions:
                     type: integer
         FacetConfiguration:
+            description:
+                Configuration for a single facet aggregation. Each entry describes a facet to compute alongside the
+                search results. The response's aggregations field returns the facet buckets. Examples TBA.
             properties:
                 aggregationName:
                     description:
-                        The name of the aggregation.
+                        Unique name for the aggregation. Required to distinguish between instances of the same facet
+                        type (instances that share the same name property).
                     type: string
                 attributes:
                     additionalProperties:
                         type: object
                     description:
-                        Additional attributes for the facet.
+                        Additional attributes required by some facets. The custom, date-range, and nested facets require
+                        a String attribute called field to set the field to aggregate results by. The date-range facet
+                        also requires a format String (such as yyyyMMddHHmmss) and a ranges object array to provide the
+                        ranges. The nested facet requires filterField, filterValue, and path String attributes. The
+                        vocabulary facet requires a String array of asset vocabulary IDs as vocabularyIds.
                     type: object
                 frequencyThreshold:
                     description:
-                        Frequency threshold for showing the terms.
+                        Minimum frequency required for terms to appear in the list of facet terms.
                     type: integer
                 maxTerms:
                     description:
-                        Maximum number of terms to be shown.
+                        Maximum number of facet terms to display, regardless of how many matching terms are found for
+                        the facet.
                     type: integer
                 name:
                     description:
-                        The name of the facet.
+                        Type of facet. Supported values are category, custom, date-range, folder, nested, site, tag,
+                        type, vocabulary, and user. The custom facet uses top-level index fields only; Object and Web
+                        Content Structure fields are indexed as nested fields, so use the nested facet for those
+                        entities.
                     type: string
                 values:
                     description:
-                        The values / selections to be filtered by.
+                        Post-filter the results by selecting values. Equivalent to clicking facet terms in the facet
+                        widget.
                     items:
                         type: object
                     type: array
             type: object
         SearchRequestBody:
+            description:
+                Request body for POST /search. Carries search context attributes (including blueprint selection and
+                empty-search behavior) and any facet aggregations to be returned alongside the results.
+            example:
+                attributes:
+                    search.empty.search: true
+                    search.experiences.blueprint.external.reference.code: PRODUCT_SEARCH
+                    search.experiences.scope.group.id: "20121"
+                facetConfigurations:
+                    -   aggregationName: asset_type
+                        maxTerms: 10
+                        name: type
             properties:
                 attributes:
                     additionalProperties:
                         type: object
+                    description:
+                        Custom search context attributes. Recognized keys are search.empty.search (set to true to return
+                        results when the search parameter is omitted from the request - equivalent to the emptySearch
+                        GET query parameter), search.experiences.blueprint.external.reference.code (External Reference
+                        Code of a Search Blueprint controlling the query and configuration - preferred over passing the
+                        blueprint ID; Search Blueprints require DXP Enterprise-tier with the Liferay Enterprise Search
+                        (LES) add-on subscription), search.experiences.blueprint.id (ID of a Search Blueprint - prefer
+                        search.experiences.blueprint.external.reference.code when available),
+                        search.experiences.scope.group.id (set when the blueprint contains elements that require a group
+                        context, such as 'Limit Search to the Current Site', 'Boost Contents in a Category for a User
+                        Segment', or 'Staging Aware'), and any other key prefixed with search.experiences. (dynamic
+                        parameters declared in the blueprint's Parameter Configuration - see
+                        https://learn.liferay.com/w/dxp/search/liferay-enterprise-search/search-blueprints/search-blueprints-configuration-reference#parameter-configuration
+                        for more information).
                     type: object
                 facetConfigurations:
+                    description:
+                        Facet aggregation configurations to apply to the search. Each entry describes a facet to compute
+                        alongside the results; the response's aggregations field returns the facet buckets.
                     items:
                         $ref: "#/components/schemas/FacetConfiguration"
                     type: array

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
@@ -309,9 +309,11 @@ paths:
                         Sharing Entry - com.liferay.sharing.model.SharingEntry, User -
                         com.liferay.portal.kernel.model.User, Web Content Article -
                         com.liferay.journal.model.JournalArticle, and Web Content Folder -
-                        com.liferay.journal.model.JournalFolder. Custom Objects and custom CMS Content Structures follow
-                        the class name format com.liferay.object.model.ObjectDefinition#<OBJECT-DEFINITION-CLASS-NAME>,
-                        where OBJECT-DEFINITION-CLASS-NAME is the Class Name of the Object Definition (for example,
+                        com.liferay.journal.model.JournalFolder. Entries marked `(CMS)` are seeded by the Liferay CMS
+                        site initializer and may be absent on instances that have not run it. Custom Objects and custom
+                        CMS Content Structures follow the class name format
+                        com.liferay.object.model.ObjectDefinition#<OBJECT-DEFINITION-CLASS-NAME>, where
+                        OBJECT-DEFINITION-CLASS-NAME is the Class Name of the Object Definition (for example,
                         com.liferay.object.model.ObjectDefinition#H4T4 for Basic Web Content (CMS)). To discover
                         available class names at runtime, call GET
                         /o/search-experiences-rest/v1.0/searchable-asset-names (admin permission required).
@@ -474,9 +476,11 @@ paths:
                         Sharing Entry - com.liferay.sharing.model.SharingEntry, User -
                         com.liferay.portal.kernel.model.User, Web Content Article -
                         com.liferay.journal.model.JournalArticle, and Web Content Folder -
-                        com.liferay.journal.model.JournalFolder. Custom Objects and custom CMS Content Structures follow
-                        the class name format com.liferay.object.model.ObjectDefinition#<OBJECT-DEFINITION-CLASS-NAME>,
-                        where OBJECT-DEFINITION-CLASS-NAME is the Class Name of the Object Definition (for example,
+                        com.liferay.journal.model.JournalFolder. Entries marked `(CMS)` are seeded by the Liferay CMS
+                        site initializer and may be absent on instances that have not run it. Custom Objects and custom
+                        CMS Content Structures follow the class name format
+                        com.liferay.object.model.ObjectDefinition#<OBJECT-DEFINITION-CLASS-NAME>, where
+                        OBJECT-DEFINITION-CLASS-NAME is the Class Name of the Object Definition (for example,
                         com.liferay.object.model.ObjectDefinition#H4T4 for Basic Web Content (CMS)). To discover
                         available class names at runtime, call GET
                         /o/search-experiences-rest/v1.0/searchable-asset-names (admin permission required).

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
@@ -163,7 +163,11 @@ paths:
     "/search":
         get:
             description:
-                "Search the company index for matching content."
+                "Use this API to search for matching content, products and other indexed data. Use the POST /search API
+                if you also want facets (aggregations) to be returned or you need to specify additional search context
+                attributes for your blueprint. Refer to
+                https://learn.liferay.com/w/dxp/integration/headless-apis/search-apis/search-api-basics for more
+                information."
             operationId: getSearchPage
             parameters:
                 -   in: query
@@ -234,7 +238,11 @@ paths:
             tags: ["SearchResult"]
         post:
             description:
-                "Search the company index for matching content."
+                "Use this API to search for matching content, products and other indexed data. Use the available request
+                body attributes to request facets (aggregations) to be also returned or to specify additional search
+                context attributes for your blueprint. Refer to
+                https://learn.liferay.com/w/dxp/integration/headless-apis/search-apis/search-api-basics for more
+                information."
             operationId: postSearchPage
             parameters:
                 -   in: query

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
@@ -31,7 +31,13 @@ components:
             description:
                 Configuration for a single facet aggregation. Each entry describes a facet to compute alongside the
                 search results. The processed facet term buckets appear in the response's `searchFacets` map, where each
-                entry's key is the `aggregationName` you chose for that facet configuration. Examples TBA.
+                entry's key is the `aggregationName` you chose for that facet configuration.
+            example:
+                aggregationName: priority
+                attributes:
+                    field: priority
+                maxTerms: 10
+                name: custom
             properties:
                 aggregationName:
                     description:
@@ -329,7 +335,8 @@ paths:
                         Use this parameter to specify and return only the fields specified in each of the items in the
                         response. When requesting multiple types of items (when parameter entryClassNames is empty or
                         specifies multiple class names), only common fields can be specified, otherwise the API returns
-                        an empty object for each result item. Examples TBA.
+                        an empty object for each result item.
+                    example: title,description,score
                     name: fields
                     required: false
                     schema:
@@ -506,7 +513,8 @@ paths:
                         Use this parameter to specify and return only the fields specified in each of the items in the
                         response. When requesting multiple types of items (when parameter entryClassNames is empty or
                         specifies multiple class names), only common fields can be specified, otherwise the API returns
-                        an empty object for each result item. Examples TBA.
+                        an empty object for each result item.
+                    example: title,description,score
                     name: fields
                     required: false
                     schema:

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
@@ -175,6 +175,7 @@ paths:
                         Specify the External Reference Code (ERC) of a search blueprint to control the search query and
                         configuration. Search Blueprints is available on DXP Enterprise-tier with Liferay Enterprise
                         Search (LES) add-on subscription.
+                    example: PRODUCT_SEARCH
                     name: blueprintExternalReferenceCode
                     schema:
                         type: string
@@ -182,6 +183,7 @@ paths:
                     description:
                         Set this to 'true' to return results even if the search parameter is omitted from the request
                         (no search keywords specified).
+                    example: true
                     name: emptySearch
                     schema:
                         type: boolean
@@ -215,6 +217,7 @@ paths:
                         com.liferay.object.model.ObjectDefinition#H4T4 for Basic Web Content (CMS)). To discover
                         available class names at runtime, call GET
                         /o/search-experiences-rest/v1.0/searchable-asset-names (admin permission required).
+                    example: com.liferay.journal.model.JournalArticle,com.liferay.blogs.model.BlogsEntry
                     name: entryClassNames
                     schema:
                         type: string
@@ -249,12 +252,14 @@ paths:
                         add-on subscription), which can encapsulate more filters and operates directly with search index
                         fields. Learn more at
                         https://learn.liferay.com/w/dxp/search/liferay-enterprise-search/search-blueprints.
+                    example: groupIds/any(g:g eq 20121)
                     name: filter
                     schema:
                         type: string
                 -   in: query
                     description:
                         Supports 'embedded' to get back nested item fields.
+                    example: embedded
                     name: nestedFields
                     schema:
                         type: string
@@ -263,6 +268,7 @@ paths:
                         Specify which page to return out of all the pages available. See
                         https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
                         for more information.
+                    example: 1
                     name: page
                     schema:
                         type: integer
@@ -271,6 +277,7 @@ paths:
                         Specify how many items you want per page. See
                         https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
                         for more information.
+                    example: 20
                     name: pageSize
                     schema:
                         type: integer
@@ -278,6 +285,7 @@ paths:
                     description:
                         Comma-separated list of fields to exclude from each result. Inverse of the fields parameter. Use
                         either fields (allow-list) or restrictFields (block-list), not both.
+                    example: actions,embedded
                     name: restrictFields
                     schema:
                         type: string
@@ -285,12 +293,14 @@ paths:
                     description:
                         Specify a list of Site, Asset Library, or Space IDs or External Reference Codes (ERCs) to
                         search. You can mix IDs and ERCs in the same request.
+                    example: "20121"
                     name: scope
                     schema:
                         type: string
                 -   in: query
                     description:
                         Search by keyword(s).
+                    example: liferay
                     name: search
                     schema:
                         type: string
@@ -313,6 +323,7 @@ paths:
                         to understand how these blueprint-added sorts interact with the sort parameter if you plan to
                         use both. Search Blueprints is available on DXP Enterprise-tier with Liferay Enterprise Search
                         (LES) add-on subscription.
+                    example: dateModified:desc
                     name: sort
                     schema:
                         type: string
@@ -369,6 +380,7 @@ paths:
                         com.liferay.object.model.ObjectDefinition#H4T4 for Basic Web Content (CMS)). To discover
                         available class names at runtime, call GET
                         /o/search-experiences-rest/v1.0/searchable-asset-names (admin permission required).
+                    example: com.liferay.journal.model.JournalArticle,com.liferay.blogs.model.BlogsEntry
                     name: entryClassNames
                     schema:
                         type: string
@@ -403,12 +415,14 @@ paths:
                         add-on subscription), which can encapsulate more filters and operates directly with search index
                         fields. Learn more at
                         https://learn.liferay.com/w/dxp/search/liferay-enterprise-search/search-blueprints.
+                    example: groupIds/any(g:g eq 20121)
                     name: filter
                     schema:
                         type: string
                 -   in: query
                     description:
                         Supports 'embedded' to get back nested item fields.
+                    example: embedded
                     name: nestedFields
                     schema:
                         type: string
@@ -417,6 +431,7 @@ paths:
                         Specify which page to return out of all the pages available. See
                         https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
                         for more information.
+                    example: 1
                     name: page
                     schema:
                         type: integer
@@ -425,6 +440,7 @@ paths:
                         Specify how many items you want per page. See
                         https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
                         for more information.
+                    example: 20
                     name: pageSize
                     schema:
                         type: integer
@@ -432,6 +448,7 @@ paths:
                     description:
                         Comma-separated list of fields to exclude from each result. Inverse of the fields parameter. Use
                         either fields (allow-list) or restrictFields (block-list), not both.
+                    example: actions,embedded
                     name: restrictFields
                     schema:
                         type: string
@@ -439,12 +456,14 @@ paths:
                     description:
                         Specify a list of Site, Asset Library, or Space IDs or External Reference Codes (ERCs) to
                         search. You can mix IDs and ERCs in the same request.
+                    example: "20121"
                     name: scope
                     schema:
                         type: string
                 -   in: query
                     description:
                         Search by keyword(s).
+                    example: liferay
                     name: search
                     schema:
                         type: string
@@ -467,6 +486,7 @@ paths:
                         to understand how these blueprint-added sorts interact with the sort parameter if you plan to
                         use both. Search Blueprints is available on DXP Enterprise-tier with Liferay Enterprise Search
                         (LES) add-on subscription.
+                    example: dateModified:desc
                     name: sort
                     schema:
                         type: string

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
@@ -31,7 +31,9 @@ components:
             description:
                 Configuration for a single facet aggregation. Each entry describes a facet to compute alongside the
                 search results. The processed facet term buckets appear in the response's `searchFacets` map, where each
-                entry's key is the `aggregationName` you chose for that facet configuration.
+                entry's key is the `aggregationName` you chose for that facet configuration and each value is an array
+                of term-bucket objects with `displayName` (locale-dependent label), `term` (raw term value), and
+                `frequency` (count of matching documents).
             example:
                 aggregationName: priority
                 attributes:
@@ -49,10 +51,15 @@ components:
                         type: object
                     description:
                         Additional attributes required by some facets. The custom, date-range, and nested facets require
-                        a String attribute called field to set the field to aggregate results by. The date-range facet
-                        also requires a format String (such as yyyyMMddHHmmss) and a ranges object array to provide the
-                        ranges. The nested facet requires filterField, filterValue, and path String attributes. The
-                        vocabulary facet requires a String array of asset vocabulary IDs as vocabularyIds.
+                        a String attribute called `field` to set the field to aggregate results by. The date-range facet
+                        also requires a `format` String (such as yyyyMMddHHmmss) and a `ranges` array of objects, each
+                        with a `label` String (display name) and a `range` String in the format `[fromDate TO toDate]`
+                        (for example, `[20240101000000 TO 20240131235959]` matching the chosen `format`). The nested
+                        facet requires `filterField`, `filterValue`, and `path` String attributes. The vocabulary facet
+                        requires a String array of asset vocabulary IDs as `vocabularyIds` (discoverable via `GET
+                        /o/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies`). Omitting required
+                        attributes for a given facet type causes the facet to be silently ignored - the request still
+                        succeeds but no aggregation appears in the response.
                     type: object
                 frequencyThreshold:
                     description:
@@ -68,7 +75,8 @@ components:
                         Type of facet. Supported values are category, custom, date-range, folder, nested, site, tag,
                         type, vocabulary, and user. The custom facet uses top-level index fields only; Object and Web
                         Content Structure fields are indexed as nested fields, so use the nested facet for those
-                        entities.
+                        entities. The server gracefully ignores unrecognized values - passing an unknown facet type does
+                        not return a 500 error; the facet is simply skipped.
                     type: string
                 values:
                     description:
@@ -117,7 +125,9 @@ components:
                     description:
                         Facet aggregation configurations to apply to the search. Each entry describes a facet to compute
                         alongside the results. The processed facet term buckets appear in the response's `searchFacets`
-                        field.
+                        field - a map keyed by `aggregationName`, where each value is an array of term-bucket objects
+                        with `displayName` (locale-dependent label), `term` (raw term value), and `frequency` (count of
+                        matching documents). Only present on POST responses when `facetConfigurations` are provided.
                     items:
                         $ref: "#/components/schemas/FacetConfiguration"
                     type: array

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
@@ -171,54 +171,148 @@ paths:
             operationId: getSearchPage
             parameters:
                 -   in: query
+                    description:
+                        Specify the External Reference Code (ERC) of a search blueprint to control the search query and
+                        configuration. Search Blueprints is available on DXP Enterprise-tier with Liferay Enterprise
+                        Search (LES) add-on subscription.
                     name: blueprintExternalReferenceCode
                     schema:
                         type: string
                 -   in: query
+                    description:
+                        Set this to 'true' to return results even if the search parameter is omitted from the request
+                        (no search keywords specified).
                     name: emptySearch
                     schema:
                         type: boolean
                 -   in: query
                     description:
-                        Model class names to be searched for. Defaults to all.
+                        A comma separated list of entryClassNames to be searched using the class names of the types to
+                        search. Defaults to all searchable types. Out-of-the-box searchable types and their
+                        corresponding class names include - Basic Document (CMS) -
+                        com.liferay.object.model.ObjectDefinition#Z7P5, Basic Web Content (CMS) -
+                        com.liferay.object.model.ObjectDefinition#H4T4, Blog (CMS) -
+                        com.liferay.object.model.ObjectDefinition#Y8H4, Blogs Entry -
+                        com.liferay.blogs.model.BlogsEntry, Bookmarks Entry -
+                        com.liferay.bookmarks.model.BookmarksEntry, Bookmarks Folder -
+                        com.liferay.bookmarks.model.BookmarksFolder, Calendar Event -
+                        com.liferay.calendar.model.CalendarBooking, Commerce Product -
+                        com.liferay.commerce.product.model.CPDefinition, Document -
+                        com.liferay.document.library.kernel.model.DLFileEntry, Documents Folder -
+                        com.liferay.document.library.kernel.model.DLFolder, Dynamic Data Lists Record -
+                        com.liferay.dynamic.data.lists.model.DDLRecord, External Video (CMS) -
+                        com.liferay.object.model.ObjectDefinition#S1T1, Form Record -
+                        com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecord, Knowledge Base Article -
+                        com.liferay.knowledge.base.model.KBArticle, Message Boards Message -
+                        com.liferay.message.boards.model.MBMessage, Object Entry Folder -
+                        com.liferay.object.model.ObjectEntryFolder, Page - com.liferay.portal.kernel.model.Layout,
+                        Sharing Entry - com.liferay.sharing.model.SharingEntry, User -
+                        com.liferay.portal.kernel.model.User, Web Content Article -
+                        com.liferay.journal.model.JournalArticle, and Web Content Folder -
+                        com.liferay.journal.model.JournalFolder. Custom Objects and custom CMS Content Structures follow
+                        the class name format com.liferay.object.model.ObjectDefinition#<OBJECT-DEFINITION-CLASS-NAME>,
+                        where OBJECT-DEFINITION-CLASS-NAME is the Class Name of the Object Definition (for example,
+                        com.liferay.object.model.ObjectDefinition#H4T4 for Basic Web Content (CMS)). To discover
+                        available class names at runtime, call GET
+                        /o/search-experiences-rest/v1.0/searchable-asset-names (admin permission required).
                     name: entryClassNames
                     schema:
                         type: string
                 -   in: query
                     description:
-                        The list of fields to be returned.
+                        Use this parameter to specify and return only the fields specified in each of the items in the
+                        response. When requesting multiple types of items (when parameter entryClassNames is empty or
+                        specifies multiple class names), only common fields can be specified, otherwise the API returns
+                        an empty object for each result item. Examples TBA.
                     name: fields
                     schema:
                         type: string
                 -   in: query
+                    description:
+                        Filters across different fields. Supported fields are creatorId (the creator User's ID),
+                        folderId (a folder's ID), groupIds (Site, Asset Library, or Space IDs - corresponding search
+                        index field is groupId), objectDefinitionId (an Object Definition's ID), status (workflow status
+                        ID - supported statuses are '-1' = Any, '0' = Approved, '1' = Pending, '2' = Draft, '3' =
+                        Expired, '4' = Denied, '5' = Inactive, '6' = Incomplete, '7' = Scheduled, '8' = In Trash, '9' =
+                        Empty), taxonomyCategoryIds (Asset category IDs), objectDefinitionExternalReferenceCode (Object
+                        Definition External Reference Code), extension (file extension), dateCreated (the date the entry
+                        was created in OData Edm.Date format YYYY-MM-DD), dateDisplay (the date the entry was displayed
+                        in OData Edm.Date format YYYY-MM-DD), dateExpiration (the date the entry expires in OData
+                        Edm.Date format YYYY-MM-DD), dateModified (the date the entry was modified in OData Edm.Date
+                        format YYYY-MM-DD), datePublish (the date the entry was published in OData Edm.Date format
+                        YYYY-MM-DD), dateReview (the date the entry should be reviewed in OData Edm.Date format
+                        YYYY-MM-DD), keywords (Asset tag names), and title (Asset title on the locale specified by the
+                        'Accept-Language' request header). See
+                        https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
+                        for more information on the standard API query parameters. For more robust filtering options,
+                        use Search Blueprints (available on DXP Enterprise-tier with Liferay Enterprise Search (LES)
+                        add-on subscription), which can encapsulate more filters and operates directly with search index
+                        fields. Learn more at
+                        https://learn.liferay.com/w/dxp/search/liferay-enterprise-search/search-blueprints.
                     name: filter
                     schema:
                         type: string
                 -   in: query
+                    description:
+                        Supports 'embedded' to get back nested item fields.
                     name: nestedFields
                     schema:
                         type: string
                 -   in: query
+                    description:
+                        Specify which page to return out of all the pages available. See
+                        https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
+                        for more information.
                     name: page
                     schema:
                         type: integer
                 -   in: query
+                    description:
+                        Specify how many items you want per page. See
+                        https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
+                        for more information.
                     name: pageSize
                     schema:
                         type: integer
                 -   in: query
+                    description:
+                        Comma-separated list of fields to exclude from each result. Inverse of the fields parameter. Use
+                        either fields (allow-list) or restrictFields (block-list), not both.
                     name: restrictFields
                     schema:
                         type: string
                 -   in: query
+                    description:
+                        Specify a list of Site, Asset Library, or Space IDs or External Reference Codes (ERCs) to
+                        search. You can mix IDs and ERCs in the same request.
                     name: scope
                     schema:
                         type: string
                 -   in: query
+                    description:
+                        Search by keyword(s).
                     name: search
                     schema:
                         type: string
                 -   in: query
+                    description:
+                        Sort results by ascending or descending order. Supported fields are dateCreated (the date the
+                        entry was created in OData Edm.Date format YYYY-MM-DD), dateDisplay (the date the entry was
+                        displayed in OData Edm.Date format YYYY-MM-DD), dateExpiration (the date the entry expires in
+                        OData Edm.Date format YYYY-MM-DD), dateModified (the date the entry was modified in OData
+                        Edm.Date format YYYY-MM-DD), datePublish (the date the entry was published in OData Edm.Date
+                        format YYYY-MM-DD), dateReview (the date the entry should be reviewed in OData Edm.Date format
+                        YYYY-MM-DD), keywords (Asset tag names - corresponding search index field is
+                        assetTagNames.lowercase), and title (Asset title on the locale specified by the
+                        'Accept-Language' request header - corresponding search index field is
+                        localized_title_[locale].keyword_lowercase where 'locale' is a language ID like 'en_US').
+                        Defaults to order by relevance score descending. See
+                        https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
+                        for more information. Note - a search blueprint can also have sort configurations. See
+                        https://learn.liferay.com/w/dxp/search/liferay-enterprise-search/search-blueprints/sorting-results-in-a-search-blueprint#search-blueprints-versus-the-headless-api
+                        to understand how these blueprint-added sorts interact with the sort parameter if you plan to
+                        use both. Search Blueprints is available on DXP Enterprise-tier with Liferay Enterprise Search
+                        (LES) add-on subscription.
                     name: sort
                     schema:
                         type: string
@@ -247,45 +341,132 @@ paths:
             parameters:
                 -   in: query
                     description:
-                        Model class names to be searched for. Defaults to all.
+                        A comma separated list of entryClassNames to be searched using the class names of the types to
+                        search. Defaults to all searchable types. Out-of-the-box searchable types and their
+                        corresponding class names include - Basic Document (CMS) -
+                        com.liferay.object.model.ObjectDefinition#Z7P5, Basic Web Content (CMS) -
+                        com.liferay.object.model.ObjectDefinition#H4T4, Blog (CMS) -
+                        com.liferay.object.model.ObjectDefinition#Y8H4, Blogs Entry -
+                        com.liferay.blogs.model.BlogsEntry, Bookmarks Entry -
+                        com.liferay.bookmarks.model.BookmarksEntry, Bookmarks Folder -
+                        com.liferay.bookmarks.model.BookmarksFolder, Calendar Event -
+                        com.liferay.calendar.model.CalendarBooking, Commerce Product -
+                        com.liferay.commerce.product.model.CPDefinition, Document -
+                        com.liferay.document.library.kernel.model.DLFileEntry, Documents Folder -
+                        com.liferay.document.library.kernel.model.DLFolder, Dynamic Data Lists Record -
+                        com.liferay.dynamic.data.lists.model.DDLRecord, External Video (CMS) -
+                        com.liferay.object.model.ObjectDefinition#S1T1, Form Record -
+                        com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecord, Knowledge Base Article -
+                        com.liferay.knowledge.base.model.KBArticle, Message Boards Message -
+                        com.liferay.message.boards.model.MBMessage, Object Entry Folder -
+                        com.liferay.object.model.ObjectEntryFolder, Page - com.liferay.portal.kernel.model.Layout,
+                        Sharing Entry - com.liferay.sharing.model.SharingEntry, User -
+                        com.liferay.portal.kernel.model.User, Web Content Article -
+                        com.liferay.journal.model.JournalArticle, and Web Content Folder -
+                        com.liferay.journal.model.JournalFolder. Custom Objects and custom CMS Content Structures follow
+                        the class name format com.liferay.object.model.ObjectDefinition#<OBJECT-DEFINITION-CLASS-NAME>,
+                        where OBJECT-DEFINITION-CLASS-NAME is the Class Name of the Object Definition (for example,
+                        com.liferay.object.model.ObjectDefinition#H4T4 for Basic Web Content (CMS)). To discover
+                        available class names at runtime, call GET
+                        /o/search-experiences-rest/v1.0/searchable-asset-names (admin permission required).
                     name: entryClassNames
                     schema:
                         type: string
                 -   in: query
                     description:
-                        The list of fields to be returned.
+                        Use this parameter to specify and return only the fields specified in each of the items in the
+                        response. When requesting multiple types of items (when parameter entryClassNames is empty or
+                        specifies multiple class names), only common fields can be specified, otherwise the API returns
+                        an empty object for each result item. Examples TBA.
                     name: fields
                     schema:
                         type: string
                 -   in: query
+                    description:
+                        Filters across different fields. Supported fields are creatorId (the creator User's ID),
+                        folderId (a folder's ID), groupIds (Site, Asset Library, or Space IDs - corresponding search
+                        index field is groupId), objectDefinitionId (an Object Definition's ID), status (workflow status
+                        ID - supported statuses are '-1' = Any, '0' = Approved, '1' = Pending, '2' = Draft, '3' =
+                        Expired, '4' = Denied, '5' = Inactive, '6' = Incomplete, '7' = Scheduled, '8' = In Trash, '9' =
+                        Empty), taxonomyCategoryIds (Asset category IDs), objectDefinitionExternalReferenceCode (Object
+                        Definition External Reference Code), extension (file extension), dateCreated (the date the entry
+                        was created in OData Edm.Date format YYYY-MM-DD), dateDisplay (the date the entry was displayed
+                        in OData Edm.Date format YYYY-MM-DD), dateExpiration (the date the entry expires in OData
+                        Edm.Date format YYYY-MM-DD), dateModified (the date the entry was modified in OData Edm.Date
+                        format YYYY-MM-DD), datePublish (the date the entry was published in OData Edm.Date format
+                        YYYY-MM-DD), dateReview (the date the entry should be reviewed in OData Edm.Date format
+                        YYYY-MM-DD), keywords (Asset tag names), and title (Asset title on the locale specified by the
+                        'Accept-Language' request header). See
+                        https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
+                        for more information on the standard API query parameters. For more robust filtering options,
+                        use Search Blueprints (available on DXP Enterprise-tier with Liferay Enterprise Search (LES)
+                        add-on subscription), which can encapsulate more filters and operates directly with search index
+                        fields. Learn more at
+                        https://learn.liferay.com/w/dxp/search/liferay-enterprise-search/search-blueprints.
                     name: filter
                     schema:
                         type: string
                 -   in: query
+                    description:
+                        Supports 'embedded' to get back nested item fields.
                     name: nestedFields
                     schema:
                         type: string
                 -   in: query
+                    description:
+                        Specify which page to return out of all the pages available. See
+                        https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
+                        for more information.
                     name: page
                     schema:
                         type: integer
                 -   in: query
+                    description:
+                        Specify how many items you want per page. See
+                        https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
+                        for more information.
                     name: pageSize
                     schema:
                         type: integer
                 -   in: query
+                    description:
+                        Comma-separated list of fields to exclude from each result. Inverse of the fields parameter. Use
+                        either fields (allow-list) or restrictFields (block-list), not both.
                     name: restrictFields
                     schema:
                         type: string
                 -   in: query
+                    description:
+                        Specify a list of Site, Asset Library, or Space IDs or External Reference Codes (ERCs) to
+                        search. You can mix IDs and ERCs in the same request.
                     name: scope
                     schema:
                         type: string
                 -   in: query
+                    description:
+                        Search by keyword(s).
                     name: search
                     schema:
                         type: string
                 -   in: query
+                    description:
+                        Sort results by ascending or descending order. Supported fields are dateCreated (the date the
+                        entry was created in OData Edm.Date format YYYY-MM-DD), dateDisplay (the date the entry was
+                        displayed in OData Edm.Date format YYYY-MM-DD), dateExpiration (the date the entry expires in
+                        OData Edm.Date format YYYY-MM-DD), dateModified (the date the entry was modified in OData
+                        Edm.Date format YYYY-MM-DD), datePublish (the date the entry was published in OData Edm.Date
+                        format YYYY-MM-DD), dateReview (the date the entry should be reviewed in OData Edm.Date format
+                        YYYY-MM-DD), keywords (Asset tag names - corresponding search index field is
+                        assetTagNames.lowercase), and title (Asset title on the locale specified by the
+                        'Accept-Language' request header - corresponding search index field is
+                        localized_title_[locale].keyword_lowercase where 'locale' is a language ID like 'en_US').
+                        Defaults to order by relevance score descending. See
+                        https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
+                        for more information. Note - a search blueprint can also have sort configurations. See
+                        https://learn.liferay.com/w/dxp/search/liferay-enterprise-search/search-blueprints/sorting-results-in-a-search-blueprint#search-blueprints-versus-the-headless-api
+                        to understand how these blueprint-added sorts interact with the sort parameter if you plan to
+                        use both. Search Blueprints is available on DXP Enterprise-tier with Liferay Enterprise Search
+                        (LES) add-on subscription.
                     name: sort
                     schema:
                         type: string

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
@@ -274,6 +274,7 @@ paths:
                         subscription.
                     example: PRODUCT_SEARCH
                     name: blueprintExternalReferenceCode
+                    required: false
                     schema:
                         type: string
                 -   in: query
@@ -283,6 +284,7 @@ paths:
                         body attribute instead.
                     example: true
                     name: emptySearch
+                    required: false
                     schema:
                         type: boolean
                 -   in: query
@@ -319,6 +321,7 @@ paths:
                         /o/search-experiences-rest/v1.0/searchable-asset-names (admin permission required).
                     example: com.liferay.journal.model.JournalArticle,com.liferay.blogs.model.BlogsEntry
                     name: entryClassNames
+                    required: false
                     schema:
                         type: string
                 -   in: query
@@ -328,6 +331,7 @@ paths:
                         specifies multiple class names), only common fields can be specified, otherwise the API returns
                         an empty object for each result item. Examples TBA.
                     name: fields
+                    required: false
                     schema:
                         type: string
                 -   in: query
@@ -355,6 +359,7 @@ paths:
                         https://learn.liferay.com/w/dxp/search/liferay-enterprise-search/search-blueprints.
                     example: groupIds/any(g:g eq 20121)
                     name: filter
+                    required: false
                     schema:
                         type: string
                 -   in: query
@@ -363,6 +368,7 @@ paths:
                         own headless API schema. The MCP Server may default to this value.
                     example: embedded
                     name: nestedFields
+                    required: false
                     schema:
                         type: string
                 -   in: query
@@ -372,6 +378,7 @@ paths:
                         for more information.
                     example: 1
                     name: page
+                    required: false
                     schema:
                         type: integer
                 -   in: query
@@ -381,6 +388,7 @@ paths:
                         for more information.
                     example: 20
                     name: pageSize
+                    required: false
                     schema:
                         type: integer
                 -   in: query
@@ -389,6 +397,7 @@ paths:
                         either fields (allow-list) or restrictFields (block-list), not both.
                     example: actions,embedded
                     name: restrictFields
+                    required: false
                     schema:
                         type: string
                 -   in: query
@@ -397,6 +406,7 @@ paths:
                         search. You can mix IDs and ERCs in the same request.
                     example: "20121"
                     name: scope
+                    required: false
                     schema:
                         type: string
                 -   in: query
@@ -404,6 +414,7 @@ paths:
                         Search by keyword(s).
                     example: liferay
                     name: search
+                    required: false
                     schema:
                         type: string
                 -   in: query
@@ -427,6 +438,7 @@ paths:
                         (LES) add-on subscription.
                     example: dateModified:desc
                     name: sort
+                    required: false
                     schema:
                         type: string
             responses:
@@ -486,6 +498,7 @@ paths:
                         /o/search-experiences-rest/v1.0/searchable-asset-names (admin permission required).
                     example: com.liferay.journal.model.JournalArticle,com.liferay.blogs.model.BlogsEntry
                     name: entryClassNames
+                    required: false
                     schema:
                         type: string
                 -   in: query
@@ -495,6 +508,7 @@ paths:
                         specifies multiple class names), only common fields can be specified, otherwise the API returns
                         an empty object for each result item. Examples TBA.
                     name: fields
+                    required: false
                     schema:
                         type: string
                 -   in: query
@@ -522,6 +536,7 @@ paths:
                         https://learn.liferay.com/w/dxp/search/liferay-enterprise-search/search-blueprints.
                     example: groupIds/any(g:g eq 20121)
                     name: filter
+                    required: false
                     schema:
                         type: string
                 -   in: query
@@ -530,6 +545,7 @@ paths:
                         own headless API schema. The MCP Server may default to this value.
                     example: embedded
                     name: nestedFields
+                    required: false
                     schema:
                         type: string
                 -   in: query
@@ -539,6 +555,7 @@ paths:
                         for more information.
                     example: 1
                     name: page
+                    required: false
                     schema:
                         type: integer
                 -   in: query
@@ -548,6 +565,7 @@ paths:
                         for more information.
                     example: 20
                     name: pageSize
+                    required: false
                     schema:
                         type: integer
                 -   in: query
@@ -556,6 +574,7 @@ paths:
                         either fields (allow-list) or restrictFields (block-list), not both.
                     example: actions,embedded
                     name: restrictFields
+                    required: false
                     schema:
                         type: string
                 -   in: query
@@ -564,6 +583,7 @@ paths:
                         search. You can mix IDs and ERCs in the same request.
                     example: "20121"
                     name: scope
+                    required: false
                     schema:
                         type: string
                 -   in: query
@@ -571,6 +591,7 @@ paths:
                         Search by keyword(s).
                     example: liferay
                     name: search
+                    required: false
                     schema:
                         type: string
                 -   in: query
@@ -594,6 +615,7 @@ paths:
                         (LES) add-on subscription.
                     example: dateModified:desc
                     name: sort
+                    required: false
                     schema:
                         type: string
             requestBody:

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
@@ -30,7 +30,8 @@ components:
         FacetConfiguration:
             description:
                 Configuration for a single facet aggregation. Each entry describes a facet to compute alongside the
-                search results. The response's aggregations field returns the facet buckets. Examples TBA.
+                search results. The processed facet term buckets appear in the response's `searchFacets` map, where each
+                entry's key is the `aggregationName` you chose for that facet configuration. Examples TBA.
             properties:
                 aggregationName:
                     description:
@@ -106,7 +107,8 @@ components:
                 facetConfigurations:
                     description:
                         Facet aggregation configurations to apply to the search. Each entry describes a facet to compute
-                        alongside the results; the response's aggregations field returns the facet buckets.
+                        alongside the results. The processed facet term buckets appear in the response's `searchFacets`
+                        field.
                     items:
                         $ref: "#/components/schemas/FacetConfiguration"
                     type: array
@@ -139,7 +141,7 @@ components:
                         -   Product News
                     groupId: "20121"
                 entryClassName: com.liferay.blogs.model.BlogsEntry
-                itemURL: /web/sites/marketing/-/blogs/release-notes-7.4
+                itemURL: /o/headless-delivery/v1.0/blog-posting/12345
                 score: 1.42
                 title: Release Notes for Liferay 7.4
             properties:
@@ -184,12 +186,13 @@ components:
                     description:
                         Fully-qualified class name of the indexed entity (for example,
                         com.liferay.blogs.model.BlogsEntry for a blog entry, com.liferay.journal.model.JournalArticle
-                        for a Web Content Article).
+                        for a Web Content Article). This value can be used directly as input to the entryClassNames
+                        query parameter in subsequent /search requests to narrow searches to that type.
                     type: string
                 itemURL:
                     description:
-                        Friendly URL where the item can be viewed in the portal. May be relative or absolute depending
-                        on configuration.
+                        The headless REST API URL to fetch the full entity. Can be called directly, or the response is
+                        included automatically when nestedFields=embedded is set.
                     format: uri
                     type: string
                 score:
@@ -259,8 +262,10 @@ paths:
                 -   in: query
                     description:
                         Specify the External Reference Code (ERC) of a search blueprint to control the search query and
-                        configuration. Search Blueprints is available on DXP Enterprise-tier with Liferay Enterprise
-                        Search (LES) add-on subscription.
+                        configuration. Preferred over the blueprint ID. For POST /search requests, use the
+                        `search.experiences.blueprint.external.reference.code` request body attribute instead. Search
+                        Blueprints is available on DXP Enterprise-tier with Liferay Enterprise Search (LES) add-on
+                        subscription.
                     example: PRODUCT_SEARCH
                     name: blueprintExternalReferenceCode
                     schema:
@@ -268,7 +273,8 @@ paths:
                 -   in: query
                     description:
                         Set this to 'true' to return results even if the search parameter is omitted from the request
-                        (no search keywords specified).
+                        (no search keywords specified). For POST /search requests, use the `search.empty.search` request
+                        body attribute instead.
                     example: true
                     name: emptySearch
                     schema:
@@ -320,18 +326,19 @@ paths:
                     description:
                         Filters across different fields. Supported fields are creatorId (the creator User's ID),
                         folderId (a folder's ID), groupIds (Site, Asset Library, or Space IDs - corresponding search
-                        index field is groupId), objectDefinitionId (an Object Definition's ID), status (workflow status
-                        ID - supported statuses are '-1' = Any, '0' = Approved, '1' = Pending, '2' = Draft, '3' =
-                        Expired, '4' = Denied, '5' = Inactive, '6' = Incomplete, '7' = Scheduled, '8' = In Trash, '9' =
-                        Empty), taxonomyCategoryIds (Asset category IDs), objectDefinitionExternalReferenceCode (Object
-                        Definition External Reference Code), extension (file extension), dateCreated (the date the entry
-                        was created in OData Edm.Date format YYYY-MM-DD), dateDisplay (the date the entry was displayed
-                        in OData Edm.Date format YYYY-MM-DD), dateExpiration (the date the entry expires in OData
-                        Edm.Date format YYYY-MM-DD), dateModified (the date the entry was modified in OData Edm.Date
-                        format YYYY-MM-DD), datePublish (the date the entry was published in OData Edm.Date format
-                        YYYY-MM-DD), dateReview (the date the entry should be reviewed in OData Edm.Date format
-                        YYYY-MM-DD), keywords (Asset tag names), and title (Asset title on the locale specified by the
-                        'Accept-Language' request header). See
+                        index field is groupId; only approved items are returned by default), objectDefinitionId (an
+                        Object Definition's ID), status (workflow status ID - supported statuses are '-1' = Any, '0' =
+                        Approved, '1' = Pending, '2' = Draft, '3' = Expired, '4' = Denied, '5' = Inactive, '6' =
+                        Incomplete, '7' = Scheduled, '8' = In Trash, '9' = Empty), taxonomyCategoryIds (Asset category
+                        IDs), objectDefinitionExternalReferenceCode (Object Definition External Reference Code),
+                        extension (file extension), dateCreated (the date the entry was created in OData Edm.Date format
+                        YYYY-MM-DD), dateDisplay (the date the entry was displayed in OData Edm.Date format YYYY-MM-DD),
+                        dateExpiration (the date the entry expires in OData Edm.Date format YYYY-MM-DD), dateModified
+                        (the date the entry was modified in OData Edm.Date format YYYY-MM-DD), datePublish (the date the
+                        entry was published in OData Edm.Date format YYYY-MM-DD), dateReview (the date the entry should
+                        be reviewed in OData Edm.Date format YYYY-MM-DD), keywords (Asset tag names), and title (Asset
+                        title on the locale specified by the 'Accept-Language' request header). Web content articles
+                        (JournalArticle) cannot be filtered by status. See
                         https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
                         for more information on the standard API query parameters. For more robust filtering options,
                         use Search Blueprints (available on DXP Enterprise-tier with Liferay Enterprise Search (LES)
@@ -344,7 +351,8 @@ paths:
                         type: string
                 -   in: query
                     description:
-                        Supports 'embedded' to get back nested item fields.
+                        Supports 'embedded' to return the full entity payload for each result, following the entity's
+                        own headless API schema. The MCP Server may default to this value.
                     example: embedded
                     name: nestedFields
                     schema:
@@ -483,18 +491,19 @@ paths:
                     description:
                         Filters across different fields. Supported fields are creatorId (the creator User's ID),
                         folderId (a folder's ID), groupIds (Site, Asset Library, or Space IDs - corresponding search
-                        index field is groupId), objectDefinitionId (an Object Definition's ID), status (workflow status
-                        ID - supported statuses are '-1' = Any, '0' = Approved, '1' = Pending, '2' = Draft, '3' =
-                        Expired, '4' = Denied, '5' = Inactive, '6' = Incomplete, '7' = Scheduled, '8' = In Trash, '9' =
-                        Empty), taxonomyCategoryIds (Asset category IDs), objectDefinitionExternalReferenceCode (Object
-                        Definition External Reference Code), extension (file extension), dateCreated (the date the entry
-                        was created in OData Edm.Date format YYYY-MM-DD), dateDisplay (the date the entry was displayed
-                        in OData Edm.Date format YYYY-MM-DD), dateExpiration (the date the entry expires in OData
-                        Edm.Date format YYYY-MM-DD), dateModified (the date the entry was modified in OData Edm.Date
-                        format YYYY-MM-DD), datePublish (the date the entry was published in OData Edm.Date format
-                        YYYY-MM-DD), dateReview (the date the entry should be reviewed in OData Edm.Date format
-                        YYYY-MM-DD), keywords (Asset tag names), and title (Asset title on the locale specified by the
-                        'Accept-Language' request header). See
+                        index field is groupId; only approved items are returned by default), objectDefinitionId (an
+                        Object Definition's ID), status (workflow status ID - supported statuses are '-1' = Any, '0' =
+                        Approved, '1' = Pending, '2' = Draft, '3' = Expired, '4' = Denied, '5' = Inactive, '6' =
+                        Incomplete, '7' = Scheduled, '8' = In Trash, '9' = Empty), taxonomyCategoryIds (Asset category
+                        IDs), objectDefinitionExternalReferenceCode (Object Definition External Reference Code),
+                        extension (file extension), dateCreated (the date the entry was created in OData Edm.Date format
+                        YYYY-MM-DD), dateDisplay (the date the entry was displayed in OData Edm.Date format YYYY-MM-DD),
+                        dateExpiration (the date the entry expires in OData Edm.Date format YYYY-MM-DD), dateModified
+                        (the date the entry was modified in OData Edm.Date format YYYY-MM-DD), datePublish (the date the
+                        entry was published in OData Edm.Date format YYYY-MM-DD), dateReview (the date the entry should
+                        be reviewed in OData Edm.Date format YYYY-MM-DD), keywords (Asset tag names), and title (Asset
+                        title on the locale specified by the 'Accept-Language' request header). Web content articles
+                        (JournalArticle) cannot be filtered by status. See
                         https://learn.liferay.com/w/dxp/integration/headless-apis/using-liferay-as-a-headless-platform/consuming-apis/api-query-parameters
                         for more information on the standard API query parameters. For more robust filtering options,
                         use Search Blueprints (available on DXP Enterprise-tier with Liferay Enterprise Search (LES)
@@ -507,7 +516,8 @@ paths:
                         type: string
                 -   in: query
                     description:
-                        Supports 'embedded' to get back nested item fields.
+                        Supports 'embedded' to return the full entity payload for each result, following the entity's
+                        own headless API schema. The MCP Server may default to this value.
                     example: embedded
                     name: nestedFields
                     schema:

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
@@ -97,6 +97,9 @@ components:
                         blueprint ID; Search Blueprints require DXP Enterprise-tier with the Liferay Enterprise Search
                         (LES) add-on subscription), search.experiences.blueprint.id (ID of a Search Blueprint - prefer
                         search.experiences.blueprint.external.reference.code when available),
+                        search.experiences.ip.address (overrides the auto-detected client IP for geolocation-aware
+                        blueprint elements such as IP-based boosting or region targeting; defaults to the actual HTTP
+                        request's client IP when omitted; LES-only since the consumers ship with Search Experiences),
                         search.experiences.scope.group.id (set when the blueprint contains elements that require a group
                         context, such as 'Limit Search to the Current Site', 'Boost Contents in a Category for a User
                         Segment', or 'Staging Aware'), and any other key prefixed with search.experiences. (dynamic

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
@@ -172,7 +172,9 @@ components:
                     type: string
                 dateReview:
                     description:
-                        The time when the item should next be reviewed.
+                        The date when the content item is scheduled for editorial review. Part of the Liferay content
+                        lifecycle; populated by Web Content Article and other content types that support a review
+                        workflow. May be null when no review date is set for the item.
                     format: date-time
                     type: string
                 description:
@@ -202,7 +204,8 @@ components:
                     description:
                         Relevance score assigned by the search engine. Higher values indicate stronger relevance to the
                         query. Typical values fall in the range 0.0 to ~10.0 depending on query complexity and blueprint
-                        configuration.
+                        configuration. Useful for threshold filtering (e.g., dropping results below a chosen score) or
+                        custom result ranking logic (combining `score` with other signals).
                     format: float
                     type: number
                 title:

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/graphql/mutation/v1_0/Mutation.java
@@ -87,7 +87,7 @@ public class Mutation {
 	}
 
 	@GraphQLField(
-		description = "Search the company index for matching content."
+		description = "Use this API to search for matching content, products and other indexed data. Choose POST over GET when you need request body features such as facets (aggregations) via `facetConfigurations`, Search Blueprint context attributes (`search.experiences.*`), or other request-body-only constructs. Refer to https://learn.liferay.com/w/dxp/integration/headless-apis/search-apis/search-api-basics for more information."
 	)
 	public java.util.Collection<SearchResult> createSearchPage(
 			@GraphQLName("entryClassNames") String entryClassNames,
@@ -265,4 +265,4 @@ public class Mutation {
 		_vulcanBatchEngineImportTaskResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:2118851640
+// LIFERAY-REST-BUILDER-HASH:1564786562

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/graphql/query/v1_0/Query.java
@@ -83,7 +83,7 @@ public class Query {
 	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {search(blueprintExternalReferenceCode: ___, emptySearch: ___, entryClassNames: ___, filter: ___, page: ___, pageSize: ___, scope: ___, search: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
-		description = "Search the company index for matching content."
+		description = "Use this API to search for matching content, products and other indexed data. Choose GET when query-string parameters are sufficient; choose POST /search when you need request body features such as `facetConfigurations` (faceted aggregations), Search Blueprint context attributes (`search.experiences.*`), or other request-body-only constructs. Refer to https://learn.liferay.com/w/dxp/integration/headless-apis/search-apis/search-api-basics for more information."
 	)
 	public SearchResultPage search(
 			@GraphQLName("blueprintExternalReferenceCode") String
@@ -257,4 +257,4 @@ public class Query {
 	private com.liferay.portal.kernel.model.User _user;
 
 }
-// LIFERAY-REST-BUILDER-HASH:550171345
+// LIFERAY-REST-BUILDER-HASH:-1282770054

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/BaseSearchResultResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/BaseSearchResultResourceImpl.java
@@ -73,55 +73,67 @@ public abstract class BaseSearchResultResourceImpl
 	 * curl -X 'GET' 'http://localhost:8080/o/search/v1.0/search'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
-		description = "Search the company index for matching content."
+		description = "Use this API to search for matching content, products and other indexed data. Choose GET when query-string parameters are sufficient; choose POST /search when you need request body features such as `facetConfigurations` (faceted aggregations), Search Blueprint context attributes (`search.experiences.*`), or other request-body-only constructs. Refer to https://learn.liferay.com/w/dxp/integration/headless-apis/search-apis/search-api-basics for more information."
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "PRODUCT_SEARCH",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "blueprintExternalReferenceCode"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "true",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "emptySearch"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "com.liferay.journal.model.JournalArticle,com.liferay.blogs.model.BlogsEntry",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "entryClassNames"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "title,description,score",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "fields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "groupIds/any(g:g eq 20121)",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "filter"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "embedded",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "nestedFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "1",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "page"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "20",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "pageSize"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "actions,embedded",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "20121,L_GUEST",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "scope"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "liferay",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "search"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "dateModified:desc",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "sort"
 			)
@@ -166,47 +178,57 @@ public abstract class BaseSearchResultResourceImpl
 	 * curl -X 'POST' 'http://localhost:8080/o/search/v1.0/search' -d $'{"attributes": ___, "facetConfigurations": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
-		description = "Search the company index for matching content."
+		description = "Use this API to search for matching content, products and other indexed data. Choose POST over GET when you need request body features such as facets (aggregations) via `facetConfigurations`, Search Blueprint context attributes (`search.experiences.*`), or other request-body-only constructs. Refer to https://learn.liferay.com/w/dxp/integration/headless-apis/search-apis/search-api-basics for more information."
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "com.liferay.journal.model.JournalArticle,com.liferay.blogs.model.BlogsEntry",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "entryClassNames"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "title,description,score",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "fields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "groupIds/any(g:g eq 20121)",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "filter"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "embedded",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "nestedFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "1",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "page"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "20",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "pageSize"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "actions,embedded",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "20121,L_GUEST",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "scope"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "liferay",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "search"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				example = "dateModified:desc",
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "sort"
 			)
@@ -900,4 +922,4 @@ public abstract class BaseSearchResultResourceImpl
 		LogFactoryUtil.getLog(BaseSearchResultResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1314395548
+// LIFERAY-REST-BUILDER-HASH:-2040772935


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91437

## What is being fixed

The OpenAPI schema for `/o/search/v1.0/search` (GET and POST) had minimal metadata, most query parameters had no description, no examples, no required/optional flags. Without that context, an LLM consuming the schema via the Liferay MCP Server, or a developer reading the API Explorer, must consult external documentation to construct correct requests

## How it is being fixed

The YAML at `modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml` is enriched per LPD-68616's "Details" table

  ## How this was tested

  1. **Runtime verification** : deployed the impl module and queried `GET /o/search/v1.0/openapi.json`. Confirmed that top-level operation descriptions, parameter `example:` values, and all schema property descriptions surface as written. Parameter-level `description`/`required` and schema-level `description`/`example` on `SearchRequestBody`/`SearchResult` are filtered out by Vulcana serialization — this is the [LPD-82751 (https://liferay.atlassian.net/browse/LPD-82751) gap. The YAML edits are correct and will surface automatically once that ticket ships.

  2. **LLM-readability test against the raw YAML** :  extracted the bundled `META-INF/liferay/rest/rest-openapi.yaml` and gave it to an LLM with 8 realistic scenarios. The LLM constructed correct requests for all 8 using only the YAML 

## Why are there no tests?

This PR contains only OpenAPI documentation enrichments (descriptions, examples) and the regenerated REST artifacts that propagate them into JavaDoc and Swagger annotations. There is no runtime behavior change, so existing integration tests in `portal-search-rest-test` cover the unchanged behavior.