### PR TITLE
LPD-93548 Limit search results pagination delta to the configured max

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/shared/search/SearchResultsPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/shared/search/SearchResultsPortletSharedSearchContributor.java
@@ -8,6 +8,7 @@ package com.liferay.portal.search.web.internal.search.results.portlet.shared.sea
 import com.liferay.portal.kernel.dao.search.SearchPaginationUtil;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.search.constants.SearchContextAttributes;
 import com.liferay.portal.search.searcher.SearchRequestBuilder;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
@@ -80,11 +81,13 @@ public class SearchResultsPortletSharedSearchContributor
 		searchRequestBuilder.paginationStartParameterName(
 			paginationStartParameterName);
 
-		int paginationDelta = GetterUtil.getInteger(
-			portletSharedSearchSettings.getParameter(
-				searchResultsPortletPreferences.
-					getPaginationDeltaParameterName()),
-			searchResultsPortletPreferences.getPaginationDelta());
+		int paginationDelta = Math.min(
+			GetterUtil.getInteger(
+				portletSharedSearchSettings.getParameter(
+					searchResultsPortletPreferences.
+						getPaginationDeltaParameterName()),
+				searchResultsPortletPreferences.getPaginationDelta()),
+			PropsValues.SEARCH_CONTAINER_PAGE_MAX_DELTA);
 
 		portletSharedSearchSettings.setPaginationDelta(paginationDelta);
 		searchRequestBuilder.size(paginationDelta);

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/results/portlet/shared/search/SearchResultsPortletSharedSearchContributorTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/results/portlet/shared/search/SearchResultsPortletSharedSearchContributorTest.java
@@ -1,0 +1,110 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.search.results.portlet.shared.search;
+
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.search.internal.legacy.searcher.SearchRequestBuilderImpl;
+import com.liferay.portal.search.internal.searcher.SearchRequestBuilderFactoryImpl;
+import com.liferay.portal.search.searcher.SearchRequest;
+import com.liferay.portal.search.searcher.SearchRequestBuilder;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.PortletPreferences;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Olivia Yu
+ */
+public class SearchResultsPortletSharedSearchContributorTest {
+
+	@ClassRule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testContributeWithPaginationDeltaAboveMaxDelta() {
+		_assertPaginationDelta(
+			PropsValues.SEARCH_CONTAINER_PAGE_MAX_DELTA,
+			String.valueOf(PropsValues.SEARCH_CONTAINER_PAGE_MAX_DELTA + 1));
+	}
+
+	@Test
+	public void testContributeWithPaginationDeltaBelowMaxDelta() {
+		int paginationDelta = PropsValues.SEARCH_CONTAINER_PAGE_MAX_DELTA - 1;
+
+		_assertPaginationDelta(
+			paginationDelta, String.valueOf(paginationDelta));
+	}
+
+	private void _assertPaginationDelta(
+		int expectedPaginationDelta, String paginationDeltaParameterValue) {
+
+		PortletSharedSearchSettings portletSharedSearchSettings =
+			_createPortletSharedSearchSettings(paginationDeltaParameterValue);
+
+		SearchResultsPortletSharedSearchContributor
+			searchResultsPortletSharedSearchContributor =
+				new SearchResultsPortletSharedSearchContributor();
+
+		searchResultsPortletSharedSearchContributor.contribute(
+			portletSharedSearchSettings);
+
+		Mockito.verify(
+			portletSharedSearchSettings
+		).setPaginationDelta(
+			expectedPaginationDelta
+		);
+
+		SearchRequestBuilder searchRequestBuilder =
+			portletSharedSearchSettings.getFederatedSearchRequestBuilder(null);
+
+		SearchRequest searchRequest = searchRequestBuilder.build();
+
+		Assert.assertEquals(
+			Integer.valueOf(expectedPaginationDelta), searchRequest.getSize());
+	}
+
+	private PortletSharedSearchSettings _createPortletSharedSearchSettings(
+		String paginationDeltaParameterValue) {
+
+		PortletSharedSearchSettings portletSharedSearchSettings = Mockito.mock(
+			PortletSharedSearchSettings.class);
+
+		SearchRequestBuilder searchRequestBuilder =
+			new SearchRequestBuilderImpl(new SearchRequestBuilderFactoryImpl());
+
+		Mockito.doReturn(
+			searchRequestBuilder
+		).when(
+			portletSharedSearchSettings
+		).getFederatedSearchRequestBuilder(
+			Mockito.any()
+		);
+
+		Mockito.doReturn(
+			paginationDeltaParameterValue
+		).when(
+			portletSharedSearchSettings
+		).getParameter(
+			"delta"
+		);
+
+		Mockito.doReturn(
+			Mockito.mock(PortletPreferences.class)
+		).when(
+			portletSharedSearchSettings
+		).getPortletPreferences();
+
+		return portletSharedSearchSettings;
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93548

## What Is Being Fixed

The Search Results portlet passes the pagination delta straight into the search request size. The delta comes from a URL parameter or the portlet preferences, so a crafted URL like `?delta=10000` makes the portlet request arbitrarily large result pages from the search engine, ignoring the `search.container.page.max.delta` portal property that caps every other paginated view.

## How It Is Being Fixed

`SearchResultsPortletSharedSearchContributor` now clamps the resolved pagination delta to `PropsValues.SEARCH_CONTAINER_PAGE_MAX_DELTA` before applying it to the search request and the shared search settings. Clamping at this point covers both input paths, since the preference value is the fallback for the URL parameter. The render side needs no change because `SearchContainer` already clamps its delta to the same property. Unit tests cover both sides of the limit: a delta above the maximum is clamped and a delta below it passes through unchanged.