### PR TITLE
LPD-93311 Add SEO configuration to the Custom Filter widget

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/portlet/CustomFilterPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/portlet/CustomFilterPortlet.java
@@ -5,9 +5,11 @@
 
 package com.liferay.portal.search.web.internal.custom.filter.portlet;
 
+import com.liferay.layout.seo.provider.LayoutSEOMetaRobotsProvider;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.searcher.SearchRequest;
 import com.liferay.portal.search.searcher.SearchResponse;
@@ -61,6 +63,13 @@ public class CustomFilterPortlet extends MVCPortlet {
 	public void render(
 			RenderRequest renderRequest, RenderResponse renderResponse)
 		throws IOException, PortletException {
+
+		String metaRobotsContent = _layoutSEOMetaRobotsProvider.getContent(
+			renderRequest);
+
+		if (Validator.isNotNull(metaRobotsContent)) {
+			renderRequest.setAttribute(WebKeys.PAGE_ROBOTS, metaRobotsContent);
+		}
 
 		PortletSharedSearchResponse portletSharedSearchResponse =
 			portletSharedSearchRequest.search(renderRequest);
@@ -166,5 +175,11 @@ public class CustomFilterPortlet extends MVCPortlet {
 
 		return false;
 	}
+
+	@Reference(
+		target = "(jakarta.portlet.name=" + CustomFilterPortletKeys.CUSTOM_FILTER + ")",
+		unbind = "-"
+	)
+	private LayoutSEOMetaRobotsProvider _layoutSEOMetaRobotsProvider;
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/portlet/CustomFilterPortletPreferences.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/portlet/CustomFilterPortletPreferences.java
@@ -5,11 +5,13 @@
 
 package com.liferay.portal.search.web.internal.custom.filter.portlet;
 
+import com.liferay.portal.search.web.internal.seo.SEOPortletPreferences;
+
 /**
  * @author Igor Nazar
  * @author Luan Maoski
  */
-public interface CustomFilterPortletPreferences {
+public interface CustomFilterPortletPreferences extends SEOPortletPreferences {
 
 	public static final String PREFERENCE_KEY_BOOST = "boost";
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/portlet/CustomFilterPortletPreferencesImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/portlet/CustomFilterPortletPreferencesImpl.java
@@ -6,7 +6,9 @@
 package com.liferay.portal.search.web.internal.custom.filter.portlet;
 
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.web.internal.portlet.preferences.BasePortletPreferences;
+import com.liferay.portal.search.web.internal.seo.SEOPortletPreferences;
 
 import jakarta.portlet.PortletPreferences;
 
@@ -93,6 +95,17 @@ public class CustomFilterPortletPreferencesImpl
 	}
 
 	@Override
+	public String getSEOParameterName() {
+		String parameterName = getParameterName();
+
+		if (Validator.isNull(parameterName)) {
+			return getFilterField();
+		}
+
+		return parameterName;
+	}
+
+	@Override
 	public boolean isDisabled() {
 		return getBoolean(
 			CustomFilterPortletPreferences.PREFERENCE_KEY_DISABLED, false);
@@ -108,6 +121,13 @@ public class CustomFilterPortletPreferencesImpl
 	public boolean isInvisible() {
 		return getBoolean(
 			CustomFilterPortletPreferences.PREFERENCE_KEY_INVISIBLE, false);
+	}
+
+	@Override
+	public boolean isWebCrawlerIndexingEnabled() {
+		return getBoolean(
+			SEOPortletPreferences.PREFERENCE_KEY_WEB_CRAWLER_INDEXING_ENABLED,
+			true);
 	}
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/portlet/seo/CustomFilterPortletLayoutSEOCanonicalURLContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/portlet/seo/CustomFilterPortletLayoutSEOCanonicalURLContributor.java
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.custom.filter.portlet.seo;
+
+import com.liferay.layout.seo.contributor.LayoutSEOCanonicalURLContributor;
+import com.liferay.portal.search.web.internal.custom.filter.constants.CustomFilterPortletKeys;
+import com.liferay.portal.search.web.internal.custom.filter.portlet.CustomFilterPortletPreferencesImpl;
+import com.liferay.portal.search.web.internal.seo.BasePortletLayoutSEOCanonicalURLContributor;
+import com.liferay.portal.search.web.internal.seo.SEOPortletPreferences;
+
+import jakarta.portlet.PortletPreferences;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Amos Fong
+ */
+@Component(
+	property = "jakarta.portlet.name=" + CustomFilterPortletKeys.CUSTOM_FILTER,
+	service = LayoutSEOCanonicalURLContributor.class
+)
+public class CustomFilterPortletLayoutSEOCanonicalURLContributor
+	extends BasePortletLayoutSEOCanonicalURLContributor {
+
+	@Override
+	protected SEOPortletPreferences getSEOPortletPreferences(
+		PortletPreferences portletPreferences) {
+
+		return new CustomFilterPortletPreferencesImpl(portletPreferences);
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/portlet/seo/CustomFilterPortletLayoutSEOMetaRobotsProvider.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/portlet/seo/CustomFilterPortletLayoutSEOMetaRobotsProvider.java
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.custom.filter.portlet.seo;
+
+import com.liferay.layout.seo.provider.LayoutSEOMetaRobotsProvider;
+import com.liferay.portal.search.web.internal.custom.filter.constants.CustomFilterPortletKeys;
+import com.liferay.portal.search.web.internal.custom.filter.portlet.CustomFilterPortletPreferencesImpl;
+import com.liferay.portal.search.web.internal.seo.BasePortletLayoutSEOMetaRobotsProvider;
+import com.liferay.portal.search.web.internal.seo.SEOPortletPreferences;
+
+import jakarta.portlet.PortletPreferences;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Amos Fong
+ */
+@Component(
+	property = "jakarta.portlet.name=" + CustomFilterPortletKeys.CUSTOM_FILTER,
+	service = LayoutSEOMetaRobotsProvider.class
+)
+public class CustomFilterPortletLayoutSEOMetaRobotsProvider
+	extends BasePortletLayoutSEOMetaRobotsProvider {
+
+	@Override
+	protected SEOPortletPreferences getSEOPortletPreferences(
+		PortletPreferences portletPreferences) {
+
+		return new CustomFilterPortletPreferencesImpl(portletPreferences);
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/portlet/seo/CustomFilterPortletLayoutSetSEORobotsContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/portlet/seo/CustomFilterPortletLayoutSetSEORobotsContributor.java
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.custom.filter.portlet.seo;
+
+import com.liferay.layout.seo.contributor.LayoutSetSEORobotsContributor;
+import com.liferay.portal.search.web.internal.custom.filter.constants.CustomFilterPortletKeys;
+import com.liferay.portal.search.web.internal.custom.filter.portlet.CustomFilterPortletPreferencesImpl;
+import com.liferay.portal.search.web.internal.seo.BasePortletLayoutSetSEORobotsContributor;
+import com.liferay.portal.search.web.internal.seo.SEOPortletPreferences;
+
+import jakarta.portlet.PortletPreferences;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Amos Fong
+ */
+@Component(
+	property = "jakarta.portlet.name=" + CustomFilterPortletKeys.CUSTOM_FILTER,
+	service = LayoutSetSEORobotsContributor.class
+)
+public class CustomFilterPortletLayoutSetSEORobotsContributor
+	extends BasePortletLayoutSetSEORobotsContributor {
+
+	@Override
+	protected String getPortletId() {
+		return CustomFilterPortletKeys.CUSTOM_FILTER;
+	}
+
+	@Override
+	protected SEOPortletPreferences getSEOPortletPreferences(
+		PortletPreferences portletPreferences) {
+
+		return new CustomFilterPortletPreferencesImpl(portletPreferences);
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/filter/configuration.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/filter/configuration.jsp
@@ -5,6 +5,8 @@
  */
 --%>
 
+<%@ taglib uri="jakarta.tags.core" prefix="c" %>
+
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
@@ -13,7 +15,8 @@ taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/template" prefix="liferay-template" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
-<%@ page import="com.liferay.portal.kernel.util.Constants" %><%@
+<%@ page import="com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil" %><%@
+page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.portal.search.web.internal.custom.filter.configuration.CustomFilterPortletInstanceConfiguration" %><%@
 page import="com.liferay.portal.search.web.internal.custom.filter.constants.CustomFilterPortletKeys" %><%@
@@ -130,6 +133,15 @@ CustomFilterPortletInstanceConfiguration customFilterPortletInstanceConfiguratio
 
 			<aui:input helpMessage="enter-the-key-of-an-alternate-search-this-widget-is-participating-on-if-not-set-widget-participates-on-default-search" label="federated-search-key" name="<%= PortletPreferencesJspUtil.getInputName(CustomFilterPortletPreferences.PREFERENCE_KEY_FEDERATED_SEARCH_KEY) %>" type="text" value="<%= customFilterPortletPreferences.getFederatedSearchKey() %>" />
 		</liferay-frontend:fieldset>
+
+		<c:if test='<%= FeatureFlagManagerUtil.isEnabled("LPD-71164") %>'>
+			<liferay-frontend:fieldset
+				collapsible="<%= true %>"
+				label="seo-configuration"
+			>
+				<aui:input helpMessage="enable-web-crawler-indexing-help" label="enable-web-crawler-indexing" name="<%= PortletPreferencesJspUtil.getInputName(CustomFilterPortletPreferences.PREFERENCE_KEY_WEB_CRAWLER_INDEXING_ENABLED) %>" type="checkbox" value="<%= customFilterPortletPreferences.isWebCrawlerIndexingEnabled() %>" />
+			</liferay-frontend:fieldset>
+		</c:if>
 	</liferay-frontend:edit-form-body>
 
 	<liferay-frontend:edit-form-footer>

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/facet/portlet/CustomFacetPortletPreferencesImplTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/facet/portlet/CustomFacetPortletPreferencesImplTest.java
@@ -34,12 +34,12 @@ public class CustomFacetPortletPreferencesImplTest {
 
 		_mockValue(
 			portletPreferences,
-			CustomFacetPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
-			StringPool.BLANK);
-		_mockValue(
-			portletPreferences,
 			CustomFacetPortletPreferences.PREFERENCE_KEY_AGGREGATION_FIELD,
 			"userName");
+		_mockValue(
+			portletPreferences,
+			CustomFacetPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
+			StringPool.BLANK);
 
 		Assert.assertEquals(
 			"userName",
@@ -55,12 +55,12 @@ public class CustomFacetPortletPreferencesImplTest {
 
 		_mockValue(
 			portletPreferences,
-			CustomFacetPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
-			"customParameter");
-		_mockValue(
-			portletPreferences,
 			CustomFacetPortletPreferences.PREFERENCE_KEY_AGGREGATION_FIELD,
 			"userName");
+		_mockValue(
+			portletPreferences,
+			CustomFacetPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
+			"customParameter");
 
 		Assert.assertEquals(
 			"customParameter",

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/facet/portlet/CustomFacetPortletPreferencesImplTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/facet/portlet/CustomFacetPortletPreferencesImplTest.java
@@ -34,19 +34,18 @@ public class CustomFacetPortletPreferencesImplTest {
 			PortletPreferences.class);
 
 		_mockValue(
-			portletPreferences,
 			CustomFacetPortletPreferences.PREFERENCE_KEY_AGGREGATION_FIELD,
-			"userName");
+			portletPreferences, "userName");
 		_mockValue(
-			portletPreferences,
 			CustomFacetPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
-			StringPool.BLANK);
+			portletPreferences, StringPool.BLANK);
+
+		CustomFacetPortletPreferencesImpl customFacetPortletPreferencesImpl =
+			new CustomFacetPortletPreferencesImpl(portletPreferences);
 
 		Assert.assertEquals(
 			"userName",
-			new CustomFacetPortletPreferencesImpl(
-				portletPreferences
-			).getSEOParameterName());
+			customFacetPortletPreferencesImpl.getSEOParameterName());
 	}
 
 	@Test
@@ -55,23 +54,22 @@ public class CustomFacetPortletPreferencesImplTest {
 			PortletPreferences.class);
 
 		_mockValue(
-			portletPreferences,
 			CustomFacetPortletPreferences.PREFERENCE_KEY_AGGREGATION_FIELD,
-			RandomTestUtil.randomString());
+			portletPreferences, RandomTestUtil.randomString());
 		_mockValue(
-			portletPreferences,
 			CustomFacetPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
-			"customParameter");
+			portletPreferences, "customParameter");
+
+		CustomFacetPortletPreferencesImpl customFacetPortletPreferencesImpl =
+			new CustomFacetPortletPreferencesImpl(portletPreferences);
 
 		Assert.assertEquals(
 			"customParameter",
-			new CustomFacetPortletPreferencesImpl(
-				portletPreferences
-			).getSEOParameterName());
+			customFacetPortletPreferencesImpl.getSEOParameterName());
 	}
 
 	private void _mockValue(
-		PortletPreferences portletPreferences, String key, String value) {
+		String key, PortletPreferences portletPreferences, String value) {
 
 		Mockito.when(
 			portletPreferences.getValue(key, StringPool.BLANK)

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/facet/portlet/CustomFacetPortletPreferencesImplTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/facet/portlet/CustomFacetPortletPreferencesImplTest.java
@@ -7,6 +7,7 @@ package com.liferay.portal.search.web.internal.custom.facet.portlet;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.search.web.internal.seo.SEOPortletPreferences;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import jakarta.portlet.PortletPreferences;
@@ -40,12 +41,12 @@ public class CustomFacetPortletPreferencesImplTest {
 			CustomFacetPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
 			portletPreferences, StringPool.BLANK);
 
-		CustomFacetPortletPreferencesImpl customFacetPortletPreferencesImpl =
+		SEOPortletPreferences seoPortletPreferences =
 			new CustomFacetPortletPreferencesImpl(portletPreferences);
 
 		Assert.assertEquals(
 			"userName",
-			customFacetPortletPreferencesImpl.getSEOParameterName());
+			seoPortletPreferences.getSEOParameterName());
 	}
 
 	@Test
@@ -60,12 +61,12 @@ public class CustomFacetPortletPreferencesImplTest {
 			CustomFacetPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
 			portletPreferences, "customParameter");
 
-		CustomFacetPortletPreferencesImpl customFacetPortletPreferencesImpl =
+		SEOPortletPreferences seoPortletPreferences =
 			new CustomFacetPortletPreferencesImpl(portletPreferences);
 
 		Assert.assertEquals(
 			"customParameter",
-			customFacetPortletPreferencesImpl.getSEOParameterName());
+			seoPortletPreferences.getSEOParameterName());
 	}
 
 	private void _mockValue(

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/facet/portlet/CustomFacetPortletPreferencesImplTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/facet/portlet/CustomFacetPortletPreferencesImplTest.java
@@ -45,8 +45,7 @@ public class CustomFacetPortletPreferencesImplTest {
 			new CustomFacetPortletPreferencesImpl(portletPreferences);
 
 		Assert.assertEquals(
-			"userName",
-			seoPortletPreferences.getSEOParameterName());
+			"userName", seoPortletPreferences.getSEOParameterName());
 	}
 
 	@Test
@@ -65,8 +64,7 @@ public class CustomFacetPortletPreferencesImplTest {
 			new CustomFacetPortletPreferencesImpl(portletPreferences);
 
 		Assert.assertEquals(
-			"customParameter",
-			seoPortletPreferences.getSEOParameterName());
+			"customParameter", seoPortletPreferences.getSEOParameterName());
 	}
 
 	private void _mockValue(

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/facet/portlet/CustomFacetPortletPreferencesImplTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/facet/portlet/CustomFacetPortletPreferencesImplTest.java
@@ -1,0 +1,82 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.custom.facet.portlet;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.PortletPreferences;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Prathima Shreenath
+ */
+public class CustomFacetPortletPreferencesImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetSEOParameterNameWhenParameterNameIsNull() {
+		PortletPreferences portletPreferences = Mockito.mock(
+			PortletPreferences.class);
+
+		_mockValue(
+			portletPreferences,
+			CustomFacetPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
+			StringPool.BLANK);
+		_mockValue(
+			portletPreferences,
+			CustomFacetPortletPreferences.PREFERENCE_KEY_AGGREGATION_FIELD,
+			"userName");
+
+		Assert.assertEquals(
+			"userName",
+			new CustomFacetPortletPreferencesImpl(
+				portletPreferences
+			).getSEOParameterName());
+	}
+
+	@Test
+	public void testGetSEOParameterNameWhenParameterNameIsSet() {
+		PortletPreferences portletPreferences = Mockito.mock(
+			PortletPreferences.class);
+
+		_mockValue(
+			portletPreferences,
+			CustomFacetPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
+			"customParameter");
+		_mockValue(
+			portletPreferences,
+			CustomFacetPortletPreferences.PREFERENCE_KEY_AGGREGATION_FIELD,
+			"userName");
+
+		Assert.assertEquals(
+			"customParameter",
+			new CustomFacetPortletPreferencesImpl(
+				portletPreferences
+			).getSEOParameterName());
+	}
+
+	private void _mockValue(
+		PortletPreferences portletPreferences, String key, String value) {
+
+		Mockito.when(
+			portletPreferences.getValue(key, StringPool.BLANK)
+		).thenReturn(
+			value
+		);
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/facet/portlet/CustomFacetPortletPreferencesImplTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/facet/portlet/CustomFacetPortletPreferencesImplTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.search.web.internal.custom.facet.portlet;
 
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import jakarta.portlet.PortletPreferences;
@@ -56,7 +57,7 @@ public class CustomFacetPortletPreferencesImplTest {
 		_mockValue(
 			portletPreferences,
 			CustomFacetPortletPreferences.PREFERENCE_KEY_AGGREGATION_FIELD,
-			"userName");
+			RandomTestUtil.randomString());
 		_mockValue(
 			portletPreferences,
 			CustomFacetPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/filter/portlet/CustomFilterPortletPreferencesImplTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/filter/portlet/CustomFilterPortletPreferencesImplTest.java
@@ -7,6 +7,7 @@ package com.liferay.portal.search.web.internal.custom.filter.portlet;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.search.web.internal.seo.SEOPortletPreferences;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import jakarta.portlet.PortletPreferences;
@@ -40,12 +41,12 @@ public class CustomFilterPortletPreferencesImplTest {
 			CustomFilterPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
 			portletPreferences, StringPool.BLANK);
 
-		CustomFilterPortletPreferencesImpl customFilterPortletPreferencesImpl =
+		SEOPortletPreferences seoPortletPreferences =
 			new CustomFilterPortletPreferencesImpl(portletPreferences);
 
 		Assert.assertEquals(
 			"modified",
-			customFilterPortletPreferencesImpl.getSEOParameterName());
+			seoPortletPreferences.getSEOParameterName());
 	}
 
 	@Test
@@ -60,12 +61,12 @@ public class CustomFilterPortletPreferencesImplTest {
 			CustomFilterPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
 			portletPreferences, "customParameter");
 
-		CustomFilterPortletPreferencesImpl customFilterPortletPreferencesImpl =
+		SEOPortletPreferences seoPortletPreferences =
 			new CustomFilterPortletPreferencesImpl(portletPreferences);
 
 		Assert.assertEquals(
 			"customParameter",
-			customFilterPortletPreferencesImpl.getSEOParameterName());
+			seoPortletPreferences.getSEOParameterName());
 	}
 
 	private void _mockValue(

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/filter/portlet/CustomFilterPortletPreferencesImplTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/filter/portlet/CustomFilterPortletPreferencesImplTest.java
@@ -34,19 +34,18 @@ public class CustomFilterPortletPreferencesImplTest {
 			PortletPreferences.class);
 
 		_mockValue(
-			portletPreferences,
 			CustomFilterPortletPreferences.PREFERENCE_KEY_FILTER_FIELD,
-			"modified");
+			portletPreferences, "modified");
 		_mockValue(
-			portletPreferences,
 			CustomFilterPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
-			StringPool.BLANK);
+			portletPreferences, StringPool.BLANK);
+
+		CustomFilterPortletPreferencesImpl customFilterPortletPreferencesImpl =
+			new CustomFilterPortletPreferencesImpl(portletPreferences);
 
 		Assert.assertEquals(
 			"modified",
-			new CustomFilterPortletPreferencesImpl(
-				portletPreferences
-			).getSEOParameterName());
+			customFilterPortletPreferencesImpl.getSEOParameterName());
 	}
 
 	@Test
@@ -55,23 +54,22 @@ public class CustomFilterPortletPreferencesImplTest {
 			PortletPreferences.class);
 
 		_mockValue(
-			portletPreferences,
 			CustomFilterPortletPreferences.PREFERENCE_KEY_FILTER_FIELD,
-			RandomTestUtil.randomString());
+			portletPreferences, RandomTestUtil.randomString());
 		_mockValue(
-			portletPreferences,
 			CustomFilterPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
-			"customParameter");
+			portletPreferences, "customParameter");
+
+		CustomFilterPortletPreferencesImpl customFilterPortletPreferencesImpl =
+			new CustomFilterPortletPreferencesImpl(portletPreferences);
 
 		Assert.assertEquals(
 			"customParameter",
-			new CustomFilterPortletPreferencesImpl(
-				portletPreferences
-			).getSEOParameterName());
+			customFilterPortletPreferencesImpl.getSEOParameterName());
 	}
 
 	private void _mockValue(
-		PortletPreferences portletPreferences, String key, String value) {
+		String key, PortletPreferences portletPreferences, String value) {
 
 		Mockito.when(
 			portletPreferences.getValue(key, StringPool.BLANK)

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/filter/portlet/CustomFilterPortletPreferencesImplTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/filter/portlet/CustomFilterPortletPreferencesImplTest.java
@@ -34,12 +34,12 @@ public class CustomFilterPortletPreferencesImplTest {
 
 		_mockValue(
 			portletPreferences,
-			CustomFilterPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
-			StringPool.BLANK);
-		_mockValue(
-			portletPreferences,
 			CustomFilterPortletPreferences.PREFERENCE_KEY_FILTER_FIELD,
 			"modified");
+		_mockValue(
+			portletPreferences,
+			CustomFilterPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
+			StringPool.BLANK);
 
 		Assert.assertEquals(
 			"modified",
@@ -55,12 +55,12 @@ public class CustomFilterPortletPreferencesImplTest {
 
 		_mockValue(
 			portletPreferences,
-			CustomFilterPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
-			"customParameter");
-		_mockValue(
-			portletPreferences,
 			CustomFilterPortletPreferences.PREFERENCE_KEY_FILTER_FIELD,
 			"modified");
+		_mockValue(
+			portletPreferences,
+			CustomFilterPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
+			"customParameter");
 
 		Assert.assertEquals(
 			"customParameter",

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/filter/portlet/CustomFilterPortletPreferencesImplTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/filter/portlet/CustomFilterPortletPreferencesImplTest.java
@@ -45,8 +45,7 @@ public class CustomFilterPortletPreferencesImplTest {
 			new CustomFilterPortletPreferencesImpl(portletPreferences);
 
 		Assert.assertEquals(
-			"modified",
-			seoPortletPreferences.getSEOParameterName());
+			"modified", seoPortletPreferences.getSEOParameterName());
 	}
 
 	@Test
@@ -65,8 +64,7 @@ public class CustomFilterPortletPreferencesImplTest {
 			new CustomFilterPortletPreferencesImpl(portletPreferences);
 
 		Assert.assertEquals(
-			"customParameter",
-			seoPortletPreferences.getSEOParameterName());
+			"customParameter", seoPortletPreferences.getSEOParameterName());
 	}
 
 	private void _mockValue(

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/filter/portlet/CustomFilterPortletPreferencesImplTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/filter/portlet/CustomFilterPortletPreferencesImplTest.java
@@ -1,0 +1,82 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.custom.filter.portlet;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.PortletPreferences;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Prathima Shreenath
+ */
+public class CustomFilterPortletPreferencesImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetSEOParameterNameWhenParameterNameIsNull() {
+		PortletPreferences portletPreferences = Mockito.mock(
+			PortletPreferences.class);
+
+		_mockValue(
+			portletPreferences,
+			CustomFilterPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
+			StringPool.BLANK);
+		_mockValue(
+			portletPreferences,
+			CustomFilterPortletPreferences.PREFERENCE_KEY_FILTER_FIELD,
+			"modified");
+
+		Assert.assertEquals(
+			"modified",
+			new CustomFilterPortletPreferencesImpl(
+				portletPreferences
+			).getSEOParameterName());
+	}
+
+	@Test
+	public void testGetSEOParameterNameWhenParameterNameIsSet() {
+		PortletPreferences portletPreferences = Mockito.mock(
+			PortletPreferences.class);
+
+		_mockValue(
+			portletPreferences,
+			CustomFilterPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
+			"customParameter");
+		_mockValue(
+			portletPreferences,
+			CustomFilterPortletPreferences.PREFERENCE_KEY_FILTER_FIELD,
+			"modified");
+
+		Assert.assertEquals(
+			"customParameter",
+			new CustomFilterPortletPreferencesImpl(
+				portletPreferences
+			).getSEOParameterName());
+	}
+
+	private void _mockValue(
+		PortletPreferences portletPreferences, String key, String value) {
+
+		Mockito.when(
+			portletPreferences.getValue(key, StringPool.BLANK)
+		).thenReturn(
+			value
+		);
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/filter/portlet/CustomFilterPortletPreferencesImplTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/filter/portlet/CustomFilterPortletPreferencesImplTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.search.web.internal.custom.filter.portlet;
 
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import jakarta.portlet.PortletPreferences;
@@ -56,7 +57,7 @@ public class CustomFilterPortletPreferencesImplTest {
 		_mockValue(
 			portletPreferences,
 			CustomFilterPortletPreferences.PREFERENCE_KEY_FILTER_FIELD,
-			"modified");
+			RandomTestUtil.randomString());
 		_mockValue(
 			portletPreferences,
 			CustomFilterPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewStructureUsagesDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewStructureUsagesDisplayContext.java
@@ -132,12 +132,9 @@ public class ViewStructureUsagesDisplayContext {
 				_language.get(_httpServletRequest, "permissions"), "get", null,
 				"modal-permissions"),
 			new FDSActionDropdownItem(
-				_language.get(
-					_httpServletRequest,
-					"are-you-sure-you-want-to-delete-this-entry"),
 				null, "trash", "delete",
-				_language.get(_httpServletRequest, "delete"), "delete",
-				"delete", "headless"));
+				_language.get(_httpServletRequest, "delete"), null, "delete",
+				null));
 	}
 
 	private static final String _STATUSES = StringUtil.merge(

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/StructureUsagesFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/StructureUsagesFDSPropsTransformer.ts
@@ -4,9 +4,11 @@
  */
 
 import {IInternalRenderer} from '@liferay/frontend-data-set-web';
+import {sub} from 'frontend-js-web';
 
 import StatusLabel from '../../common/components/StatusLabel';
 import {getScopeExternalReferenceCode} from '../../common/utils/getScopeExternalReferenceCode';
+import confirmAndDeleteEntryAction from './actions/confirmAndDeleteEntryAction';
 import AuthorRenderer from './cell_renderers/AuthorRenderer';
 import SpaceRendererWithCache from './cell_renderers/SpaceRendererWithCache';
 import TypeRenderer from './cell_renderers/TypeRenderer';
@@ -48,5 +50,38 @@ export default function StructureUsagesFDSPropsTransformer({
 			],
 		},
 		hideManagementBarInEmptyState: true,
+		onActionDropdownItemClick({
+			action,
+			event,
+			itemData,
+			loadData,
+		}: {
+			action: {data: {id: string}};
+			event: Event;
+			itemData: {
+				embedded: {
+					actions: {delete: {href: string; method: string}};
+				};
+				title: string;
+			};
+			loadData: () => void;
+		}) {
+			if (action?.data?.id === 'delete') {
+				event?.preventDefault();
+
+				confirmAndDeleteEntryAction({
+					bodyHTML: Liferay.Language.get(
+						'are-you-sure-you-want-to-delete-this-entry'
+					),
+					deleteAction: itemData.embedded.actions.delete,
+					loadData,
+					successMessage: sub(
+						Liferay.Language.get('x-was-successfully-deleted'),
+						`<strong>${Liferay.Util.escapeHTML(itemData.title)}</strong>`
+					),
+					title: Liferay.Language.get('delete-entry'),
+				});
+			}
+		},
 	};
 }

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
@@ -732,13 +732,13 @@ test(
 );
 
 test(
-	'Basic Web Content usages list includes assets that use the structure',
-	{tag: '@LPD-89302'},
+	'View Usages lists the assets using the structure and deletes them with the CMS confirmation modal',
+	{tag: ['@LPD-89302', '@LPD-89560']},
 	async ({apiHelpers, page, structuresPage}) => {
 		const applicationName = 'cms/basic-web-contents';
 		const title = `Content ${getRandomString()}`;
 
-		const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+		await apiHelpers.objectEntry.postObjectEntry(
 			{
 				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
 				title,
@@ -747,53 +747,22 @@ test(
 			'Default'
 		);
 
-		try {
-			await structuresPage.goto();
+		// Open the usages list of the structure
 
-			await structuresPage.execItemAction({
-				action: 'View Usages',
-				filter: 'Basic Web Content',
-			});
+		await structuresPage.goto();
 
+		await structuresPage.execItemAction({
+			action: 'View Usages',
+			filter: 'Basic Web Content',
+		});
+
+		await test.step('Usages list includes the asset', async () => {
 			await page.locator('.fds').waitFor();
 
 			await expect(page.getByRole('row', {name: title})).toBeVisible();
-		}
-		finally {
-			await apiHelpers.objectEntry.deleteObjectEntry(
-				applicationName,
-				String(objectEntry.id)
-			);
-		}
-	}
-);
+		});
 
-test(
-	'View Usages delete action opens the CMS confirmation modal instead of a native confirm dialog',
-	{tag: '@LPD-89560'},
-	async ({apiHelpers, page, structuresPage}) => {
-		const applicationName = 'cms/basic-web-contents';
-		const title = `Content ${getRandomString()}`;
-
-		const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
-			{
-				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-				title,
-			},
-			applicationName,
-			'Default'
-		);
-
-		try {
-
-			// Open the usages list of the structure
-
-			await structuresPage.goto();
-
-			await structuresPage.execItemAction({
-				action: 'View Usages',
-				filter: 'Basic Web Content',
-			});
+		await test.step('Delete shows the CMS confirmation modal', async () => {
 
 			// Open the delete action of the usage entry
 
@@ -819,13 +788,7 @@ test(
 			await waitForAlert(page, `${title} was successfully deleted`, {
 				type: 'success',
 			});
-		}
-		finally {
-			await apiHelpers.objectEntry.deleteObjectEntry(
-				applicationName,
-				String(objectEntry.id)
-			);
-		}
+		});
 	}
 );
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
@@ -769,6 +769,67 @@ test(
 );
 
 test(
+	'View Usages delete action opens the CMS confirmation modal instead of a native confirm dialog',
+	{tag: '@LPD-89560'},
+	async ({apiHelpers, page, structuresPage}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const title = `Content ${getRandomString()}`;
+
+		const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title,
+			},
+			applicationName,
+			'Default'
+		);
+
+		try {
+
+			// Open the usages list of the structure
+
+			await structuresPage.goto();
+
+			await structuresPage.execItemAction({
+				action: 'View Usages',
+				filter: 'Basic Web Content',
+			});
+
+			// Open the delete action of the usage entry
+
+			await structuresPage.dataSetFragmentPage.execItemAction({
+				action: 'Delete',
+				filter: title,
+			});
+
+			// The CMS confirmation modal must appear instead of a native
+			// confirm dialog
+
+			await expect(
+				page.getByText('Are you sure you want to delete this entry?')
+			).toBeVisible();
+
+			// Confirm the deletion
+
+			await page
+				.locator('.liferay-modal')
+				.getByRole('button', {exact: true, name: 'Delete'})
+				.click();
+
+			await waitForAlert(page, `${title} was successfully deleted`, {
+				type: 'success',
+			});
+		}
+		finally {
+			await apiHelpers.objectEntry.deleteObjectEntry(
+				applicationName,
+				String(objectEntry.id)
+			);
+		}
+	}
+);
+
+test(
 	'Permissions of a Content Structure can be modified',
 	{tag: '@LPD-89302'},
 	async ({apiHelpers, page, structuresPage}) => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93311

## What Is Being Fixed

The Custom Filter widget had no way to control how search engines index a page once a filter parameter is applied. The Custom Facet widget already supported this, but Custom Filter did not, so filtered URLs from Custom Filter could be crawled and indexed.

## How It Is Being Fixed

SEO support is added to the Custom Filter widget, mirroring the existing Custom Facet implementation. The widget configuration gains a web crawler indexing toggle, and the preferences expose the SEO parameter name (the configured parameter name, falling back to the filter field) and the web crawler indexing flag. Three contributors are registered for the portlet: a canonical URL contributor, a layout meta robots provider, and a layout set robots contributor. The portlet render path sets the page robots attribute so a "noindex, nofollow" tag is emitted when indexing is disabled and the filter parameter is present. Unit tests cover the SEO parameter name fallback for both the Custom Filter and Custom Facet preferences.

## PR Check

**pr-check: PASS** — tested on `579e064c66886a7bab2419839307fe7ea7854eed`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| JSP Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "579e064c66886a7bab2419839307fe7ea7854eed"} -->
