### PR TITLE
LPD-78170 Add collection ordering UI for Object field properties

### DIFF
--- a/modules/apps/asset/asset-list-web/package.json
+++ b/modules/apps/asset/asset-list-web/package.json
@@ -11,6 +11,7 @@
 		"@clayui/list": "^3.164.0",
 		"@clayui/multi-select": "^3.164.0",
 		"@clayui/tooltip": "^3.164.0",
+		"@liferay/frontend-js-state-web": "*",
 		"@liferay/layout-js-components-web": "*",
 		"asset-taglib": "*",
 		"classnames": "2.3.1",

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/filter.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/filter.jsp
@@ -40,9 +40,9 @@
 
 	<div id="<portlet:namespace />ConditionForm"></div>
 
-	<div>
-		<c:choose>
-			<c:when test='<%= FeatureFlagManagerUtil.isEnabled("LPD-74731") %>'>
+	<c:choose>
+		<c:when test='<%= FeatureFlagManagerUtil.isEnabled("LPD-74731") %>'>
+			<div id="<portlet:namespace />collectionFilterBuilderWrapper">
 				<react:component
 					module="{CollectionFilterBuilder} from asset-list-web"
 					props='<%=
@@ -65,33 +65,63 @@
 						).build()
 					%>'
 				/>
-			</c:when>
-			<c:otherwise>
-				<!-- Move AssetFilterBuilder here for FF LPD-74731 -->
-			</c:otherwise>
-		</c:choose>
-	</div>
+			</div>
 
-	<div>
-		<react:component
-			module="{AssetFilterBuilder} from asset-list-web"
-			props='<%=
-				HashMapBuilder.<String, Object>put(
-					"categorySelectorURL", editAssetListDisplayContext.getCategorySelectorURL()
-				).put(
-					"disabled", editAssetListDisplayContext.isLiveGroup()
-				).put(
-					"groupIds", ListUtil.fromArray(editAssetListDisplayContext.getReferencedModelsGroupIds())
-				).put(
-					"namespace", liferayPortletResponse.getNamespace()
-				).put(
-					"rules", editAssetListDisplayContext.getAutoFieldRulesJSONArray()
-				).put(
-					"tagSelectorURL", editAssetListDisplayContext.getTagSelectorURL()
-				).put(
-					"vocabularyIds", editAssetListDisplayContext.getVocabularyIds()
-				).build()
-			%>'
-		/>
-	</div>
+			<div id="<portlet:namespace />assetFilterBuilderWrapper">
+				<react:component
+					module="{AssetFilterBuilder} from asset-list-web"
+					props='<%=
+						HashMapBuilder.<String, Object>put(
+							"categorySelectorURL", editAssetListDisplayContext.getCategorySelectorURL()
+						).put(
+							"disabled", editAssetListDisplayContext.isLiveGroup()
+						).put(
+							"groupIds", ListUtil.fromArray(editAssetListDisplayContext.getReferencedModelsGroupIds())
+						).put(
+							"namespace", liferayPortletResponse.getNamespace()
+						).put(
+							"rules", editAssetListDisplayContext.getAutoFieldRulesJSONArray()
+						).put(
+							"tagSelectorURL", editAssetListDisplayContext.getTagSelectorURL()
+						).put(
+							"vocabularyIds", editAssetListDisplayContext.getVocabularyIds()
+						).build()
+					%>'
+				/>
+			</div>
+
+			<liferay-frontend:component
+				context='<%=
+					HashMapBuilder.<String, Object>put(
+						"namespace", liferayPortletResponse.getNamespace()
+					).build()
+				%>'
+				module="{FilterVisibility} from asset-list-web"
+			/>
+		</c:when>
+		<c:otherwise>
+			<div>
+				<react:component
+					module="{AssetFilterBuilder} from asset-list-web"
+					props='<%=
+						HashMapBuilder.<String, Object>put(
+							"categorySelectorURL", editAssetListDisplayContext.getCategorySelectorURL()
+						).put(
+							"disabled", editAssetListDisplayContext.isLiveGroup()
+						).put(
+							"groupIds", ListUtil.fromArray(editAssetListDisplayContext.getReferencedModelsGroupIds())
+						).put(
+							"namespace", liferayPortletResponse.getNamespace()
+						).put(
+							"rules", editAssetListDisplayContext.getAutoFieldRulesJSONArray()
+						).put(
+							"tagSelectorURL", editAssetListDisplayContext.getTagSelectorURL()
+						).put(
+							"vocabularyIds", editAssetListDisplayContext.getVocabularyIds()
+						).build()
+					%>'
+				/>
+			</div>
+		</c:otherwise>
+	</c:choose>
 </liferay-frontend:fieldset>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/filter.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/filter.jsp
@@ -57,8 +57,6 @@
 						).put(
 							"properties", editAssetListDisplayContext.getTypePropertiesJSONArray()
 						).put(
-							"propertiesURL", editAssetListDisplayContext.getTypePropertiesURL()
-						).put(
 							"tagSelectorURL", editAssetListDisplayContext.getTagSelectorURL()
 						).put(
 							"vocabularyIds", editAssetListDisplayContext.getVocabularyIds()

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/ordering.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/ordering.jsp
@@ -28,8 +28,6 @@
 							"namespace", liferayPortletResponse.getNamespace()
 						).put(
 							"properties", editAssetListDisplayContext.getTypePropertiesJSONArray()
-						).put(
-							"propertiesURL", editAssetListDisplayContext.getTypePropertiesURL()
 						).build()
 					%>'
 				/>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/ordering.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/ordering.jsp
@@ -26,6 +26,10 @@
 							"initialOrderByType2", editAssetListDisplayContext.getOrderByType2()
 						).put(
 							"namespace", liferayPortletResponse.getNamespace()
+						).put(
+							"properties", editAssetListDisplayContext.getTypePropertiesJSONArray()
+						).put(
+							"propertiesURL", editAssetListDisplayContext.getTypePropertiesURL()
 						).build()
 					%>'
 				/>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/ordering.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/ordering.jsp
@@ -10,110 +10,146 @@
 <liferay-frontend:fieldset
 	disabled="<%= editAssetListDisplayContext.isLiveGroup() %>"
 >
-	<clay:row
-		id='<%= liferayPortletResponse.getNamespace() + "ordering" %>'
-	>
-		<clay:col
-			md="6"
-		>
-
-			<%
-			String orderByColumn1 = editAssetListDisplayContext.getOrderByColumn1();
-			%>
-
-			<div class="h5"><liferay-ui:message key="order-by" /></div>
-
-			<aui:select aria-label='<%= LanguageUtil.get(request, "order-by") %>' label="" name="TypeSettingsProperties--orderByColumn1--" wrapperCssClass="d-inline-flex">
-				<aui:option label="title" selected='<%= Objects.equals(orderByColumn1, "title") %>' value="title" />
-				<aui:option label="create-date" selected='<%= Objects.equals(orderByColumn1, "createDate") %>' value="createDate" />
-				<aui:option label="modified-date" selected='<%= Objects.equals(orderByColumn1, "modifiedDate") %>' value="modifiedDate" />
-				<aui:option label="publish-date" selected='<%= Objects.equals(orderByColumn1, "publishDate") %>' value="publishDate" />
-				<aui:option label="expiration-date" selected='<%= Objects.equals(orderByColumn1, "expirationDate") %>' value="expirationDate" />
-				<aui:option label="priority" selected='<%= Objects.equals(orderByColumn1, "priority") %>' value="priority" />
-			</aui:select>
-
-			<%
-			String orderByType1 = editAssetListDisplayContext.getOrderByType1();
-			%>
-
-			<div class="d-inline-flex order-by-type-container">
-				<clay:button
-					borderless="<%= true %>"
-					cssClass='<%= StringUtil.equalsIgnoreCase(orderByType1, "DESC") ? "hide icon" : "icon" %>'
-					displayType="secondary"
-					icon="order-list-up"
-					monospaced="<%= true %>"
-					title="descending"
+	<c:choose>
+		<c:when test='<%= FeatureFlagManagerUtil.isEnabled("LPD-74731") %>'>
+			<div>
+				<react:component
+					module="{CollectionOrdering} from asset-list-web"
+					props='<%=
+						HashMapBuilder.<String, Object>put(
+							"initialOrderByColumn1", editAssetListDisplayContext.getOrderByColumn1()
+						).put(
+							"initialOrderByColumn2", editAssetListDisplayContext.getOrderByColumn2()
+						).put(
+							"initialOrderByType1", editAssetListDisplayContext.getOrderByType1()
+						).put(
+							"initialOrderByType2", editAssetListDisplayContext.getOrderByType2()
+						).put(
+							"namespace", liferayPortletResponse.getNamespace()
+						).build()
+					%>'
 				/>
-
-				<clay:button
-					borderless="<%= true %>"
-					cssClass='<%= StringUtil.equalsIgnoreCase(orderByType1, "ASC") ? "hide icon" : "icon" %>'
-					displayType="secondary"
-					icon="order-list-down"
-					monospaced="<%= true %>"
-					title="ascending"
-				/>
-
-				<aui:input cssClass="order-by-type-field" name="TypeSettingsProperties--orderByType1--" type="hidden" value="<%= orderByType1 %>" />
 			</div>
-		</clay:col>
+		</c:when>
+		<c:otherwise>
+			<clay:row
+				id='<%= liferayPortletResponse.getNamespace() + "ordering" %>'
+			>
+				<clay:col
+					md="6"
+				>
 
-		<clay:col
-			md="6"
-		>
+					<%
+					String orderByColumn1 = editAssetListDisplayContext.getOrderByColumn1();
+					%>
 
-			<%
-			String orderByColumn2 = editAssetListDisplayContext.getOrderByColumn2();
-			%>
+					<div class="h5"><liferay-ui:message key="order-by" /></div>
 
-			<div class="h5"><liferay-ui:message key="and-then-by" /></div>
+					<aui:select aria-label='<%= LanguageUtil.get(request, "order-by") %>' label="" name="TypeSettingsProperties--orderByColumn1--" wrapperCssClass="d-inline-flex">
+						<aui:option label="title" selected='<%= Objects.equals(orderByColumn1, "title") %>' value="title" />
 
-			<aui:select aria-label='<%= LanguageUtil.get(request, "and-then-by") %>' label="" name="TypeSettingsProperties--orderByColumn2--" wrapperCssClass="d-inline-flex">
-				<aui:option label="title" selected='<%= Objects.equals(orderByColumn2, "title") %>' value="title" />
-				<aui:option label="create-date" selected='<%= Objects.equals(orderByColumn2, "createDate") %>' value="createDate" />
-				<aui:option label="modified-date" selected='<%= Objects.equals(orderByColumn2, "modifiedDate") %>' value="modifiedDate" />
-				<aui:option label="publish-date" selected='<%= Objects.equals(orderByColumn2, "publishDate") %>' value="publishDate" />
-				<aui:option label="expiration-date" selected='<%= Objects.equals(orderByColumn2, "expirationDate") %>' value="expirationDate" />
-				<aui:option label="priority" selected='<%= Objects.equals(orderByColumn2, "priority") %>' value="priority" />
-			</aui:select>
+						<aui:option label="create-date" selected='<%= Objects.equals(orderByColumn1, "createDate") %>' value="createDate" />
 
-			<%
-			String orderByType2 = editAssetListDisplayContext.getOrderByType2();
-			%>
+						<aui:option label="modified-date" selected='<%= Objects.equals(orderByColumn1, "modifiedDate") %>' value="modifiedDate" />
 
-			<div class="d-inline-flex order-by-type-container">
-				<clay:button
-					borderless="<%= true %>"
-					cssClass='<%= StringUtil.equalsIgnoreCase(orderByType2, "DESC") ? "hide icon" : "icon" %>'
-					displayType="secondary"
-					icon="order-list-up"
-					monospaced="<%= true %>"
-					title="descending"
-				/>
+						<aui:option label="publish-date" selected='<%= Objects.equals(orderByColumn1, "publishDate") %>' value="publishDate" />
 
-				<clay:button
-					borderless="<%= true %>"
-					cssClass='<%= StringUtil.equalsIgnoreCase(orderByType2, "ASC") ? "hide icon" : "icon" %>'
-					displayType="secondary"
-					icon="order-list-down"
-					monospaced="<%= true %>"
-					title="ascending"
-				/>
+						<aui:option label="expiration-date" selected='<%= Objects.equals(orderByColumn1, "expirationDate") %>' value="expirationDate" />
 
-				<aui:input cssClass="order-by-type-field" name="TypeSettingsProperties--orderByType2--" type="hidden" value="<%= orderByType2 %>" />
-			</div>
-		</clay:col>
-	</clay:row>
+						<aui:option label="priority" selected='<%= Objects.equals(orderByColumn1, "priority") %>' value="priority" />
+					</aui:select>
+
+					<%
+					String orderByType1 = editAssetListDisplayContext.getOrderByType1();
+					%>
+
+					<div class="d-inline-flex order-by-type-container">
+						<clay:button
+							borderless="<%= true %>"
+							cssClass='<%= StringUtil.equalsIgnoreCase(orderByType1, "DESC") ? "hide icon" : "icon" %>'
+							displayType="secondary"
+							icon="order-list-up"
+							monospaced="<%= true %>"
+							title="descending"
+						/>
+
+						<clay:button
+							borderless="<%= true %>"
+							cssClass='<%= StringUtil.equalsIgnoreCase(orderByType1, "ASC") ? "hide icon" : "icon" %>'
+							displayType="secondary"
+							icon="order-list-down"
+							monospaced="<%= true %>"
+							title="ascending"
+						/>
+
+						<aui:input cssClass="order-by-type-field" name="TypeSettingsProperties--orderByType1--" type="hidden" value="<%= orderByType1 %>" />
+					</div>
+				</clay:col>
+
+				<clay:col
+					md="6"
+				>
+
+					<%
+					String orderByColumn2 = editAssetListDisplayContext.getOrderByColumn2();
+					%>
+
+					<div class="h5">
+						<liferay-ui:message key="and-then-by" />
+					</div>
+
+					<aui:select aria-label='<%= LanguageUtil.get(request, "and-then-by") %>' label="" name="TypeSettingsProperties--orderByColumn2--" wrapperCssClass="d-inline-flex">
+						<aui:option label="title" selected='<%= Objects.equals(orderByColumn2, "title") %>' value="title" />
+
+						<aui:option label="create-date" selected='<%= Objects.equals(orderByColumn2, "createDate") %>' value="createDate" />
+
+						<aui:option label="modified-date" selected='<%= Objects.equals(orderByColumn2, "modifiedDate") %>' value="modifiedDate" />
+
+						<aui:option label="publish-date" selected='<%= Objects.equals(orderByColumn2, "publishDate") %>' value="publishDate" />
+
+						<aui:option label="expiration-date" selected='<%= Objects.equals(orderByColumn2, "expirationDate") %>' value="expirationDate" />
+
+						<aui:option label="priority" selected='<%= Objects.equals(orderByColumn2, "priority") %>' value="priority" />
+					</aui:select>
+
+					<%
+					String orderByType2 = editAssetListDisplayContext.getOrderByType2();
+					%>
+
+					<div class="d-inline-flex order-by-type-container">
+						<clay:button
+							borderless="<%= true %>"
+							cssClass='<%= StringUtil.equalsIgnoreCase(orderByType2, "DESC") ? "hide icon" : "icon" %>'
+							displayType="secondary"
+							icon="order-list-up"
+							monospaced="<%= true %>"
+							title="descending"
+						/>
+
+						<clay:button
+							borderless="<%= true %>"
+							cssClass='<%= StringUtil.equalsIgnoreCase(orderByType2, "ASC") ? "hide icon" : "icon" %>'
+							displayType="secondary"
+							icon="order-list-down"
+							monospaced="<%= true %>"
+							title="ascending"
+						/>
+
+						<aui:input cssClass="order-by-type-field" name="TypeSettingsProperties--orderByType2--" type="hidden" value="<%= orderByType2 %>" />
+					</div>
+				</clay:col>
+			</clay:row>
+
+			<liferay-frontend:component
+				context='<%=
+					HashMapBuilder.<String, Object>put(
+						"iconCssClass", ".icon"
+					).put(
+						"orderingContainerId", liferayPortletResponse.getNamespace() + "ordering"
+					).build()
+				%>'
+				module="{Ordering} from asset-list-web"
+			/>
+		</c:otherwise>
+	</c:choose>
 </liferay-frontend:fieldset>
-
-<liferay-frontend:component
-	context='<%=
-		HashMapBuilder.<String, Object>put(
-			"iconCssClass", ".icon"
-		).put(
-			"orderingContainerId", liferayPortletResponse.getNamespace() + "ordering"
-		).build()
-	%>'
-	module="{Ordering} from asset-list-web"
-/>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
@@ -35,14 +35,16 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 
 			<%
 			for (long classNameId : editAssetListDisplayContext.getAvailableClassNameIds()) {
-				String label = _getLabel(ClassNameLocalServiceUtil.getClassName(classNameId), locale, company);
+				ClassName className = ClassNameLocalServiceUtil.getClassName(classNameId);
+
+				String label = _getLabel(className, locale, company);
 
 				if (Arrays.binarySearch(classNameIds, classNameId) < 0) {
 					typesLeftList.add(new KeyValuePair(String.valueOf(classNameId), label));
 				}
 			%>
 
-				<aui:option label="<%= label %>" selected="<%= (classNameIds.length == 1) && (classNameId == classNameIds[0]) %>" value="<%= classNameId %>" />
+				<aui:option data-cms="<%= _isCMS(className, company) %>" label="<%= label %>" selected="<%= (classNameIds.length == 1) && (classNameId == classNameIds[0]) %>" value="<%= classNameId %>" />
 
 			<%
 			}
@@ -326,12 +328,16 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 private String _getLabel(ClassName className, Locale locale, Company company) {
 	String label = ResourceActionsUtil.getModelResource(locale, className.getValue());
 
-	ObjectDefinition objectDefinition = ObjectDefinitionLocalServiceUtil.fetchObjectDefinitionByClassName(company.getCompanyId(), className.getValue());
-
-	if ((objectDefinition != null) && objectDefinition.isCMS()) {
+	if (_isCMS(className, company)) {
 		label = StringUtil.appendParentheticalSuffix(label, "CMS");
 	}
 
 	return label;
+}
+
+private boolean _isCMS(ClassName className, Company company) {
+	ObjectDefinition objectDefinition = ObjectDefinitionLocalServiceUtil.fetchObjectDefinitionByClassName(company.getCompanyId(), className.getValue());
+
+	return (objectDefinition != null) && objectDefinition.isCMS();
 }
 %>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
@@ -319,6 +319,10 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 	context='<%=
 		HashMapBuilder.<String, Object>put(
 			"classTypes", classTypesList
+		).put(
+			"initialProperties", editAssetListDisplayContext.getTypePropertiesJSONArray()
+		).put(
+			"propertiesURL", editAssetListDisplayContext.getTypePropertiesURL()
 		).build()
 	%>'
 	module="{Source} from asset-list-web"

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/FilterVisibility.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/FilterVisibility.js
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export default function ({namespace}) {
+	const assetSelector = document.getElementById(`${namespace}anyAssetType`);
+	const assetWrapper = document.getElementById(
+		`${namespace}assetFilterBuilderWrapper`
+	);
+	const collectionWrapper = document.getElementById(
+		`${namespace}collectionFilterBuilderWrapper`
+	);
+
+	if (!assetSelector || !assetWrapper || !collectionWrapper) {
+		return;
+	}
+
+	const updateVisibility = () => {
+		const selectedOption =
+			assetSelector.options[assetSelector.selectedIndex];
+
+		const isSingleCMSType =
+			!!selectedOption && selectedOption.dataset.cms === 'true';
+
+		collectionWrapper.classList.toggle('hide', !isSingleCMSType);
+		assetWrapper.classList.toggle('hide', isSingleCMSType);
+	};
+
+	updateVisibility();
+
+	Liferay.on(`${namespace}sourceChange`, updateVisibility);
+}

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/FilterVisibility.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/FilterVisibility.js
@@ -4,12 +4,12 @@
  */
 
 export default function ({namespace}) {
-	const assetSelector = document.getElementById(`${namespace}anyAssetType`);
+	const assetSelector = document.getElementById(namespace + 'anyAssetType');
 	const assetWrapper = document.getElementById(
-		`${namespace}assetFilterBuilderWrapper`
+		namespace + 'assetFilterBuilderWrapper'
 	);
 	const collectionWrapper = document.getElementById(
-		`${namespace}collectionFilterBuilderWrapper`
+		namespace + 'collectionFilterBuilderWrapper'
 	);
 
 	if (!assetSelector || !assetWrapper || !collectionWrapper) {
@@ -29,5 +29,11 @@ export default function ({namespace}) {
 
 	updateVisibility();
 
-	Liferay.on(`${namespace}sourceChange`, updateVisibility);
+	Liferay.on(namespace + 'sourceChange', updateVisibility);
+
+	return {
+		destroy() {
+			Liferay.detach(namespace + 'sourceChange', updateVisibility);
+		},
+	};
 }

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/Source.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/Source.js
@@ -72,6 +72,14 @@ export default function ({
 	const eventDelegates = [];
 
 	const refreshProperties = () => {
+
+		// Refetches the filterable properties using `propertiesURL` upon
+		// changes to the asset source (type / subtype selectors) and writes
+		// the result to `propertiesAtom`.
+		//
+		// CollectionFilterBuilder and CollectionOrdering React components
+		// subscribe to that atom via `useTypeProperties`.
+
 		if (!propertiesURL) {
 			return;
 		}
@@ -81,6 +89,10 @@ export default function ({
 		let classNameIds = [];
 
 		if (assetTypeValue === 'false') {
+
+			// Multi-selection: collect every option out of the hidden
+			// <select> the JSP populates with the user's picks.
+
 			classNameIds = Array.from(assetMultipleSelector?.options || []).map(
 				(option) => option.value
 			);
@@ -92,6 +104,10 @@ export default function ({
 		let classTypeIds = [];
 
 		if (classNameIds.length === 1) {
+
+			// Subtype selection: Subtypes only make sense when exactly one
+			// asset type is selected — the subtype UI is hidden otherwise.
+
 			const classType = classTypes.find(
 				(ct) => `${ct.classNameId}` === classNameIds[0]
 			);
@@ -101,6 +117,11 @@ export default function ({
 					subtypeSelector[classType.className]?.value;
 
 				if (subtypeValue === 'false') {
+
+					// Multi-subtype selection: same pattern as
+					// classNameIds above, but the element id is
+					// namespaced with the class name.
+
 					const multiSubtypeSelect = document.getElementById(
 						`${namespace}${classType.className}currentClassTypeIds`
 					);

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/Source.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/Source.js
@@ -71,15 +71,15 @@ export default function ({
 
 	const eventDelegates = [];
 
+	/**
+	 * Refetches the filterable properties using `propertiesURL` upon
+	 * changes to the asset source (type / subtype selectors) and writes
+	 * the result to `propertiesAtom`.
+	 *
+	 * CollectionFilterBuilder and CollectionOrdering React components
+	 * subscribe to that atom via `useTypeProperties`.
+	 */
 	const refreshProperties = () => {
-
-		// Refetches the filterable properties using `propertiesURL` upon
-		// changes to the asset source (type / subtype selectors) and writes
-		// the result to `propertiesAtom`.
-		//
-		// CollectionFilterBuilder and CollectionOrdering React components
-		// subscribe to that atom via `useTypeProperties`.
-
 		if (!propertiesURL) {
 			return;
 		}

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/Source.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/Source.js
@@ -3,16 +3,27 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {State} from '@liferay/frontend-js-state-web';
 import {openSelectionModal} from 'frontend-js-components-web';
 import {
 	addParams,
 	delegate,
+	fetch,
 	sub,
 	toggleDisabled,
 	toggleSelectBox,
 } from 'frontend-js-web';
 
-export default function ({classTypes, namespace}) {
+import {propertiesAtom} from './atoms/propertiesAtom';
+
+export default function ({
+	classTypes,
+	initialProperties,
+	namespace,
+	propertiesURL,
+}) {
+	State.write(propertiesAtom, initialProperties || []);
+
 	const mapDDMStructures = {};
 
 	const assetMultipleSelector = document.getElementById(
@@ -60,8 +71,72 @@ export default function ({classTypes, namespace}) {
 
 	const eventDelegates = [];
 
+	const refreshProperties = () => {
+		if (!propertiesURL) {
+			return;
+		}
+
+		const assetTypeValue = assetSelector?.value || '';
+
+		let classNameIds = [];
+
+		if (assetTypeValue === 'false') {
+			classNameIds = Array.from(assetMultipleSelector?.options || []).map(
+				(option) => option.value
+			);
+		}
+		else if (assetTypeValue && assetTypeValue !== 'true') {
+			classNameIds = [assetTypeValue];
+		}
+
+		let classTypeIds = [];
+
+		if (classNameIds.length === 1) {
+			const classType = classTypes.find(
+				(ct) => `${ct.classNameId}` === classNameIds[0]
+			);
+
+			if (classType) {
+				const subtypeValue =
+					subtypeSelector[classType.className]?.value;
+
+				if (subtypeValue === 'false') {
+					const multiSubtypeSelect = document.getElementById(
+						`${namespace}${classType.className}currentClassTypeIds`
+					);
+
+					classTypeIds = Array.from(
+						multiSubtypeSelect?.options || []
+					).map((option) => option.value);
+				}
+				else if (subtypeValue && subtypeValue !== 'true') {
+					classTypeIds = [subtypeValue];
+				}
+			}
+		}
+
+		fetch(
+			addParams(
+				{
+					[`${namespace}classNameIds`]: classNameIds.join(','),
+					[`${namespace}classTypeIds`]: classTypeIds.join(','),
+				},
+				propertiesURL
+			)
+		)
+			.then((response) => response.json())
+			.then((data) => State.write(propertiesAtom, data || []))
+			.catch((error) => {
+				if (process.env.NODE_ENV === 'development') {
+					console.error('Failed to fetch type properties: ', error);
+				}
+			});
+	};
+
 	const fireSourceChange = () => {
 		Liferay.fire(`${namespace}sourceChange`);
+
+		refreshProperties();
 	};
 
 	const createElement = (label, classNames, attributes, content) => {

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/atoms/propertiesAtom.ts
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/atoms/propertiesAtom.ts
@@ -1,0 +1,13 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {State} from '@liferay/frontend-js-state-web';
+
+import type {FilterPropertyGroup} from '../components/CollectionFilterBuilder/types';
+
+export const propertiesAtom = State.atom<FilterPropertyGroup[]>(
+	'assetListTypeProperties',
+	[]
+);

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionFilterBuilder/config.ts
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionFilterBuilder/config.ts
@@ -7,7 +7,6 @@ export type Config = {
 	categorySelectorURL?: string;
 	groupIds?: string[];
 	namespace: string;
-	propertiesURL?: string;
 	tagSelectorURL?: string;
 	vocabularyIds?: string[];
 };

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionFilterBuilder/index.tsx
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionFilterBuilder/index.tsx
@@ -57,7 +57,7 @@ function serializeValue(
 interface CollectionFilterBuilderProps extends Config {
 	initialConditions?: Array<Omit<FilterCondition, 'id'>>;
 	onChange?: (state: FilterCondition[]) => void;
-	properties: FilterProperty[];
+	properties: FilterPropertyGroup[];
 }
 
 /**
@@ -93,7 +93,7 @@ export default function CollectionFilterBuilder({
 			: [{id: uuidv4()}]
 	);
 
-	const [properties, setProperties] = useState<FilterProperty[]>(
+	const [properties, setProperties] = useState<FilterPropertyGroup[]>(
 		initialProperties || []
 	);
 
@@ -119,14 +119,7 @@ export default function CollectionFilterBuilder({
 				],
 				label: '',
 			},
-			...(properties.length
-				? [
-						{
-							items: properties,
-							label: Liferay.Language.get('common-fields'),
-						},
-					]
-				: []),
+			...properties,
 		],
 		[properties]
 	);

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionFilterBuilder/index.tsx
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionFilterBuilder/index.tsx
@@ -71,7 +71,6 @@ export default function CollectionFilterBuilder({
 	namespace,
 	onChange,
 	properties: initialProperties,
-	propertiesURL,
 	tagSelectorURL,
 	vocabularyIds,
 }: CollectionFilterBuilderProps) {
@@ -79,7 +78,6 @@ export default function CollectionFilterBuilder({
 		categorySelectorURL,
 		groupIds,
 		namespace,
-		propertiesURL,
 		tagSelectorURL,
 		vocabularyIds,
 	});
@@ -93,11 +91,7 @@ export default function CollectionFilterBuilder({
 			: [{id: uuidv4()}]
 	);
 
-	const properties = useTypeProperties(
-		namespace,
-		propertiesURL,
-		initialProperties
-	);
+	const properties = useTypeProperties(initialProperties);
 
 	const propertiesWithAssetFields = useMemo<FilterPropertyGroup[]>(
 		() => [

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionFilterBuilder/index.tsx
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionFilterBuilder/index.tsx
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {addParams, fetch} from 'frontend-js-web';
-import React, {useEffect, useMemo, useState} from 'react';
+import React, {useMemo, useState} from 'react';
 import {v4 as uuidv4} from 'uuid';
 
+import useTypeProperties from '../../hooks/useTypeProperties';
 import {ConditionBuilder} from './ConditionBuilder';
 import {Config, initializeConfig} from './config';
 import {RELATIVE_DATE_VALUES} from './operators';
@@ -93,8 +93,10 @@ export default function CollectionFilterBuilder({
 			: [{id: uuidv4()}]
 	);
 
-	const [properties, setProperties] = useState<FilterPropertyGroup[]>(
-		initialProperties || []
+	const properties = useTypeProperties(
+		namespace,
+		propertiesURL,
+		initialProperties
 	);
 
 	const propertiesWithAssetFields = useMemo<FilterPropertyGroup[]>(
@@ -165,109 +167,6 @@ export default function CollectionFilterBuilder({
 
 				return true;
 			});
-
-	useEffect(() => {
-		if (!propertiesURL) {
-			return undefined;
-		}
-
-		// Refetches the filterable properties whenever the user changes the
-		// collection's asset source (type / subtype selectors), fired in
-		// event sourceChange. The available fields depend on the selected
-		// class names + class types.
-
-		const assetTypeListenerHandler = () => {
-
-			// The `anyAssetType` select holds 'true' (any type), 'false'
-			// (multi-selection), or a single classNameId value.
-
-			const assetTypeSelector = document.getElementById(
-				`${namespace}anyAssetType`
-			) as HTMLSelectElement | null;
-
-			const assetTypeValue = assetTypeSelector?.value || '';
-
-			let classNameIds: string[] = [];
-
-			if (assetTypeValue === 'false') {
-
-				// Multi-selection: collect every option out of the hidden
-				// <select> the JSP populates with the user's picks.
-
-				const multiSelector = document.getElementById(
-					`${namespace}currentClassNameIds`
-				) as HTMLSelectElement | null;
-
-				classNameIds = Array.from(multiSelector?.options || []).map(
-					(option) => option.value
-				);
-			}
-			else if (assetTypeValue && assetTypeValue !== 'true') {
-				classNameIds = [assetTypeValue];
-			}
-
-			let classTypeIds: string[] = [];
-
-			// Subtypes only make sense when exactly one asset type is
-			// selected — the subtype UI is hidden otherwise.
-
-			if (classNameIds.length === 1) {
-				const subtypeContainer = document.querySelector(
-					'.asset-subtype:not(.hide)'
-				);
-
-				const subtypeSelector = subtypeContainer?.querySelector(
-					`[id^="${namespace}anyClassType"]`
-				) as HTMLSelectElement | null;
-
-				const subtypeValue = subtypeSelector?.value;
-
-				if (subtypeValue === 'false' && subtypeContainer) {
-
-					// Multi-subtype selection: same pattern as
-					// classNameIds above, but the element id is
-					// namespaced with the class name.
-
-					const className =
-						subtypeContainer.getAttribute('data-class-name');
-
-					const multiSubtypeSelect = document.getElementById(
-						`${namespace}${className}currentClassTypeIds`
-					) as HTMLSelectElement | null;
-
-					classTypeIds = Array.from(
-						multiSubtypeSelect?.options || []
-					).map((option) => option.value);
-				}
-				else if (subtypeValue && subtypeValue !== 'true') {
-					classTypeIds = [subtypeValue];
-				}
-			}
-
-			fetch(
-				addParams(
-					{
-						[`${namespace}classNameIds`]: classNameIds.join(','),
-						[`${namespace}classTypeIds`]: classTypeIds.join(','),
-					},
-					propertiesURL
-				)
-			)
-				.then((response) => response.json())
-				.then((data) => setProperties(data || []))
-				.catch((error) =>
-					console.error('Failed to fetch type properties: ', error)
-				);
-		};
-
-		const eventName = `${namespace}sourceChange`;
-
-		Liferay.on(eventName, assetTypeListenerHandler);
-
-		return () => {
-			Liferay.detach(eventName, assetTypeListenerHandler);
-		};
-	}, [namespace, propertiesURL]);
 
 	const handleChange = (newConditions: FilterCondition[]) => {
 		setConditions(newConditions);

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionFilterBuilder/types.ts
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionFilterBuilder/types.ts
@@ -26,7 +26,8 @@ export interface FilterProperty {
 	label: string;
 	name: string;
 	options?: PropertyOption[];
-	type: PropertyType;
+	sortable?: boolean;
+	type?: PropertyType;
 }
 
 export interface FilterPropertyGroup {

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
@@ -5,26 +5,67 @@
 
 import ClayButton from '@clayui/button';
 import {Option, Picker} from '@clayui/core';
+import DropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
-import React, {useState} from 'react';
+import React, {useMemo, useState} from 'react';
+
+import useTypeProperties from '../../hooks/useTypeProperties';
+
+import type {
+	FilterProperty,
+	FilterPropertyGroup,
+} from '../CollectionFilterBuilder/types';
 
 type OrderByType = 'ASC' | 'DESC';
 
-const ORDER_BY_OPTIONS: Array<{label: string; value: string}> = [
-	{label: Liferay.Language.get('title'), value: 'title'},
-	{label: Liferay.Language.get('create-date'), value: 'createDate'},
-	{label: Liferay.Language.get('modified-date'), value: 'modifiedDate'},
-	{label: Liferay.Language.get('publish-date'), value: 'publishDate'},
-	{label: Liferay.Language.get('expiration-date'), value: 'expirationDate'},
-	{label: Liferay.Language.get('priority'), value: 'priority'},
-];
+type OrderBySelection = Pick<
+	FilterProperty,
+	'classNameId' | 'classTypeId' | 'name'
+>;
+
+function getPropertyKey(
+	classNameId: number | undefined,
+	classTypeId: number | undefined,
+	name: string | undefined
+): string {
+	return `${classNameId ?? ''}|${classTypeId ?? ''}|${name ?? ''}`;
+}
+
+function isGroup(
+	item: FilterProperty | FilterPropertyGroup
+): item is FilterPropertyGroup {
+	return 'items' in item;
+}
+
+function parseInitialOrderByColumn(value: string): OrderBySelection {
+	if (value.startsWith('{')) {
+		try {
+			const parsed = JSON.parse(value);
+
+			return {
+				classNameId: parsed.classNameId,
+				classTypeId: parsed.classTypeId,
+				name: parsed.name,
+			};
+		}
+		catch {}
+	}
+
+	return {
+		classNameId: undefined,
+		classTypeId: undefined,
+		name: value,
+	};
+}
 
 interface OrderByFieldProps {
 	columnName: string;
-	columnValue: string;
+	columnValue: OrderBySelection;
+	items: Array<FilterProperty | FilterPropertyGroup>;
 	label: string;
-	onColumnChange: (column: string) => void;
+	onColumnChange: (selection: OrderBySelection) => void;
 	onTypeChange: (type: OrderByType) => void;
+	propertiesMap: Map<string, OrderBySelection>;
 	typeName: string;
 	typeValue: OrderByType;
 }
@@ -32,13 +73,20 @@ interface OrderByFieldProps {
 function OrderByField({
 	columnName,
 	columnValue,
+	items,
 	label,
 	onColumnChange,
 	onTypeChange,
+	propertiesMap,
 	typeName,
 	typeValue,
 }: OrderByFieldProps) {
 	const ascending = typeValue === 'ASC';
+	const selectedKey = getPropertyKey(
+		columnValue.classNameId,
+		columnValue.classTypeId,
+		columnValue.name
+	);
 
 	return (
 		<div className="col-md-6">
@@ -47,15 +95,58 @@ function OrderByField({
 			<div className="d-inline-flex">
 				<Picker
 					aria-label={label}
-					items={ORDER_BY_OPTIONS}
-					onSelectionChange={(key) => onColumnChange(key as string)}
-					selectedKey={columnValue}
+					items={items}
+					onSelectionChange={(key) => {
+						const selection = propertiesMap.get(key as string);
+
+						if (selection) {
+							onColumnChange(selection);
+						}
+					}}
+					selectedKey={selectedKey}
 				>
-					{(item) => <Option key={item.value}>{item.label}</Option>}
+					{(item) =>
+						isGroup(item) ? (
+							<DropDown.Group
+								header={item.label}
+								items={item.items}
+							>
+								{(option) => (
+									<Option
+										key={getPropertyKey(
+											option.classNameId,
+											option.classTypeId,
+											option.name
+										)}
+									>
+										{option.label}
+									</Option>
+								)}
+							</DropDown.Group>
+						) : (
+							<Option
+								key={getPropertyKey(
+									item.classNameId,
+									item.classTypeId,
+									item.name
+								)}
+							>
+								{item.label}
+							</Option>
+						)
+					}
 				</Picker>
 			</div>
 
-			<input name={columnName} type="hidden" value={columnValue} />
+			<input
+				name={columnName}
+				type="hidden"
+				value={
+					columnValue.classNameId && columnValue.classTypeId
+						? JSON.stringify(columnValue)
+						: columnValue.name
+				}
+			/>
 
 			<div className="d-inline-flex">
 				<ClayButton
@@ -81,6 +172,44 @@ function OrderByField({
 			</div>
 
 			<input name={typeName} type="hidden" value={typeValue} />
+
+			{process.env.NODE_ENV === 'development' && (
+				<>
+					<div className="mt-4">
+						<code>{columnName}</code>
+
+						<pre
+							style={{
+								background: '#f5f5f5',
+								borderRadius: 4,
+								fontSize: 11,
+								marginTop: 8,
+								padding: 12,
+							}}
+						>
+							{columnValue.classNameId && columnValue.classTypeId
+								? JSON.stringify(columnValue)
+								: columnValue.name}
+						</pre>
+					</div>
+
+					<div className="mt-4">
+						<code>{typeName}</code>
+
+						<pre
+							style={{
+								background: '#f5f5f5',
+								borderRadius: 4,
+								fontSize: 11,
+								marginTop: 8,
+								padding: 12,
+							}}
+						>
+							{typeValue}
+						</pre>
+					</div>
+				</>
+			)}
 		</div>
 	);
 }
@@ -91,30 +220,71 @@ interface CollectionOrderingProps {
 	initialOrderByType1?: OrderByType;
 	initialOrderByType2?: OrderByType;
 	namespace: string;
+	properties?: FilterPropertyGroup[];
+	propertiesURL?: string;
 }
 
 export default function CollectionOrdering({
-	initialOrderByColumn1 = 'title',
-	initialOrderByColumn2 = 'title',
+	initialOrderByColumn1 = '',
+	initialOrderByColumn2 = '',
 	initialOrderByType1 = 'ASC',
 	initialOrderByType2 = 'ASC',
 	namespace,
+	properties: initialProperties,
+	propertiesURL,
 }: CollectionOrderingProps) {
-	const [orderByColumn1, setOrderByColumn1] = useState(initialOrderByColumn1);
-	const [orderByColumn2, setOrderByColumn2] = useState(initialOrderByColumn2);
+	const [orderByColumn1, setOrderByColumn1] = useState<OrderBySelection>(() =>
+		parseInitialOrderByColumn(initialOrderByColumn1)
+	);
+	const [orderByColumn2, setOrderByColumn2] = useState<OrderBySelection>(() =>
+		parseInitialOrderByColumn(initialOrderByColumn2)
+	);
 	const [orderByType1, setOrderByType1] =
 		useState<OrderByType>(initialOrderByType1);
 	const [orderByType2, setOrderByType2] =
 		useState<OrderByType>(initialOrderByType2);
+
+	const properties = useTypeProperties(
+		namespace,
+		propertiesURL,
+		initialProperties
+	);
+
+	const items = useMemo<Array<FilterProperty | FilterPropertyGroup>>(() => {
+		return properties
+			.map(({items, label}) => ({
+				items: items.filter((property) => property.sortable !== false),
+				label,
+			}))
+			.filter(({items}) => items.length);
+	}, [properties]);
+
+	const propertiesMap = useMemo(() => {
+		const map = new Map<string, OrderBySelection>();
+
+		properties
+			.flatMap((group) => group.items)
+			.forEach(({classNameId, classTypeId, name}) => {
+				map.set(getPropertyKey(classNameId, classTypeId, name), {
+					classNameId,
+					classTypeId,
+					name,
+				});
+			});
+
+		return map;
+	}, [properties]);
 
 	return (
 		<div className="row">
 			<OrderByField
 				columnName={`${namespace}TypeSettingsProperties--orderByColumn1--`}
 				columnValue={orderByColumn1}
+				items={items}
 				label={Liferay.Language.get('order-by')}
 				onColumnChange={setOrderByColumn1}
 				onTypeChange={setOrderByType1}
+				propertiesMap={propertiesMap}
 				typeName={`${namespace}TypeSettingsProperties--orderByType1--`}
 				typeValue={orderByType1}
 			/>
@@ -122,9 +292,11 @@ export default function CollectionOrdering({
 			<OrderByField
 				columnName={`${namespace}TypeSettingsProperties--orderByColumn2--`}
 				columnValue={orderByColumn2}
+				items={items}
 				label={Liferay.Language.get('and-then-by')}
 				onColumnChange={setOrderByColumn2}
 				onTypeChange={setOrderByType2}
+				propertiesMap={propertiesMap}
 				typeName={`${namespace}TypeSettingsProperties--orderByType2--`}
 				typeValue={orderByType2}
 			/>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
@@ -50,8 +50,10 @@ function parseInitialOrderByColumn(value: string): OrderBySelection {
 				};
 			}
 		}
-		catch {
-			console.error('Failed to parse initial selection: ', value);
+		catch (error) {
+			if (process.env.NODE_ENV === 'development') {
+				console.error('Failed to parse initial selection: ', error);
+			}
 		}
 	}
 

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
@@ -225,7 +225,6 @@ interface CollectionOrderingProps {
 	initialOrderByType2?: OrderByType;
 	namespace: string;
 	properties?: FilterPropertyGroup[];
-	propertiesURL?: string;
 }
 
 export default function CollectionOrdering({
@@ -235,7 +234,6 @@ export default function CollectionOrdering({
 	initialOrderByType2 = 'ASC',
 	namespace,
 	properties: initialProperties,
-	propertiesURL,
 }: CollectionOrderingProps) {
 	const [orderByColumn1, setOrderByColumn1] = useState<OrderBySelection>(() =>
 		parseInitialOrderByColumn(initialOrderByColumn1)
@@ -248,11 +246,7 @@ export default function CollectionOrdering({
 	const [orderByType2, setOrderByType2] =
 		useState<OrderByType>(initialOrderByType2);
 
-	const properties = useTypeProperties(
-		namespace,
-		propertiesURL,
-		initialProperties
-	);
+	const properties = useTypeProperties(initialProperties);
 
 	const items = useMemo<Array<FilterProperty | FilterPropertyGroup>>(() => {
 		return properties

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
@@ -1,0 +1,133 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton from '@clayui/button';
+import {Option, Picker} from '@clayui/core';
+import ClayIcon from '@clayui/icon';
+import React, {useState} from 'react';
+
+type OrderByType = 'ASC' | 'DESC';
+
+const ORDER_BY_OPTIONS: Array<{label: string; value: string}> = [
+	{label: Liferay.Language.get('title'), value: 'title'},
+	{label: Liferay.Language.get('create-date'), value: 'createDate'},
+	{label: Liferay.Language.get('modified-date'), value: 'modifiedDate'},
+	{label: Liferay.Language.get('publish-date'), value: 'publishDate'},
+	{label: Liferay.Language.get('expiration-date'), value: 'expirationDate'},
+	{label: Liferay.Language.get('priority'), value: 'priority'},
+];
+
+interface OrderByFieldProps {
+	columnName: string;
+	columnValue: string;
+	label: string;
+	onColumnChange: (column: string) => void;
+	onTypeChange: (type: OrderByType) => void;
+	typeName: string;
+	typeValue: OrderByType;
+}
+
+function OrderByField({
+	columnName,
+	columnValue,
+	label,
+	onColumnChange,
+	onTypeChange,
+	typeName,
+	typeValue,
+}: OrderByFieldProps) {
+	const ascending = typeValue === 'ASC';
+
+	return (
+		<div className="col-md-6">
+			<div className="h5">{label}</div>
+
+			<div className="d-inline-flex">
+				<Picker
+					aria-label={label}
+					items={ORDER_BY_OPTIONS}
+					onSelectionChange={(key) => onColumnChange(key as string)}
+					selectedKey={columnValue}
+				>
+					{(item) => <Option key={item.value}>{item.label}</Option>}
+				</Picker>
+			</div>
+
+			<input name={columnName} type="hidden" value={columnValue} />
+
+			<div className="d-inline-flex">
+				<ClayButton
+					aria-label={
+						ascending
+							? Liferay.Language.get('ascending')
+							: Liferay.Language.get('descending')
+					}
+					borderless
+					displayType="secondary"
+					monospaced
+					onClick={() => onTypeChange(ascending ? 'DESC' : 'ASC')}
+					title={
+						ascending
+							? Liferay.Language.get('ascending')
+							: Liferay.Language.get('descending')
+					}
+				>
+					<ClayIcon
+						symbol={ascending ? 'order-list-up' : 'order-list-down'}
+					/>
+				</ClayButton>
+			</div>
+
+			<input name={typeName} type="hidden" value={typeValue} />
+		</div>
+	);
+}
+
+interface CollectionOrderingProps {
+	initialOrderByColumn1?: string;
+	initialOrderByColumn2?: string;
+	initialOrderByType1?: OrderByType;
+	initialOrderByType2?: OrderByType;
+	namespace: string;
+}
+
+export default function CollectionOrdering({
+	initialOrderByColumn1 = 'title',
+	initialOrderByColumn2 = 'title',
+	initialOrderByType1 = 'ASC',
+	initialOrderByType2 = 'ASC',
+	namespace,
+}: CollectionOrderingProps) {
+	const [orderByColumn1, setOrderByColumn1] = useState(initialOrderByColumn1);
+	const [orderByColumn2, setOrderByColumn2] = useState(initialOrderByColumn2);
+	const [orderByType1, setOrderByType1] =
+		useState<OrderByType>(initialOrderByType1);
+	const [orderByType2, setOrderByType2] =
+		useState<OrderByType>(initialOrderByType2);
+
+	return (
+		<div className="row">
+			<OrderByField
+				columnName={`${namespace}TypeSettingsProperties--orderByColumn1--`}
+				columnValue={orderByColumn1}
+				label={Liferay.Language.get('order-by')}
+				onColumnChange={setOrderByColumn1}
+				onTypeChange={setOrderByType1}
+				typeName={`${namespace}TypeSettingsProperties--orderByType1--`}
+				typeValue={orderByType1}
+			/>
+
+			<OrderByField
+				columnName={`${namespace}TypeSettingsProperties--orderByColumn2--`}
+				columnValue={orderByColumn2}
+				label={Liferay.Language.get('and-then-by')}
+				onColumnChange={setOrderByColumn2}
+				onTypeChange={setOrderByType2}
+				typeName={`${namespace}TypeSettingsProperties--orderByType2--`}
+				typeValue={orderByType2}
+			/>
+		</div>
+	);
+}

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
@@ -37,8 +37,10 @@ function isGroup(
 	return 'items' in item;
 }
 
-function parseInitialOrderByColumn(value: string): OrderBySelection {
-	if (value.startsWith('{')) {
+function parseInitialOrderByColumn(
+	value: string | null | undefined
+): OrderBySelection {
+	if (value && value.startsWith('{')) {
 		try {
 			const parsed = JSON.parse(value);
 
@@ -60,7 +62,7 @@ function parseInitialOrderByColumn(value: string): OrderBySelection {
 	return {
 		classNameId: undefined,
 		classTypeId: undefined,
-		name: value,
+		name: value || '',
 	};
 }
 
@@ -148,7 +150,7 @@ function OrderByField({
 				name={columnName}
 				type="hidden"
 				value={
-					columnValue.classNameId && columnValue.classTypeId
+					columnValue.classNameId !== undefined
 						? JSON.stringify(columnValue)
 						: columnValue.name
 				}

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
@@ -42,13 +42,17 @@ function parseInitialOrderByColumn(value: string): OrderBySelection {
 		try {
 			const parsed = JSON.parse(value);
 
-			return {
-				classNameId: parsed.classNameId,
-				classTypeId: parsed.classTypeId,
-				name: parsed.name,
-			};
+			if (parsed && typeof parsed === 'object') {
+				return {
+					classNameId: parsed.classNameId,
+					classTypeId: parsed.classTypeId,
+					name: parsed.name,
+				};
+			}
 		}
-		catch {}
+		catch {
+			console.error('Failed to parse initial selection: ', value);
+		}
 	}
 
 	return {
@@ -152,8 +156,8 @@ function OrderByField({
 				<ClayButton
 					aria-label={
 						ascending
-							? Liferay.Language.get('ascending')
-							: Liferay.Language.get('descending')
+							? Liferay.Language.get('descending')
+							: Liferay.Language.get('ascending')
 					}
 					borderless
 					displayType="secondary"
@@ -161,8 +165,8 @@ function OrderByField({
 					onClick={() => onTypeChange(ascending ? 'DESC' : 'ASC')}
 					title={
 						ascending
-							? Liferay.Language.get('ascending')
-							: Liferay.Language.get('descending')
+							? Liferay.Language.get('descending')
+							: Liferay.Language.get('ascending')
 					}
 				>
 					<ClayIcon
@@ -253,7 +257,9 @@ export default function CollectionOrdering({
 	const items = useMemo<Array<FilterProperty | FilterPropertyGroup>>(() => {
 		return properties
 			.map(({items, label}) => ({
-				items: items.filter((property) => property.sortable !== false),
+				items: (items ?? []).filter(
+					(property) => property.sortable !== false
+				),
 				label,
 			}))
 			.filter(({items}) => items.length);
@@ -263,7 +269,7 @@ export default function CollectionOrdering({
 		const map = new Map<string, OrderBySelection>();
 
 		properties
-			.flatMap((group) => group.items)
+			.flatMap((group) => group.items ?? [])
 			.forEach(({classNameId, classTypeId, name}) => {
 				map.set(getPropertyKey(classNameId, classTypeId, name), {
 					classNameId,

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/hooks/useTypeProperties.ts
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/hooks/useTypeProperties.ts
@@ -1,0 +1,170 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {addParams, fetch} from 'frontend-js-web';
+import {useEffect, useState} from 'react';
+
+import type {FilterPropertyGroup} from '../components/CollectionFilterBuilder/types';
+
+interface Store {
+	listeners: Set<(properties: FilterPropertyGroup[]) => void>;
+	properties: FilterPropertyGroup[];
+}
+
+const stores = new Map<string, Store>();
+
+// Refetches the filterable properties whenever the user changes the
+// collection's asset source (type / subtype selectors), fired in
+// event sourceChange. The available fields depend on the selected
+// class names + class types.
+
+function fetchProperties(
+	namespace: string,
+	propertiesURL: string,
+	store: Store
+): void {
+	const assetTypeSelector = document.getElementById(
+		`${namespace}anyAssetType`
+	) as HTMLSelectElement | null;
+
+	const assetTypeValue = assetTypeSelector?.value || '';
+
+	let classNameIds: string[] = [];
+
+	if (assetTypeValue === 'false') {
+
+		// Multi-selection: collect every option out of the hidden
+		// <select> the JSP populates with the user's picks.
+
+		const multiSelector = document.getElementById(
+			`${namespace}currentClassNameIds`
+		) as HTMLSelectElement | null;
+
+		classNameIds = Array.from(multiSelector?.options || []).map(
+			(option) => option.value
+		);
+	}
+	else if (assetTypeValue && assetTypeValue !== 'true') {
+		classNameIds = [assetTypeValue];
+	}
+
+	let classTypeIds: string[] = [];
+
+	// Subtypes only make sense when exactly one asset type is
+	// selected — the subtype UI is hidden otherwise.
+
+	if (classNameIds.length === 1) {
+		const subtypeContainer = document.querySelector(
+			'.asset-subtype:not(.hide)'
+		);
+
+		const subtypeSelector = subtypeContainer?.querySelector(
+			`[id^="${namespace}anyClassType"]`
+		) as HTMLSelectElement | null;
+
+		const subtypeValue = subtypeSelector?.value;
+
+		if (subtypeValue === 'false' && subtypeContainer) {
+
+			// Multi-subtype selection: same pattern as
+			// classNameIds above, but the element id is
+			// namespaced with the class name.
+
+			const className = subtypeContainer.getAttribute('data-class-name');
+
+			const multiSubtypeSelect = document.getElementById(
+				`${namespace}${className}currentClassTypeIds`
+			) as HTMLSelectElement | null;
+
+			classTypeIds = Array.from(multiSubtypeSelect?.options || []).map(
+				(option) => option.value
+			);
+		}
+		else if (subtypeValue && subtypeValue !== 'true') {
+			classTypeIds = [subtypeValue];
+		}
+	}
+
+	fetch(
+		addParams(
+			{
+				[`${namespace}classNameIds`]: classNameIds.join(','),
+				[`${namespace}classTypeIds`]: classTypeIds.join(','),
+			},
+			propertiesURL
+		)
+	)
+		.then((response) => response.json())
+		.then((data) => {
+			store.properties = data || [];
+			store.listeners.forEach((listener) => listener(store.properties));
+		})
+		.catch((error) =>
+			console.error('Failed to fetch type properties: ', error)
+		);
+}
+
+// Single store per (namespace, propertiesURL) shared by every consumer of the
+// hook so the Liferay event listener and fetch run once, regardless of how
+// many React roots mount this hook.
+
+function getStore(
+	namespace: string,
+	propertiesURL: string,
+	initialProperties: FilterPropertyGroup[]
+): Store {
+	const key = `${namespace}|${propertiesURL}`;
+
+	let store = stores.get(key);
+
+	if (!store) {
+		const newStore: Store = {
+			listeners: new Set(),
+			properties: initialProperties,
+		};
+
+		stores.set(key, newStore);
+
+		Liferay.on(`${namespace}sourceChange`, () =>
+			fetchProperties(namespace, propertiesURL, newStore)
+		);
+
+		store = newStore;
+	}
+
+	return store;
+}
+
+export default function useTypeProperties(
+	namespace: string,
+	propertiesURL?: string,
+	initialProperties: FilterPropertyGroup[] = []
+): FilterPropertyGroup[] {
+	const [properties, setProperties] =
+		useState<FilterPropertyGroup[]>(initialProperties);
+
+	useEffect(() => {
+		if (!propertiesURL) {
+			return undefined;
+		}
+
+		const store = getStore(namespace, propertiesURL, initialProperties);
+
+		setProperties(store.properties);
+
+		store.listeners.add(setProperties);
+
+		return () => {
+			store.listeners.delete(setProperties);
+		};
+
+		// initialProperties is intentionally omitted. It's only used on the
+		// first run to populate the store; subsequent consumers read the
+		// store's current properties.
+		// eslint-disable-next-line
+	}, [namespace, propertiesURL]);
+
+	return properties;
+}

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/hooks/useTypeProperties.ts
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/hooks/useTypeProperties.ts
@@ -3,168 +3,32 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {addParams, fetch} from 'frontend-js-web';
-import {useEffect, useState} from 'react';
+import {useLiferayState} from '@liferay/frontend-js-state-web/react';
+import {deepClone} from 'frontend-js-web';
+import {useMemo} from 'react';
+
+import {propertiesAtom} from '../atoms/propertiesAtom';
 
 import type {FilterPropertyGroup} from '../components/CollectionFilterBuilder/types';
 
-interface Store {
-	listeners: Set<(properties: FilterPropertyGroup[]) => void>;
-	properties: FilterPropertyGroup[];
-}
-
-const stores = new Map<string, Store>();
-
-// Refetches the filterable properties whenever the user changes the
-// collection's asset source (type / subtype selectors), fired in
-// event sourceChange. The available fields depend on the selected
-// class names + class types.
-
-function fetchProperties(
-	namespace: string,
-	propertiesURL: string,
-	store: Store
-): void {
-	const assetTypeSelector = document.getElementById(
-		`${namespace}anyAssetType`
-	) as HTMLSelectElement | null;
-
-	const assetTypeValue = assetTypeSelector?.value || '';
-
-	let classNameIds: string[] = [];
-
-	if (assetTypeValue === 'false') {
-
-		// Multi-selection: collect every option out of the hidden
-		// <select> the JSP populates with the user's picks.
-
-		const multiSelector = document.getElementById(
-			`${namespace}currentClassNameIds`
-		) as HTMLSelectElement | null;
-
-		classNameIds = Array.from(multiSelector?.options || []).map(
-			(option) => option.value
-		);
-	}
-	else if (assetTypeValue && assetTypeValue !== 'true') {
-		classNameIds = [assetTypeValue];
-	}
-
-	let classTypeIds: string[] = [];
-
-	// Subtypes only make sense when exactly one asset type is
-	// selected — the subtype UI is hidden otherwise.
-
-	if (classNameIds.length === 1) {
-		const subtypeContainer = document.querySelector(
-			'.asset-subtype:not(.hide)'
-		);
-
-		const subtypeSelector = subtypeContainer?.querySelector(
-			`[id^="${namespace}anyClassType"]`
-		) as HTMLSelectElement | null;
-
-		const subtypeValue = subtypeSelector?.value;
-
-		if (subtypeValue === 'false' && subtypeContainer) {
-
-			// Multi-subtype selection: same pattern as
-			// classNameIds above, but the element id is
-			// namespaced with the class name.
-
-			const className = subtypeContainer.getAttribute('data-class-name');
-
-			const multiSubtypeSelect = document.getElementById(
-				`${namespace}${className}currentClassTypeIds`
-			) as HTMLSelectElement | null;
-
-			classTypeIds = Array.from(multiSubtypeSelect?.options || []).map(
-				(option) => option.value
-			);
-		}
-		else if (subtypeValue && subtypeValue !== 'true') {
-			classTypeIds = [subtypeValue];
-		}
-	}
-
-	fetch(
-		addParams(
-			{
-				[`${namespace}classNameIds`]: classNameIds.join(','),
-				[`${namespace}classTypeIds`]: classTypeIds.join(','),
-			},
-			propertiesURL
-		)
-	)
-		.then((response) => response.json())
-		.then((data) => {
-			store.properties = data || [];
-			store.listeners.forEach((listener) => listener(store.properties));
-		})
-		.catch((error) =>
-			console.error('Failed to fetch type properties: ', error)
-		);
-}
-
-// Single store per (namespace, propertiesURL) shared by every consumer of the
-// hook so the Liferay event listener and fetch run once, regardless of how
-// many React roots mount this hook.
-
-function getStore(
-	namespace: string,
-	propertiesURL: string,
-	initialProperties: FilterPropertyGroup[]
-): Store {
-	const key = `${namespace}|${propertiesURL}`;
-
-	let store = stores.get(key);
-
-	if (!store) {
-		const newStore: Store = {
-			listeners: new Set(),
-			properties: initialProperties,
-		};
-
-		stores.set(key, newStore);
-
-		Liferay.on(`${namespace}sourceChange`, () =>
-			fetchProperties(namespace, propertiesURL, newStore)
-		);
-
-		store = newStore;
-	}
-
-	return store;
-}
-
+/**
+ * Subscribes to the shared properties atom and returns its current value,
+ * falling back to `initialValue` until the atom has been seeded.
+ *
+ * Atom values from `@liferay/frontend-js-state-web` are deeply frozen, but
+ * ClayUI components (e.g. `<Picker>` via `useCollection`) mutate items to
+ * attach internal keys. The returned value is cloned so consumers can hand
+ * it off to ClayUI without hitting "object is not extensible" errors.
+ */
 export default function useTypeProperties(
-	namespace: string,
-	propertiesURL?: string,
-	initialProperties: FilterPropertyGroup[] = []
+	initialValue: FilterPropertyGroup[] = []
 ): FilterPropertyGroup[] {
-	const [properties, setProperties] =
-		useState<FilterPropertyGroup[]>(initialProperties);
+	const [atomProperties] = useLiferayState(propertiesAtom);
 
-	useEffect(() => {
-		if (!propertiesURL) {
-			return undefined;
-		}
+	const cloned = useMemo(
+		() => deepClone(atomProperties) as FilterPropertyGroup[],
+		[atomProperties]
+	);
 
-		const store = getStore(namespace, propertiesURL, initialProperties);
-
-		setProperties(store.properties);
-
-		store.listeners.add(setProperties);
-
-		return () => {
-			store.listeners.delete(setProperties);
-		};
-
-		// initialProperties is intentionally omitted. It's only used on the
-		// first run to populate the store; subsequent consumers read the
-		// store's current properties.
-		// eslint-disable-next-line
-	}, [namespace, propertiesURL]);
-
-	return properties;
+	return cloned.length ? cloned : initialValue;
 }

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/hooks/useTypeProperties.ts
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/hooks/useTypeProperties.ts
@@ -30,5 +30,5 @@ export default function useTypeProperties(
 		[atomProperties]
 	);
 
-	return cloned.length ? cloned : initialValue;
+	return cloned && cloned.length ? cloned : initialValue || [];
 }

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/index.js
@@ -7,6 +7,7 @@ export {default as AssetEntryListDropdownDefaultPropsTransformer} from './AssetE
 export {default as AssetListEntryVariationDefaultPropsTransformer} from './AssetListEntryVariationDefaultPropsTransformer';
 export {default as EditAssetListEntryManualDefaultPropsTransformer} from './EditAssetListEntryManualDefaultPropsTransformer';
 export {default as EmptyResultMessagePropsTransformer} from './EmptyResultMessagePropsTransformer';
+export {default as FilterVisibility} from './FilterVisibility';
 export {default as InfoCollectionProviderDropdownDefaultPropsTransformer} from './InfoCollectionProviderDropdownDefaultPropsTransformer';
 export {default as ListItemsDropdownPropsTransformer} from './ListItemsDropdownPropsTransformer';
 export {default as ManagementToolbarPropsTransformer} from './ManagementToolbarPropsTransformer';

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/index.js
@@ -17,5 +17,6 @@ export {default as Source} from './Source';
 export {default as TopLinkEventHandler} from './TopLinkEventHandler';
 export {default as AssetFilterBuilder} from './components/AssetFilterBuilder/index';
 export {default as CollectionFilterBuilder} from './components/CollectionFilterBuilder/index';
+export {default as CollectionOrdering} from './components/CollectionOrdering/index';
 export {default as VariationsNav} from './components/VariationsNav/index';
 export {default as openDeleteAssetEntryListModal} from './openDeleteAssetEntryListModal';

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "d22528a4f3184a209d699f10a2ce45c627f458ab",
+	"@generated": "56ba87d26b1d8e1aefe6517777dd87651acd40a5",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -11,6 +11,12 @@
 		"module": "es2022",
 		"moduleResolution": "node",
 		"paths": {
+			"@liferay/frontend-js-state-web": [
+				"../../../../../../../frontend-js/frontend-js-state-web/src/main/resources/META-INF/resources/main/index.ts"
+			],
+			"@liferay/frontend-js-state-web/react": [
+				"../../../../../../../frontend-js/frontend-js-state-web/src/main/resources/META-INF/resources/react/index.ts"
+			],
 			"@liferay/layout-js-components-web": [
 				"../../../../../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/js/index.ts"
 			],
@@ -43,6 +49,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-state-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/servlet/taglib/util/LayoutActionDropdownItemsProviderTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/servlet/taglib/util/LayoutActionDropdownItemsProviderTest.java
@@ -59,8 +59,7 @@ public class LayoutActionDropdownItemsProviderTest {
 			LayoutConstants.TYPE_FULL_PAGE_APPLICATION, true, true);
 		_testIsShowMakeACopyAction(LayoutConstants.TYPE_PANEL, false, false);
 		_testIsShowMakeACopyAction(LayoutConstants.TYPE_PANEL, true, true);
-		_testIsShowMakeACopyAction(
-			LayoutConstants.TYPE_PORTLET, false, false);
+		_testIsShowMakeACopyAction(LayoutConstants.TYPE_PORTLET, false, false);
 		_testIsShowMakeACopyAction(LayoutConstants.TYPE_PORTLET, true, true);
 	}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/PropertiesFeatureFlagsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/PropertiesFeatureFlagsCheck.java
@@ -123,8 +123,11 @@ public class PropertiesFeatureFlagsCheck extends BaseFileCheck {
 				featureFlagKeys.addAll(
 					_getFeatureFlagKeys(fileContent, _featureFlagPattern5));
 				featureFlagKeys.addAll(
-					_getFeatureFlagKeysByFeatureFlagManagerUtilIsEnabledCall(
-						fileContent, true));
+					_getFeatureFlagKeysByFeatureFlagManagerUtilCall(
+						fileContent, true, "checkEnabled"));
+				featureFlagKeys.addAll(
+					_getFeatureFlagKeysByFeatureFlagManagerUtilCall(
+						fileContent, true, "isEnabled"));
 				featureFlagKeys.addAll(
 					_getFeatureFlagKeysByMapUtilSingletonDictionaryCall(
 						fileContent));
@@ -137,8 +140,11 @@ public class PropertiesFeatureFlagsCheck extends BaseFileCheck {
 				featureFlagKeys.addAll(
 					_getFeatureFlagKeys(fileContent, _featureFlagPattern2));
 				featureFlagKeys.addAll(
-					_getFeatureFlagKeysByFeatureFlagManagerUtilIsEnabledCall(
-						fileContent, false));
+					_getFeatureFlagKeysByFeatureFlagManagerUtilCall(
+						fileContent, false, "checkEnabled"));
+				featureFlagKeys.addAll(
+					_getFeatureFlagKeysByFeatureFlagManagerUtilCall(
+						fileContent, false, "isEnabled"));
 			}
 			else {
 				featureFlagKeys.addAll(
@@ -339,16 +345,16 @@ public class PropertiesFeatureFlagsCheck extends BaseFileCheck {
 		return featureFlagKeys;
 	}
 
-	private List<String>
-		_getFeatureFlagKeysByFeatureFlagManagerUtilIsEnabledCall(
-			String content, boolean javaSource) {
+	private List<String> _getFeatureFlagKeysByFeatureFlagManagerUtilCall(
+		String content, boolean javaSource, String methodName) {
 
 		List<String> featureFlagKeys = new ArrayList<>();
 
 		int x = -1;
 
 		while (true) {
-			x = content.indexOf("FeatureFlagManagerUtil.isEnabled(", x + 1);
+			x = content.indexOf(
+				"FeatureFlagManagerUtil." + methodName + "(", x + 1);
 
 			if (x == -1) {
 				return featureFlagKeys;


### PR DESCRIPTION
Resent from https://github.com/liferay-search/liferay-portal/pull/1925

https://liferay.atlassian.net/browse/LPD-78170 - Order by CMS and Site scope Object fields in Dynamic Collections

Changes are behind the feature flag
`feature.flag.LPD-74731=true`

Backend requirements/notes:
- The legacy ordering component includes the DDM Structures with javascript after selection. In order to have the same functionality, it would be good to include the DDM Structures in the resource command, with the same name convention (like `ddm__keyword__...`)
- Add `sortable` to the properties (only necessary when specified as `false`) 
- Type-specific Object fields are saved as `{classNameId, classTypeId, propertyName}` (dev-only debugger is available to show!)

Tried this out on top of Felipe's changes in https://github.com/liferay-search/liferay-portal/pull/1942 in order to view correct fields:
<img width="896" height="453" alt="Screenshot 2026-05-21 at 3 01 33 PM" src="https://github.com/user-attachments/assets/b039c9ce-c6dc-45b4-8299-5460310de5f5" />

<img width="915" height="455" alt="Screenshot 2026-05-21 at 3 02 30 PM" src="https://github.com/user-attachments/assets/8d2d0976-f789-4e62-90b8-4645bd261ef8" />
