### PR TITLE
LPD-93681 Keep custom facet visible when a search returns no results

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/facet/display/context/builder/CustomFacetDisplayContextBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/facet/display/context/builder/CustomFacetDisplayContextBuilder.java
@@ -83,15 +83,17 @@ public class CustomFacetDisplayContextBuilder {
 			return _buildRangeAggregationCustomFacetDisplayContext();
 		}
 
-		return new CustomFacetDisplayContext(
-			_aggregationType,
+		List<BucketDisplayContext> bucketDisplayContexts =
 			_buildTermsAggregationBucketDisplayContexts(
-				getTermsAggregationTermCollectors()),
-			null, _customFacetPortletInstanceConfiguration, null,
-			getDisplayCaption(), _getDisplayStyleGroupId(), _from,
-			isNothingSelected(), _paginationStartParameterName, _parameterName,
-			_getFirstParameterValue(), _parameterValues, isRenderNothing(),
-			_showInputRange, _to);
+				getTermsAggregationTermCollectors());
+
+		return new CustomFacetDisplayContext(
+			_aggregationType, bucketDisplayContexts, null,
+			_customFacetPortletInstanceConfiguration, null, getDisplayCaption(),
+			_getDisplayStyleGroupId(), _from, isNothingSelected(),
+			_paginationStartParameterName, _parameterName,
+			_getFirstParameterValue(), _parameterValues,
+			isRenderNothing(bucketDisplayContexts), _showInputRange, _to);
 	}
 
 	public CustomFacetDisplayContextBuilder currentURL(String currentURL) {
@@ -267,8 +269,10 @@ public class CustomFacetDisplayContextBuilder {
 		return false;
 	}
 
-	protected boolean isRenderNothing() {
-		if (_totalHits > 0) {
+	protected boolean isRenderNothing(
+		List<BucketDisplayContext> bucketDisplayContexts) {
+
+		if ((_totalHits > 0) || !bucketDisplayContexts.isEmpty()) {
 			return false;
 		}
 
@@ -382,14 +386,17 @@ public class CustomFacetDisplayContextBuilder {
 	private CustomFacetDisplayContext
 		_buildRangeAggregationCustomFacetDisplayContext() {
 
+		List<BucketDisplayContext> bucketDisplayContexts =
+			_buildRangeAggregationBucketDisplayContexts();
+
 		return new CustomFacetDisplayContext(
-			_aggregationType, _buildRangeAggregationBucketDisplayContexts(),
+			_aggregationType, bucketDisplayContexts,
 			_buildCalendarDisplayContext(),
 			_customFacetPortletInstanceConfiguration,
 			_buildCustomRangeBucketDisplayContext(), getDisplayCaption(),
 			_getDisplayStyleGroupId(), _from, isNothingSelected(),
 			_paginationStartParameterName, _parameterName, null, null,
-			isRenderNothing(), _showInputRange, _to);
+			isRenderNothing(bucketDisplayContexts), _showInputRange, _to);
 	}
 
 	private BucketDisplayContext _buildTermsAggregationBucketDisplayContext(

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/facet/display/context/CustomFacetDisplayContextBuilderTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/facet/display/context/CustomFacetDisplayContextBuilderTest.java
@@ -323,6 +323,40 @@ public class CustomFacetDisplayContextBuilderTest
 	}
 
 	@Test
+	public void testIsRenderNothingFalseWithNoHitsAndRanges() throws Exception {
+		CustomFacetDisplayContextBuilder customFacetDisplayContextBuilder =
+			_createCustomFacetDisplayContextBuilder(_AGGREGATION_TYPE_RANGE);
+
+		_mockFacetConfiguration("one=[200 TO 300]", "two=[400 TO 500]");
+
+		CustomFacetDisplayContext customFacetDisplayContext =
+			customFacetDisplayContextBuilder.totalHits(
+				0
+			).build();
+
+		Assert.assertFalse(customFacetDisplayContext.isRenderNothing());
+	}
+
+	@Test
+	public void testIsRenderNothingFalseWithNoHitsAndTermCollectors()
+		throws Exception {
+
+		setUpTermCollectors(
+			facetCollector,
+			Collections.singletonList(createTermCollector(createTerm(), 0)));
+
+		CustomFacetDisplayContextBuilder customFacetDisplayContextBuilder =
+			_createCustomFacetDisplayContextBuilder(_AGGREGATION_TYPE_TERMS);
+
+		CustomFacetDisplayContext customFacetDisplayContext =
+			customFacetDisplayContextBuilder.totalHits(
+				0
+			).build();
+
+		Assert.assertFalse(customFacetDisplayContext.isRenderNothing());
+	}
+
+	@Test
 	public void testIsRenderNothingFalseWithSelectedDateRange()
 		throws Exception {
 
@@ -391,7 +425,7 @@ public class CustomFacetDisplayContextBuilderTest
 		Assert.assertFalse(bucketDisplayContext.isSelected());
 
 		Assert.assertTrue(facetDisplayContext.isNothingSelected());
-		Assert.assertTrue(facetDisplayContext.isRenderNothing());
+		Assert.assertFalse(facetDisplayContext.isRenderNothing());
 		Assert.assertEquals(
 			parameterValue, facetDisplayContext.getParameterValue());
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93681

## What Is Being Fixed

A Custom Facet configured with Frequency Threshold 0 disappears from the page when a search returns no results, while a Category Facet configured the same way stays visible. LPS-194520 already made threshold 0 reach the search engine as `min_doc_count: 0`, so the aggregation returns every field value as a zero-frequency bucket even on a zero-hit search — but the custom facet's display layer discarded those buckets and hid the portlet whenever the total hit count was zero.

## How It Is Being Fixed

`CustomFacetDisplayContextBuilder.isRenderNothing()` now receives the bucket display contexts built for the response and keeps the facet visible whenever there are buckets to display, matching the category and tags facets' behavior. With the default threshold of 1 nothing changes: `min_doc_count: 1` returns no buckets on a zero-hit search, so the facet still hides. Unit tests cover the new zero-hit rendering for both terms and range aggregations, and the `testOneTerm` override now matches the shared facet contract in `BaseFacetDisplayContextTestCase`.