### PR TITLE
LPD-82794 es upgrade v4

### DIFF
--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/configuration/ElasticsearchConfigurationWrapper.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/configuration/ElasticsearchConfigurationWrapper.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentSkipListSet;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Bryan Engler
@@ -306,6 +307,10 @@ public class ElasticsearchConfigurationWrapper
 	private volatile ElasticsearchConfiguration _elasticsearchConfiguration;
 	private final Set<ElasticsearchConfigurationObserver>
 		_elasticsearchConfigurationObservers = new ConcurrentSkipListSet<>();
+
+	@Reference(target = "(elasticsearch.configuration.ready=true)")
+	private Object _elasticsearchConfigurationReady;
+
 	private volatile ElasticsearchConfiguration
 		_propsElasticsearchConfiguration;
 	private volatile Map<String, Object> _propsMap = Collections.emptyMap();

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/sidecar/activator/SearchElasticsearch8ImplBundleActivator.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/sidecar/activator/SearchElasticsearch8ImplBundleActivator.java
@@ -7,19 +7,34 @@ package com.liferay.portal.search.elasticsearch8.internal.sidecar.activator;
 
 import com.liferay.petra.process.ProcessChannel;
 import com.liferay.petra.process.ProcessExecutor;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.concurrent.SystemExecutorServiceUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Release;
+import com.liferay.portal.kernel.module.util.ServiceLatch;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.search.elasticsearch8.internal.sidecar.PersistedProcessUtil;
+import com.liferay.portal.tools.DBUpgrader;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.Serializable;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
 
 /**
  * @author Tina Tian
@@ -37,27 +52,155 @@ public class SearchElasticsearch8ImplBundleActivator
 	public void start(BundleContext bundleContext) throws Exception {
 		File sidecarProcessFile = bundleContext.getDataFile("sidecar.process");
 
-		if (!sidecarProcessFile.exists()) {
+		if (sidecarProcessFile.exists()) {
+			ServiceReference<ProcessExecutor> serviceReference =
+				bundleContext.getServiceReference(ProcessExecutor.class);
+
+			ExecutorService executorService =
+				SystemExecutorServiceUtil.getExecutorService();
+
+			_future = executorService.submit(
+				() -> PersistedProcessUtil.start(
+					bundleContext.getService(serviceReference),
+					sidecarProcessFile));
+		}
+
+		if ((!DBUpgrader.isUpgradeClient() &&
+			 !DBUpgrader.isUpgradeDatabaseAutoRunEnabled() &&
+			 !StartupHelperUtil.isUpgrading()) ||
+			!_hasLegacyElasticsearchConfiguration(bundleContext)) {
+
+			_publishElasticsearchConfigurationReady(bundleContext);
+
 			return;
 		}
 
-		ServiceReference<ProcessExecutor> serviceReference =
-			bundleContext.getServiceReference(ProcessExecutor.class);
+		Bundle bundle = bundleContext.getBundle();
 
-		ExecutorService executorService =
-			SystemExecutorServiceUtil.getExecutorService();
+		ServiceLatch serviceLatch = new ServiceLatch(bundleContext);
 
-		_future = executorService.submit(
-			() -> PersistedProcessUtil.start(
-				bundleContext.getService(serviceReference),
-				sidecarProcessFile));
+		serviceLatch.waitFor(
+			StringBundler.concat(
+				"(&(objectClass=", Release.class.getName(),
+				")(release.bundle.symbolic.name=", bundle.getSymbolicName(),
+				")(release.schema.version>=1.0.0))"));
+
+		serviceLatch.openOn(
+			() -> _publishElasticsearchConfigurationReady(bundleContext));
 	}
 
 	@Override
 	public void stop(BundleContext bundleContext) throws Exception {
+		if (_elasticsearchConfigurationReadyServiceRegistration != null) {
+			_elasticsearchConfigurationReadyServiceRegistration.unregister();
+
+			_elasticsearchConfigurationReadyServiceRegistration = null;
+		}
 	}
+
+	private int _getElasticsearchVersion(String string) {
+		String elasticsearch = "elasticsearch";
+
+		int index = string.indexOf(elasticsearch);
+
+		if (index == -1) {
+			return -1;
+		}
+
+		int beginIndex = index + elasticsearch.length();
+
+		int endIndex = beginIndex;
+
+		while ((endIndex < string.length()) &&
+			   Character.isDigit(string.charAt(endIndex))) {
+
+			endIndex++;
+		}
+
+		if (endIndex == beginIndex) {
+			return -1;
+		}
+
+		return GetterUtil.getInteger(string.substring(beginIndex, endIndex));
+	}
+
+	private boolean _hasLegacyElasticsearchConfiguration(
+		BundleContext bundleContext) {
+
+		ServiceReference<ConfigurationAdmin> serviceReference =
+			bundleContext.getServiceReference(ConfigurationAdmin.class);
+
+		if (serviceReference == null) {
+			return false;
+		}
+
+		ConfigurationAdmin configurationAdmin = bundleContext.getService(
+			serviceReference);
+
+		try {
+			Configuration[] configurations =
+				configurationAdmin.listConfigurations(
+					"(|(service.pid=*Elasticsearch*Configuration)" +
+						"(service.factoryPid=*Elasticsearch*Configuration))");
+
+			if (configurations == null) {
+				return false;
+			}
+
+			Bundle bundle = bundleContext.getBundle();
+
+			int runtimeVersion = _getElasticsearchVersion(
+				bundle.getSymbolicName());
+
+			for (Configuration configuration : configurations) {
+				String pid = configuration.getFactoryPid();
+
+				if (pid == null) {
+					pid = configuration.getPid();
+				}
+
+				int configurationVersion = _getElasticsearchVersion(pid);
+
+				if (configurationVersion != runtimeVersion) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+		catch (InvalidSyntaxException | IOException exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to query ConfigurationAdmin for legacy " +
+						"Elasticsearch configurations",
+					exception);
+			}
+
+			return false;
+		}
+		finally {
+			bundleContext.ungetService(serviceReference);
+		}
+	}
+
+	private void _publishElasticsearchConfigurationReady(
+		BundleContext bundleContext) {
+
+		_elasticsearchConfigurationReadyServiceRegistration =
+			bundleContext.registerService(
+				Object.class, new Object(),
+				HashMapDictionaryBuilder.<String, Object>put(
+					"elasticsearch.configuration.ready", "true"
+				).build());
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SearchElasticsearch8ImplBundleActivator.class);
 
 	private static volatile Future
 		<ObjectValuePair<ProcessChannel<Serializable>, byte[]>> _future;
+
+	private ServiceRegistration<Object>
+		_elasticsearchConfigurationReadyServiceRegistration;
 
 }

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/upgrade/v1_0_0/ElasticsearchConfigurationUpgradeProcess.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/upgrade/v1_0_0/ElasticsearchConfigurationUpgradeProcess.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.search.elasticsearch8.internal.upgrade.v1_0_0;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.persistence.upgrade.ConfigurationUpgradeStepFactory;
 import com.liferay.portal.file.install.constants.FileInstallConstants;
@@ -162,6 +163,19 @@ public class ElasticsearchConfigurationUpgradeProcess extends UpgradeProcess {
 				ElasticsearchConnectionConfiguration.class.getName());
 
 		upgradeStep.upgrade();
+
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			StringBundler.concat(
+				"(service.factoryPid=",
+				ElasticsearchConnectionConfiguration.class.getName(), ")"));
+
+		if (configurations == null) {
+			return;
+		}
+
+		for (Configuration configuration : configurations) {
+			configuration.update(configuration.getProperties());
+		}
 	}
 
 	private static final String _CLASS_NAME_ELASTICSEARCH_CONFIGURATION =

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-test/src/testIntegration/java/com/liferay/portal/search/elasticsearch8/internal/upgrade/v1_0_0/test/ElasticsearchConfigurationUpgradeProcessTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-test/src/testIntegration/java/com/liferay/portal/search/elasticsearch8/internal/upgrade/v1_0_0/test/ElasticsearchConfigurationUpgradeProcessTest.java
@@ -59,7 +59,7 @@ public class ElasticsearchConfigurationUpgradeProcessTest {
 			).put(
 				"embeddedHttpPort", 9202
 			).put(
-				"operationMode", "EMBEDDED"
+				"operationMode", "REMOTE"
 			).put(
 				"restClientLoggerLevel", "ERROR"
 			).put(
@@ -79,7 +79,7 @@ public class ElasticsearchConfigurationUpgradeProcessTest {
 			).put(
 				"embeddedHttpPort", 9202
 			).put(
-				"operationMode", "EMBEDDED"
+				"operationMode", "REMOTE"
 			).put(
 				"restClientLoggerLevel", "ERROR"
 			).put(
@@ -112,7 +112,7 @@ public class ElasticsearchConfigurationUpgradeProcessTest {
 		Assert.assertNull(properties.get("embeddedHttpPort"));
 		Assert.assertNull(properties.get("operationMode"));
 		Assert.assertEquals(
-			Boolean.FALSE,
+			Boolean.TRUE,
 			GetterUtil.getBoolean(properties.get("productionModeEnabled")));
 		Assert.assertNull(properties.get("restClientLoggerLevel"));
 		Assert.assertEquals(

--- a/modules/apps/portal-search-elasticsearch8/source-formatter-suppressions.xml
+++ b/modules/apps/portal-search-elasticsearch8/source-formatter-suppressions.xml
@@ -4,6 +4,7 @@
 	<checkstyle>
 		<suppress checks="CompanyIterationCheck" files=".*" />
 		<suppress checks="UnprocessedExceptionCheck" files="portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/index/CompanyIndexHelper\.java" />
+		<suppress checks="UnusedVariableCheck" files="portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/configuration/ElasticsearchConfigurationWrapper\.java" />
 	</checkstyle>
 	<source-check>
 		<suppress checks="JavaComponentAnnotationsCheck" files=".*" />


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-82794

Implemented a gating mechanism to wait until the Elasticsearch Configuration is upgraded before trying to start Sidecar or connect to Elasticsearch.

This has been through many refinements with @shuyangzhou and @tinatian - previous version here: https://github.com/liferay-core-infra/liferay-portal/pull/9843 and this direction is approved by Core.