### PR TITLE
LPD-95234 LPD-95236 Fix search widget locator and add Region label

### DIFF
--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -12641,6 +12641,7 @@ model.resource.com.liferay.portal.kernel.model.Phone=Phone
 model.resource.com.liferay.portal.kernel.model.Portlet=Portlet
 model.resource.com.liferay.portal.kernel.model.PortletPreferenceValue=Portlet Preference Value
 model.resource.com.liferay.portal.kernel.model.PortletPreferences=Asset Publisher
+model.resource.com.liferay.portal.kernel.model.Region=Region
 model.resource.com.liferay.portal.kernel.model.Repository=Repository
 model.resource.com.liferay.portal.kernel.model.ResourcePermission=Permissions
 model.resource.com.liferay.portal.kernel.model.Role=Role

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/search/Search.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/search/Search.path
@@ -12,7 +12,7 @@
 <tbody>
 <tr>
 	<td>ADD_PORTLET_LINK</td>
-	<td>//button[contains(.,'Search')]/following-sibling::div//div[contains(@class,'item-body')]//*[normalize-space(text())='${key_portletName}']/../../..//button[contains(@class,'item-add')]</td>
+	<td>//button[contains(.,'Search')]/following-sibling::div//div[contains(@class,'item-body')]//*[normalize-space(text())='${key_portletName}']/../../../..//button[contains(@class,'item-add')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95234 - Element is not present at "//button[contains(.,'Search')]/following-sibling::div//div[contains(@class,'item-body')]//*[normalize... [Functional] (search)
https://liferay.atlassian.net/browse/LPD-95236 - model.resource.com.liferay.portal.kernel.model.Region should have human-readable label [Functional] (search) (playwright)

## What Is Being Fixed

- A functional (Poshi) test fails with "Element is not present" when adding the Search widget — the `ADD_PORTLET_LINK` XPath locator no longer matches the current widget-selector DOM structure (LPD-95234).
- The `Region` model resource has no human-readable label, so it surfaces as the raw model class name in permission and UI contexts (LPD-95236).

## How It Is Being Fixed

- Update the `ADD_PORTLET_LINK` locator in `Search.path` to traverse one additional ancestor level (`/../../..` → `/../../../..`) so it resolves the add button against the current `item-body` markup.
- Add `model.resource.com.liferay.portal.kernel.model.Region=Region` to `Language.properties`, in alphabetical order.

## Why Are There No Tests?

- These changes are a language-key addition and a Poshi locator correction (test infrastructure); neither introduces production logic that can be unit- or integration-tested. The locator fix is itself what makes the existing functional test pass.

## PR Check

**pr-check: PASS** — tested on `55335d649986de1f949eb9603a42ebd06c625979`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "55335d649986de1f949eb9603a42ebd06c625979"} -->
