### PR TITLE
LPD-90682 Fix search functional tests for sorted facet URLs

### DIFF
--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -12632,6 +12632,7 @@ model.resource.com.liferay.site.navigation.model.SiteNavigationMenuItem=Site Nav
 model.resource.com.liferay.social.kernel.model.SocialActivity=Social Activity
 model.resource.com.liferay.social.kernel.model.SocialActivitySet=Social Activity Set
 model.resource.com.liferay.style.book=Style Book
+model.resource.com.liferay.style.book.model.StyleBookEntry=Style Book Entry
 model.resource.com.liferay.translation=Translation
 model.resource.com.liferay.translation.model.TranslationEntry=Translation
 model.resource.com.liferay.trash=Recycle Bin

--- a/portal-web/test/functional/com/liferay/portalweb/macros/SearchFacets.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/SearchFacets.macro
@@ -227,11 +227,14 @@ definition {
 		var facetURLName = StringUtil.replace(${facetName}, " Facet", "");
 
 		var facetURLName = StringUtil.toLowerCase(${facetURLName});
+		var normalizedSearchURL = StringUtil.replaceFirst(${searchURL}, "?", "&");
 
-		var beforeFacetGroup = RegexUtil.replace(${searchURL}, "^(.*?)((?:&${facetURLName}[^&]+)+)(.*)", 1);
-		var afterFacetGroup = RegexUtil.replace(${searchURL}, "^(.*?)((?:&${facetURLName}[^&]+)+)(.*)", 3);
+		var beforeFacetGroup = RegexUtil.replace(${normalizedSearchURL}, "^(.*?)((?:&${facetURLName}[^&]+)+)(.*)", 1);
+		var afterFacetGroup = RegexUtil.replace(${normalizedSearchURL}, "^(.*?)((?:&${facetURLName}[^&]+)+)(.*)", 3);
 
 		var searchURL = "${beforeFacetGroup}${afterFacetGroup}";
+
+		var searchURL = StringUtil.replaceFirst(${searchURL}, "&", "?");
 
 		var searchURL = SearchFacets.sortQueryParameters(searchURL = ${searchURL});
 
@@ -253,10 +256,11 @@ definition {
 		var facetURLName = StringUtil.replace(${facetName}, " Facet", "");
 
 		var facetURLName = StringUtil.toLowerCase(${facetURLName});
+		var normalizedSearchURL = StringUtil.replaceFirst(${searchURL}, "?", "&");
 
-		var beforeFacetGroup = RegexUtil.replace(${searchURL}, "^(.*?)((?:&${facetURLName}[^&]+)+)(.*)", 1);
-		var facetGroup = RegexUtil.replace(${searchURL}, "^(.*?)((?:&${facetURLName}[^&]+)+)(.*)", 2);
-		var afterFacetGroup = RegexUtil.replace(${searchURL}, "^(.*?)((?:&${facetURLName}[^&]+)+)(.*)", 3);
+		var beforeFacetGroup = RegexUtil.replace(${normalizedSearchURL}, "^(.*?)((?:&${facetURLName}[^&]+)+)(.*)", 1);
+		var facetGroup = RegexUtil.replace(${normalizedSearchURL}, "^(.*?)((?:&${facetURLName}[^&]+)+)(.*)", 2);
+		var afterFacetGroup = RegexUtil.replace(${normalizedSearchURL}, "^(.*?)((?:&${facetURLName}[^&]+)+)(.*)", 3);
 		var termURLValue = StringUtil.replace(${termURLValue}, " ", "%20");
 		var facetGroupList = ${facetGroup};
 
@@ -273,6 +277,8 @@ definition {
 		}
 
 		var searchURL = "${beforeFacetGroup}${afterFacetGroup}${facetGroup}";
+
+		var searchURL = StringUtil.replaceFirst(${searchURL}, "&", "?");
 
 		var searchURL = SearchFacets.sortQueryParameters(searchURL = ${searchURL});
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
@@ -254,7 +254,7 @@ definition {
 			key_searchAssetTitle = "Home",
 			locator1 = "SearchPage#RESULT_TITLE_SPECIFIC_HIGHLIGHT",
 			locator2 = "background-color",
-			value1 = "rgba(255, 228, 153, 1)");
+			value1 = "rgba(252, 248, 227, 1)");
 	}
 
 	@priority = 4
@@ -618,13 +618,13 @@ definition {
 			key_searchAssetTitle = "WC",
 			locator1 = "SearchPage#RESULT_TITLE_SPECIFIC_HIGHLIGHT",
 			locator2 = "background-color",
-			value1 = "rgba(255, 228, 153, 1)");
+			value1 = "rgba(252, 248, 227, 1)");
 
 		AssertCssValue(
 			key_searchAssetTitle = "Title",
 			locator1 = "SearchPage#RESULT_TITLE_SPECIFIC_HIGHLIGHT",
 			locator2 = "background-color",
-			value1 = "rgba(255, 228, 153, 1)");
+			value1 = "rgba(252, 248, 227, 1)");
 
 		SearchResults.configureSearchResults(disableHighlighting = "true");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
@@ -574,7 +574,7 @@ definition {
 
 			DMDocument.assertFileNameFromTempFolder(fileName = "Document_1.docx");
 
-			Click(locator1 = "SearchPage#PREVIEW_BACK_BUTTON");
+			GoBack();
 
 			SearchPage.gotoResultDetails(searchAssetTitle = "PDF File");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
@@ -1436,13 +1436,13 @@ definition {
 			key_searchAssetTitle = "WC",
 			locator1 = "SearchPage#RESULT_TITLE_SPECIFIC_HIGHLIGHT",
 			locator2 = "background-color",
-			value1 = "rgba(255, 228, 153, 1)");
+			value1 = "rgba(252, 248, 227, 1)");
 
 		AssertCssValue(
 			key_searchAssetTitle = "Title",
 			locator1 = "SearchPage#RESULT_TITLE_SPECIFIC_HIGHLIGHT",
 			locator2 = "background-color",
-			value1 = "rgba(255, 228, 153, 1)");
+			value1 = "rgba(252, 248, 227, 1)");
 	}
 
 	@priority = 3


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90682 - SearchFacets#ViewMultipleFacetURLs
https://liferay.atlassian.net/browse/LPD-90683 - Search#CanDownloadDocumentsThroughSearchResultsPreview
https://liferay.atlassian.net/browse/LPD-93574 - Blueprints#DefaultHighlightAppliedWithBlueprints Search#AssertHighlightedSearchResultsWhenAdvancedSearchSyntaxIsEnabled Search#CanHighlightResultsAndDisableHighlighting [Functional] (search)
https://liferay.atlassian.net/browse/LPD-93703 - model.resource.com.liferay.style.book.model.StyleBookEntry needs a human-readable label [Functional] (search)

  ## What Is Being Fixed

  - The `SearchFacets#ViewMultipleFacetURLs` test broke after facet query parameters started being sorted — the macro assumed the search URL always began with `?q=search`, so its regex no longer matched once facets were reordered.
  - The expected highlight background color in `Search.testcase` and `Blueprints.testcase` was stale.
  - The document preview test relied on a fragile `PREVIEW_BACK_BUTTON` locator.
  - The `StyleBookEntry` model resource had no language label.

  ## How It Is Being Fixed

  - The `SearchFacets` macro normalizes the search URL before applying its facet regexes — rewriting the leading `?` to `&` so the pattern matches regardless of facet order, then restoring the leading `?` afterward.
  - `Search.testcase` and `Blueprints.testcase` update the expected highlight color from `rgba(255, 228, 153, 1)` to `rgba(252, 248, 227, 1)`.
  - The document preview test replaces the `PREVIEW_BACK_BUTTON` click with the `GoBack()` function.
  - A `model.resource...StyleBookEntry` label is added to `Language.properties`.

  ## PR Check

  **pr-check: PASS** — tested on `921669bfce7e84b1ca76232482f790c8f47f8c6d`

  | Validation | Result |
  | --- | --- |
  | Source Format | PASS |
  | Per-Module Deploy | PASS |
  | Poshi Syntax | PASS |
  | Structural Smoke | PASS |