### PR TITLE
LPD-78170 Update visibility rules for filter component (uqb)

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/FilterVisibility.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/FilterVisibility.js
@@ -23,7 +23,8 @@ export default function ({namespace}) {
 		const isSingleCMSType =
 			!!selectedOption && selectedOption.dataset.cms === 'true';
 
-		const isMultiSelection = assetSelector.value === 'false';
+		const isMultiSelection =
+			assetSelector.value === 'false' || assetSelector.value === 'true';
 
 		const showCollection = isSingleCMSType || isMultiSelection;
 

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/FilterVisibility.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/FilterVisibility.js
@@ -28,8 +28,8 @@ export default function ({namespace}) {
 
 		const showCollection = isSingleCMSType || isMultiSelection;
 
-		collectionWrapper.classList.toggle('hide', !showCollection);
 		assetWrapper.classList.toggle('hide', showCollection);
+		collectionWrapper.classList.toggle('hide', !showCollection);
 	};
 
 	updateVisibility();

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/FilterVisibility.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/FilterVisibility.js
@@ -23,8 +23,12 @@ export default function ({namespace}) {
 		const isSingleCMSType =
 			!!selectedOption && selectedOption.dataset.cms === 'true';
 
-		collectionWrapper.classList.toggle('hide', !isSingleCMSType);
-		assetWrapper.classList.toggle('hide', isSingleCMSType);
+		const isMultiSelection = assetSelector.value === 'false';
+
+		const showCollection = isSingleCMSType || isMultiSelection;
+
+		collectionWrapper.classList.toggle('hide', !showCollection);
+		assetWrapper.classList.toggle('hide', showCollection);
 	};
 
 	updateVisibility();

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/Source.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/Source.js
@@ -70,6 +70,16 @@ export default function ({
 	const eventDelegates = [];
 
 	/**
+	 * When more than one asset type or subtype is selected, the per-type field
+	 * groups can collide, so expose only the first "Common Fields" group
+	 * shared across every type.
+	 */
+	const collapseToCommonFields = (groups, {classNameIds, classTypeIds}) =>
+		classNameIds.length > 1 || classTypeIds.length > 1
+			? groups.slice(0, 1)
+			: groups;
+
+	/**
 	 * Reads the currently selected asset type(s) and subtype(s) from the
 	 * source panel selectors.
 	 */
@@ -128,21 +138,6 @@ export default function ({
 
 		return {classNameIds, classTypeIds};
 	};
-
-	/**
-	 * When more than one asset type or subtype is selected, the per-type field
-	 * groups can collide, so expose only the first "Common Fields" group
-	 * shared across every type.
-	 */
-	const collapseToCommonFields = (groups, {classNameIds, classTypeIds}) =>
-		classNameIds.length > 1 || classTypeIds.length > 1
-			? groups.slice(0, 1)
-			: groups;
-
-	State.write(
-		propertiesAtom,
-		collapseToCommonFields(initialProperties || [], getSelectedIds())
-	);
 
 	/**
 	 * Refetches the filterable properties using `propertiesURL` upon
@@ -440,8 +435,6 @@ export default function ({
 		eventDelegates.push(changeSubtypeSelector);
 	});
 
-	toggleSubclasses(assetSelector.value);
-
 	const onChangeAssetSelector = () => {
 		ddmStructureFieldNameInput.value = '';
 		ddmStructureFieldValueInput.value = '';
@@ -566,10 +559,16 @@ export default function ({
 
 	eventDelegates.push(clickOpenModal);
 
+	toggleSubclasses(assetSelector.value);
 	toggleSelectBox(
 		`${namespace}anyAssetType`,
 		'false',
 		`${namespace}classNamesBoxes`
+	);
+
+	State.write(
+		propertiesAtom,
+		collapseToCommonFields(initialProperties || [], getSelectedIds())
 	);
 
 	return {

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/Source.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/Source.js
@@ -22,8 +22,6 @@ export default function ({
 	namespace,
 	propertiesURL,
 }) {
-	State.write(propertiesAtom, initialProperties || []);
-
 	const mapDDMStructures = {};
 
 	const assetMultipleSelector = document.getElementById(
@@ -72,18 +70,10 @@ export default function ({
 	const eventDelegates = [];
 
 	/**
-	 * Refetches the filterable properties using `propertiesURL` upon
-	 * changes to the asset source (type / subtype selectors) and writes
-	 * the result to `propertiesAtom`.
-	 *
-	 * CollectionFilterBuilder and CollectionOrdering React components
-	 * subscribe to that atom via `useTypeProperties`.
+	 * Reads the currently selected asset type(s) and subtype(s) from the
+	 * source panel selectors.
 	 */
-	const refreshProperties = () => {
-		if (!propertiesURL) {
-			return;
-		}
-
+	const getSelectedIds = () => {
 		const assetTypeValue = assetSelector?.value || '';
 
 		let classNameIds = [];
@@ -136,6 +126,39 @@ export default function ({
 			}
 		}
 
+		return {classNameIds, classTypeIds};
+	};
+
+	/**
+	 * When more than one asset type or subtype is selected, the per-type field
+	 * groups can collide, so expose only the first "Common Fields" group
+	 * shared across every type.
+	 */
+	const collapseToCommonFields = (groups, {classNameIds, classTypeIds}) =>
+		classNameIds.length > 1 || classTypeIds.length > 1
+			? groups.slice(0, 1)
+			: groups;
+
+	State.write(
+		propertiesAtom,
+		collapseToCommonFields(initialProperties || [], getSelectedIds())
+	);
+
+	/**
+	 * Refetches the filterable properties using `propertiesURL` upon
+	 * changes to the asset source (type / subtype selectors) and writes
+	 * the result to `propertiesAtom`.
+	 *
+	 * CollectionFilterBuilder and CollectionOrdering React components
+	 * subscribe to that atom via `useTypeProperties`.
+	 */
+	const refreshProperties = () => {
+		if (!propertiesURL) {
+			return;
+		}
+
+		const {classNameIds, classTypeIds} = getSelectedIds();
+
 		fetch(
 			addParams(
 				{
@@ -146,7 +169,15 @@ export default function ({
 			)
 		)
 			.then((response) => response.json())
-			.then((data) => State.write(propertiesAtom, data || []))
+			.then((data) =>
+				State.write(
+					propertiesAtom,
+					collapseToCommonFields(data || [], {
+						classNameIds,
+						classTypeIds,
+					})
+				)
+			)
 			.catch((error) => {
 				if (process.env.NODE_ENV === 'development') {
 					console.error('Failed to fetch type properties: ', error);

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionFilterBuilder/index.tsx
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionFilterBuilder/index.tsx
@@ -191,7 +191,7 @@ export default function CollectionFilterBuilder({
 
 					<pre
 						style={{
-							border: '1px #f5f5f5 dashed',
+							background: 'var(--gray-100)',
 							borderRadius: 4,
 							fontSize: 11,
 							marginTop: 8,

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionFilterBuilder/index.tsx
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionFilterBuilder/index.tsx
@@ -191,7 +191,7 @@ export default function CollectionFilterBuilder({
 
 					<pre
 						style={{
-							background: '#f5f5f5',
+							border: '1px #f5f5f5 dashed',
 							borderRadius: 4,
 							fontSize: 11,
 							marginTop: 8,

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
@@ -188,7 +188,7 @@ function OrderByField({
 
 						<pre
 							style={{
-								border: '1px #f5f5f5 dashed',
+								background: 'var(--gray-100)',
 								borderRadius: 4,
 								fontSize: 11,
 								marginTop: 8,
@@ -206,7 +206,7 @@ function OrderByField({
 
 						<pre
 							style={{
-								border: '1px #f5f5f5 dashed',
+								background: 'var(--gray-100)',
 								borderRadius: 4,
 								fontSize: 11,
 								marginTop: 8,

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
@@ -188,7 +188,7 @@ function OrderByField({
 
 						<pre
 							style={{
-								background: '#f5f5f5',
+								border: '1px #f5f5f5 dashed',
 								borderRadius: 4,
 								fontSize: 11,
 								marginTop: 8,
@@ -206,7 +206,7 @@ function OrderByField({
 
 						<pre
 							style={{
-								background: '#f5f5f5',
+								border: '1px #f5f5f5 dashed',
 								borderRadius: 4,
 								fontSize: 11,
 								marginTop: 8,


### PR DESCRIPTION
Continuation of https://github.com/liferay-search/liferay-portal/pull/1948

https://liferay.atlassian.net/browse/LPD-78170 - Order by CMS and Site scope Object fields in Dynamic Collections

Changes are behind the feature flag
`feature.flag.LPD-74731=true`

## What is Being Updated
  - Shows the filter UI only when a CMS item type is selected OR when the "Select Types" or "All Types" option is chosen on the Source side.
  - Limits the whole list of properties to only "Common Fields" when there's more than one type/subtype selected.
  - Simple update to the debugger UI, after theme changes

<img width="789" height="1075" alt="Screenshot 2026-06-09 at 9 15 33 AM" src="https://github.com/user-attachments/assets/a13052f1-4ff0-4296-8c26-c8e056f712ba" />

## PR Check

**pr-check: PASS** — tested on `81238b025de6b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| JavaScript Unit Tests | PASS |
| JSP Compile | PASS |
| Per-Module Deploy | PASS |

<!-- pr-check {"result": "success", "sha": "81238b025de6b0f5480df64c3aa8dd470edb5ded"} -->