### PR TITLE
LPD-88409 Update expected steps related to iframe selection (categories in Collections)

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/asset/assetlist/AssetListsAdmin.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/asset/assetlist/AssetListsAdmin.macro
@@ -30,8 +30,6 @@ definition {
 				locator1 = "Treeview#NODE_CHECKBOX");
 		}
 
-		SelectFrameTop();
-
 		Click(locator1 = "Button#DONE");
 
 		PortletEntry.save();

--- a/portal-web/test/functional/com/liferay/portalweb/macros/asset/categories/AssetCategorization.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/asset/categories/AssetCategorization.macro
@@ -89,9 +89,7 @@ definition {
 
 	@summary = "Default summary"
 	macro gotoSelectCategory() {
-		IFrame.selectCategoryFrame();
-
-		Portlet.expandTree();
+		AssertVisible(locator1 = "Modal#BODY");
 	}
 
 	@summary = "Default summary"

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Treeview.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Treeview.path
@@ -12,7 +12,7 @@
 <tbody>
 <tr>
 	<td>NODE_CHECKBOX</td>
-	<td>//*[contains(@class,'component-text') or contains(@class,'flex-grow')][normalize-space(text())='${key_nodeName}']/ancestor::div[contains(@class,'treeview')]//input[@type='checkbox']</td>
+	<td>//*[contains(@class,'component-text') or contains(@class,'flex-grow')][normalize-space(text())='${key_nodeName}']/ancestor::div[contains(@class,'treeview')]//input[@type='checkbox'] | //*[contains(@class,'treeview-item')][.//text()[normalize-space()='${key_nodeName}']]//input[@type='checkbox']</td>
 	<td></td>
 </tr>
 <tr>
@@ -42,7 +42,7 @@
 </tr>
 <tr>
 	<td>NODE_ITEM</td>
-	<td>//div[contains(@class,'card-horizontal')]//div[contains(@class,'card-body')][contains(.,'${key_nodeName}')] | //li[contains(@class,'treeview-item')]//*[contains(@class,'component-text') or contains(@class,'flex-grow')][normalize-space(text())='${key_nodeName}']</td>
+	<td>//div[contains(@class,'card-horizontal')]//div[contains(@class,'card-body')][contains(.,'${key_nodeName}')] | //li[contains(@class,'treeview-item')]//*[contains(@class,'component-text') or contains(@class,'flex-grow')][normalize-space(text())='${key_nodeName}'] | //*[contains(@class,'treeview-item')][.//text()[normalize-space()='${key_nodeName}']]</td>
 	<td></td>
 </tr>
 <tr>
@@ -67,7 +67,7 @@
 </tr>
 <tr>
 	<td>NODE_UNSELECTED</td>
-	<td>//div[contains(@class,'card-type-directory') and not(contains(@class,'selected'))]/div[contains(@class,'card-horizontal')]//span[contains(.,'${key_nodeName}')] | //div[contains(@role,'treeitem') and not(contains(@class,'active'))]//*[contains(@class,'component-text') or contains(@class,'flex-grow')][normalize-space(text())='${key_nodeName}']</td>
+	<td>//div[contains(@class,'card-type-directory') and not(contains(@class,'selected'))]/div[contains(@class,'card-horizontal')]//span[contains(.,'${key_nodeName}')] | //div[contains(@role,'treeitem') and not(contains(@class,'active'))]//*[contains(@class,'component-text') or contains(@class,'flex-grow')][normalize-space(text())='${key_nodeName}'] | //*[contains(@class,'treeview-item') and (not(@aria-selected) or @aria-selected='false')][.//text()[normalize-space()='${key_nodeName}']]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/collections/Collections.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/collections/Collections.testcase
@@ -1197,9 +1197,9 @@ definition {
 
 			AssetCategorization.gotoSelectCategory();
 
-			for (var vocabularyName : list "Language (Test Site Name),Region (Test Site Name)") {
+			for (var categoryName : list "Category Name 1,Category Name 2") {
 				AssertElementPresent(
-					key_nodeName = ${vocabularyName},
+					key_nodeName = ${categoryName},
 					locator1 = "Treeview#NODE_ITEM");
 			}
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88409 - Technical Task | Single and multiple selection in Category selector

Follow up on poshi tests

## What is this trying to solve?
This should help with some of the failing tests on https://testray.liferay.com/web/testray#/project/35392/routines/590307/build/480373699?filter=%7B%22error%22%3A%22%2F%2Fdiv%5Bcontains%28%40class%2C%27modal-body%27%29%5D%2F%2Fiframe%22%7D&filterSchema=buildResults&page=1

- Collections#FilterCollectionItemsByGlobalCategory
- Collections#ViewAllTwoCategoriesInDynamicCollection
- Collections#ViewContentOfAVariant

## How am I fixing it?
Commit 93d2595c7ec6d migrated AssetVocabularyCategoriesSelector from the iframe-based selection modal to the inline TreeItemSelectorModal, so the macros that switched into and out of an iframe to pick categories stopped finding any iframe. 

Wait for the modal-body to render instead, drop the now-redundant SelectFrameTop call after the picker, and extend Treeview paths.

## How can you verify that it works?
Run associated tests.