### PR TITLE
LPD-93566 Preserve legacy multiselect field mappings during upgrade

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v3_1_3/SXPBlueprintAndSXPElementUpgradeProcess.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/upgrade/v3_1_3/SXPBlueprintAndSXPElementUpgradeProcess.java
@@ -146,86 +146,31 @@ public class SXPBlueprintAndSXPElementUpgradeProcess extends UpgradeProcess {
 		return false;
 	}
 
-	private boolean _removeLegacyFieldMappingLabels(
-		JSONArray elementInstanceJSONArray) {
+	private boolean _isLegacyMultiselectFieldMappings(
+		JSONArray fieldMappingsJSONArray) {
 
-		boolean changed = false;
+		boolean legacyMultiselect = false;
 
-		for (int i = 0; i < elementInstanceJSONArray.length(); i++) {
-			JSONObject elementDefinitionJSONObject =
-				JSONUtil.getValueAsJSONObject(
-					elementInstanceJSONArray.getJSONObject(i),
-					"JSONObject/sxpElement", "JSONObject/elementDefinition");
+		for (int i = 0; i < fieldMappingsJSONArray.length(); i++) {
+			JSONObject fieldMappingJSONObject =
+				fieldMappingsJSONArray.getJSONObject(i);
 
-			if (elementDefinitionJSONObject == null) {
+			if (fieldMappingJSONObject == null) {
 				continue;
 			}
 
-			if (_removeLegacyFieldMappingLabels(elementDefinitionJSONObject)) {
-				changed = true;
+			if (fieldMappingJSONObject.has("field")) {
+				return false;
+			}
+
+			if (fieldMappingJSONObject.has("label") ||
+				fieldMappingJSONObject.has("value")) {
+
+				legacyMultiselect = true;
 			}
 		}
 
-		return changed;
-	}
-
-	private boolean _removeLegacyFieldMappingLabels(
-		JSONObject elementDefinitionJSONObject) {
-
-		JSONArray fieldSetsJSONArray = JSONUtil.getValueAsJSONArray(
-			elementDefinitionJSONObject, "JSONObject/uiConfiguration",
-			"JSONArray/fieldSets");
-
-		if (fieldSetsJSONArray == null) {
-			return false;
-		}
-
-		boolean changed = false;
-
-		for (int i = 0; i < fieldSetsJSONArray.length(); i++) {
-			JSONObject fieldSetJSONObject = fieldSetsJSONArray.getJSONObject(i);
-
-			if (fieldSetJSONObject == null) {
-				continue;
-			}
-
-			JSONArray fieldsJSONArray = fieldSetJSONObject.getJSONArray(
-				"fields");
-
-			if (fieldsJSONArray == null) {
-				continue;
-			}
-
-			for (int j = 0; j < fieldsJSONArray.length(); j++) {
-				JSONObject fieldJSONObject = fieldsJSONArray.getJSONObject(j);
-
-				if (fieldJSONObject == null) {
-					continue;
-				}
-
-				JSONArray fieldMappingsJSONArray = fieldJSONObject.getJSONArray(
-					"fieldMappings");
-
-				if (fieldMappingsJSONArray == null) {
-					continue;
-				}
-
-				for (int k = 0; k < fieldMappingsJSONArray.length(); k++) {
-					JSONObject fieldMappingJSONObject =
-						fieldMappingsJSONArray.getJSONObject(k);
-
-					if ((fieldMappingJSONObject != null) &&
-						fieldMappingJSONObject.has("label")) {
-
-						fieldMappingJSONObject.remove("label");
-
-						changed = true;
-					}
-				}
-			}
-		}
-
-		return changed;
+		return legacyMultiselect;
 	}
 
 	private void _upgradeConfigurationEntry(
@@ -303,6 +248,100 @@ public class SXPBlueprintAndSXPElementUpgradeProcess extends UpgradeProcess {
 		}
 	}
 
+	private boolean _upgradeLegacyFieldMappings(
+		JSONArray elementInstanceJSONArray) {
+
+		boolean changed = false;
+
+		for (int i = 0; i < elementInstanceJSONArray.length(); i++) {
+			JSONObject elementDefinitionJSONObject =
+				JSONUtil.getValueAsJSONObject(
+					elementInstanceJSONArray.getJSONObject(i),
+					"JSONObject/sxpElement", "JSONObject/elementDefinition");
+
+			if (elementDefinitionJSONObject == null) {
+				continue;
+			}
+
+			if (_upgradeLegacyFieldMappings(elementDefinitionJSONObject)) {
+				changed = true;
+			}
+		}
+
+		return changed;
+	}
+
+	private boolean _upgradeLegacyFieldMappings(
+		JSONObject elementDefinitionJSONObject) {
+
+		JSONArray fieldSetsJSONArray = JSONUtil.getValueAsJSONArray(
+			elementDefinitionJSONObject, "JSONObject/uiConfiguration",
+			"JSONArray/fieldSets");
+
+		if (fieldSetsJSONArray == null) {
+			return false;
+		}
+
+		boolean changed = false;
+
+		for (int i = 0; i < fieldSetsJSONArray.length(); i++) {
+			JSONObject fieldSetJSONObject = fieldSetsJSONArray.getJSONObject(i);
+
+			if (fieldSetJSONObject == null) {
+				continue;
+			}
+
+			JSONArray fieldsJSONArray = fieldSetJSONObject.getJSONArray(
+				"fields");
+
+			if (fieldsJSONArray == null) {
+				continue;
+			}
+
+			for (int j = 0; j < fieldsJSONArray.length(); j++) {
+				JSONObject fieldJSONObject = fieldsJSONArray.getJSONObject(j);
+
+				if (fieldJSONObject == null) {
+					continue;
+				}
+
+				JSONArray fieldMappingsJSONArray = fieldJSONObject.getJSONArray(
+					"fieldMappings");
+
+				if (fieldMappingsJSONArray == null) {
+					continue;
+				}
+
+				if (_isLegacyMultiselectFieldMappings(fieldMappingsJSONArray)) {
+					fieldJSONObject.put(
+						"defaultValue", fieldMappingsJSONArray
+					).remove(
+						"fieldMappings"
+					);
+
+					changed = true;
+
+					continue;
+				}
+
+				for (int k = 0; k < fieldMappingsJSONArray.length(); k++) {
+					JSONObject fieldMappingJSONObject =
+						fieldMappingsJSONArray.getJSONObject(k);
+
+					if ((fieldMappingJSONObject != null) &&
+						fieldMappingJSONObject.has("label")) {
+
+						fieldMappingJSONObject.remove("label");
+
+						changed = true;
+					}
+				}
+			}
+		}
+
+		return changed;
+	}
+
 	private void _upgradeSXPBlueprint(
 			PreparedStatement preparedStatement2, ResultSet resultSet)
 		throws SQLException {
@@ -320,7 +359,7 @@ public class SXPBlueprintAndSXPElementUpgradeProcess extends UpgradeProcess {
 			JSONArray elementInstanceJSONArray = _jsonFactory.createJSONArray(
 				elementInstancesJSON);
 
-			boolean changed = _removeLegacyFieldMappingLabels(
+			boolean changed = _upgradeLegacyFieldMappings(
 				elementInstanceJSONArray);
 
 			if (_hasLimitSearchToTheseSites(elementInstanceJSONArray)) {
@@ -368,7 +407,7 @@ public class SXPBlueprintAndSXPElementUpgradeProcess extends UpgradeProcess {
 			JSONObject elementDefinitionJSONObject =
 				_jsonFactory.createJSONObject(elementDefinitionJSON);
 
-			if (!_removeLegacyFieldMappingLabels(elementDefinitionJSONObject)) {
+			if (!_upgradeLegacyFieldMappings(elementDefinitionJSONObject)) {
 				return;
 			}
 

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/upgrade/v3_1_3/test/SXPBlueprintAndSXPElementUpgradeProcessTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/upgrade/v3_1_3/test/SXPBlueprintAndSXPElementUpgradeProcessTest.java
@@ -9,6 +9,8 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -151,6 +153,45 @@ public class SXPBlueprintAndSXPElementUpgradeProcessTest {
 	}
 
 	@Test
+	public void testUpgradeDoesNotMoveMixedFieldMappingsToDefaultValue()
+		throws Exception {
+
+		String field = RandomTestUtil.randomString();
+		String name = RandomTestUtil.randomString();
+		String type = RandomTestUtil.randomString();
+		String value = RandomTestUtil.randomString();
+
+		_assertUpgradeField(
+			JSONUtil.put(
+				"fieldMappings",
+				JSONUtil.putAll(
+					JSONUtil.put("value", value), JSONUtil.put("field", field))
+			).put(
+				"name", name
+			).put(
+				"type", type
+			),
+			JSONUtil.put(
+				"fieldMappings",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"label", RandomTestUtil.randomString()
+					).put(
+						"value", value
+					),
+					JSONUtil.put(
+						"field", field
+					).put(
+						"label", RandomTestUtil.randomString()
+					))
+			).put(
+				"name", name
+			).put(
+				"type", type
+			));
+	}
+
+	@Test
 	public void testUpgradeHandlesLegacyFieldMappingLabel() throws Exception {
 		String elementDefinitionJSON = _readJSON(
 			"legacyFieldMappingLabelElementDefinition");
@@ -209,6 +250,69 @@ public class SXPBlueprintAndSXPElementUpgradeProcessTest {
 	}
 
 	@Test
+	public void testUpgradeLeavesFieldMappingListUnchanged() throws Exception {
+		JSONObject fieldJSONObject = JSONUtil.put(
+			"fieldMappings",
+			JSONUtil.putAll(
+				JSONUtil.put(
+					"boost", RandomTestUtil.randomInt()
+				).put(
+					"field", RandomTestUtil.randomString()
+				).put(
+					"locale", RandomTestUtil.randomString()
+				),
+				JSONUtil.put(
+					"boost", RandomTestUtil.randomInt()
+				).put(
+					"field", RandomTestUtil.randomString()
+				).put(
+					"locale", RandomTestUtil.randomString()
+				))
+		).put(
+			"name", RandomTestUtil.randomString()
+		).put(
+			"type", RandomTestUtil.randomString()
+		);
+
+		_assertUpgradeField(fieldJSONObject, fieldJSONObject);
+	}
+
+	@Test
+	public void testUpgradeMovesLegacyMultiselectFieldMappingsToDefaultValue()
+		throws Exception {
+
+		JSONArray fieldMappingsJSONArray = JSONUtil.putAll(
+			JSONUtil.put(
+				"label", RandomTestUtil.randomString()
+			).put(
+				"value", RandomTestUtil.randomString()
+			),
+			JSONUtil.put(
+				"label", RandomTestUtil.randomString()
+			).put(
+				"value", RandomTestUtil.randomString()
+			));
+		String name = RandomTestUtil.randomString();
+		String type = RandomTestUtil.randomString();
+
+		_assertUpgradeField(
+			JSONUtil.put(
+				"defaultValue", fieldMappingsJSONArray
+			).put(
+				"name", name
+			).put(
+				"type", type
+			),
+			JSONUtil.put(
+				"fieldMappings", fieldMappingsJSONArray
+			).put(
+				"name", name
+			).put(
+				"type", type
+			));
+	}
+
+	@Test
 	public void testUpgradeSXPBlueprintWithUnknownLegacyField()
 		throws Exception {
 
@@ -247,6 +351,78 @@ public class SXPBlueprintAndSXPElementUpgradeProcessTest {
 			JSONCompareMode.STRICT);
 	}
 
+	private void _assertUpgradeField(
+			JSONObject expectedFieldJSONObject, JSONObject fieldJSONObject)
+		throws Exception {
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		JSONArray elementInstancesJSONArray = _toElementInstancesJSONArray(
+			externalReferenceCode, fieldJSONObject);
+
+		String elementInstancesJSON = elementInstancesJSONArray.toString();
+
+		Assert.assertNotNull(
+			ElementInstanceUtil.toElementInstances(elementInstancesJSON));
+
+		SXPBlueprint sxpBlueprint = _sxpBlueprintLocalService.addSXPBlueprint(
+			null, TestPropsValues.getUserId(), StringPool.BLANK,
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			StringPool.BLANK, SXPBlueprintConstants.SCHEMA_VERSION,
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			ServiceContextTestUtil.getServiceContext(
+				_group1, TestPropsValues.getUserId()));
+
+		sxpBlueprint.setElementInstancesJSON(elementInstancesJSON);
+
+		sxpBlueprint = _sxpBlueprintLocalService.updateSXPBlueprint(
+			sxpBlueprint);
+
+		SXPElement sxpElement = _sxpElementLocalService.addSXPElement(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			Collections.singletonMap(LocaleUtil.US, StringPool.BLANK),
+			_getElementDefinitionJSON(elementInstancesJSONArray),
+			StringPool.BLANK, StringPool.BLANK, true, StringPool.BLANK,
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			0,
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getCompanyId(), TestPropsValues.getGroupId(),
+				TestPropsValues.getUserId()));
+
+		_runUpgrade();
+
+		JSONArray expectedElementInstancesJSONArray =
+			_toElementInstancesJSONArray(
+				externalReferenceCode, expectedFieldJSONObject);
+
+		sxpBlueprint = _sxpBlueprintLocalService.fetchSXPBlueprint(
+			sxpBlueprint.getSXPBlueprintId());
+
+		JSONAssert.assertEquals(
+			expectedElementInstancesJSONArray.toString(),
+			sxpBlueprint.getElementInstancesJSON(), JSONCompareMode.STRICT);
+
+		sxpElement = _sxpElementLocalService.fetchSXPElement(
+			sxpElement.getSXPElementId());
+
+		JSONAssert.assertEquals(
+			_getElementDefinitionJSON(expectedElementInstancesJSONArray),
+			sxpElement.getElementDefinitionJSON(), JSONCompareMode.STRICT);
+	}
+
+	private String _getElementDefinitionJSON(
+		JSONArray elementInstancesJSONArray) {
+
+		JSONObject elementDefinitionJSONObject = JSONUtil.getValueAsJSONObject(
+			elementInstancesJSONArray.getJSONObject(0), "JSONObject/sxpElement",
+			"JSONObject/elementDefinition");
+
+		return elementDefinitionJSONObject.toString();
+	}
+
 	private String _readJSON(String name) {
 		return StringUtil.read(
 			_clazz,
@@ -264,6 +440,26 @@ public class SXPBlueprintAndSXPElementUpgradeProcessTest {
 		upgradeProcess.upgrade();
 
 		_multiVMPool.clear();
+	}
+
+	private JSONArray _toElementInstancesJSONArray(
+		String externalReferenceCode, JSONObject fieldJSONObject) {
+
+		return JSONUtil.put(
+			JSONUtil.put(
+				"sxpElement",
+				JSONUtil.put(
+					"elementDefinition",
+					JSONUtil.put(
+						"uiConfiguration",
+						JSONUtil.put(
+							"fieldSets",
+							JSONUtil.put(
+								JSONUtil.put(
+									"fields", JSONUtil.put(fieldJSONObject)))))
+				).put(
+					"externalReferenceCode", externalReferenceCode
+				)));
 	}
 
 	private final Class<?> _clazz = getClass();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93566

## Root Cause
The v3_1_1 upgrade renamed every array-valued "defaultValue" to "fieldMappings" without checking the field type, wrongly sweeping up multiselect options ({label, value} pairs). The v3.1.3 label removal then treated those misfiled options as real field mappings and stripped them, collapsing the multiselect's selected values. This moves multiselect arrays back to defaultValue before the label removal runs.

## What Is Being Fixed

Legacy multiselect configuration fields stored their selected options as label and value pairs inside the field's `fieldMappings` array. During the v3.1.3 search experiences upgrade those pairs were lost: the upgrade only stripped stray `label` keys, and because `fieldMappings` deserializes through the `FieldMapping` model (which recognizes only `field`, `boost`, and `locale`), every label and value pair collapsed to an empty object, leaving `"fieldMappings": [{}, {}, {}, {}]`.

## How It Is Being Fixed

The upgrade now detects when a field's `fieldMappings` array holds multiselect label and value pairs rather than real field mappings (no `field` key present) and moves the whole array to the field's `defaultValue`, removing the `fieldMappings` key. This matches where the editor reads multiselect values from, so the selected options survive the upgrade. Fields with genuine field mappings keep the existing label-removal behavior. The change applies to both stored blueprints and SXP element definitions, and an integration test covers the multiselect case end to end.