### PR TITLE
LPD-88609 Apply common field filters to asset list query

### DIFF
--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -201,7 +201,7 @@ public class AssetListFiltersUtil {
 	}
 
 	private static String _normalizeDateValue(
-		String value, boolean dateTime, boolean endOfBound) {
+		boolean dateTime, boolean endOfBound, String value) {
 
 		if (Validator.isNull(value)) {
 			return null;
@@ -257,7 +257,10 @@ public class AssetListFiltersUtil {
 			calendar.add(Calendar.DAY_OF_MONTH, -7);
 		}
 
-		return _format.format(calendar.getTime());
+		Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyyMMddHHmmss");
+
+		return format.format(calendar.getTime());
 	}
 
 	private static BooleanClause<Query> _toClause(
@@ -349,8 +352,8 @@ public class AssetListFiltersUtil {
 			String upperTerm = _emptyToNull(valueJSONArray.getString(1));
 
 			if (dateType) {
-				lowerTerm = _normalizeDateValue(lowerTerm, false, false);
-				upperTerm = _normalizeDateValue(upperTerm, false, true);
+				lowerTerm = _normalizeDateValue(false, false, lowerTerm);
+				upperTerm = _normalizeDateValue(false, true, upperTerm);
 			}
 
 			return new TermRangeQuery(field, lowerTerm, upperTerm, true, true);
@@ -364,28 +367,28 @@ public class AssetListFiltersUtil {
 
 		if (operatorName.equals("ge")) {
 			String lowerTerm =
-				dateType ? _normalizeDateValue(value, false, false) : value;
+				dateType ? _normalizeDateValue(false, false, value) : value;
 
 			return new TermRangeQuery(field, lowerTerm, null, true, false);
 		}
 
 		if (operatorName.equals("gt")) {
 			String lowerTerm =
-				dateType ? _normalizeDateValue(value, false, true) : value;
+				dateType ? _normalizeDateValue(false, true, value) : value;
 
 			return new TermRangeQuery(field, lowerTerm, null, false, false);
 		}
 
 		if (operatorName.equals("le")) {
 			String upperTerm =
-				dateType ? _normalizeDateValue(value, false, true) : value;
+				dateType ? _normalizeDateValue(false, true, value) : value;
 
 			return new TermRangeQuery(field, null, upperTerm, false, true);
 		}
 
 		if (operatorName.equals("lt")) {
 			String upperTerm =
-				dateType ? _normalizeDateValue(value, false, false) : value;
+				dateType ? _normalizeDateValue(false, false, value) : value;
 
 			return new TermRangeQuery(field, null, upperTerm, false, false);
 		}
@@ -415,8 +418,8 @@ public class AssetListFiltersUtil {
 			(operatorName.equals("eq") || operatorName.equals("not-eq"))) {
 
 			return new TermRangeQuery(
-				field, _normalizeDateValue(value, false, false),
-				_normalizeDateValue(value, false, true), true, true);
+				field, _normalizeDateValue(false, false, value),
+				_normalizeDateValue(false, true, value), true, true);
 		}
 
 		if (type.equals("decimal") || type.equals("integer")) {
@@ -486,6 +489,8 @@ public class AssetListFiltersUtil {
 			return null;
 		}
 
+		BooleanQuery booleanQuery = new BooleanQuery();
+
 		String quantifier = filterJSONObject.getString("quantifier");
 
 		BooleanClauseOccur booleanClauseOccur = BooleanClauseOccur.SHOULD;
@@ -493,8 +498,6 @@ public class AssetListFiltersUtil {
 		if (Objects.equals(quantifier, "all")) {
 			booleanClauseOccur = BooleanClauseOccur.MUST;
 		}
-
-		BooleanQuery booleanQuery = new BooleanQuery();
 
 		for (int i = 0; i < valueJSONArray.length(); i++) {
 			JSONObject itemJSONObject = valueJSONArray.getJSONObject(i);
@@ -535,8 +538,8 @@ public class AssetListFiltersUtil {
 			String upperTerm = _emptyToNull(valueJSONArray.getString(1));
 
 			if (dateSubfield) {
-				lowerTerm = _normalizeDateValue(lowerTerm, dateTime, false);
-				upperTerm = _normalizeDateValue(upperTerm, dateTime, true);
+				lowerTerm = _normalizeDateValue(dateTime, false, lowerTerm);
+				upperTerm = _normalizeDateValue(dateTime, true, upperTerm);
 			}
 
 			return new TermRangeQuery(
@@ -551,7 +554,7 @@ public class AssetListFiltersUtil {
 
 		if (operatorName.equals("ge")) {
 			String lowerTerm =
-				dateSubfield ? _normalizeDateValue(value, dateTime, false) :
+				dateSubfield ? _normalizeDateValue(dateTime, false, value) :
 					value;
 
 			return new TermRangeQuery(subfield, lowerTerm, null, true, false);
@@ -559,7 +562,7 @@ public class AssetListFiltersUtil {
 
 		if (operatorName.equals("gt")) {
 			String lowerTerm =
-				dateSubfield ? _normalizeDateValue(value, dateTime, true) :
+				dateSubfield ? _normalizeDateValue(dateTime, true, value) :
 					value;
 
 			return new TermRangeQuery(subfield, lowerTerm, null, false, false);
@@ -567,7 +570,7 @@ public class AssetListFiltersUtil {
 
 		if (operatorName.equals("le")) {
 			String upperTerm =
-				dateSubfield ? _normalizeDateValue(value, dateTime, true) :
+				dateSubfield ? _normalizeDateValue(dateTime, true, value) :
 					value;
 
 			return new TermRangeQuery(subfield, null, upperTerm, false, true);
@@ -575,7 +578,7 @@ public class AssetListFiltersUtil {
 
 		if (operatorName.equals("lt")) {
 			String upperTerm =
-				dateSubfield ? _normalizeDateValue(value, dateTime, false) :
+				dateSubfield ? _normalizeDateValue(dateTime, false, value) :
 					value;
 
 			return new TermRangeQuery(subfield, null, upperTerm, false, false);
@@ -618,8 +621,8 @@ public class AssetListFiltersUtil {
 				objectField.getDBType());
 
 			return new TermRangeQuery(
-				subfield, _normalizeDateValue(value, dateTime, false),
-				_normalizeDateValue(value, dateTime, true), true, true);
+				subfield, _normalizeDateValue(dateTime, false, value),
+				_normalizeDateValue(dateTime, true, value), true, true);
 		}
 
 		if (subfield.endsWith(".value_keyword")) {
@@ -664,8 +667,6 @@ public class AssetListFiltersUtil {
 		).put(
 			"viewCount", "integer"
 		).build();
-	private static final Format _format =
-		FastDateFormatFactoryUtil.getSimpleDateFormat("yyyyMMddHHmmss");
 	private static final Set<String> _localizedCommonFieldNames =
 		SetUtil.fromArray(Field.TITLE);
 	private static final Map<String, String> _metadataCommonFieldNames =

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -150,6 +150,30 @@ public class AssetListFiltersUtil {
 		return false;
 	}
 
+	private static String _normalizeDateValue(
+		String value, boolean dateTime, boolean endOfBound) {
+
+		if (Validator.isNull(value)) {
+			return null;
+		}
+
+		String digits = value.replaceAll("[^0-9]", "");
+
+		if (dateTime) {
+			String padded = digits + "000000000000";
+
+			String paddedDigits = padded.substring(0, 12);
+
+			return paddedDigits + (endOfBound ? "59" : "00");
+		}
+
+		String padded = digits + "00000000";
+
+		String paddedDigits = padded.substring(0, 8);
+
+		return paddedDigits + (endOfBound ? "235959" : "000000");
+	}
+
 	private static NestedQuery _toNestedQuery(
 		long companyId, JSONObject jsonObject, Locale locale) {
 
@@ -177,7 +201,7 @@ public class AssetListFiltersUtil {
 		String subfield = _getSubfield(locale, objectField);
 
 		Query valueQuery = _toValueQuery(
-			jsonObject, subfield, operatorName, value);
+			jsonObject, subfield, operatorName, value, objectField);
 
 		if (valueQuery == null) {
 			return null;
@@ -197,7 +221,19 @@ public class AssetListFiltersUtil {
 	}
 
 	private static Query _toRangeQuery(
-		JSONObject filterJSONObject, String subfield, String operatorName) {
+		JSONObject filterJSONObject, String subfield, String operatorName,
+		ObjectField objectField) {
+
+		boolean dateSubfield = subfield.endsWith(".value_date");
+
+		boolean dateTime = false;
+
+		if (dateSubfield &&
+			ObjectFieldConstants.DB_TYPE_DATE_TIME.equals(
+				objectField.getDBType())) {
+
+			dateTime = true;
+		}
 
 		if (operatorName.equals("between")) {
 			JSONArray valueJSONArray = filterJSONObject.getJSONArray("value");
@@ -206,12 +242,16 @@ public class AssetListFiltersUtil {
 				return null;
 			}
 
-			String lowerTerm = valueJSONArray.getString(0);
-			String upperTerm = valueJSONArray.getString(1);
+			String lowerTerm = _emptyToNull(valueJSONArray.getString(0));
+			String upperTerm = _emptyToNull(valueJSONArray.getString(1));
+
+			if (dateSubfield) {
+				lowerTerm = _normalizeDateValue(lowerTerm, dateTime, false);
+				upperTerm = _normalizeDateValue(upperTerm, dateTime, true);
+			}
 
 			return new TermRangeQuery(
-				subfield, _emptyToNull(lowerTerm), _emptyToNull(upperTerm),
-				true, true);
+				subfield, lowerTerm, upperTerm, true, true);
 		}
 
 		String value = filterJSONObject.getString("value");
@@ -221,19 +261,35 @@ public class AssetListFiltersUtil {
 		}
 
 		if (operatorName.equals("gt")) {
-			return new TermRangeQuery(subfield, value, null, false, false);
+			String lowerTerm =
+				dateSubfield ? _normalizeDateValue(value, dateTime, true) :
+					value;
+
+			return new TermRangeQuery(subfield, lowerTerm, null, false, false);
 		}
 
 		if (operatorName.equals("ge")) {
-			return new TermRangeQuery(subfield, value, null, true, false);
+			String lowerTerm =
+				dateSubfield ? _normalizeDateValue(value, dateTime, false) :
+					value;
+
+			return new TermRangeQuery(subfield, lowerTerm, null, true, false);
 		}
 
 		if (operatorName.equals("lt")) {
-			return new TermRangeQuery(subfield, null, value, false, false);
+			String upperTerm =
+				dateSubfield ? _normalizeDateValue(value, dateTime, false) :
+					value;
+
+			return new TermRangeQuery(subfield, null, upperTerm, false, false);
 		}
 
 		if (operatorName.equals("le")) {
-			return new TermRangeQuery(subfield, null, value, false, true);
+			String upperTerm =
+				dateSubfield ? _normalizeDateValue(value, dateTime, true) :
+					value;
+
+			return new TermRangeQuery(subfield, null, upperTerm, false, true);
 		}
 
 		return null;
@@ -241,13 +297,25 @@ public class AssetListFiltersUtil {
 
 	private static Query _toValueQuery(
 		JSONObject filterJSONObject, String subfield, String operatorName,
-		String value) {
+		String value, ObjectField objectField) {
 
 		if (operatorName.equals("between") || operatorName.equals("gt") ||
 			operatorName.equals("ge") || operatorName.equals("lt") ||
 			operatorName.equals("le")) {
 
-			return _toRangeQuery(filterJSONObject, subfield, operatorName);
+			return _toRangeQuery(
+				filterJSONObject, subfield, operatorName, objectField);
+		}
+
+		if (subfield.endsWith(".value_date") &&
+			(operatorName.equals("eq") || operatorName.equals("not-eq"))) {
+
+			boolean dateTime = ObjectFieldConstants.DB_TYPE_DATE_TIME.equals(
+				objectField.getDBType());
+
+			return new TermRangeQuery(
+				subfield, _normalizeDateValue(value, dateTime, false),
+				_normalizeDateValue(value, dateTime, true), true, true);
 		}
 
 		if (subfield.endsWith(".value_boolean") ||

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -486,9 +486,9 @@ public class AssetListFiltersUtil {
 			return null;
 		}
 
-		BooleanClauseOccur booleanClauseOccur = BooleanClauseOccur.SHOULD;
-
 		String quantifier = filterJSONObject.getString("quantifier");
+
+		BooleanClauseOccur booleanClauseOccur = BooleanClauseOccur.SHOULD;
 
 		if (Objects.equals(quantifier, "all")) {
 			booleanClauseOccur = BooleanClauseOccur.MUST;

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -602,9 +602,9 @@ public class AssetListFiltersUtil {
 			}
 		}
 
-		if (operatorName.equals("between") || operatorName.equals("gt") ||
-			operatorName.equals("ge") || operatorName.equals("lt") ||
-			operatorName.equals("le")) {
+		if (operatorName.equals("between") || operatorName.equals("ge") ||
+			operatorName.equals("gt") || operatorName.equals("le") ||
+			operatorName.equals("lt")) {
 
 			return _toRangeQuery(
 				filterJSONObject, subfield, operatorName, objectField);

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -486,12 +486,12 @@ public class AssetListFiltersUtil {
 			return null;
 		}
 
-		BooleanClauseOccur innerOccur = BooleanClauseOccur.SHOULD;
+		BooleanClauseOccur booleanClauseOccur = BooleanClauseOccur.SHOULD;
 
 		String quantifier = filterJSONObject.getString("quantifier");
 
 		if (Objects.equals(quantifier, "all")) {
-			innerOccur = BooleanClauseOccur.MUST;
+			booleanClauseOccur = BooleanClauseOccur.MUST;
 		}
 
 		BooleanQuery booleanQuery = new BooleanQuery();
@@ -502,7 +502,8 @@ public class AssetListFiltersUtil {
 			String value = StringUtil.toLowerCase(
 				itemJSONObject.getString("value"));
 
-			booleanQuery.add(new TermQuery(subfield, value), innerOccur);
+			booleanQuery.add(
+				new TermQuery(subfield, value), booleanClauseOccur);
 		}
 
 		return booleanQuery;

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -119,7 +119,7 @@ public class AssetListFiltersUtil {
 	}
 
 	private static String _getCommonFieldName(
-		String propertyName, Locale locale) {
+		Locale locale, String propertyName) {
 
 		if (!_commonFieldTypes.containsKey(propertyName)) {
 			return null;
@@ -271,7 +271,7 @@ public class AssetListFiltersUtil {
 
 		if (_isCommonFieldRow(jsonObject)) {
 			return _toCommonFieldClause(
-				jsonObject, jsonObject.getString("propertyName"), locale);
+				jsonObject, locale, jsonObject.getString("propertyName"));
 		}
 
 		ObjectField objectField = _fetchObjectField(
@@ -284,11 +284,11 @@ public class AssetListFiltersUtil {
 
 		if (objectField.isMetadata()) {
 			return _toCommonFieldClause(
-				jsonObject, _aliasMetadataName(objectField.getName()), locale);
+				jsonObject, locale, _aliasMetadataName(objectField.getName()));
 		}
 
 		NestedQuery nestedQuery = _toNestedQuery(
-			jsonObject, objectField, locale);
+			jsonObject, locale, objectField);
 
 		if (nestedQuery == null) {
 			return null;
@@ -298,13 +298,13 @@ public class AssetListFiltersUtil {
 	}
 
 	private static BooleanClause<Query> _toCommonFieldClause(
-		JSONObject jsonObject, String propertyName, Locale locale) {
+		JSONObject jsonObject, Locale locale, String propertyName) {
 
 		if (Validator.isNull(propertyName)) {
 			return null;
 		}
 
-		String field = _getCommonFieldName(propertyName, locale);
+		String field = _getCommonFieldName(locale, propertyName);
 		String type = _getCommonFieldType(propertyName);
 
 		if ((field == null) || (type == null)) {
@@ -315,8 +315,9 @@ public class AssetListFiltersUtil {
 			jsonObject.getString("operatorName"), "contains");
 
 		Query valueQuery = _toCommonFieldValueQuery(
-			jsonObject, field, operatorName, type,
-			_localizedCommonFieldNames.contains(propertyName));
+			field, jsonObject,
+			_localizedCommonFieldNames.contains(propertyName), operatorName,
+			type);
 
 		if (valueQuery == null) {
 			return null;
@@ -341,7 +342,7 @@ public class AssetListFiltersUtil {
 	}
 
 	private static Query _toCommonFieldRangeQuery(
-		JSONObject jsonObject, String field, String operatorName, String type) {
+		String field, JSONObject jsonObject, String operatorName, String type) {
 
 		boolean dateType = type.equals("date");
 
@@ -401,15 +402,15 @@ public class AssetListFiltersUtil {
 	}
 
 	private static Query _toCommonFieldValueQuery(
-		JSONObject jsonObject, String field, String operatorName, String type,
-		boolean localized) {
+		String field, JSONObject jsonObject, boolean localized,
+		String operatorName, String type) {
 
 		if (operatorName.equals("between") || operatorName.equals("ge") ||
 			operatorName.equals("gt") || operatorName.equals("le") ||
 			operatorName.equals("lt")) {
 
 			return _toCommonFieldRangeQuery(
-				jsonObject, field, operatorName, type);
+				field, jsonObject, operatorName, type);
 		}
 
 		String value = jsonObject.getString("value");
@@ -449,7 +450,7 @@ public class AssetListFiltersUtil {
 	}
 
 	private static NestedQuery _toNestedQuery(
-		JSONObject jsonObject, ObjectField objectField, Locale locale) {
+		JSONObject jsonObject, Locale locale, ObjectField objectField) {
 
 		String propertyName = jsonObject.getString("propertyName");
 		String value = jsonObject.getString("value");

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.MatchAllQuery;
 import com.liferay.portal.kernel.search.MatchQuery;
 import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
@@ -27,7 +28,9 @@ import com.liferay.portal.kernel.search.TermRangeQuery;
 import com.liferay.portal.kernel.search.WildcardQuery;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -37,7 +40,9 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * @author Joshua Cords
@@ -54,14 +59,16 @@ public class AssetListFiltersUtil {
 		BooleanQuery booleanQuery = new BooleanQuery();
 
 		for (int i = 0; i < filtersJSONArray.length(); i++) {
-			NestedQuery nestedQuery = _toNestedQuery(
+			BooleanClause<Query> booleanClause = _toClause(
 				companyId, filtersJSONArray.getJSONObject(i), locale);
 
-			if (nestedQuery == null) {
+			if (booleanClause == null) {
 				continue;
 			}
 
-			booleanQuery.add(nestedQuery, BooleanClauseOccur.MUST);
+			booleanQuery.add(
+				booleanClause.getClause(),
+				booleanClause.getBooleanClauseOccur());
 		}
 
 		if (!booleanQuery.hasClauses()) {
@@ -107,6 +114,24 @@ public class AssetListFiltersUtil {
 			objectDefinition.getObjectDefinitionId(), name);
 	}
 
+	private static String _getCommonFieldName(
+		String propertyName, Locale locale) {
+
+		if (!_commonFieldTypes.containsKey(propertyName)) {
+			return null;
+		}
+
+		if (_localizedCommonFieldNames.contains(propertyName)) {
+			return Field.getLocalizedName(locale, "localized_" + propertyName);
+		}
+
+		return propertyName;
+	}
+
+	private static String _getCommonFieldType(String propertyName) {
+		return _commonFieldTypes.get(propertyName);
+	}
+
 	private static String _getSubfield(Locale locale, ObjectField objectField) {
 		if (objectField.isIndexedAsKeyword()) {
 			return "nestedFieldArray.value_keyword";
@@ -149,6 +174,16 @@ public class AssetListFiltersUtil {
 		}
 
 		return "nestedFieldArray.value_text";
+	}
+
+	private static boolean _isCommonFieldRow(JSONObject jsonObject) {
+		if ((jsonObject.getLong("classNameId") <= 0) &&
+			(jsonObject.getLong("classTypeId") <= 0)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private static boolean _isNegatedOperator(String operatorName) {
@@ -223,24 +258,194 @@ public class AssetListFiltersUtil {
 		return _format.format(calendar.getTime());
 	}
 
-	private static NestedQuery _toNestedQuery(
+	private static BooleanClause<Query> _toClause(
 		long companyId, JSONObject jsonObject, Locale locale) {
 
 		if (jsonObject == null) {
 			return null;
 		}
 
+		if (_isCommonFieldRow(jsonObject)) {
+			return _toCommonFieldClause(
+				jsonObject, jsonObject.getString("propertyName"), locale);
+		}
+
+		ObjectField objectField = _fetchObjectField(
+			jsonObject.getLong("classNameId"), companyId,
+			jsonObject.getString("propertyName"));
+
+		if (objectField == null) {
+			return null;
+		}
+
+		NestedQuery nestedQuery = _toNestedQuery(
+			jsonObject, objectField, locale);
+
+		if (nestedQuery == null) {
+			return null;
+		}
+
+		return new BooleanClause<>(nestedQuery, BooleanClauseOccur.MUST);
+	}
+
+	private static BooleanClause<Query> _toCommonFieldClause(
+		JSONObject jsonObject, String propertyName, Locale locale) {
+
+		if (Validator.isNull(propertyName)) {
+			return null;
+		}
+
+		String field = _getCommonFieldName(propertyName, locale);
+		String type = _getCommonFieldType(propertyName);
+
+		if ((field == null) || (type == null)) {
+			return null;
+		}
+
+		String operatorName = GetterUtil.getString(
+			jsonObject.getString("operatorName"), "contains");
+
+		Query valueQuery = _toCommonFieldValueQuery(
+			jsonObject, field, operatorName, type,
+			_localizedCommonFieldNames.contains(propertyName));
+
+		if (valueQuery == null) {
+			return null;
+		}
+
+		if (_isNegatedOperator(operatorName)) {
+
+			// A standalone MUST_NOT clause matches no documents, so anchor
+			// the negation with a positive MatchAllQuery. The nested path does
+			// not need this because its negation lives inside a positive
+			// NestedQuery.
+
+			BooleanQuery booleanQuery = new BooleanQuery();
+
+			booleanQuery.add(new MatchAllQuery(), BooleanClauseOccur.MUST);
+			booleanQuery.add(valueQuery, BooleanClauseOccur.MUST_NOT);
+
+			return new BooleanClause<>(booleanQuery, BooleanClauseOccur.MUST);
+		}
+
+		return new BooleanClause<>(valueQuery, BooleanClauseOccur.MUST);
+	}
+
+	private static Query _toCommonFieldRangeQuery(
+		JSONObject jsonObject, String field, String operatorName, String type) {
+
+		boolean dateType = type.equals("date");
+
+		if (operatorName.equals("between")) {
+			JSONArray valueJSONArray = jsonObject.getJSONArray("value");
+
+			if ((valueJSONArray == null) || (valueJSONArray.length() < 2)) {
+				return null;
+			}
+
+			String lowerTerm = _emptyToNull(valueJSONArray.getString(0));
+			String upperTerm = _emptyToNull(valueJSONArray.getString(1));
+
+			if (dateType) {
+				lowerTerm = _normalizeDateValue(lowerTerm, false, false);
+				upperTerm = _normalizeDateValue(upperTerm, false, true);
+			}
+
+			return new TermRangeQuery(field, lowerTerm, upperTerm, true, true);
+		}
+
+		String value = jsonObject.getString("value");
+
+		if (Validator.isNull(value)) {
+			return null;
+		}
+
+		if (operatorName.equals("ge")) {
+			String lowerTerm =
+				dateType ? _normalizeDateValue(value, false, false) : value;
+
+			return new TermRangeQuery(field, lowerTerm, null, true, false);
+		}
+
+		if (operatorName.equals("gt")) {
+			String lowerTerm =
+				dateType ? _normalizeDateValue(value, false, true) : value;
+
+			return new TermRangeQuery(field, lowerTerm, null, false, false);
+		}
+
+		if (operatorName.equals("le")) {
+			String upperTerm =
+				dateType ? _normalizeDateValue(value, false, true) : value;
+
+			return new TermRangeQuery(field, null, upperTerm, false, true);
+		}
+
+		if (operatorName.equals("lt")) {
+			String upperTerm =
+				dateType ? _normalizeDateValue(value, false, false) : value;
+
+			return new TermRangeQuery(field, null, upperTerm, false, false);
+		}
+
+		return null;
+	}
+
+	private static Query _toCommonFieldValueQuery(
+		JSONObject jsonObject, String field, String operatorName, String type,
+		boolean localized) {
+
+		if (operatorName.equals("between") || operatorName.equals("ge") ||
+			operatorName.equals("gt") || operatorName.equals("le") ||
+			operatorName.equals("lt")) {
+
+			return _toCommonFieldRangeQuery(
+				jsonObject, field, operatorName, type);
+		}
+
+		String value = jsonObject.getString("value");
+
+		if (Validator.isNull(value)) {
+			return null;
+		}
+
+		if (type.equals("date") &&
+			(operatorName.equals("eq") || operatorName.equals("not-eq"))) {
+
+			return new TermRangeQuery(
+				field, _normalizeDateValue(value, false, false),
+				_normalizeDateValue(value, false, true), true, true);
+		}
+
+		if (type.equals("decimal") || type.equals("integer")) {
+			return new TermQuery(field, value);
+		}
+
+		// Localized fields (title) are indexed as analyzed text, so match them
+		// through the analyzer. Other text fields (userName,
+		// externalReferenceCode) are keywords matched exactly or by substring.
+
+		if (localized) {
+			return new MatchQuery(field, value);
+		}
+
+		if (operatorName.equals("contains") ||
+			operatorName.equals("not-contains")) {
+
+			return new WildcardQuery(
+				field, StringPool.STAR + value + StringPool.STAR);
+		}
+
+		return new TermQuery(field, value);
+	}
+
+	private static NestedQuery _toNestedQuery(
+		JSONObject jsonObject, ObjectField objectField, Locale locale) {
+
 		String propertyName = jsonObject.getString("propertyName");
 		String value = jsonObject.getString("value");
 
 		if (Validator.isNull(propertyName) || Validator.isNull(value)) {
-			return null;
-		}
-
-		ObjectField objectField = _fetchObjectField(
-			jsonObject.getLong("classNameId"), companyId, propertyName);
-
-		if (objectField == null) {
 			return null;
 		}
 
@@ -434,8 +639,42 @@ public class AssetListFiltersUtil {
 		return new MatchQuery(subfield, value);
 	}
 
+	// Common Fields are indexed at the document root by
+	// AssetEntryDocumentContributor, not under nestedFieldArray. Keep this
+	// registry in sync with the group emitted by
+	// AssetListTypePropertiesUtil#_getCommonFieldsItemsJSONArray.
+
+	private static final Map<String, String> _commonFieldTypes =
+		HashMapBuilder.put(
+			Field.CREATE_DATE, "date"
+		).put(
+			Field.DISPLAY_DATE, "date"
+		).put(
+			Field.EXPIRATION_DATE, "date"
+		).put(
+			Field.MODIFIED_DATE, "date"
+		).put(
+			Field.PRIORITY, "decimal"
+		).put(
+			Field.PUBLISH_DATE, "date"
+		).put(
+			Field.REVIEW_DATE, "date"
+		).put(
+			Field.STATUS, "integer"
+		).put(
+			Field.TITLE, "text"
+		).put(
+			Field.USER_NAME, "text"
+		).put(
+			"externalReferenceCode", "text"
+		).put(
+			"viewCount", "integer"
+		).build();
+
 	private static final Format _format =
 		FastDateFormatFactoryUtil.getSimpleDateFormat("yyyyMMddHHmmss");
+	private static final Set<String> _localizedCommonFieldNames =
+		SetUtil.fromArray(Field.TITLE);
 	private static final List<String> _relativeDateValues = Arrays.asList(
 		"last-year", "next-month", "now", "past-24-hours", "past-day",
 		"past-month", "past-week", "past-year");

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.search.MatchQuery;
 import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.TermQuery;
+import com.liferay.portal.kernel.search.TermRangeQuery;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -59,6 +60,14 @@ public class AssetListFiltersUtil {
 		return new BooleanClause[] {
 			new BooleanClause<>(booleanQuery, BooleanClauseOccur.MUST)
 		};
+	}
+
+	private static String _emptyToNull(String value) {
+		if (Validator.isNull(value)) {
+			return null;
+		}
+
+		return value;
 	}
 
 	private static ObjectDefinition _fetchObjectDefinition(
@@ -167,7 +176,8 @@ public class AssetListFiltersUtil {
 
 		String subfield = _getSubfield(locale, objectField);
 
-		Query valueQuery = _toValueQuery(subfield, operatorName, value);
+		Query valueQuery = _toValueQuery(
+			jsonObject, subfield, operatorName, value);
 
 		if (valueQuery == null) {
 			return null;
@@ -186,8 +196,59 @@ public class AssetListFiltersUtil {
 		return new NestedQuery("nestedFieldArray", booleanQuery);
 	}
 
+	private static Query _toRangeQuery(
+		JSONObject filterJSONObject, String subfield, String operatorName) {
+
+		if (operatorName.equals("between")) {
+			JSONArray valueJSONArray = filterJSONObject.getJSONArray("value");
+
+			if ((valueJSONArray == null) || (valueJSONArray.length() < 2)) {
+				return null;
+			}
+
+			String lowerTerm = valueJSONArray.getString(0);
+			String upperTerm = valueJSONArray.getString(1);
+
+			return new TermRangeQuery(
+				subfield, _emptyToNull(lowerTerm), _emptyToNull(upperTerm),
+				true, true);
+		}
+
+		String value = filterJSONObject.getString("value");
+
+		if (Validator.isNull(value)) {
+			return null;
+		}
+
+		if (operatorName.equals("gt")) {
+			return new TermRangeQuery(subfield, value, null, false, false);
+		}
+
+		if (operatorName.equals("ge")) {
+			return new TermRangeQuery(subfield, value, null, true, false);
+		}
+
+		if (operatorName.equals("lt")) {
+			return new TermRangeQuery(subfield, null, value, false, false);
+		}
+
+		if (operatorName.equals("le")) {
+			return new TermRangeQuery(subfield, null, value, false, true);
+		}
+
+		return null;
+	}
+
 	private static Query _toValueQuery(
-		String subfield, String operatorName, String value) {
+		JSONObject filterJSONObject, String subfield, String operatorName,
+		String value) {
+
+		if (operatorName.equals("between") || operatorName.equals("gt") ||
+			operatorName.equals("ge") || operatorName.equals("lt") ||
+			operatorName.equals("le")) {
+
+			return _toRangeQuery(filterJSONObject, subfield, operatorName);
+		}
 
 		if (subfield.endsWith(".value_boolean") ||
 			subfield.endsWith(".value_date") ||

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -10,6 +10,8 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldLocalServiceUtil;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -22,6 +24,7 @@ import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.TermQuery;
 import com.liferay.portal.kernel.search.TermRangeQuery;
+import com.liferay.portal.kernel.search.WildcardQuery;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -215,6 +218,11 @@ public class AssetListFiltersUtil {
 			new TermQuery("nestedFieldArray.fieldName", propertyName),
 			BooleanClauseOccur.MUST);
 		booleanQuery.add(
+			new TermQuery(
+				"nestedFieldArray.valueFieldName",
+				subfield.substring(subfield.indexOf(CharPool.PERIOD) + 1)),
+			BooleanClauseOccur.MUST);
+		booleanQuery.add(
 			valueQuery,
 			_isNegatedOperator(operatorName) ? BooleanClauseOccur.MUST_NOT :
 				BooleanClauseOccur.MUST);
@@ -332,11 +340,19 @@ public class AssetListFiltersUtil {
 		JSONObject filterJSONObject, String subfield, String operatorName,
 		String value, ObjectField objectField) {
 
-		if (subfield.endsWith(".value_keyword") &&
-			(operatorName.equals("contains") ||
-			 operatorName.equals("not-contains"))) {
+		if (operatorName.equals("contains") ||
+			operatorName.equals("not-contains")) {
 
-			return _toPicklistQuery(filterJSONObject, subfield);
+			if (objectField.getListTypeDefinitionId() != 0) {
+				return _toPicklistQuery(filterJSONObject, subfield);
+			}
+
+			if (subfield.endsWith(".value_keyword")) {
+				return new WildcardQuery(
+					subfield,
+					StringPool.STAR + StringUtil.toLowerCase(value) +
+						StringPool.STAR);
+			}
 		}
 
 		if (operatorName.equals("between") || operatorName.equals("gt") ||
@@ -358,11 +374,13 @@ public class AssetListFiltersUtil {
 				_normalizeDateValue(value, dateTime, true), true, true);
 		}
 
+		if (subfield.endsWith(".value_keyword")) {
+			return new TermQuery(subfield, StringUtil.toLowerCase(value));
+		}
+
 		if (subfield.endsWith(".value_boolean") ||
-			subfield.endsWith(".value_date") ||
 			subfield.endsWith(".value_double") ||
 			subfield.endsWith(".value_integer") ||
-			subfield.endsWith(".value_keyword") ||
 			subfield.endsWith(".value_long") || operatorName.equals("eq") ||
 			operatorName.equals("not-eq")) {
 

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -80,6 +80,10 @@ public class AssetListFiltersUtil {
 		};
 	}
 
+	private static String _aliasMetadataName(String name) {
+		return _metadataCommonFieldNames.getOrDefault(name, name);
+	}
+
 	private static String _emptyToNull(String value) {
 		if (Validator.isNull(value)) {
 			return null;
@@ -276,6 +280,11 @@ public class AssetListFiltersUtil {
 
 		if (objectField == null) {
 			return null;
+		}
+
+		if (objectField.isMetadata()) {
+			return _toCommonFieldClause(
+				jsonObject, _aliasMetadataName(objectField.getName()), locale);
 		}
 
 		NestedQuery nestedQuery = _toNestedQuery(
@@ -675,6 +684,12 @@ public class AssetListFiltersUtil {
 		FastDateFormatFactoryUtil.getSimpleDateFormat("yyyyMMddHHmmss");
 	private static final Set<String> _localizedCommonFieldNames =
 		SetUtil.fromArray(Field.TITLE);
+	private static final Map<String, String> _metadataCommonFieldNames =
+		HashMapBuilder.put(
+			"creator", Field.USER_NAME
+		).put(
+			"modifiedDate", Field.MODIFIED_DATE
+		).build();
 	private static final List<String> _relativeDateValues = Arrays.asList(
 		"last-year", "next-month", "now", "past-24-hours", "past-day",
 		"past-month", "past-week", "past-year");

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -453,7 +453,7 @@ public class AssetListFiltersUtil {
 		String subfield = _getSubfield(locale, objectField);
 
 		Query valueQuery = _toValueQuery(
-			jsonObject, subfield, operatorName, value, objectField);
+			jsonObject, objectField, operatorName, subfield, value);
 
 		if (valueQuery == null) {
 			return null;
@@ -509,8 +509,8 @@ public class AssetListFiltersUtil {
 	}
 
 	private static Query _toRangeQuery(
-		JSONObject filterJSONObject, String subfield, String operatorName,
-		ObjectField objectField) {
+		JSONObject filterJSONObject, ObjectField objectField,
+		String operatorName, String subfield) {
 
 		boolean dateSubfield = subfield.endsWith(".value_date");
 
@@ -548,14 +548,6 @@ public class AssetListFiltersUtil {
 			return null;
 		}
 
-		if (operatorName.equals("gt")) {
-			String lowerTerm =
-				dateSubfield ? _normalizeDateValue(value, dateTime, true) :
-					value;
-
-			return new TermRangeQuery(subfield, lowerTerm, null, false, false);
-		}
-
 		if (operatorName.equals("ge")) {
 			String lowerTerm =
 				dateSubfield ? _normalizeDateValue(value, dateTime, false) :
@@ -564,12 +556,12 @@ public class AssetListFiltersUtil {
 			return new TermRangeQuery(subfield, lowerTerm, null, true, false);
 		}
 
-		if (operatorName.equals("lt")) {
-			String upperTerm =
-				dateSubfield ? _normalizeDateValue(value, dateTime, false) :
+		if (operatorName.equals("gt")) {
+			String lowerTerm =
+				dateSubfield ? _normalizeDateValue(value, dateTime, true) :
 					value;
 
-			return new TermRangeQuery(subfield, null, upperTerm, false, false);
+			return new TermRangeQuery(subfield, lowerTerm, null, false, false);
 		}
 
 		if (operatorName.equals("le")) {
@@ -580,12 +572,20 @@ public class AssetListFiltersUtil {
 			return new TermRangeQuery(subfield, null, upperTerm, false, true);
 		}
 
+		if (operatorName.equals("lt")) {
+			String upperTerm =
+				dateSubfield ? _normalizeDateValue(value, dateTime, false) :
+					value;
+
+			return new TermRangeQuery(subfield, null, upperTerm, false, false);
+		}
+
 		return null;
 	}
 
 	private static Query _toValueQuery(
-		JSONObject filterJSONObject, String subfield, String operatorName,
-		String value, ObjectField objectField) {
+		JSONObject filterJSONObject, ObjectField objectField,
+		String operatorName, String subfield, String value) {
 
 		if (operatorName.equals("contains") ||
 			operatorName.equals("not-contains")) {
@@ -607,7 +607,7 @@ public class AssetListFiltersUtil {
 			operatorName.equals("lt")) {
 
 			return _toRangeQuery(
-				filterJSONObject, subfield, operatorName, objectField);
+				filterJSONObject, objectField, operatorName, subfield);
 		}
 
 		if (subfield.endsWith(".value_date") &&

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -24,9 +24,11 @@ import com.liferay.portal.kernel.search.TermQuery;
 import com.liferay.portal.kernel.search.TermRangeQuery;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * @author Joshua Cords
@@ -220,6 +222,37 @@ public class AssetListFiltersUtil {
 		return new NestedQuery("nestedFieldArray", booleanQuery);
 	}
 
+	private static Query _toPicklistQuery(
+		JSONObject filterJSONObject, String subfield) {
+
+		JSONArray valueJSONArray = filterJSONObject.getJSONArray("value");
+
+		if ((valueJSONArray == null) || (valueJSONArray.length() == 0)) {
+			return null;
+		}
+
+		BooleanClauseOccur innerOccur = BooleanClauseOccur.SHOULD;
+
+		String quantifier = filterJSONObject.getString("quantifier");
+
+		if (Objects.equals(quantifier, "all")) {
+			innerOccur = BooleanClauseOccur.MUST;
+		}
+
+		BooleanQuery booleanQuery = new BooleanQuery();
+
+		for (int i = 0; i < valueJSONArray.length(); i++) {
+			JSONObject itemJSONObject = valueJSONArray.getJSONObject(i);
+
+			String value = StringUtil.toLowerCase(
+				itemJSONObject.getString("value"));
+
+			booleanQuery.add(new TermQuery(subfield, value), innerOccur);
+		}
+
+		return booleanQuery;
+	}
+
 	private static Query _toRangeQuery(
 		JSONObject filterJSONObject, String subfield, String operatorName,
 		ObjectField objectField) {
@@ -298,6 +331,13 @@ public class AssetListFiltersUtil {
 	private static Query _toValueQuery(
 		JSONObject filterJSONObject, String subfield, String operatorName,
 		String value, ObjectField objectField) {
+
+		if (subfield.endsWith(".value_keyword") &&
+			(operatorName.equals("contains") ||
+			 operatorName.equals("not-contains"))) {
+
+			return _toPicklistQuery(filterJSONObject, subfield);
+		}
 
 		if (operatorName.equals("between") || operatorName.equals("gt") ||
 			operatorName.equals("ge") || operatorName.equals("lt") ||

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -257,8 +257,6 @@ public class AssetListFiltersUtil {
 			calendar.add(Calendar.DAY_OF_MONTH, -7);
 		}
 
-		// "now" requires no offset.
-
 		return _format.format(calendar.getTime());
 	}
 
@@ -324,12 +322,6 @@ public class AssetListFiltersUtil {
 		}
 
 		if (_isNegatedOperator(operatorName)) {
-
-			// A standalone MUST_NOT clause matches no documents, so anchor
-			// the negation with a positive MatchAllQuery. The nested path does
-			// not need this because its negation lives inside a positive
-			// NestedQuery.
-
 			BooleanQuery booleanQuery = new BooleanQuery();
 
 			booleanQuery.add(new MatchAllQuery(), BooleanClauseOccur.MUST);
@@ -430,10 +422,6 @@ public class AssetListFiltersUtil {
 		if (type.equals("decimal") || type.equals("integer")) {
 			return new TermQuery(field, value);
 		}
-
-		// Localized fields (title) are indexed as analyzed text, so match them
-		// through the analyzer. Other text fields (userName,
-		// externalReferenceCode) are keywords matched exactly or by substring.
 
 		if (localized) {
 			return new MatchQuery(field, value);
@@ -649,11 +637,6 @@ public class AssetListFiltersUtil {
 		return new MatchQuery(subfield, value);
 	}
 
-	// Common Fields are indexed at the document root by
-	// AssetEntryDocumentContributor, not under nestedFieldArray. Keep this
-	// registry in sync with the group emitted by
-	// AssetListTypePropertiesUtil#_getCommonFieldsItemsJSONArray.
-
 	private static final Map<String, String> _commonFieldTypes =
 		HashMapBuilder.put(
 			Field.CREATE_DATE, "date"
@@ -680,7 +663,6 @@ public class AssetListFiltersUtil {
 		).put(
 			"viewCount", "integer"
 		).build();
-
 	private static final Format _format =
 		FastDateFormatFactoryUtil.getSimpleDateFormat("yyyyMMddHHmmss");
 	private static final Set<String> _localizedCommonFieldNames =

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -25,11 +25,17 @@ import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.TermQuery;
 import com.liferay.portal.kernel.search.TermRangeQuery;
 import com.liferay.portal.kernel.search.WildcardQuery;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.text.Format;
+
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -162,6 +168,12 @@ public class AssetListFiltersUtil {
 			return null;
 		}
 
+		String relativeDateValue = _resolveRelativeDateValue(value);
+
+		if (relativeDateValue != null) {
+			value = relativeDateValue;
+		}
+
 		String digits = value.replaceAll("[^0-9]", "");
 
 		if (dateTime) {
@@ -177,6 +189,38 @@ public class AssetListFiltersUtil {
 		String paddedDigits = padded.substring(0, 8);
 
 		return paddedDigits + (endOfBound ? "235959" : "000000");
+	}
+
+	private static String _resolveRelativeDateValue(String value) {
+		if (!_relativeDateValues.contains(value)) {
+			return null;
+		}
+
+		Calendar calendar = Calendar.getInstance();
+
+		calendar.set(Calendar.MILLISECOND, 0);
+		calendar.set(Calendar.MINUTE, 0);
+		calendar.set(Calendar.SECOND, 0);
+
+		if (value.equals("last-year") || value.equals("past-year")) {
+			calendar.add(Calendar.YEAR, -1);
+		}
+		else if (value.equals("next-month")) {
+			calendar.add(Calendar.MONTH, 1);
+		}
+		else if (value.equals("past-24-hours") || value.equals("past-day")) {
+			calendar.add(Calendar.DAY_OF_MONTH, -1);
+		}
+		else if (value.equals("past-month")) {
+			calendar.add(Calendar.MONTH, -1);
+		}
+		else if (value.equals("past-week")) {
+			calendar.add(Calendar.DAY_OF_MONTH, -7);
+		}
+
+		// "now" requires no offset.
+
+		return _format.format(calendar.getTime());
 	}
 
 	private static NestedQuery _toNestedQuery(
@@ -389,5 +433,11 @@ public class AssetListFiltersUtil {
 
 		return new MatchQuery(subfield, value);
 	}
+
+	private static final Format _format =
+		FastDateFormatFactoryUtil.getSimpleDateFormat("yyyyMMddHHmmss");
+	private static final List<String> _relativeDateValues = Arrays.asList(
+		"last-year", "next-month", "now", "past-24-hours", "past-day",
+		"past-month", "past-week", "past-year");
 
 }

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.search.MatchQuery;
 import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.TermQuery;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -130,6 +131,16 @@ public class AssetListFiltersUtil {
 		return "nestedFieldArray.value_text";
 	}
 
+	private static boolean _isNegatedOperator(String operatorName) {
+		if (operatorName.equals("not-contains") ||
+			operatorName.equals("not-eq")) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	private static NestedQuery _toNestedQuery(
 		long companyId, JSONObject jsonObject, Locale locale) {
 
@@ -151,25 +162,40 @@ public class AssetListFiltersUtil {
 			return null;
 		}
 
+		String operatorName = GetterUtil.getString(
+			jsonObject.getString("operatorName"), "contains");
+
+		String subfield = _getSubfield(locale, objectField);
+
+		Query valueQuery = _toValueQuery(subfield, operatorName, value);
+
+		if (valueQuery == null) {
+			return null;
+		}
+
 		BooleanQuery booleanQuery = new BooleanQuery();
 
 		booleanQuery.add(
 			new TermQuery("nestedFieldArray.fieldName", propertyName),
 			BooleanClauseOccur.MUST);
 		booleanQuery.add(
-			_toQuery(_getSubfield(locale, objectField), value),
-			BooleanClauseOccur.MUST);
+			valueQuery,
+			_isNegatedOperator(operatorName) ? BooleanClauseOccur.MUST_NOT :
+				BooleanClauseOccur.MUST);
 
 		return new NestedQuery("nestedFieldArray", booleanQuery);
 	}
 
-	private static Query _toQuery(String subfield, String value) {
+	private static Query _toValueQuery(
+		String subfield, String operatorName, String value) {
+
 		if (subfield.endsWith(".value_boolean") ||
 			subfield.endsWith(".value_date") ||
 			subfield.endsWith(".value_double") ||
 			subfield.endsWith(".value_integer") ||
 			subfield.endsWith(".value_keyword") ||
-			subfield.endsWith(".value_long")) {
+			subfield.endsWith(".value_long") || operatorName.equals("eq") ||
+			operatorName.equals("not-eq")) {
 
 			return new TermQuery(subfield, value);
 		}

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -276,12 +276,12 @@ public class AssetListFiltersUtilTest {
 				BooleanClauseOccur.MUST_NOT,
 				_buildFilter("not-eq", "title", "keyword"), "title"));
 
-		ObjectField localizedSubtitle = _setUpObjectField(
+		ObjectField subtitleObjectField = _setUpObjectField(
 			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 			ObjectFieldConstants.DB_TYPE_STRING, "subtitle");
 
 		Mockito.when(
-			localizedSubtitle.isLocalized()
+			subtitleObjectField.isLocalized()
 		).thenReturn(
 			true
 		);

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -567,6 +567,38 @@ public class AssetListFiltersUtilTest {
 			Arrays.toString(booleanClauses), 0, booleanClauses.length);
 	}
 
+	@Test
+	public void testRoutesMetadataObjectFieldsToCommonFieldPath() {
+		_setUpMetadataObjectField(
+			"modifiedDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
+			ObjectFieldConstants.DB_TYPE_DATE);
+
+		_assertTermRangeQuery(
+			_runAndAssertCommonFieldRow(
+				_buildFilter("eq", "modifiedDate", "2026-01-15")),
+			"modified", "20260115000000", "20260115235959", true, true);
+
+		_setUpMetadataObjectField(
+			"creator", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING);
+
+		_assertTermQuery(
+			_runAndAssertCommonFieldRow(_buildFilter("eq", "creator", "Alice")),
+			"userName", "Alice");
+
+		_setUpMetadataObjectField(
+			"id", ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
+			ObjectFieldConstants.DB_TYPE_LONG);
+
+		BooleanClause[] booleanClauses =
+			AssetListFiltersUtil.getFiltersBooleanClauses(
+				_COMPANY_ID, JSONUtil.putAll(_buildFilter("eq", "id", "5")),
+				LocaleUtil.US);
+
+		Assert.assertEquals(
+			Arrays.toString(booleanClauses), 0, booleanClauses.length);
+	}
+
 	private static MockedStatic<ObjectDefinitionLocalServiceUtil>
 		_createObjectDefinitionLocalServiceUtilMockedStatic() {
 
@@ -950,6 +982,20 @@ public class AssetListFiltersUtilTest {
 		);
 
 		localizationUtil.setLocalization(localization);
+	}
+
+	private ObjectField _setUpMetadataObjectField(
+		String name, String businessType, String dbType) {
+
+		ObjectField objectField = _setUpObjectField(name, businessType, dbType);
+
+		Mockito.when(
+			objectField.isMetadata()
+		).thenReturn(
+			true
+		);
+
+		return objectField;
 	}
 
 	private ObjectField _setUpObjectField(

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -11,7 +11,6 @@ import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldLocalServiceUtil;
 import com.liferay.portal.json.JSONFactoryImpl;
-import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -64,6 +63,90 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
+	public void testBooleanEqBuildsTermQuery() {
+		_stubObjectField(
+			"visible", ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN,
+			ObjectFieldConstants.DB_TYPE_BOOLEAN);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"visible", _buildFilter("eq", "visible", "true"),
+			BooleanClauseOccur.MUST);
+
+		_assertTermQuery(valueQuery, "nestedFieldArray.value_boolean", "true");
+	}
+
+	@Test
+	public void testDecimalEqBuildsTermQuery() {
+		_stubObjectField(
+			"priority", ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
+			ObjectFieldConstants.DB_TYPE_DOUBLE);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"priority", _buildFilter("eq", "priority", "3.14"),
+			BooleanClauseOccur.MUST);
+
+		_assertTermQuery(valueQuery, "nestedFieldArray.value_double", "3.14");
+	}
+
+	@Test
+	public void testIntegerEqBuildsTermQuery() {
+		_stubObjectField(
+			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
+			ObjectFieldConstants.DB_TYPE_INTEGER);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"viewCount", _buildFilter("eq", "viewCount", "5"),
+			BooleanClauseOccur.MUST);
+
+		_assertTermQuery(valueQuery, "nestedFieldArray.value_integer", "5");
+	}
+
+	@Test
+	public void testIntegerNotEqWrapsTermQueryInMustNot() {
+		_stubObjectField(
+			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
+			ObjectFieldConstants.DB_TYPE_INTEGER);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"viewCount", _buildFilter("not-eq", "viewCount", "5"),
+			BooleanClauseOccur.MUST_NOT);
+
+		_assertTermQuery(valueQuery, "nestedFieldArray.value_integer", "5");
+	}
+
+	@Test
+	public void testLocalizedTextEqUsesLocalizedSubfield() {
+		ObjectField objectField = _stubObjectField(
+			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING);
+
+		Mockito.when(
+			objectField.isLocalized()
+		).thenReturn(
+			true
+		);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"title", _buildFilter("eq", "title", "keyword"),
+			BooleanClauseOccur.MUST);
+
+		_assertTermQuery(valueQuery, "nestedFieldArray.value_en_US", "keyword");
+	}
+
+	@Test
+	public void testLongIntegerEqBuildsTermQuery() {
+		_stubObjectField(
+			"externalId", ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
+			ObjectFieldConstants.DB_TYPE_LONG);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"externalId", _buildFilter("eq", "externalId", "99999"),
+			BooleanClauseOccur.MUST);
+
+		_assertTermQuery(valueQuery, "nestedFieldArray.value_long", "99999");
+	}
+
+	@Test
 	public void testReturnsEmptyClausesWhenFiltersJSONArrayIsEmpty() {
 		BooleanClause[] booleanClauses =
 			AssetListFiltersUtil.getFiltersBooleanClauses(
@@ -89,18 +172,38 @@ public class AssetListFiltersUtilTest {
 			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 			ObjectFieldConstants.DB_TYPE_STRING);
 
-		JSONArray filtersJSONArray = JSONUtil.putAll(
-			_buildFilter("contains", "title", "keyword"));
-
-		BooleanClause[] booleanClauses =
-			AssetListFiltersUtil.getFiltersBooleanClauses(
-				filtersJSONArray, _COMPANY_ID, LocaleUtil.US);
-
-		Query valueQuery = _assertNestedRow(
-			booleanClauses, 0, "title", BooleanClauseOccur.MUST);
+		Query valueQuery = _runAndAssertNestedRow(
+			"title", _buildFilter("contains", "title", "keyword"),
+			BooleanClauseOccur.MUST);
 
 		Assert.assertTrue(
 			valueQuery.toString(), valueQuery instanceof MatchQuery);
+	}
+
+	@Test
+	public void testTextEqBuildsTermQuery() {
+		_stubObjectField(
+			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"title", _buildFilter("eq", "title", "keyword"),
+			BooleanClauseOccur.MUST);
+
+		_assertTermQuery(valueQuery, "nestedFieldArray.value_text", "keyword");
+	}
+
+	@Test
+	public void testTextNotEqWrapsTermQueryInMustNot() {
+		_stubObjectField(
+			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"title", _buildFilter("not-eq", "title", "keyword"),
+			BooleanClauseOccur.MUST_NOT);
+
+		_assertTermQuery(valueQuery, "nestedFieldArray.value_text", "keyword");
 	}
 
 	private static MockedStatic<ObjectDefinitionLocalServiceUtil>
@@ -178,6 +281,23 @@ public class AssetListFiltersUtilTest {
 		).getClause();
 	}
 
+	private void _assertTermQuery(
+		Query query, String expectedField, String expectedValue) {
+
+		Assert.assertTrue(query.toString(), query instanceof TermQuery);
+
+		TermQuery termQuery = (TermQuery)query;
+
+		Assert.assertEquals(
+			expectedField,
+			termQuery.getQueryTerm(
+			).getField());
+		Assert.assertEquals(
+			expectedValue,
+			termQuery.getQueryTerm(
+			).getValue());
+	}
+
 	private JSONObject _buildFilter(
 		String operatorName, String propertyName, String value) {
 
@@ -192,6 +312,18 @@ public class AssetListFiltersUtilTest {
 		).put(
 			"value", value
 		);
+	}
+
+	private Query _runAndAssertNestedRow(
+		String propertyName, JSONObject filterJSONObject,
+		BooleanClauseOccur expectedValueOccur) {
+
+		BooleanClause[] booleanClauses =
+			AssetListFiltersUtil.getFiltersBooleanClauses(
+				JSONUtil.putAll(filterJSONObject), _COMPANY_ID, LocaleUtil.US);
+
+		return _assertNestedRow(
+			booleanClauses, 0, propertyName, expectedValueOccur);
 	}
 
 	private ObjectField _stubObjectField(

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -87,7 +87,7 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
-	public void testHandlesCommonFieldOperators() {
+	public void testGetFiltersBooleanClausesWithCommonFieldOperators() {
 		_assertMatchQuery(
 			"localized_title_en_US", "Apple",
 			_runAndAssertCommonFieldRow(
@@ -153,7 +153,7 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
-	public void testHandlesDateAndDateTimeOperators() {
+	public void testGetFiltersBooleanClausesWithDateAndDateTimeOperators() {
 		_setUpObjectField(
 			ObjectFieldConstants.BUSINESS_TYPE_DATE,
 			ObjectFieldConstants.DB_TYPE_DATE, "dueDate");
@@ -213,7 +213,7 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
-	public void testHandlesEqualityOperators() {
+	public void testGetFiltersBooleanClausesWithEqualityOperators() {
 		_setUpObjectField(
 			ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN,
 			ObjectFieldConstants.DB_TYPE_BOOLEAN, "visible");
@@ -294,7 +294,23 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
-	public void testHandlesKeywordTextContainsOperators() {
+	public void testGetFiltersBooleanClausesWithInvalidInput() {
+		BooleanClause[] booleanClauses =
+			AssetListFiltersUtil.getFiltersBooleanClauses(
+				_COMPANY_ID, null, LocaleUtil.US);
+
+		Assert.assertEquals(
+			Arrays.toString(booleanClauses), 0, booleanClauses.length);
+
+		booleanClauses = AssetListFiltersUtil.getFiltersBooleanClauses(
+			_COMPANY_ID, JSONFactoryUtil.createJSONArray(), LocaleUtil.US);
+
+		Assert.assertEquals(
+			Arrays.toString(booleanClauses), 0, booleanClauses.length);
+	}
+
+	@Test
+	public void testGetFiltersBooleanClausesWithKeywordTextContainsOperators() {
 		_setUpKeywordTextObjectField("learnDocumentation");
 
 		_assertWildcardQuery(
@@ -320,7 +336,40 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
-	public void testHandlesNumericRangeOperators() {
+	public void testGetFiltersBooleanClausesWithMetadataObjectFields() {
+		_setUpMetadataObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_DATE,
+			ObjectFieldConstants.DB_TYPE_DATE, "modifiedDate");
+
+		_assertTermRangeQuery(
+			"modified", true, true, "20260115000000", "20260115235959",
+			_runAndAssertCommonFieldRow(
+				_buildFilter("eq", "modifiedDate", "2026-01-15")));
+
+		_setUpMetadataObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, "creator");
+
+		_assertTermQuery(
+			"userName", "Alice",
+			_runAndAssertCommonFieldRow(
+				_buildFilter("eq", "creator", "Alice")));
+
+		_setUpMetadataObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
+			ObjectFieldConstants.DB_TYPE_LONG, "id");
+
+		BooleanClause[] booleanClauses =
+			AssetListFiltersUtil.getFiltersBooleanClauses(
+				_COMPANY_ID, JSONUtil.putAll(_buildFilter("eq", "id", "5")),
+				LocaleUtil.US);
+
+		Assert.assertEquals(
+			Arrays.toString(booleanClauses), 0, booleanClauses.length);
+	}
+
+	@Test
+	public void testGetFiltersBooleanClausesWithNumericRangeOperators() {
 		_setUpObjectField(
 			ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
 			ObjectFieldConstants.DB_TYPE_INTEGER, "viewCount");
@@ -389,7 +438,7 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
-	public void testHandlesPicklistMultiValueOperators() {
+	public void testGetFiltersBooleanClausesWithPicklistMultiValueOperators() {
 		_setUpPicklistObjectField("status");
 
 		_assertPicklistBooleanQuery(
@@ -476,7 +525,7 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
-	public void testHandlesRelativeDateOperators() {
+	public void testGetFiltersBooleanClausesWithRelativeDateOperators() {
 		_setUpObjectField(
 			ObjectFieldConstants.BUSINESS_TYPE_DATE,
 			ObjectFieldConstants.DB_TYPE_DATE, "dueDate");
@@ -525,7 +574,7 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
-	public void testHandlesTextContainsOperators() {
+	public void testGetFiltersBooleanClausesWithTextContainsOperators() {
 		_setUpObjectField(
 			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 			ObjectFieldConstants.DB_TYPE_STRING, "title");
@@ -557,55 +606,6 @@ public class AssetListFiltersUtilTest {
 		Assert.assertTrue(
 			containsWithQuantifierQuery.toString(),
 			containsWithQuantifierQuery instanceof MatchQuery);
-	}
-
-	@Test
-	public void testReturnsEmptyClausesForInvalidInput() {
-		BooleanClause[] booleanClauses =
-			AssetListFiltersUtil.getFiltersBooleanClauses(
-				_COMPANY_ID, null, LocaleUtil.US);
-
-		Assert.assertEquals(
-			Arrays.toString(booleanClauses), 0, booleanClauses.length);
-
-		booleanClauses = AssetListFiltersUtil.getFiltersBooleanClauses(
-			_COMPANY_ID, JSONFactoryUtil.createJSONArray(), LocaleUtil.US);
-
-		Assert.assertEquals(
-			Arrays.toString(booleanClauses), 0, booleanClauses.length);
-	}
-
-	@Test
-	public void testRoutesMetadataObjectFieldsToCommonFieldPath() {
-		_setUpMetadataObjectField(
-			ObjectFieldConstants.BUSINESS_TYPE_DATE,
-			ObjectFieldConstants.DB_TYPE_DATE, "modifiedDate");
-
-		_assertTermRangeQuery(
-			"modified", true, true, "20260115000000", "20260115235959",
-			_runAndAssertCommonFieldRow(
-				_buildFilter("eq", "modifiedDate", "2026-01-15")));
-
-		_setUpMetadataObjectField(
-			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-			ObjectFieldConstants.DB_TYPE_STRING, "creator");
-
-		_assertTermQuery(
-			"userName", "Alice",
-			_runAndAssertCommonFieldRow(
-				_buildFilter("eq", "creator", "Alice")));
-
-		_setUpMetadataObjectField(
-			ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
-			ObjectFieldConstants.DB_TYPE_LONG, "id");
-
-		BooleanClause[] booleanClauses =
-			AssetListFiltersUtil.getFiltersBooleanClauses(
-				_COMPANY_ID, JSONUtil.putAll(_buildFilter("eq", "id", "5")),
-				LocaleUtil.US);
-
-		Assert.assertEquals(
-			Arrays.toString(booleanClauses), 0, booleanClauses.length);
 	}
 
 	private static MockedStatic<ObjectDefinitionLocalServiceUtil>

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -386,6 +386,117 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
+	public void testPicklistContainsAllBuildsMustOfTermQueries() {
+		_stubPicklistObjectField("status");
+
+		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
+			"contains", "status",
+			JSONUtil.putAll(
+				_picklistValueJSONObject("approved"),
+				_picklistValueJSONObject("draft"))
+		).put(
+			"quantifier", "all"
+		);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"status", filterJSONObject, BooleanClauseOccur.MUST);
+
+		_assertPicklistBooleanQuery(
+			valueQuery, BooleanClauseOccur.MUST, "approved", "draft");
+	}
+
+	@Test
+	public void testPicklistContainsAnyBuildsShouldOfTermQueries() {
+		_stubPicklistObjectField("status");
+
+		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
+			"contains", "status",
+			JSONUtil.putAll(
+				_picklistValueJSONObject("approved"),
+				_picklistValueJSONObject("draft"))
+		).put(
+			"quantifier", "any"
+		);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"status", filterJSONObject, BooleanClauseOccur.MUST);
+
+		_assertPicklistBooleanQuery(
+			valueQuery, BooleanClauseOccur.SHOULD, "approved", "draft");
+	}
+
+	@Test
+	public void testPicklistContainsDefaultsToAnyWhenQuantifierMissing() {
+		_stubPicklistObjectField("status");
+
+		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
+			"contains", "status",
+			JSONUtil.putAll(_picklistValueJSONObject("approved")));
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"status", filterJSONObject, BooleanClauseOccur.MUST);
+
+		_assertPicklistBooleanQuery(
+			valueQuery, BooleanClauseOccur.SHOULD, "approved");
+	}
+
+	@Test
+	public void testPicklistEmptyValueArraySkipsRow() {
+		_stubPicklistObjectField("status");
+
+		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
+			"contains", "status", JSONFactoryUtil.createJSONArray()
+		).put(
+			"quantifier", "any"
+		);
+
+		BooleanClause[] booleanClauses =
+			AssetListFiltersUtil.getFiltersBooleanClauses(
+				JSONUtil.putAll(filterJSONObject), _COMPANY_ID, LocaleUtil.US);
+
+		Assert.assertEquals(
+			Arrays.toString(booleanClauses), 0, booleanClauses.length);
+	}
+
+	@Test
+	public void testPicklistNotContainsAnyWrapsInMustNot() {
+		_stubPicklistObjectField("status");
+
+		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
+			"not-contains", "status",
+			JSONUtil.putAll(
+				_picklistValueJSONObject("approved"),
+				_picklistValueJSONObject("draft"))
+		).put(
+			"quantifier", "any"
+		);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"status", filterJSONObject, BooleanClauseOccur.MUST_NOT);
+
+		_assertPicklistBooleanQuery(
+			valueQuery, BooleanClauseOccur.SHOULD, "approved", "draft");
+	}
+
+	@Test
+	public void testPicklistValuesAreLowercased() {
+		_stubPicklistObjectField("status");
+
+		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
+			"contains", "status",
+			JSONUtil.putAll(_picklistValueJSONObject("Approved"))
+		).put(
+			"quantifier", "any"
+		);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"status", filterJSONObject, BooleanClauseOccur.MUST);
+
+		_assertPicklistBooleanQuery(
+			valueQuery, BooleanClauseOccur.SHOULD, "approved");
+	}
+
+	@Test
 	public void testReturnsEmptyClausesWhenFiltersJSONArrayIsEmpty() {
 		BooleanClause[] booleanClauses =
 			AssetListFiltersUtil.getFiltersBooleanClauses(
@@ -553,6 +664,35 @@ public class AssetListFiltersUtilTest {
 		).getClause();
 	}
 
+	private void _assertPicklistBooleanQuery(
+		Query query, BooleanClauseOccur expectedInnerOccur,
+		String... expectedValues) {
+
+		Assert.assertTrue(query.toString(), query instanceof BooleanQuery);
+
+		BooleanQuery booleanQuery = (BooleanQuery)query;
+
+		List<BooleanClause<Query>> innerBooleanClauses = booleanQuery.clauses();
+
+		Assert.assertEquals(
+			innerBooleanClauses.toString(), expectedValues.length,
+			innerBooleanClauses.size());
+
+		for (int i = 0; i < expectedValues.length; i++) {
+			Assert.assertEquals(
+				expectedInnerOccur,
+				innerBooleanClauses.get(
+					i
+				).getBooleanClauseOccur());
+
+			_assertTermQuery(
+				innerBooleanClauses.get(
+					i
+				).getClause(),
+				"nestedFieldArray.value_keyword", expectedValues[i]);
+		}
+	}
+
 	private void _assertTermQuery(
 		Query query, String expectedField, String expectedValue) {
 
@@ -617,6 +757,14 @@ public class AssetListFiltersUtilTest {
 			"propertyName", propertyName
 		).put(
 			"value", valueJSONArray
+		);
+	}
+
+	private JSONObject _picklistValueJSONObject(String value) {
+		return JSONUtil.put(
+			"label", value
+		).put(
+			"value", value
 		);
 	}
 
@@ -698,6 +846,20 @@ public class AssetListFiltersUtilTest {
 			() -> PortalUtil.getClassName(_CLASS_NAME_ID)
 		).thenReturn(
 			"com.liferay.test.Class" + _CLASS_NAME_ID
+		);
+
+		return objectField;
+	}
+
+	private ObjectField _stubPicklistObjectField(String name) {
+		ObjectField objectField = _stubObjectField(
+			name, ObjectFieldConstants.BUSINESS_TYPE_PICKLIST,
+			ObjectFieldConstants.DB_TYPE_STRING);
+
+		Mockito.when(
+			objectField.isIndexedAsKeyword()
+		).thenReturn(
+			true
 		);
 
 		return objectField;

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -22,6 +22,8 @@ import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.TermQuery;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Localization;
+import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
@@ -60,6 +62,8 @@ public class AssetListFiltersUtilTest {
 		_objectDefinitionLocalServiceUtilMockedStatic.reset();
 		_objectFieldLocalServiceUtilMockedStatic.reset();
 		_portalUtilMockedStatic.reset();
+
+		_setUpLocalizationUtil();
 	}
 
 	@Test
@@ -150,7 +154,7 @@ public class AssetListFiltersUtilTest {
 	public void testReturnsEmptyClausesWhenFiltersJSONArrayIsEmpty() {
 		BooleanClause[] booleanClauses =
 			AssetListFiltersUtil.getFiltersBooleanClauses(
-				JSONFactoryUtil.createJSONArray(), _COMPANY_ID, LocaleUtil.US);
+				_COMPANY_ID, JSONFactoryUtil.createJSONArray(), LocaleUtil.US);
 
 		Assert.assertEquals(
 			Arrays.toString(booleanClauses), 0, booleanClauses.length);
@@ -160,7 +164,7 @@ public class AssetListFiltersUtilTest {
 	public void testReturnsEmptyClausesWhenFiltersJSONArrayIsNull() {
 		BooleanClause[] booleanClauses =
 			AssetListFiltersUtil.getFiltersBooleanClauses(
-				null, _COMPANY_ID, LocaleUtil.US);
+				_COMPANY_ID, null, LocaleUtil.US);
 
 		Assert.assertEquals(
 			Arrays.toString(booleanClauses), 0, booleanClauses.length);
@@ -320,10 +324,26 @@ public class AssetListFiltersUtilTest {
 
 		BooleanClause[] booleanClauses =
 			AssetListFiltersUtil.getFiltersBooleanClauses(
-				JSONUtil.putAll(filterJSONObject), _COMPANY_ID, LocaleUtil.US);
+				_COMPANY_ID, JSONUtil.putAll(filterJSONObject), LocaleUtil.US);
 
 		return _assertNestedRow(
 			booleanClauses, 0, propertyName, expectedValueOccur);
+	}
+
+	private void _setUpLocalizationUtil() {
+		LocalizationUtil localizationUtil = new LocalizationUtil();
+
+		Localization localization = Mockito.mock(Localization.class);
+
+		Mockito.when(
+			localization.getLocalizedName(
+				Mockito.anyString(), Mockito.anyString())
+		).thenAnswer(
+			invocation ->
+				invocation.getArgument(0) + "_" + invocation.getArgument(1)
+		);
+
+		localizationUtil.setLocalization(localization);
 	}
 
 	private ObjectField _stubObjectField(

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.search.TermQuery;
 import com.liferay.portal.kernel.search.TermRangeQuery;
 import com.liferay.portal.kernel.search.WildcardQuery;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Localization;
@@ -1075,13 +1076,14 @@ public class AssetListFiltersUtilTest {
 		return objectField;
 	}
 
-	private static final long _CLASS_NAME_ID = 30601L;
+	private static final long _CLASS_NAME_ID = RandomTestUtil.randomLong();
 
-	private static final long _CLASS_TYPE_ID = 42L;
+	private static final long _CLASS_TYPE_ID = RandomTestUtil.randomLong();
 
-	private static final long _COMPANY_ID = 12345L;
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
 
-	private static final long _LIST_TYPE_DEFINITION_ID = 77L;
+	private static final long _LIST_TYPE_DEFINITION_ID =
+		RandomTestUtil.randomLong();
 
 	private static final MockedStatic<ObjectDefinitionLocalServiceUtil>
 		_objectDefinitionLocalServiceUtilMockedStatic =

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -11,6 +11,7 @@ import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldLocalServiceUtil;
 import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -21,6 +22,7 @@ import com.liferay.portal.kernel.search.MatchQuery;
 import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.TermQuery;
+import com.liferay.portal.kernel.search.TermRangeQuery;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -80,6 +82,23 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
+	public void testDecimalBetweenBuildsRangeQuery() {
+		_stubObjectField(
+			"priority", ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
+			ObjectFieldConstants.DB_TYPE_DOUBLE);
+
+		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
+			"between", "priority", JSONUtil.putAll("1.0", "5.0"));
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"priority", filterJSONObject, BooleanClauseOccur.MUST);
+
+		_assertTermRangeQuery(
+			valueQuery, "nestedFieldArray.value_double", "1.0", "5.0", true,
+			true);
+	}
+
+	@Test
 	public void testDecimalEqBuildsTermQuery() {
 		_stubObjectField(
 			"priority", ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
@@ -93,6 +112,38 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
+	public void testDecimalGtBuildsRangeQuery() {
+		_stubObjectField(
+			"priority", ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
+			ObjectFieldConstants.DB_TYPE_DOUBLE);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"priority", _buildFilter("gt", "priority", "3.14"),
+			BooleanClauseOccur.MUST);
+
+		_assertTermRangeQuery(
+			valueQuery, "nestedFieldArray.value_double", "3.14", null, false,
+			false);
+	}
+
+	@Test
+	public void testIntegerBetweenBuildsRangeQueryWithBothBounds() {
+		_stubObjectField(
+			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
+			ObjectFieldConstants.DB_TYPE_INTEGER);
+
+		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
+			"between", "viewCount", JSONUtil.putAll("5", "10"));
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"viewCount", filterJSONObject, BooleanClauseOccur.MUST);
+
+		_assertTermRangeQuery(
+			valueQuery, "nestedFieldArray.value_integer", "5", "10", true,
+			true);
+	}
+
+	@Test
 	public void testIntegerEqBuildsTermQuery() {
 		_stubObjectField(
 			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
@@ -103,6 +154,66 @@ public class AssetListFiltersUtilTest {
 			BooleanClauseOccur.MUST);
 
 		_assertTermQuery(valueQuery, "nestedFieldArray.value_integer", "5");
+	}
+
+	@Test
+	public void testIntegerGeBuildsRangeQueryWithInclusiveLowerBound() {
+		_stubObjectField(
+			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
+			ObjectFieldConstants.DB_TYPE_INTEGER);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"viewCount", _buildFilter("ge", "viewCount", "5"),
+			BooleanClauseOccur.MUST);
+
+		_assertTermRangeQuery(
+			valueQuery, "nestedFieldArray.value_integer", "5", null, true,
+			false);
+	}
+
+	@Test
+	public void testIntegerGtBuildsRangeQuery() {
+		_stubObjectField(
+			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
+			ObjectFieldConstants.DB_TYPE_INTEGER);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"viewCount", _buildFilter("gt", "viewCount", "5"),
+			BooleanClauseOccur.MUST);
+
+		_assertTermRangeQuery(
+			valueQuery, "nestedFieldArray.value_integer", "5", null, false,
+			false);
+	}
+
+	@Test
+	public void testIntegerLeBuildsRangeQueryWithInclusiveUpperBound() {
+		_stubObjectField(
+			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
+			ObjectFieldConstants.DB_TYPE_INTEGER);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"viewCount", _buildFilter("le", "viewCount", "5"),
+			BooleanClauseOccur.MUST);
+
+		_assertTermRangeQuery(
+			valueQuery, "nestedFieldArray.value_integer", null, "5", false,
+			true);
+	}
+
+	@Test
+	public void testIntegerLtBuildsRangeQuery() {
+		_stubObjectField(
+			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
+			ObjectFieldConstants.DB_TYPE_INTEGER);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"viewCount", _buildFilter("lt", "viewCount", "5"),
+			BooleanClauseOccur.MUST);
+
+		_assertTermRangeQuery(
+			valueQuery, "nestedFieldArray.value_integer", null, "5", false,
+			false);
 	}
 
 	@Test
@@ -135,6 +246,23 @@ public class AssetListFiltersUtilTest {
 			BooleanClauseOccur.MUST);
 
 		_assertTermQuery(valueQuery, "nestedFieldArray.value_en_US", "keyword");
+	}
+
+	@Test
+	public void testLongIntegerBetweenBuildsRangeQuery() {
+		_stubObjectField(
+			"externalId", ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
+			ObjectFieldConstants.DB_TYPE_LONG);
+
+		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
+			"between", "externalId", JSONUtil.putAll("100", "200"));
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"externalId", filterJSONObject, BooleanClauseOccur.MUST);
+
+		_assertTermRangeQuery(
+			valueQuery, "nestedFieldArray.value_long", "100", "200", true,
+			true);
 	}
 
 	@Test
@@ -335,6 +463,24 @@ public class AssetListFiltersUtilTest {
 			).getValue());
 	}
 
+	private void _assertTermRangeQuery(
+		Query query, String expectedField, String expectedLower,
+		String expectedUpper, boolean expectedIncludesLower,
+		boolean expectedIncludesUpper) {
+
+		Assert.assertTrue(query.toString(), query instanceof TermRangeQuery);
+
+		TermRangeQuery termRangeQuery = (TermRangeQuery)query;
+
+		Assert.assertEquals(expectedField, termRangeQuery.getField());
+		Assert.assertEquals(expectedLower, termRangeQuery.getLowerTerm());
+		Assert.assertEquals(expectedUpper, termRangeQuery.getUpperTerm());
+		Assert.assertEquals(
+			expectedIncludesLower, termRangeQuery.includesLower());
+		Assert.assertEquals(
+			expectedIncludesUpper, termRangeQuery.includesUpper());
+	}
+
 	private JSONObject _buildFilter(
 		String operatorName, String propertyName, String value) {
 
@@ -348,6 +494,22 @@ public class AssetListFiltersUtilTest {
 			"propertyName", propertyName
 		).put(
 			"value", value
+		);
+	}
+
+	private JSONObject _buildFilterWithJSONArrayValue(
+		String operatorName, String propertyName, JSONArray valueJSONArray) {
+
+		return JSONUtil.put(
+			"classNameId", _CLASS_NAME_ID
+		).put(
+			"classTypeId", _CLASS_TYPE_ID
+		).put(
+			"operatorName", operatorName
+		).put(
+			"propertyName", propertyName
+		).put(
+			"value", valueJSONArray
 		);
 	}
 

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -82,6 +82,113 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
+	public void testDateBetweenNormalizesBothBounds() {
+		_stubObjectField(
+			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
+			ObjectFieldConstants.DB_TYPE_DATE);
+
+		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
+			"between", "dueDate", JSONUtil.putAll("2026-01-15", "2026-01-20"));
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"dueDate", filterJSONObject, BooleanClauseOccur.MUST);
+
+		_assertTermRangeQuery(
+			valueQuery, "nestedFieldArray.value_date", "20260115000000",
+			"20260120235959", true, true);
+	}
+
+	@Test
+	public void testDateEqBuildsOneDayRangeQuery() {
+		_stubObjectField(
+			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
+			ObjectFieldConstants.DB_TYPE_DATE);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"dueDate", _buildFilter("eq", "dueDate", "2026-01-15"),
+			BooleanClauseOccur.MUST);
+
+		_assertTermRangeQuery(
+			valueQuery, "nestedFieldArray.value_date", "20260115000000",
+			"20260115235959", true, true);
+	}
+
+	@Test
+	public void testDateGeNormalizesValueToStartOfDay() {
+		_stubObjectField(
+			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
+			ObjectFieldConstants.DB_TYPE_DATE);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"dueDate", _buildFilter("ge", "dueDate", "2026-01-15"),
+			BooleanClauseOccur.MUST);
+
+		_assertTermRangeQuery(
+			valueQuery, "nestedFieldArray.value_date", "20260115000000", null,
+			true, false);
+	}
+
+	@Test
+	public void testDateGtNormalizesValueToEndOfDay() {
+		_stubObjectField(
+			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
+			ObjectFieldConstants.DB_TYPE_DATE);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"dueDate", _buildFilter("gt", "dueDate", "2026-01-15"),
+			BooleanClauseOccur.MUST);
+
+		_assertTermRangeQuery(
+			valueQuery, "nestedFieldArray.value_date", "20260115235959", null,
+			false, false);
+	}
+
+	@Test
+	public void testDateLeNormalizesValueToEndOfDay() {
+		_stubObjectField(
+			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
+			ObjectFieldConstants.DB_TYPE_DATE);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"dueDate", _buildFilter("le", "dueDate", "2026-01-15"),
+			BooleanClauseOccur.MUST);
+
+		_assertTermRangeQuery(
+			valueQuery, "nestedFieldArray.value_date", null, "20260115235959",
+			false, true);
+	}
+
+	@Test
+	public void testDateLtNormalizesValueToStartOfDay() {
+		_stubObjectField(
+			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
+			ObjectFieldConstants.DB_TYPE_DATE);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"dueDate", _buildFilter("lt", "dueDate", "2026-01-15"),
+			BooleanClauseOccur.MUST);
+
+		_assertTermRangeQuery(
+			valueQuery, "nestedFieldArray.value_date", null, "20260115000000",
+			false, false);
+	}
+
+	@Test
+	public void testDateTimeEqBuildsOneMinuteRangeQuery() {
+		_stubObjectField(
+			"reminderAt", ObjectFieldConstants.BUSINESS_TYPE_DATE_TIME,
+			ObjectFieldConstants.DB_TYPE_DATE_TIME);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"reminderAt", _buildFilter("eq", "reminderAt", "2026-01-15 10:30"),
+			BooleanClauseOccur.MUST);
+
+		_assertTermRangeQuery(
+			valueQuery, "nestedFieldArray.value_date", "20260115103000",
+			"20260115103059", true, true);
+	}
+
+	@Test
 	public void testDecimalBetweenBuildsRangeQuery() {
 		_stubObjectField(
 			"priority", ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -142,7 +142,10 @@ public class AssetListFiltersUtilTest {
 		BooleanClause[] booleanClauses =
 			AssetListFiltersUtil.getFiltersBooleanClauses(
 				_COMPANY_ID,
-				JSONUtil.putAll(_buildCommonFieldFilter("eq", "bogus", "x")),
+				JSONUtil.putAll(
+					_buildCommonFieldFilter(
+						"eq", RandomTestUtil.randomString(),
+						RandomTestUtil.randomString())),
 				LocaleUtil.US);
 
 		Assert.assertEquals(

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -1,0 +1,267 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.list.internal.util;
+
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
+import com.liferay.object.service.ObjectFieldLocalServiceUtil;
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.search.BooleanClause;
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.MatchQuery;
+import com.liferay.portal.kernel.search.NestedQuery;
+import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.TermQuery;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Felipe Lorenz
+ */
+public class AssetListFiltersUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@AfterClass
+	public static void tearDownClass() {
+		_objectDefinitionLocalServiceUtilMockedStatic.close();
+		_objectFieldLocalServiceUtilMockedStatic.close();
+		_portalUtilMockedStatic.close();
+	}
+
+	@Before
+	public void setUp() {
+		_objectDefinitionLocalServiceUtilMockedStatic.reset();
+		_objectFieldLocalServiceUtilMockedStatic.reset();
+		_portalUtilMockedStatic.reset();
+	}
+
+	@Test
+	public void testReturnsEmptyClausesWhenFiltersJSONArrayIsEmpty() {
+		BooleanClause[] booleanClauses =
+			AssetListFiltersUtil.getFiltersBooleanClauses(
+				JSONFactoryUtil.createJSONArray(), _COMPANY_ID, LocaleUtil.US);
+
+		Assert.assertEquals(
+			Arrays.toString(booleanClauses), 0, booleanClauses.length);
+	}
+
+	@Test
+	public void testReturnsEmptyClausesWhenFiltersJSONArrayIsNull() {
+		BooleanClause[] booleanClauses =
+			AssetListFiltersUtil.getFiltersBooleanClauses(
+				null, _COMPANY_ID, LocaleUtil.US);
+
+		Assert.assertEquals(
+			Arrays.toString(booleanClauses), 0, booleanClauses.length);
+	}
+
+	@Test
+	public void testTextContainsBuildsMatchQueryInsideNestedEnvelope() {
+		_stubObjectField(
+			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING);
+
+		JSONArray filtersJSONArray = JSONUtil.putAll(
+			_buildFilter("contains", "title", "keyword"));
+
+		BooleanClause[] booleanClauses =
+			AssetListFiltersUtil.getFiltersBooleanClauses(
+				filtersJSONArray, _COMPANY_ID, LocaleUtil.US);
+
+		Query valueQuery = _assertNestedRow(
+			booleanClauses, 0, "title", BooleanClauseOccur.MUST);
+
+		Assert.assertTrue(
+			valueQuery.toString(), valueQuery instanceof MatchQuery);
+	}
+
+	private static MockedStatic<ObjectDefinitionLocalServiceUtil>
+		_createObjectDefinitionLocalServiceUtilMockedStatic() {
+
+		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
+
+		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
+
+		return Mockito.mockStatic(ObjectDefinitionLocalServiceUtil.class);
+	}
+
+	private Query _assertNestedRow(
+		BooleanClause[] booleanClauses, int rowIndex, String propertyName,
+		BooleanClauseOccur expectedValueOccur) {
+
+		Assert.assertEquals(
+			Arrays.toString(booleanClauses), 1, booleanClauses.length);
+
+		BooleanClause<?> outerBooleanClause = booleanClauses[0];
+
+		Assert.assertEquals(
+			BooleanClauseOccur.MUST,
+			outerBooleanClause.getBooleanClauseOccur());
+
+		BooleanQuery outerBooleanQuery =
+			(BooleanQuery)outerBooleanClause.getClause();
+
+		List<BooleanClause<Query>> rowBooleanClauses =
+			outerBooleanQuery.clauses();
+
+		Assert.assertTrue(rowIndex < rowBooleanClauses.size());
+
+		NestedQuery nestedQuery = (NestedQuery)rowBooleanClauses.get(
+			rowIndex
+		).getClause();
+
+		Assert.assertEquals("nestedFieldArray", nestedQuery.getPath());
+
+		BooleanQuery innerBooleanQuery = (BooleanQuery)nestedQuery.getQuery();
+
+		List<BooleanClause<Query>> innerBooleanClauses =
+			innerBooleanQuery.clauses();
+
+		Assert.assertEquals(
+			innerBooleanClauses.toString(), 2, innerBooleanClauses.size());
+
+		TermQuery fieldNameTermQuery = (TermQuery)innerBooleanClauses.get(
+			0
+		).getClause();
+
+		Assert.assertEquals(
+			"nestedFieldArray.fieldName",
+			fieldNameTermQuery.getQueryTerm(
+			).getField());
+		Assert.assertEquals(
+			propertyName,
+			fieldNameTermQuery.getQueryTerm(
+			).getValue());
+
+		Assert.assertEquals(
+			BooleanClauseOccur.MUST,
+			innerBooleanClauses.get(
+				0
+			).getBooleanClauseOccur());
+
+		Assert.assertEquals(
+			expectedValueOccur,
+			innerBooleanClauses.get(
+				1
+			).getBooleanClauseOccur());
+
+		return innerBooleanClauses.get(
+			1
+		).getClause();
+	}
+
+	private JSONObject _buildFilter(
+		String operatorName, String propertyName, String value) {
+
+		return JSONUtil.put(
+			"classNameId", _CLASS_NAME_ID
+		).put(
+			"classTypeId", _CLASS_TYPE_ID
+		).put(
+			"operatorName", operatorName
+		).put(
+			"propertyName", propertyName
+		).put(
+			"value", value
+		);
+	}
+
+	private ObjectField _stubObjectField(
+		String name, String businessType, String dbType) {
+
+		ObjectField objectField = Mockito.mock(ObjectField.class);
+
+		Mockito.when(
+			objectField.getBusinessType()
+		).thenReturn(
+			businessType
+		);
+
+		Mockito.when(
+			objectField.getDBType()
+		).thenReturn(
+			dbType
+		);
+
+		Mockito.when(
+			objectField.getName()
+		).thenReturn(
+			name
+		);
+
+		ObjectDefinition objectDefinition = Mockito.mock(
+			ObjectDefinition.class);
+
+		Mockito.when(
+			objectDefinition.getObjectDefinitionId()
+		).thenReturn(
+			_CLASS_TYPE_ID
+		);
+
+		_objectDefinitionLocalServiceUtilMockedStatic.when(
+			() -> ObjectDefinitionLocalServiceUtil.fetchObjectDefinition(
+				_CLASS_TYPE_ID)
+		).thenReturn(
+			objectDefinition
+		);
+
+		_objectFieldLocalServiceUtilMockedStatic.when(
+			() -> ObjectFieldLocalServiceUtil.fetchObjectField(
+				_CLASS_TYPE_ID, name)
+		).thenReturn(
+			objectField
+		);
+
+		_portalUtilMockedStatic.when(
+			() -> PortalUtil.getClassName(_CLASS_NAME_ID)
+		).thenReturn(
+			"com.liferay.test.Class" + _CLASS_NAME_ID
+		);
+
+		return objectField;
+	}
+
+	private static final long _CLASS_NAME_ID = 30601L;
+
+	private static final long _CLASS_TYPE_ID = 42L;
+
+	private static final long _COMPANY_ID = 12345L;
+
+	private static final MockedStatic<ObjectDefinitionLocalServiceUtil>
+		_objectDefinitionLocalServiceUtilMockedStatic =
+			_createObjectDefinitionLocalServiceUtilMockedStatic();
+	private static final MockedStatic<ObjectFieldLocalServiceUtil>
+		_objectFieldLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			ObjectFieldLocalServiceUtil.class);
+	private static final MockedStatic<PortalUtil> _portalUtilMockedStatic =
+		Mockito.mockStatic(PortalUtil.class);
+
+}

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -1055,7 +1055,7 @@ public class AssetListFiltersUtilTest {
 		Mockito.when(
 			objectField.getListTypeDefinitionId()
 		).thenReturn(
-			_LIST_TYPE_DEFINITION_ID
+			RandomTestUtil.randomLong()
 		);
 
 		Mockito.when(
@@ -1072,9 +1072,6 @@ public class AssetListFiltersUtilTest {
 	private static final long _CLASS_TYPE_ID = RandomTestUtil.randomLong();
 
 	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
-
-	private static final long _LIST_TYPE_DEFINITION_ID =
-		RandomTestUtil.randomLong();
 
 	private static final MockedStatic<ObjectDefinitionLocalServiceUtil>
 		_objectDefinitionLocalServiceUtilMockedStatic =

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -70,7 +70,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testBooleanEqBuildsTermQuery() {
-		_stubObjectField(
+		_setUpObjectField(
 			"visible", ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN,
 			ObjectFieldConstants.DB_TYPE_BOOLEAN);
 
@@ -83,7 +83,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testDateBetweenNormalizesBothBounds() {
-		_stubObjectField(
+		_setUpObjectField(
 			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
 			ObjectFieldConstants.DB_TYPE_DATE);
 
@@ -100,7 +100,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testDateEqBuildsOneDayRangeQuery() {
-		_stubObjectField(
+		_setUpObjectField(
 			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
 			ObjectFieldConstants.DB_TYPE_DATE);
 
@@ -115,7 +115,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testDateGeNormalizesValueToStartOfDay() {
-		_stubObjectField(
+		_setUpObjectField(
 			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
 			ObjectFieldConstants.DB_TYPE_DATE);
 
@@ -130,7 +130,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testDateGtNormalizesValueToEndOfDay() {
-		_stubObjectField(
+		_setUpObjectField(
 			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
 			ObjectFieldConstants.DB_TYPE_DATE);
 
@@ -145,7 +145,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testDateLeNormalizesValueToEndOfDay() {
-		_stubObjectField(
+		_setUpObjectField(
 			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
 			ObjectFieldConstants.DB_TYPE_DATE);
 
@@ -160,7 +160,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testDateLtNormalizesValueToStartOfDay() {
-		_stubObjectField(
+		_setUpObjectField(
 			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
 			ObjectFieldConstants.DB_TYPE_DATE);
 
@@ -175,7 +175,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testDateTimeEqBuildsOneMinuteRangeQuery() {
-		_stubObjectField(
+		_setUpObjectField(
 			"reminderAt", ObjectFieldConstants.BUSINESS_TYPE_DATE_TIME,
 			ObjectFieldConstants.DB_TYPE_DATE_TIME);
 
@@ -190,7 +190,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testDecimalBetweenBuildsRangeQuery() {
-		_stubObjectField(
+		_setUpObjectField(
 			"priority", ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
 			ObjectFieldConstants.DB_TYPE_DOUBLE);
 
@@ -207,7 +207,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testDecimalEqBuildsTermQuery() {
-		_stubObjectField(
+		_setUpObjectField(
 			"priority", ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
 			ObjectFieldConstants.DB_TYPE_DOUBLE);
 
@@ -220,7 +220,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testDecimalGtBuildsRangeQuery() {
-		_stubObjectField(
+		_setUpObjectField(
 			"priority", ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
 			ObjectFieldConstants.DB_TYPE_DOUBLE);
 
@@ -235,7 +235,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testIntegerBetweenBuildsRangeQueryWithBothBounds() {
-		_stubObjectField(
+		_setUpObjectField(
 			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
 			ObjectFieldConstants.DB_TYPE_INTEGER);
 
@@ -252,7 +252,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testIntegerEqBuildsTermQuery() {
-		_stubObjectField(
+		_setUpObjectField(
 			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
 			ObjectFieldConstants.DB_TYPE_INTEGER);
 
@@ -265,7 +265,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testIntegerGeBuildsRangeQueryWithInclusiveLowerBound() {
-		_stubObjectField(
+		_setUpObjectField(
 			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
 			ObjectFieldConstants.DB_TYPE_INTEGER);
 
@@ -280,7 +280,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testIntegerGtBuildsRangeQuery() {
-		_stubObjectField(
+		_setUpObjectField(
 			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
 			ObjectFieldConstants.DB_TYPE_INTEGER);
 
@@ -295,7 +295,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testIntegerLeBuildsRangeQueryWithInclusiveUpperBound() {
-		_stubObjectField(
+		_setUpObjectField(
 			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
 			ObjectFieldConstants.DB_TYPE_INTEGER);
 
@@ -310,7 +310,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testIntegerLtBuildsRangeQuery() {
-		_stubObjectField(
+		_setUpObjectField(
 			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
 			ObjectFieldConstants.DB_TYPE_INTEGER);
 
@@ -325,7 +325,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testIntegerNotEqWrapsTermQueryInMustNot() {
-		_stubObjectField(
+		_setUpObjectField(
 			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
 			ObjectFieldConstants.DB_TYPE_INTEGER);
 
@@ -338,7 +338,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testLocalizedTextEqUsesLocalizedSubfield() {
-		ObjectField objectField = _stubObjectField(
+		ObjectField objectField = _setUpObjectField(
 			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 			ObjectFieldConstants.DB_TYPE_STRING);
 
@@ -357,7 +357,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testLongIntegerBetweenBuildsRangeQuery() {
-		_stubObjectField(
+		_setUpObjectField(
 			"externalId", ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
 			ObjectFieldConstants.DB_TYPE_LONG);
 
@@ -374,7 +374,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testLongIntegerEqBuildsTermQuery() {
-		_stubObjectField(
+		_setUpObjectField(
 			"externalId", ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
 			ObjectFieldConstants.DB_TYPE_LONG);
 
@@ -387,7 +387,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testPicklistContainsAllBuildsMustOfTermQueries() {
-		_stubPicklistObjectField("status");
+		_setUpPicklistObjectField("status");
 
 		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
 			"contains", "status",
@@ -407,7 +407,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testPicklistContainsAnyBuildsShouldOfTermQueries() {
-		_stubPicklistObjectField("status");
+		_setUpPicklistObjectField("status");
 
 		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
 			"contains", "status",
@@ -427,7 +427,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testPicklistContainsDefaultsToAnyWhenQuantifierMissing() {
-		_stubPicklistObjectField("status");
+		_setUpPicklistObjectField("status");
 
 		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
 			"contains", "status",
@@ -442,7 +442,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testPicklistEmptyValueArraySkipsRow() {
-		_stubPicklistObjectField("status");
+		_setUpPicklistObjectField("status");
 
 		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
 			"contains", "status", JSONFactoryUtil.createJSONArray()
@@ -460,7 +460,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testPicklistNotContainsAnyWrapsInMustNot() {
-		_stubPicklistObjectField("status");
+		_setUpPicklistObjectField("status");
 
 		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
 			"not-contains", "status",
@@ -480,7 +480,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testPicklistValuesAreLowercased() {
-		_stubPicklistObjectField("status");
+		_setUpPicklistObjectField("status");
 
 		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
 			"contains", "status",
@@ -518,7 +518,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testTextContainsBuildsMatchQueryInsideNestedEnvelope() {
-		_stubObjectField(
+		_setUpObjectField(
 			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 			ObjectFieldConstants.DB_TYPE_STRING);
 
@@ -532,7 +532,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testTextContainsIgnoresQuantifierOnTextField() {
-		_stubObjectField(
+		_setUpObjectField(
 			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 			ObjectFieldConstants.DB_TYPE_STRING);
 
@@ -551,7 +551,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testTextEqBuildsTermQuery() {
-		_stubObjectField(
+		_setUpObjectField(
 			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 			ObjectFieldConstants.DB_TYPE_STRING);
 
@@ -564,7 +564,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testTextNotContainsWrapsMatchQueryInMustNot() {
-		_stubObjectField(
+		_setUpObjectField(
 			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 			ObjectFieldConstants.DB_TYPE_STRING);
 
@@ -578,7 +578,7 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testTextNotEqWrapsTermQueryInMustNot() {
-		_stubObjectField(
+		_setUpObjectField(
 			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 			ObjectFieldConstants.DB_TYPE_STRING);
 
@@ -796,7 +796,7 @@ public class AssetListFiltersUtilTest {
 		localizationUtil.setLocalization(localization);
 	}
 
-	private ObjectField _stubObjectField(
+	private ObjectField _setUpObjectField(
 		String name, String businessType, String dbType) {
 
 		ObjectField objectField = Mockito.mock(ObjectField.class);
@@ -851,8 +851,8 @@ public class AssetListFiltersUtilTest {
 		return objectField;
 	}
 
-	private ObjectField _stubPicklistObjectField(String name) {
-		ObjectField objectField = _stubObjectField(
+	private ObjectField _setUpPicklistObjectField(String name) {
+		ObjectField objectField = _setUpObjectField(
 			name, ObjectFieldConstants.BUSINESS_TYPE_PICKLIST,
 			ObjectFieldConstants.DB_TYPE_STRING);
 

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.search.MatchAllQuery;
 import com.liferay.portal.kernel.search.MatchQuery;
 import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.QueryTerm;
 import com.liferay.portal.kernel.search.TermQuery;
 import com.liferay.portal.kernel.search.TermRangeQuery;
 import com.liferay.portal.kernel.search.WildcardQuery;
@@ -674,9 +675,9 @@ public class AssetListFiltersUtilTest {
 
 		Assert.assertTrue(rowIndex < rowBooleanClauses.size());
 
-		NestedQuery nestedQuery = (NestedQuery)rowBooleanClauses.get(
-			rowIndex
-		).getClause();
+		BooleanClause<Query> rowBooleanClause = rowBooleanClauses.get(rowIndex);
+
+		NestedQuery nestedQuery = (NestedQuery)rowBooleanClause.getClause();
 
 		Assert.assertEquals("nestedFieldArray", nestedQuery.getPath());
 
@@ -688,49 +689,45 @@ public class AssetListFiltersUtilTest {
 		Assert.assertEquals(
 			innerBooleanClauses.toString(), 3, innerBooleanClauses.size());
 
-		TermQuery fieldNameTermQuery = (TermQuery)innerBooleanClauses.get(
-			0
-		).getClause();
+		BooleanClause<Query> fieldNameBooleanClause = innerBooleanClauses.get(
+			0);
+
+		TermQuery fieldNameTermQuery =
+			(TermQuery)fieldNameBooleanClause.getClause();
+
+		QueryTerm fieldNameQueryTerm = fieldNameTermQuery.getQueryTerm();
 
 		Assert.assertEquals(
-			"nestedFieldArray.fieldName",
-			fieldNameTermQuery.getQueryTerm(
-			).getField());
-		Assert.assertEquals(
-			propertyName,
-			fieldNameTermQuery.getQueryTerm(
-			).getValue());
+			"nestedFieldArray.fieldName", fieldNameQueryTerm.getField());
+		Assert.assertEquals(propertyName, fieldNameQueryTerm.getValue());
 
 		Assert.assertEquals(
 			BooleanClauseOccur.MUST,
-			innerBooleanClauses.get(
-				0
-			).getBooleanClauseOccur());
+			fieldNameBooleanClause.getBooleanClauseOccur());
 
-		TermQuery valueFieldNameTermQuery = (TermQuery)innerBooleanClauses.get(
-			1
-		).getClause();
+		BooleanClause<Query> valueFieldNameBooleanClause =
+			innerBooleanClauses.get(1);
+
+		TermQuery valueFieldNameTermQuery =
+			(TermQuery)valueFieldNameBooleanClause.getClause();
+
+		QueryTerm valueFieldNameQueryTerm =
+			valueFieldNameTermQuery.getQueryTerm();
 
 		Assert.assertEquals(
 			"nestedFieldArray.valueFieldName",
-			valueFieldNameTermQuery.getQueryTerm(
-			).getField());
+			valueFieldNameQueryTerm.getField());
 
 		Assert.assertEquals(
 			BooleanClauseOccur.MUST,
-			innerBooleanClauses.get(
-				1
-			).getBooleanClauseOccur());
+			valueFieldNameBooleanClause.getBooleanClauseOccur());
+
+		BooleanClause<Query> valueBooleanClause = innerBooleanClauses.get(2);
 
 		Assert.assertEquals(
-			expectedValueOccur,
-			innerBooleanClauses.get(
-				2
-			).getBooleanClauseOccur());
+			expectedValueOccur, valueBooleanClause.getBooleanClauseOccur());
 
-		return innerBooleanClauses.get(
-			2
-		).getClause();
+		return valueBooleanClause.getClause();
 	}
 
 	private void _assertPicklistBooleanQuery(
@@ -748,17 +745,14 @@ public class AssetListFiltersUtilTest {
 			innerBooleanClauses.size());
 
 		for (int i = 0; i < expectedValues.length; i++) {
+			BooleanClause<Query> booleanClause = innerBooleanClauses.get(i);
+
 			Assert.assertEquals(
-				expectedInnerOccur,
-				innerBooleanClauses.get(
-					i
-				).getBooleanClauseOccur());
+				expectedInnerOccur, booleanClause.getBooleanClauseOccur());
 
 			_assertTermQuery(
 				"nestedFieldArray.value_keyword", expectedValues[i],
-				innerBooleanClauses.get(
-					i
-				).getClause());
+				booleanClause.getClause());
 		}
 	}
 
@@ -769,14 +763,10 @@ public class AssetListFiltersUtilTest {
 
 		TermQuery termQuery = (TermQuery)query;
 
-		Assert.assertEquals(
-			expectedField,
-			termQuery.getQueryTerm(
-			).getField());
-		Assert.assertEquals(
-			expectedValue,
-			termQuery.getQueryTerm(
-			).getValue());
+		QueryTerm queryTerm = termQuery.getQueryTerm();
+
+		Assert.assertEquals(expectedField, queryTerm.getField());
+		Assert.assertEquals(expectedValue, queryTerm.getValue());
 	}
 
 	private void _assertTermRangeQuery(
@@ -804,14 +794,10 @@ public class AssetListFiltersUtilTest {
 
 		WildcardQuery wildcardQuery = (WildcardQuery)query;
 
-		Assert.assertEquals(
-			expectedField,
-			wildcardQuery.getQueryTerm(
-			).getField());
-		Assert.assertEquals(
-			expectedValue,
-			wildcardQuery.getQueryTerm(
-			).getValue());
+		QueryTerm queryTerm = wildcardQuery.getQueryTerm();
+
+		Assert.assertEquals(expectedField, queryTerm.getField());
+		Assert.assertEquals(expectedValue, queryTerm.getValue());
 	}
 
 	private JSONObject _buildCommonFieldFilter(
@@ -897,10 +883,10 @@ public class AssetListFiltersUtilTest {
 		BooleanQuery outerBooleanQuery =
 			(BooleanQuery)booleanClauses[0].getClause();
 
-		BooleanClause<Query> rowBooleanClause = outerBooleanQuery.clauses(
-		).get(
-			0
-		);
+		List<BooleanClause<Query>> rowBooleanClauses =
+			outerBooleanQuery.clauses();
+
+		BooleanClause<Query> rowBooleanClause = rowBooleanClauses.get(0);
 
 		Assert.assertEquals(
 			BooleanClauseOccur.MUST, rowBooleanClause.getBooleanClauseOccur());
@@ -914,25 +900,23 @@ public class AssetListFiltersUtilTest {
 		Assert.assertEquals(
 			negatedBooleanClauses.toString(), 2, negatedBooleanClauses.size());
 
+		BooleanClause<Query> matchAllBooleanClause = negatedBooleanClauses.get(
+			0);
+
 		Assert.assertTrue(
-			negatedBooleanClauses.get(
-				0
-			).getClause() instanceof MatchAllQuery);
+			matchAllBooleanClause.getClause() instanceof MatchAllQuery);
 		Assert.assertEquals(
 			BooleanClauseOccur.MUST,
-			negatedBooleanClauses.get(
-				0
-			).getBooleanClauseOccur());
+			matchAllBooleanClause.getBooleanClauseOccur());
+
+		BooleanClause<Query> negatedBooleanClause = negatedBooleanClauses.get(
+			1);
 
 		Assert.assertEquals(
 			BooleanClauseOccur.MUST_NOT,
-			negatedBooleanClauses.get(
-				1
-			).getBooleanClauseOccur());
+			negatedBooleanClause.getBooleanClauseOccur());
 
-		return negatedBooleanClauses.get(
-			1
-		).getClause();
+		return negatedBooleanClause.getClause();
 	}
 
 	private Query _runAndAssertNestedRow(

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -24,18 +24,25 @@ import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.TermQuery;
 import com.liferay.portal.kernel.search.TermRangeQuery;
 import com.liferay.portal.kernel.search.WildcardQuery;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.util.FastDateFormatFactoryImpl;
+
+import java.text.Format;
 
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,6 +59,13 @@ public class AssetListFiltersUtilTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		ReflectionTestUtil.setFieldValue(
+			FastDateFormatFactoryUtil.class, "_fastDateFormatFactory",
+			new FastDateFormatFactoryImpl());
+	}
 
 	@AfterClass
 	public static void tearDownClass() {
@@ -390,6 +404,55 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
+	public void testHandlesRelativeDateOperators() {
+		_setUpObjectField(
+			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
+			ObjectFieldConstants.DB_TYPE_DATE);
+
+		String lastYearLowerTerm = _runRelativeDateGeLowerTerm("last-year");
+		String nextMonthLowerTerm = _runRelativeDateGeLowerTerm("next-month");
+		String nowLowerTerm = _runRelativeDateGeLowerTerm("now");
+		String past24HoursLowerTerm = _runRelativeDateGeLowerTerm(
+			"past-24-hours");
+		String pastDayLowerTerm = _runRelativeDateGeLowerTerm("past-day");
+		String pastMonthLowerTerm = _runRelativeDateGeLowerTerm("past-month");
+		String pastWeekLowerTerm = _runRelativeDateGeLowerTerm("past-week");
+		String pastYearLowerTerm = _runRelativeDateGeLowerTerm("past-year");
+
+		for (String lowerTerm :
+				new String[] {
+					lastYearLowerTerm, nextMonthLowerTerm, nowLowerTerm,
+					past24HoursLowerTerm, pastDayLowerTerm, pastMonthLowerTerm,
+					pastWeekLowerTerm, pastYearLowerTerm
+				}) {
+
+			Assert.assertEquals(lowerTerm, 14, lowerTerm.length());
+			Assert.assertTrue(lowerTerm, lowerTerm.endsWith("000000"));
+		}
+
+		Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyyMMdd");
+
+		Assert.assertEquals(format.format(new Date()) + "000000", nowLowerTerm);
+
+		Assert.assertEquals(lastYearLowerTerm, pastYearLowerTerm);
+		Assert.assertEquals(past24HoursLowerTerm, pastDayLowerTerm);
+
+		Assert.assertTrue(pastYearLowerTerm.compareTo(pastMonthLowerTerm) < 0);
+		Assert.assertTrue(pastMonthLowerTerm.compareTo(pastWeekLowerTerm) < 0);
+		Assert.assertTrue(pastWeekLowerTerm.compareTo(pastDayLowerTerm) < 0);
+		Assert.assertTrue(pastDayLowerTerm.compareTo(nowLowerTerm) < 0);
+		Assert.assertTrue(nowLowerTerm.compareTo(nextMonthLowerTerm) < 0);
+
+		_assertTermRangeQuery(
+			_runAndAssertNestedRow(
+				"dueDate", _buildFilter("le", "dueDate", "now"),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_date", null,
+			format.format(new Date()) + "235959", false, true);
+	}
+
+	@Test
 	public void testHandlesTextContainsOperators() {
 		_setUpObjectField(
 			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
@@ -663,6 +726,18 @@ public class AssetListFiltersUtilTest {
 			booleanClauses, 0, propertyName, expectedValueOccur);
 	}
 
+	private String _runRelativeDateGeLowerTerm(String value) {
+		Query query = _runAndAssertNestedRow(
+			"dueDate", _buildFilter("ge", "dueDate", value),
+			BooleanClauseOccur.MUST);
+
+		Assert.assertTrue(query.toString(), query instanceof TermRangeQuery);
+
+		TermRangeQuery termRangeQuery = (TermRangeQuery)query;
+
+		return termRangeQuery.getLowerTerm();
+	}
+
 	private ObjectField _setUpKeywordTextObjectField(String name) {
 		ObjectField objectField = _setUpObjectField(
 			name, ObjectFieldConstants.BUSINESS_TYPE_TEXT,
@@ -727,8 +802,9 @@ public class AssetListFiltersUtilTest {
 
 		_objectDefinitionLocalServiceUtilMockedStatic.when(
 			() ->
-				ObjectDefinitionLocalServiceUtil.fetchObjectDefinitionByClassName(
-					_COMPANY_ID, "com.liferay.test.Class" + _CLASS_NAME_ID)
+				ObjectDefinitionLocalServiceUtil.
+					fetchObjectDefinitionByClassName(
+						_COMPANY_ID, "com.liferay.test.Class" + _CLASS_NAME_ID)
 		).thenReturn(
 			objectDefinition
 		);

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -69,524 +69,415 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
-	public void testBooleanEqBuildsTermQuery() {
-		_setUpObjectField(
-			"visible", ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN,
-			ObjectFieldConstants.DB_TYPE_BOOLEAN);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"visible", _buildFilter("eq", "visible", "true"),
-			BooleanClauseOccur.MUST);
-
-		_assertTermQuery(valueQuery, "nestedFieldArray.value_boolean", "true");
-	}
-
-	@Test
-	public void testDateBetweenNormalizesBothBounds() {
+	public void testHandlesDateAndDateTimeOperators() {
 		_setUpObjectField(
 			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
 			ObjectFieldConstants.DB_TYPE_DATE);
 
-		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
-			"between", "dueDate", JSONUtil.putAll("2026-01-15", "2026-01-20"));
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"dueDate", filterJSONObject, BooleanClauseOccur.MUST);
+		// Date eq builds a one-day range query.
 
 		_assertTermRangeQuery(
-			valueQuery, "nestedFieldArray.value_date", "20260115000000",
-			"20260120235959", true, true);
-	}
+			_runAndAssertNestedRow(
+				"dueDate", _buildFilter("eq", "dueDate", "2026-01-15"),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_date", "20260115000000", "20260115235959",
+			true, true);
 
-	@Test
-	public void testDateEqBuildsOneDayRangeQuery() {
-		_setUpObjectField(
-			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
-			ObjectFieldConstants.DB_TYPE_DATE);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"dueDate", _buildFilter("eq", "dueDate", "2026-01-15"),
-			BooleanClauseOccur.MUST);
+		// Date gt normalizes the value to the end of the day, exclusive.
 
 		_assertTermRangeQuery(
-			valueQuery, "nestedFieldArray.value_date", "20260115000000",
-			"20260115235959", true, true);
-	}
+			_runAndAssertNestedRow(
+				"dueDate", _buildFilter("gt", "dueDate", "2026-01-15"),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_date", "20260115235959", null, false,
+			false);
 
-	@Test
-	public void testDateGeNormalizesValueToStartOfDay() {
-		_setUpObjectField(
-			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
-			ObjectFieldConstants.DB_TYPE_DATE);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"dueDate", _buildFilter("ge", "dueDate", "2026-01-15"),
-			BooleanClauseOccur.MUST);
+		// Date ge normalizes the value to the start of the day, inclusive.
 
 		_assertTermRangeQuery(
-			valueQuery, "nestedFieldArray.value_date", "20260115000000", null,
-			true, false);
-	}
+			_runAndAssertNestedRow(
+				"dueDate", _buildFilter("ge", "dueDate", "2026-01-15"),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_date", "20260115000000", null, true, false);
 
-	@Test
-	public void testDateGtNormalizesValueToEndOfDay() {
-		_setUpObjectField(
-			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
-			ObjectFieldConstants.DB_TYPE_DATE);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"dueDate", _buildFilter("gt", "dueDate", "2026-01-15"),
-			BooleanClauseOccur.MUST);
+		// Date lt normalizes the value to the start of the day, exclusive.
 
 		_assertTermRangeQuery(
-			valueQuery, "nestedFieldArray.value_date", "20260115235959", null,
-			false, false);
-	}
+			_runAndAssertNestedRow(
+				"dueDate", _buildFilter("lt", "dueDate", "2026-01-15"),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_date", null, "20260115000000", false,
+			false);
 
-	@Test
-	public void testDateLeNormalizesValueToEndOfDay() {
-		_setUpObjectField(
-			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
-			ObjectFieldConstants.DB_TYPE_DATE);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"dueDate", _buildFilter("le", "dueDate", "2026-01-15"),
-			BooleanClauseOccur.MUST);
+		// Date le normalizes the value to the end of the day, inclusive.
 
 		_assertTermRangeQuery(
-			valueQuery, "nestedFieldArray.value_date", null, "20260115235959",
-			false, true);
-	}
+			_runAndAssertNestedRow(
+				"dueDate", _buildFilter("le", "dueDate", "2026-01-15"),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_date", null, "20260115235959", false, true);
 
-	@Test
-	public void testDateLtNormalizesValueToStartOfDay() {
-		_setUpObjectField(
-			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
-			ObjectFieldConstants.DB_TYPE_DATE);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"dueDate", _buildFilter("lt", "dueDate", "2026-01-15"),
-			BooleanClauseOccur.MUST);
+		// Date between normalizes both bounds.
 
 		_assertTermRangeQuery(
-			valueQuery, "nestedFieldArray.value_date", null, "20260115000000",
-			false, false);
-	}
+			_runAndAssertNestedRow(
+				"dueDate",
+				_buildFilterWithJSONArrayValue(
+					"between", "dueDate",
+					JSONUtil.putAll("2026-01-15", "2026-01-20")),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_date", "20260115000000", "20260120235959",
+			true, true);
 
-	@Test
-	public void testDateTimeEqBuildsOneMinuteRangeQuery() {
+		// Date-time eq builds a one-minute range query.
+
 		_setUpObjectField(
 			"reminderAt", ObjectFieldConstants.BUSINESS_TYPE_DATE_TIME,
 			ObjectFieldConstants.DB_TYPE_DATE_TIME);
 
-		Query valueQuery = _runAndAssertNestedRow(
-			"reminderAt", _buildFilter("eq", "reminderAt", "2026-01-15 10:30"),
-			BooleanClauseOccur.MUST);
-
 		_assertTermRangeQuery(
-			valueQuery, "nestedFieldArray.value_date", "20260115103000",
-			"20260115103059", true, true);
+			_runAndAssertNestedRow(
+				"reminderAt",
+				_buildFilter("eq", "reminderAt", "2026-01-15 10:30"),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_date", "20260115103000", "20260115103059",
+			true, true);
 	}
 
 	@Test
-	public void testDecimalBetweenBuildsRangeQuery() {
+	public void testHandlesEqualityOperators() {
+
+		// Boolean eq.
+
+		_setUpObjectField(
+			"visible", ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN,
+			ObjectFieldConstants.DB_TYPE_BOOLEAN);
+
+		_assertTermQuery(
+			_runAndAssertNestedRow(
+				"visible", _buildFilter("eq", "visible", "true"),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_boolean", "true");
+
+		// Integer eq + not-eq.
+
+		_setUpObjectField(
+			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
+			ObjectFieldConstants.DB_TYPE_INTEGER);
+
+		_assertTermQuery(
+			_runAndAssertNestedRow(
+				"viewCount", _buildFilter("eq", "viewCount", "5"),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_integer", "5");
+
+		_assertTermQuery(
+			_runAndAssertNestedRow(
+				"viewCount", _buildFilter("not-eq", "viewCount", "5"),
+				BooleanClauseOccur.MUST_NOT),
+			"nestedFieldArray.value_integer", "5");
+
+		// Long integer eq.
+
+		_setUpObjectField(
+			"externalId", ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
+			ObjectFieldConstants.DB_TYPE_LONG);
+
+		_assertTermQuery(
+			_runAndAssertNestedRow(
+				"externalId", _buildFilter("eq", "externalId", "99999"),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_long", "99999");
+
+		// Decimal eq.
+
 		_setUpObjectField(
 			"priority", ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
 			ObjectFieldConstants.DB_TYPE_DOUBLE);
 
-		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
-			"between", "priority", JSONUtil.putAll("1.0", "5.0"));
+		_assertTermQuery(
+			_runAndAssertNestedRow(
+				"priority", _buildFilter("eq", "priority", "3.14"),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_double", "3.14");
 
-		Query valueQuery = _runAndAssertNestedRow(
-			"priority", filterJSONObject, BooleanClauseOccur.MUST);
+		// Text eq + not-eq.
 
-		_assertTermRangeQuery(
-			valueQuery, "nestedFieldArray.value_double", "1.0", "5.0", true,
-			true);
-	}
-
-	@Test
-	public void testDecimalEqBuildsTermQuery() {
 		_setUpObjectField(
-			"priority", ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
-			ObjectFieldConstants.DB_TYPE_DOUBLE);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"priority", _buildFilter("eq", "priority", "3.14"),
-			BooleanClauseOccur.MUST);
-
-		_assertTermQuery(valueQuery, "nestedFieldArray.value_double", "3.14");
-	}
-
-	@Test
-	public void testDecimalGtBuildsRangeQuery() {
-		_setUpObjectField(
-			"priority", ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
-			ObjectFieldConstants.DB_TYPE_DOUBLE);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"priority", _buildFilter("gt", "priority", "3.14"),
-			BooleanClauseOccur.MUST);
-
-		_assertTermRangeQuery(
-			valueQuery, "nestedFieldArray.value_double", "3.14", null, false,
-			false);
-	}
-
-	@Test
-	public void testIntegerBetweenBuildsRangeQueryWithBothBounds() {
-		_setUpObjectField(
-			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
-			ObjectFieldConstants.DB_TYPE_INTEGER);
-
-		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
-			"between", "viewCount", JSONUtil.putAll("5", "10"));
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"viewCount", filterJSONObject, BooleanClauseOccur.MUST);
-
-		_assertTermRangeQuery(
-			valueQuery, "nestedFieldArray.value_integer", "5", "10", true,
-			true);
-	}
-
-	@Test
-	public void testIntegerEqBuildsTermQuery() {
-		_setUpObjectField(
-			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
-			ObjectFieldConstants.DB_TYPE_INTEGER);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"viewCount", _buildFilter("eq", "viewCount", "5"),
-			BooleanClauseOccur.MUST);
-
-		_assertTermQuery(valueQuery, "nestedFieldArray.value_integer", "5");
-	}
-
-	@Test
-	public void testIntegerGeBuildsRangeQueryWithInclusiveLowerBound() {
-		_setUpObjectField(
-			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
-			ObjectFieldConstants.DB_TYPE_INTEGER);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"viewCount", _buildFilter("ge", "viewCount", "5"),
-			BooleanClauseOccur.MUST);
-
-		_assertTermRangeQuery(
-			valueQuery, "nestedFieldArray.value_integer", "5", null, true,
-			false);
-	}
-
-	@Test
-	public void testIntegerGtBuildsRangeQuery() {
-		_setUpObjectField(
-			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
-			ObjectFieldConstants.DB_TYPE_INTEGER);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"viewCount", _buildFilter("gt", "viewCount", "5"),
-			BooleanClauseOccur.MUST);
-
-		_assertTermRangeQuery(
-			valueQuery, "nestedFieldArray.value_integer", "5", null, false,
-			false);
-	}
-
-	@Test
-	public void testIntegerLeBuildsRangeQueryWithInclusiveUpperBound() {
-		_setUpObjectField(
-			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
-			ObjectFieldConstants.DB_TYPE_INTEGER);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"viewCount", _buildFilter("le", "viewCount", "5"),
-			BooleanClauseOccur.MUST);
-
-		_assertTermRangeQuery(
-			valueQuery, "nestedFieldArray.value_integer", null, "5", false,
-			true);
-	}
-
-	@Test
-	public void testIntegerLtBuildsRangeQuery() {
-		_setUpObjectField(
-			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
-			ObjectFieldConstants.DB_TYPE_INTEGER);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"viewCount", _buildFilter("lt", "viewCount", "5"),
-			BooleanClauseOccur.MUST);
-
-		_assertTermRangeQuery(
-			valueQuery, "nestedFieldArray.value_integer", null, "5", false,
-			false);
-	}
-
-	@Test
-	public void testIntegerNotEqWrapsTermQueryInMustNot() {
-		_setUpObjectField(
-			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
-			ObjectFieldConstants.DB_TYPE_INTEGER);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"viewCount", _buildFilter("not-eq", "viewCount", "5"),
-			BooleanClauseOccur.MUST_NOT);
-
-		_assertTermQuery(valueQuery, "nestedFieldArray.value_integer", "5");
-	}
-
-	@Test
-	public void testLocalizedTextEqUsesLocalizedSubfield() {
-		ObjectField objectField = _setUpObjectField(
 			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 			ObjectFieldConstants.DB_TYPE_STRING);
 
+		_assertTermQuery(
+			_runAndAssertNestedRow(
+				"title", _buildFilter("eq", "title", "keyword"),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_text", "keyword");
+
+		_assertTermQuery(
+			_runAndAssertNestedRow(
+				"title", _buildFilter("not-eq", "title", "keyword"),
+				BooleanClauseOccur.MUST_NOT),
+			"nestedFieldArray.value_text", "keyword");
+
+		// Localized text eq uses the locale-suffixed subfield.
+
+		ObjectField localizedSubtitle = _setUpObjectField(
+			"subtitle", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING);
+
 		Mockito.when(
-			objectField.isLocalized()
+			localizedSubtitle.isLocalized()
 		).thenReturn(
 			true
 		);
 
-		Query valueQuery = _runAndAssertNestedRow(
-			"title", _buildFilter("eq", "title", "keyword"),
-			BooleanClauseOccur.MUST);
-
-		_assertTermQuery(valueQuery, "nestedFieldArray.value_en_US", "keyword");
+		_assertTermQuery(
+			_runAndAssertNestedRow(
+				"subtitle", _buildFilter("eq", "subtitle", "keyword"),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_en_US", "keyword");
 	}
 
 	@Test
-	public void testLongIntegerBetweenBuildsRangeQuery() {
+	public void testHandlesNumericRangeOperators() {
 		_setUpObjectField(
-			"externalId", ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
-			ObjectFieldConstants.DB_TYPE_LONG);
+			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
+			ObjectFieldConstants.DB_TYPE_INTEGER);
 
-		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
-			"between", "externalId", JSONUtil.putAll("100", "200"));
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"externalId", filterJSONObject, BooleanClauseOccur.MUST);
+		// Integer gt: exclusive lower bound.
 
 		_assertTermRangeQuery(
-			valueQuery, "nestedFieldArray.value_long", "100", "200", true,
-			true);
-	}
+			_runAndAssertNestedRow(
+				"viewCount", _buildFilter("gt", "viewCount", "5"),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_integer", "5", null, false, false);
 
-	@Test
-	public void testLongIntegerEqBuildsTermQuery() {
+		// Integer ge: inclusive lower bound.
+
+		_assertTermRangeQuery(
+			_runAndAssertNestedRow(
+				"viewCount", _buildFilter("ge", "viewCount", "5"),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_integer", "5", null, true, false);
+
+		// Integer lt: exclusive upper bound.
+
+		_assertTermRangeQuery(
+			_runAndAssertNestedRow(
+				"viewCount", _buildFilter("lt", "viewCount", "5"),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_integer", null, "5", false, false);
+
+		// Integer le: inclusive upper bound.
+
+		_assertTermRangeQuery(
+			_runAndAssertNestedRow(
+				"viewCount", _buildFilter("le", "viewCount", "5"),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_integer", null, "5", false, true);
+
+		// Integer between: both bounds inclusive, read from a JSONArray value.
+
+		_assertTermRangeQuery(
+			_runAndAssertNestedRow(
+				"viewCount",
+				_buildFilterWithJSONArrayValue(
+					"between", "viewCount", JSONUtil.putAll("5", "10")),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_integer", "5", "10", true, true);
+
+		// Decimal gt.
+
+		_setUpObjectField(
+			"priority", ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
+			ObjectFieldConstants.DB_TYPE_DOUBLE);
+
+		_assertTermRangeQuery(
+			_runAndAssertNestedRow(
+				"priority", _buildFilter("gt", "priority", "3.14"),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_double", "3.14", null, false, false);
+
+		// Decimal between.
+
+		_assertTermRangeQuery(
+			_runAndAssertNestedRow(
+				"priority",
+				_buildFilterWithJSONArrayValue(
+					"between", "priority", JSONUtil.putAll("1.0", "5.0")),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_double", "1.0", "5.0", true, true);
+
+		// Long integer between.
+
 		_setUpObjectField(
 			"externalId", ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
 			ObjectFieldConstants.DB_TYPE_LONG);
 
-		Query valueQuery = _runAndAssertNestedRow(
-			"externalId", _buildFilter("eq", "externalId", "99999"),
+		_assertTermRangeQuery(
+			_runAndAssertNestedRow(
+				"externalId",
+				_buildFilterWithJSONArrayValue(
+					"between", "externalId", JSONUtil.putAll("100", "200")),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_long", "100", "200", true, true);
+	}
+
+	@Test
+	public void testHandlesPicklistMultiValueOperators() {
+		_setUpPicklistObjectField("status");
+
+		// contains + any: SHOULD of TermQuerys.
+
+		_assertPicklistBooleanQuery(
+			_runAndAssertNestedRow(
+				"status",
+				_buildFilterWithJSONArrayValue(
+					"contains", "status",
+					JSONUtil.putAll(
+						_picklistValueJSONObject("approved"),
+						_picklistValueJSONObject("draft"))
+				).put(
+					"quantifier", "any"
+				),
+				BooleanClauseOccur.MUST),
+			BooleanClauseOccur.SHOULD, "approved", "draft");
+
+		// contains + all: MUST of TermQuerys.
+
+		_assertPicklistBooleanQuery(
+			_runAndAssertNestedRow(
+				"status",
+				_buildFilterWithJSONArrayValue(
+					"contains", "status",
+					JSONUtil.putAll(
+						_picklistValueJSONObject("approved"),
+						_picklistValueJSONObject("draft"))
+				).put(
+					"quantifier", "all"
+				),
+				BooleanClauseOccur.MUST),
+			BooleanClauseOccur.MUST, "approved", "draft");
+
+		// Missing quantifier defaults to any (SHOULD).
+
+		_assertPicklistBooleanQuery(
+			_runAndAssertNestedRow(
+				"status",
+				_buildFilterWithJSONArrayValue(
+					"contains", "status",
+					JSONUtil.putAll(_picklistValueJSONObject("approved"))),
+				BooleanClauseOccur.MUST),
+			BooleanClauseOccur.SHOULD, "approved");
+
+		// not-contains wraps the inner BooleanQuery in MUST_NOT.
+
+		_assertPicklistBooleanQuery(
+			_runAndAssertNestedRow(
+				"status",
+				_buildFilterWithJSONArrayValue(
+					"not-contains", "status",
+					JSONUtil.putAll(
+						_picklistValueJSONObject("approved"),
+						_picklistValueJSONObject("draft"))
+				).put(
+					"quantifier", "any"
+				),
+				BooleanClauseOccur.MUST_NOT),
+			BooleanClauseOccur.SHOULD, "approved", "draft");
+
+		// Picklist values are lowercased before being added to the TermQuery.
+
+		_assertPicklistBooleanQuery(
+			_runAndAssertNestedRow(
+				"status",
+				_buildFilterWithJSONArrayValue(
+					"contains", "status",
+					JSONUtil.putAll(_picklistValueJSONObject("Approved"))
+				).put(
+					"quantifier", "any"
+				),
+				BooleanClauseOccur.MUST),
+			BooleanClauseOccur.SHOULD, "approved");
+
+		// An empty value array drops the row.
+
+		BooleanClause[] booleanClauses =
+			AssetListFiltersUtil.getFiltersBooleanClauses(
+				_COMPANY_ID,
+				JSONUtil.putAll(
+					_buildFilterWithJSONArrayValue(
+						"contains", "status", JSONFactoryUtil.createJSONArray()
+					).put(
+						"quantifier", "any"
+					)),
+				LocaleUtil.US);
+
+		Assert.assertEquals(
+			Arrays.toString(booleanClauses), 0, booleanClauses.length);
+	}
+
+	@Test
+	public void testHandlesTextContainsOperators() {
+		_setUpObjectField(
+			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING);
+
+		// contains: MatchQuery under MUST.
+
+		Query containsQuery = _runAndAssertNestedRow(
+			"title", _buildFilter("contains", "title", "keyword"),
 			BooleanClauseOccur.MUST);
 
-		_assertTermQuery(valueQuery, "nestedFieldArray.value_long", "99999");
+		Assert.assertTrue(
+			containsQuery.toString(), containsQuery instanceof MatchQuery);
+
+		// not-contains: MatchQuery under MUST_NOT.
+
+		Query notContainsQuery = _runAndAssertNestedRow(
+			"title", _buildFilter("not-contains", "title", "keyword"),
+			BooleanClauseOccur.MUST_NOT);
+
+		Assert.assertTrue(
+			notContainsQuery.toString(),
+			notContainsQuery instanceof MatchQuery);
+
+		// Quantifier on a text row is silently ignored (FE sets it but the
+		// value is a single string).
+
+		Query containsWithQuantifierQuery = _runAndAssertNestedRow(
+			"title",
+			_buildFilter(
+				"contains", "title", "keyword"
+			).put(
+				"quantifier", "any"
+			),
+			BooleanClauseOccur.MUST);
+
+		Assert.assertTrue(
+			containsWithQuantifierQuery.toString(),
+			containsWithQuantifierQuery instanceof MatchQuery);
 	}
 
 	@Test
-	public void testPicklistContainsAllBuildsMustOfTermQueries() {
-		_setUpPicklistObjectField("status");
+	public void testReturnsEmptyClausesForInvalidInput() {
 
-		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
-			"contains", "status",
-			JSONUtil.putAll(
-				_picklistValueJSONObject("approved"),
-				_picklistValueJSONObject("draft"))
-		).put(
-			"quantifier", "all"
-		);
+		// Null filtersJSONArray.
 
-		Query valueQuery = _runAndAssertNestedRow(
-			"status", filterJSONObject, BooleanClauseOccur.MUST);
-
-		_assertPicklistBooleanQuery(
-			valueQuery, BooleanClauseOccur.MUST, "approved", "draft");
-	}
-
-	@Test
-	public void testPicklistContainsAnyBuildsShouldOfTermQueries() {
-		_setUpPicklistObjectField("status");
-
-		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
-			"contains", "status",
-			JSONUtil.putAll(
-				_picklistValueJSONObject("approved"),
-				_picklistValueJSONObject("draft"))
-		).put(
-			"quantifier", "any"
-		);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"status", filterJSONObject, BooleanClauseOccur.MUST);
-
-		_assertPicklistBooleanQuery(
-			valueQuery, BooleanClauseOccur.SHOULD, "approved", "draft");
-	}
-
-	@Test
-	public void testPicklistContainsDefaultsToAnyWhenQuantifierMissing() {
-		_setUpPicklistObjectField("status");
-
-		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
-			"contains", "status",
-			JSONUtil.putAll(_picklistValueJSONObject("approved")));
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"status", filterJSONObject, BooleanClauseOccur.MUST);
-
-		_assertPicklistBooleanQuery(
-			valueQuery, BooleanClauseOccur.SHOULD, "approved");
-	}
-
-	@Test
-	public void testPicklistEmptyValueArraySkipsRow() {
-		_setUpPicklistObjectField("status");
-
-		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
-			"contains", "status", JSONFactoryUtil.createJSONArray()
-		).put(
-			"quantifier", "any"
-		);
-
-		BooleanClause[] booleanClauses =
-			AssetListFiltersUtil.getFiltersBooleanClauses(
-				JSONUtil.putAll(filterJSONObject), _COMPANY_ID, LocaleUtil.US);
-
-		Assert.assertEquals(
-			Arrays.toString(booleanClauses), 0, booleanClauses.length);
-	}
-
-	@Test
-	public void testPicklistNotContainsAnyWrapsInMustNot() {
-		_setUpPicklistObjectField("status");
-
-		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
-			"not-contains", "status",
-			JSONUtil.putAll(
-				_picklistValueJSONObject("approved"),
-				_picklistValueJSONObject("draft"))
-		).put(
-			"quantifier", "any"
-		);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"status", filterJSONObject, BooleanClauseOccur.MUST_NOT);
-
-		_assertPicklistBooleanQuery(
-			valueQuery, BooleanClauseOccur.SHOULD, "approved", "draft");
-	}
-
-	@Test
-	public void testPicklistValuesAreLowercased() {
-		_setUpPicklistObjectField("status");
-
-		JSONObject filterJSONObject = _buildFilterWithJSONArrayValue(
-			"contains", "status",
-			JSONUtil.putAll(_picklistValueJSONObject("Approved"))
-		).put(
-			"quantifier", "any"
-		);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"status", filterJSONObject, BooleanClauseOccur.MUST);
-
-		_assertPicklistBooleanQuery(
-			valueQuery, BooleanClauseOccur.SHOULD, "approved");
-	}
-
-	@Test
-	public void testReturnsEmptyClausesWhenFiltersJSONArrayIsEmpty() {
-		BooleanClause[] booleanClauses =
-			AssetListFiltersUtil.getFiltersBooleanClauses(
-				_COMPANY_ID, JSONFactoryUtil.createJSONArray(), LocaleUtil.US);
-
-		Assert.assertEquals(
-			Arrays.toString(booleanClauses), 0, booleanClauses.length);
-	}
-
-	@Test
-	public void testReturnsEmptyClausesWhenFiltersJSONArrayIsNull() {
 		BooleanClause[] booleanClauses =
 			AssetListFiltersUtil.getFiltersBooleanClauses(
 				_COMPANY_ID, null, LocaleUtil.US);
 
 		Assert.assertEquals(
 			Arrays.toString(booleanClauses), 0, booleanClauses.length);
-	}
 
-	@Test
-	public void testTextContainsBuildsMatchQueryInsideNestedEnvelope() {
-		_setUpObjectField(
-			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-			ObjectFieldConstants.DB_TYPE_STRING);
+		// Empty filtersJSONArray.
 
-		Query valueQuery = _runAndAssertNestedRow(
-			"title", _buildFilter("contains", "title", "keyword"),
-			BooleanClauseOccur.MUST);
+		booleanClauses = AssetListFiltersUtil.getFiltersBooleanClauses(
+			_COMPANY_ID, JSONFactoryUtil.createJSONArray(), LocaleUtil.US);
 
-		Assert.assertTrue(
-			valueQuery.toString(), valueQuery instanceof MatchQuery);
-	}
-
-	@Test
-	public void testTextContainsIgnoresQuantifierOnTextField() {
-		_setUpObjectField(
-			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-			ObjectFieldConstants.DB_TYPE_STRING);
-
-		JSONObject filterJSONObject = _buildFilter(
-			"contains", "title", "keyword"
-		).put(
-			"quantifier", "any"
-		);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"title", filterJSONObject, BooleanClauseOccur.MUST);
-
-		Assert.assertTrue(
-			valueQuery.toString(), valueQuery instanceof MatchQuery);
-	}
-
-	@Test
-	public void testTextEqBuildsTermQuery() {
-		_setUpObjectField(
-			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-			ObjectFieldConstants.DB_TYPE_STRING);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"title", _buildFilter("eq", "title", "keyword"),
-			BooleanClauseOccur.MUST);
-
-		_assertTermQuery(valueQuery, "nestedFieldArray.value_text", "keyword");
-	}
-
-	@Test
-	public void testTextNotContainsWrapsMatchQueryInMustNot() {
-		_setUpObjectField(
-			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-			ObjectFieldConstants.DB_TYPE_STRING);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"title", _buildFilter("not-contains", "title", "keyword"),
-			BooleanClauseOccur.MUST_NOT);
-
-		Assert.assertTrue(
-			valueQuery.toString(), valueQuery instanceof MatchQuery);
-	}
-
-	@Test
-	public void testTextNotEqWrapsTermQueryInMustNot() {
-		_setUpObjectField(
-			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-			ObjectFieldConstants.DB_TYPE_STRING);
-
-		Query valueQuery = _runAndAssertNestedRow(
-			"title", _buildFilter("not-eq", "title", "keyword"),
-			BooleanClauseOccur.MUST_NOT);
-
-		_assertTermQuery(valueQuery, "nestedFieldArray.value_text", "keyword");
+		Assert.assertEquals(
+			Arrays.toString(booleanClauses), 0, booleanClauses.length);
 	}
 
 	private static MockedStatic<ObjectDefinitionLocalServiceUtil>

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.TermQuery;
 import com.liferay.portal.kernel.search.TermRangeQuery;
+import com.liferay.portal.kernel.search.WildcardQuery;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -74,16 +75,12 @@ public class AssetListFiltersUtilTest {
 			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
 			ObjectFieldConstants.DB_TYPE_DATE);
 
-		// Date eq builds a one-day range query.
-
 		_assertTermRangeQuery(
 			_runAndAssertNestedRow(
 				"dueDate", _buildFilter("eq", "dueDate", "2026-01-15"),
 				BooleanClauseOccur.MUST),
 			"nestedFieldArray.value_date", "20260115000000", "20260115235959",
 			true, true);
-
-		// Date gt normalizes the value to the end of the day, exclusive.
 
 		_assertTermRangeQuery(
 			_runAndAssertNestedRow(
@@ -92,15 +89,11 @@ public class AssetListFiltersUtilTest {
 			"nestedFieldArray.value_date", "20260115235959", null, false,
 			false);
 
-		// Date ge normalizes the value to the start of the day, inclusive.
-
 		_assertTermRangeQuery(
 			_runAndAssertNestedRow(
 				"dueDate", _buildFilter("ge", "dueDate", "2026-01-15"),
 				BooleanClauseOccur.MUST),
 			"nestedFieldArray.value_date", "20260115000000", null, true, false);
-
-		// Date lt normalizes the value to the start of the day, exclusive.
 
 		_assertTermRangeQuery(
 			_runAndAssertNestedRow(
@@ -109,15 +102,11 @@ public class AssetListFiltersUtilTest {
 			"nestedFieldArray.value_date", null, "20260115000000", false,
 			false);
 
-		// Date le normalizes the value to the end of the day, inclusive.
-
 		_assertTermRangeQuery(
 			_runAndAssertNestedRow(
 				"dueDate", _buildFilter("le", "dueDate", "2026-01-15"),
 				BooleanClauseOccur.MUST),
 			"nestedFieldArray.value_date", null, "20260115235959", false, true);
-
-		// Date between normalizes both bounds.
 
 		_assertTermRangeQuery(
 			_runAndAssertNestedRow(
@@ -128,8 +117,6 @@ public class AssetListFiltersUtilTest {
 				BooleanClauseOccur.MUST),
 			"nestedFieldArray.value_date", "20260115000000", "20260120235959",
 			true, true);
-
-		// Date-time eq builds a one-minute range query.
 
 		_setUpObjectField(
 			"reminderAt", ObjectFieldConstants.BUSINESS_TYPE_DATE_TIME,
@@ -146,9 +133,6 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testHandlesEqualityOperators() {
-
-		// Boolean eq.
-
 		_setUpObjectField(
 			"visible", ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN,
 			ObjectFieldConstants.DB_TYPE_BOOLEAN);
@@ -158,8 +142,6 @@ public class AssetListFiltersUtilTest {
 				"visible", _buildFilter("eq", "visible", "true"),
 				BooleanClauseOccur.MUST),
 			"nestedFieldArray.value_boolean", "true");
-
-		// Integer eq + not-eq.
 
 		_setUpObjectField(
 			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
@@ -177,8 +159,6 @@ public class AssetListFiltersUtilTest {
 				BooleanClauseOccur.MUST_NOT),
 			"nestedFieldArray.value_integer", "5");
 
-		// Long integer eq.
-
 		_setUpObjectField(
 			"externalId", ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
 			ObjectFieldConstants.DB_TYPE_LONG);
@@ -189,8 +169,6 @@ public class AssetListFiltersUtilTest {
 				BooleanClauseOccur.MUST),
 			"nestedFieldArray.value_long", "99999");
 
-		// Decimal eq.
-
 		_setUpObjectField(
 			"priority", ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
 			ObjectFieldConstants.DB_TYPE_DOUBLE);
@@ -200,8 +178,6 @@ public class AssetListFiltersUtilTest {
 				"priority", _buildFilter("eq", "priority", "3.14"),
 				BooleanClauseOccur.MUST),
 			"nestedFieldArray.value_double", "3.14");
-
-		// Text eq + not-eq.
 
 		_setUpObjectField(
 			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
@@ -218,8 +194,6 @@ public class AssetListFiltersUtilTest {
 				"title", _buildFilter("not-eq", "title", "keyword"),
 				BooleanClauseOccur.MUST_NOT),
 			"nestedFieldArray.value_text", "keyword");
-
-		// Localized text eq uses the locale-suffixed subfield.
 
 		ObjectField localizedSubtitle = _setUpObjectField(
 			"subtitle", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
@@ -239,12 +213,36 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
+	public void testHandlesKeywordTextContainsOperators() {
+		_setUpKeywordTextObjectField("learnDocumentation");
+
+		_assertWildcardQuery(
+			_runAndAssertNestedRow(
+				"learnDocumentation",
+				_buildFilter("contains", "learnDocumentation", "Alpha"),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_keyword", "*alpha*");
+
+		_assertWildcardQuery(
+			_runAndAssertNestedRow(
+				"learnDocumentation",
+				_buildFilter("not-contains", "learnDocumentation", "Alpha"),
+				BooleanClauseOccur.MUST_NOT),
+			"nestedFieldArray.value_keyword", "*alpha*");
+
+		_assertTermQuery(
+			_runAndAssertNestedRow(
+				"learnDocumentation",
+				_buildFilter("eq", "learnDocumentation", "Alpha"),
+				BooleanClauseOccur.MUST),
+			"nestedFieldArray.value_keyword", "alpha");
+	}
+
+	@Test
 	public void testHandlesNumericRangeOperators() {
 		_setUpObjectField(
 			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
 			ObjectFieldConstants.DB_TYPE_INTEGER);
-
-		// Integer gt: exclusive lower bound.
 
 		_assertTermRangeQuery(
 			_runAndAssertNestedRow(
@@ -252,15 +250,11 @@ public class AssetListFiltersUtilTest {
 				BooleanClauseOccur.MUST),
 			"nestedFieldArray.value_integer", "5", null, false, false);
 
-		// Integer ge: inclusive lower bound.
-
 		_assertTermRangeQuery(
 			_runAndAssertNestedRow(
 				"viewCount", _buildFilter("ge", "viewCount", "5"),
 				BooleanClauseOccur.MUST),
 			"nestedFieldArray.value_integer", "5", null, true, false);
-
-		// Integer lt: exclusive upper bound.
 
 		_assertTermRangeQuery(
 			_runAndAssertNestedRow(
@@ -268,15 +262,11 @@ public class AssetListFiltersUtilTest {
 				BooleanClauseOccur.MUST),
 			"nestedFieldArray.value_integer", null, "5", false, false);
 
-		// Integer le: inclusive upper bound.
-
 		_assertTermRangeQuery(
 			_runAndAssertNestedRow(
 				"viewCount", _buildFilter("le", "viewCount", "5"),
 				BooleanClauseOccur.MUST),
 			"nestedFieldArray.value_integer", null, "5", false, true);
-
-		// Integer between: both bounds inclusive, read from a JSONArray value.
 
 		_assertTermRangeQuery(
 			_runAndAssertNestedRow(
@@ -285,8 +275,6 @@ public class AssetListFiltersUtilTest {
 					"between", "viewCount", JSONUtil.putAll("5", "10")),
 				BooleanClauseOccur.MUST),
 			"nestedFieldArray.value_integer", "5", "10", true, true);
-
-		// Decimal gt.
 
 		_setUpObjectField(
 			"priority", ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
@@ -298,8 +286,6 @@ public class AssetListFiltersUtilTest {
 				BooleanClauseOccur.MUST),
 			"nestedFieldArray.value_double", "3.14", null, false, false);
 
-		// Decimal between.
-
 		_assertTermRangeQuery(
 			_runAndAssertNestedRow(
 				"priority",
@@ -307,8 +293,6 @@ public class AssetListFiltersUtilTest {
 					"between", "priority", JSONUtil.putAll("1.0", "5.0")),
 				BooleanClauseOccur.MUST),
 			"nestedFieldArray.value_double", "1.0", "5.0", true, true);
-
-		// Long integer between.
 
 		_setUpObjectField(
 			"externalId", ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
@@ -327,8 +311,6 @@ public class AssetListFiltersUtilTest {
 	public void testHandlesPicklistMultiValueOperators() {
 		_setUpPicklistObjectField("status");
 
-		// contains + any: SHOULD of TermQuerys.
-
 		_assertPicklistBooleanQuery(
 			_runAndAssertNestedRow(
 				"status",
@@ -342,8 +324,6 @@ public class AssetListFiltersUtilTest {
 				),
 				BooleanClauseOccur.MUST),
 			BooleanClauseOccur.SHOULD, "approved", "draft");
-
-		// contains + all: MUST of TermQuerys.
 
 		_assertPicklistBooleanQuery(
 			_runAndAssertNestedRow(
@@ -359,8 +339,6 @@ public class AssetListFiltersUtilTest {
 				BooleanClauseOccur.MUST),
 			BooleanClauseOccur.MUST, "approved", "draft");
 
-		// Missing quantifier defaults to any (SHOULD).
-
 		_assertPicklistBooleanQuery(
 			_runAndAssertNestedRow(
 				"status",
@@ -369,8 +347,6 @@ public class AssetListFiltersUtilTest {
 					JSONUtil.putAll(_picklistValueJSONObject("approved"))),
 				BooleanClauseOccur.MUST),
 			BooleanClauseOccur.SHOULD, "approved");
-
-		// not-contains wraps the inner BooleanQuery in MUST_NOT.
 
 		_assertPicklistBooleanQuery(
 			_runAndAssertNestedRow(
@@ -386,8 +362,6 @@ public class AssetListFiltersUtilTest {
 				BooleanClauseOccur.MUST_NOT),
 			BooleanClauseOccur.SHOULD, "approved", "draft");
 
-		// Picklist values are lowercased before being added to the TermQuery.
-
 		_assertPicklistBooleanQuery(
 			_runAndAssertNestedRow(
 				"status",
@@ -399,8 +373,6 @@ public class AssetListFiltersUtilTest {
 				),
 				BooleanClauseOccur.MUST),
 			BooleanClauseOccur.SHOULD, "approved");
-
-		// An empty value array drops the row.
 
 		BooleanClause[] booleanClauses =
 			AssetListFiltersUtil.getFiltersBooleanClauses(
@@ -423,16 +395,12 @@ public class AssetListFiltersUtilTest {
 			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 			ObjectFieldConstants.DB_TYPE_STRING);
 
-		// contains: MatchQuery under MUST.
-
 		Query containsQuery = _runAndAssertNestedRow(
 			"title", _buildFilter("contains", "title", "keyword"),
 			BooleanClauseOccur.MUST);
 
 		Assert.assertTrue(
 			containsQuery.toString(), containsQuery instanceof MatchQuery);
-
-		// not-contains: MatchQuery under MUST_NOT.
 
 		Query notContainsQuery = _runAndAssertNestedRow(
 			"title", _buildFilter("not-contains", "title", "keyword"),
@@ -441,9 +409,6 @@ public class AssetListFiltersUtilTest {
 		Assert.assertTrue(
 			notContainsQuery.toString(),
 			notContainsQuery instanceof MatchQuery);
-
-		// Quantifier on a text row is silently ignored (FE sets it but the
-		// value is a single string).
 
 		Query containsWithQuantifierQuery = _runAndAssertNestedRow(
 			"title",
@@ -461,17 +426,12 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testReturnsEmptyClausesForInvalidInput() {
-
-		// Null filtersJSONArray.
-
 		BooleanClause[] booleanClauses =
 			AssetListFiltersUtil.getFiltersBooleanClauses(
 				_COMPANY_ID, null, LocaleUtil.US);
 
 		Assert.assertEquals(
 			Arrays.toString(booleanClauses), 0, booleanClauses.length);
-
-		// Empty filtersJSONArray.
 
 		booleanClauses = AssetListFiltersUtil.getFiltersBooleanClauses(
 			_COMPANY_ID, JSONFactoryUtil.createJSONArray(), LocaleUtil.US);
@@ -523,7 +483,7 @@ public class AssetListFiltersUtilTest {
 			innerBooleanQuery.clauses();
 
 		Assert.assertEquals(
-			innerBooleanClauses.toString(), 2, innerBooleanClauses.size());
+			innerBooleanClauses.toString(), 3, innerBooleanClauses.size());
 
 		TermQuery fieldNameTermQuery = (TermQuery)innerBooleanClauses.get(
 			0
@@ -544,14 +504,29 @@ public class AssetListFiltersUtilTest {
 				0
 			).getBooleanClauseOccur());
 
+		TermQuery valueFieldNameTermQuery = (TermQuery)innerBooleanClauses.get(
+			1
+		).getClause();
+
 		Assert.assertEquals(
-			expectedValueOccur,
+			"nestedFieldArray.valueFieldName",
+			valueFieldNameTermQuery.getQueryTerm(
+			).getField());
+
+		Assert.assertEquals(
+			BooleanClauseOccur.MUST,
 			innerBooleanClauses.get(
 				1
 			).getBooleanClauseOccur());
 
+		Assert.assertEquals(
+			expectedValueOccur,
+			innerBooleanClauses.get(
+				2
+			).getBooleanClauseOccur());
+
 		return innerBooleanClauses.get(
-			1
+			2
 		).getClause();
 	}
 
@@ -619,6 +594,23 @@ public class AssetListFiltersUtilTest {
 			expectedIncludesUpper, termRangeQuery.includesUpper());
 	}
 
+	private void _assertWildcardQuery(
+		Query query, String expectedField, String expectedValue) {
+
+		Assert.assertTrue(query.toString(), query instanceof WildcardQuery);
+
+		WildcardQuery wildcardQuery = (WildcardQuery)query;
+
+		Assert.assertEquals(
+			expectedField,
+			wildcardQuery.getQueryTerm(
+			).getField());
+		Assert.assertEquals(
+			expectedValue,
+			wildcardQuery.getQueryTerm(
+			).getValue());
+	}
+
 	private JSONObject _buildFilter(
 		String operatorName, String propertyName, String value) {
 
@@ -669,6 +661,20 @@ public class AssetListFiltersUtilTest {
 
 		return _assertNestedRow(
 			booleanClauses, 0, propertyName, expectedValueOccur);
+	}
+
+	private ObjectField _setUpKeywordTextObjectField(String name) {
+		ObjectField objectField = _setUpObjectField(
+			name, ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING);
+
+		Mockito.when(
+			objectField.isIndexedAsKeyword()
+		).thenReturn(
+			true
+		);
+
+		return objectField;
 	}
 
 	private void _setUpLocalizationUtil() {
@@ -748,6 +754,12 @@ public class AssetListFiltersUtilTest {
 			ObjectFieldConstants.DB_TYPE_STRING);
 
 		Mockito.when(
+			objectField.getListTypeDefinitionId()
+		).thenReturn(
+			_LIST_TYPE_DEFINITION_ID
+		);
+
+		Mockito.when(
 			objectField.isIndexedAsKeyword()
 		).thenReturn(
 			true
@@ -761,6 +773,8 @@ public class AssetListFiltersUtilTest {
 	private static final long _CLASS_TYPE_ID = 42L;
 
 	private static final long _COMPANY_ID = 12345L;
+
+	private static final long _LIST_TYPE_DEFINITION_ID = 77L;
 
 	private static final MockedStatic<ObjectDefinitionLocalServiceUtil>
 		_objectDefinitionLocalServiceUtilMockedStatic =

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.MatchAllQuery;
 import com.liferay.portal.kernel.search.MatchQuery;
 import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
@@ -81,6 +82,69 @@ public class AssetListFiltersUtilTest {
 		_portalUtilMockedStatic.reset();
 
 		_setUpLocalizationUtil();
+	}
+
+	@Test
+	public void testHandlesCommonFieldOperators() {
+		_assertMatchQuery(
+			_runAndAssertCommonFieldRow(
+				_buildCommonFieldFilter("eq", "title", "Apple")),
+			"localized_title_en_US", "Apple");
+		_assertMatchQuery(
+			_runAndAssertCommonFieldRow(
+				_buildCommonFieldFilter("contains", "title", "App")),
+			"localized_title_en_US", "App");
+
+		_assertTermQuery(
+			_runAndAssertCommonFieldRow(
+				_buildCommonFieldFilter("eq", "userName", "Alice")),
+			"userName", "Alice");
+		_assertWildcardQuery(
+			_runAndAssertNegatedCommonFieldRow(
+				_buildCommonFieldFilter("not-contains", "userName", "Alice")),
+			"userName", "*Alice*");
+
+		_assertTermQuery(
+			_runAndAssertCommonFieldRow(
+				_buildCommonFieldFilter("eq", "viewCount", "5")),
+			"viewCount", "5");
+		_assertTermQuery(
+			_runAndAssertNegatedCommonFieldRow(
+				_buildCommonFieldFilter("not-eq", "status", "0")),
+			"status", "0");
+
+		_assertTermRangeQuery(
+			_runAndAssertCommonFieldRow(
+				_buildCommonFieldFilter("gt", "priority", "0.5")),
+			"priority", "0.5", null, false, false);
+
+		_assertTermRangeQuery(
+			_runAndAssertCommonFieldRow(
+				_buildCommonFieldFilter("eq", "modified", "2026-01-15")),
+			"modified", "20260115000000", "20260115235959", true, true);
+		_assertTermRangeQuery(
+			_runAndAssertNegatedCommonFieldRow(
+				_buildCommonFieldFilter("not-eq", "modified", "2026-01-15")),
+			"modified", "20260115000000", "20260115235959", true, true);
+		_assertTermRangeQuery(
+			_runAndAssertCommonFieldRow(
+				_buildCommonFieldFilter("gt", "createDate", "2026-01-15")),
+			"createDate", "20260115235959", null, false, false);
+		_assertTermRangeQuery(
+			_runAndAssertCommonFieldRow(
+				_buildCommonFieldFilterWithJSONArrayValue(
+					"between", "modified",
+					JSONUtil.putAll("2026-01-15", "2026-01-20"))),
+			"modified", "20260115000000", "20260120235959", true, true);
+
+		BooleanClause[] booleanClauses =
+			AssetListFiltersUtil.getFiltersBooleanClauses(
+				_COMPANY_ID,
+				JSONUtil.putAll(_buildCommonFieldFilter("eq", "bogus", "x")),
+				LocaleUtil.US);
+
+		Assert.assertEquals(
+			Arrays.toString(booleanClauses), 0, booleanClauses.length);
 	}
 
 	@Test
@@ -513,6 +577,45 @@ public class AssetListFiltersUtilTest {
 		return Mockito.mockStatic(ObjectDefinitionLocalServiceUtil.class);
 	}
 
+	private Query _assertCommonFieldRow(BooleanClause[] booleanClauses) {
+		Assert.assertEquals(
+			Arrays.toString(booleanClauses), 1, booleanClauses.length);
+
+		BooleanClause<?> outerBooleanClause = booleanClauses[0];
+
+		Assert.assertEquals(
+			BooleanClauseOccur.MUST,
+			outerBooleanClause.getBooleanClauseOccur());
+
+		BooleanQuery outerBooleanQuery =
+			(BooleanQuery)outerBooleanClause.getClause();
+
+		List<BooleanClause<Query>> rowBooleanClauses =
+			outerBooleanQuery.clauses();
+
+		BooleanClause<Query> rowBooleanClause = rowBooleanClauses.get(0);
+
+		Assert.assertEquals(
+			BooleanClauseOccur.MUST, rowBooleanClause.getBooleanClauseOccur());
+
+		Query query = rowBooleanClause.getClause();
+
+		Assert.assertFalse(query.toString(), query instanceof NestedQuery);
+
+		return query;
+	}
+
+	private void _assertMatchQuery(
+		Query query, String expectedField, String expectedValue) {
+
+		Assert.assertTrue(query.toString(), query instanceof MatchQuery);
+
+		MatchQuery matchQuery = (MatchQuery)query;
+
+		Assert.assertEquals(expectedField, matchQuery.getField());
+		Assert.assertEquals(expectedValue, matchQuery.getValue());
+	}
+
 	private Query _assertNestedRow(
 		BooleanClause[] booleanClauses, int rowIndex, String propertyName,
 		BooleanClauseOccur expectedValueOccur) {
@@ -674,6 +777,30 @@ public class AssetListFiltersUtilTest {
 			).getValue());
 	}
 
+	private JSONObject _buildCommonFieldFilter(
+		String operatorName, String propertyName, String value) {
+
+		return JSONUtil.put(
+			"operatorName", operatorName
+		).put(
+			"propertyName", propertyName
+		).put(
+			"value", value
+		);
+	}
+
+	private JSONObject _buildCommonFieldFilterWithJSONArrayValue(
+		String operatorName, String propertyName, JSONArray valueJSONArray) {
+
+		return JSONUtil.put(
+			"operatorName", operatorName
+		).put(
+			"propertyName", propertyName
+		).put(
+			"value", valueJSONArray
+		);
+	}
+
 	private JSONObject _buildFilter(
 		String operatorName, String propertyName, String value) {
 
@@ -712,6 +839,63 @@ public class AssetListFiltersUtilTest {
 		).put(
 			"value", value
 		);
+	}
+
+	private Query _runAndAssertCommonFieldRow(JSONObject filterJSONObject) {
+		return _assertCommonFieldRow(
+			AssetListFiltersUtil.getFiltersBooleanClauses(
+				_COMPANY_ID, JSONUtil.putAll(filterJSONObject), LocaleUtil.US));
+	}
+
+	private Query _runAndAssertNegatedCommonFieldRow(
+		JSONObject filterJSONObject) {
+
+		BooleanClause[] booleanClauses =
+			AssetListFiltersUtil.getFiltersBooleanClauses(
+				_COMPANY_ID, JSONUtil.putAll(filterJSONObject), LocaleUtil.US);
+
+		Assert.assertEquals(
+			Arrays.toString(booleanClauses), 1, booleanClauses.length);
+
+		BooleanQuery outerBooleanQuery =
+			(BooleanQuery)booleanClauses[0].getClause();
+
+		BooleanClause<Query> rowBooleanClause = outerBooleanQuery.clauses(
+		).get(
+			0
+		);
+
+		Assert.assertEquals(
+			BooleanClauseOccur.MUST, rowBooleanClause.getBooleanClauseOccur());
+
+		BooleanQuery negatedBooleanQuery =
+			(BooleanQuery)rowBooleanClause.getClause();
+
+		List<BooleanClause<Query>> negatedBooleanClauses =
+			negatedBooleanQuery.clauses();
+
+		Assert.assertEquals(
+			negatedBooleanClauses.toString(), 2, negatedBooleanClauses.size());
+
+		Assert.assertTrue(
+			negatedBooleanClauses.get(
+				0
+			).getClause() instanceof MatchAllQuery);
+		Assert.assertEquals(
+			BooleanClauseOccur.MUST,
+			negatedBooleanClauses.get(
+				0
+			).getBooleanClauseOccur());
+
+		Assert.assertEquals(
+			BooleanClauseOccur.MUST_NOT,
+			negatedBooleanClauses.get(
+				1
+			).getBooleanClauseOccur());
+
+		return negatedBooleanClauses.get(
+			1
+		).getClause();
 	}
 
 	private Query _runAndAssertNestedRow(

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -726,8 +726,9 @@ public class AssetListFiltersUtilTest {
 		);
 
 		_objectDefinitionLocalServiceUtilMockedStatic.when(
-			() -> ObjectDefinitionLocalServiceUtil.fetchObjectDefinition(
-				_CLASS_TYPE_ID)
+			() ->
+				ObjectDefinitionLocalServiceUtil.fetchObjectDefinitionByClassName(
+					_COMPANY_ID, "com.liferay.test.Class" + _CLASS_NAME_ID)
 		).thenReturn(
 			objectDefinition
 		);

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -10,6 +10,8 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldLocalServiceUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -88,37 +90,46 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testGetFiltersBooleanClausesWithCommonFieldOperators() {
+		String priority = String.valueOf(RandomTestUtil.randomDouble());
+		String status = String.valueOf(RandomTestUtil.randomInt());
+		String titleContainsValue = RandomTestUtil.randomString();
+		String titleEqValue = RandomTestUtil.randomString();
+		String userName = RandomTestUtil.randomString();
+		String viewCount = String.valueOf(RandomTestUtil.randomInt());
+
 		_assertMatchQuery(
-			"localized_title_en_US", "Apple",
+			"localized_title_en_US", titleEqValue,
 			_runAndAssertCommonFieldRow(
-				_buildCommonFieldFilter("eq", "title", "Apple")));
+				_buildCommonFieldFilter("eq", "title", titleEqValue)));
 		_assertMatchQuery(
-			"localized_title_en_US", "App",
+			"localized_title_en_US", titleContainsValue,
 			_runAndAssertCommonFieldRow(
-				_buildCommonFieldFilter("contains", "title", "App")));
+				_buildCommonFieldFilter(
+					"contains", "title", titleContainsValue)));
 
 		_assertTermQuery(
-			"userName", "Alice",
+			"userName", userName,
 			_runAndAssertCommonFieldRow(
-				_buildCommonFieldFilter("eq", "userName", "Alice")));
+				_buildCommonFieldFilter("eq", "userName", userName)));
 		_assertWildcardQuery(
-			"userName", "*Alice*",
+			"userName",
+			StringBundler.concat(StringPool.STAR, userName, StringPool.STAR),
 			_runAndAssertNegatedCommonFieldRow(
-				_buildCommonFieldFilter("not-contains", "userName", "Alice")));
+				_buildCommonFieldFilter("not-contains", "userName", userName)));
 
 		_assertTermQuery(
-			"viewCount", "5",
+			"viewCount", viewCount,
 			_runAndAssertCommonFieldRow(
-				_buildCommonFieldFilter("eq", "viewCount", "5")));
+				_buildCommonFieldFilter("eq", "viewCount", viewCount)));
 		_assertTermQuery(
-			"status", "0",
+			"status", status,
 			_runAndAssertNegatedCommonFieldRow(
-				_buildCommonFieldFilter("not-eq", "status", "0")));
+				_buildCommonFieldFilter("not-eq", "status", status)));
 
 		_assertTermRangeQuery(
-			"priority", false, false, "0.5", null,
+			"priority", false, false, priority, null,
 			_runAndAssertCommonFieldRow(
-				_buildCommonFieldFilter("gt", "priority", "0.5")));
+				_buildCommonFieldFilter("gt", "priority", priority)));
 
 		_assertTermRangeQuery(
 			"modified", true, true, "20260115000000", "20260115235959",
@@ -228,53 +239,61 @@ public class AssetListFiltersUtilTest {
 			ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
 			ObjectFieldConstants.DB_TYPE_INTEGER, "viewCount");
 
-		_assertTermQuery(
-			"nestedFieldArray.value_integer", "5",
-			_runAndAssertNestedRow(
-				BooleanClauseOccur.MUST, _buildFilter("eq", "viewCount", "5"),
-				"viewCount"));
+		String viewCount = String.valueOf(RandomTestUtil.randomInt());
 
 		_assertTermQuery(
-			"nestedFieldArray.value_integer", "5",
+			"nestedFieldArray.value_integer", viewCount,
+			_runAndAssertNestedRow(
+				BooleanClauseOccur.MUST,
+				_buildFilter("eq", "viewCount", viewCount), "viewCount"));
+
+		_assertTermQuery(
+			"nestedFieldArray.value_integer", viewCount,
 			_runAndAssertNestedRow(
 				BooleanClauseOccur.MUST_NOT,
-				_buildFilter("not-eq", "viewCount", "5"), "viewCount"));
+				_buildFilter("not-eq", "viewCount", viewCount), "viewCount"));
 
 		_setUpObjectField(
 			ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
 			ObjectFieldConstants.DB_TYPE_LONG, "externalId");
 
+		String externalId = String.valueOf(RandomTestUtil.randomLong());
+
 		_assertTermQuery(
-			"nestedFieldArray.value_long", "99999",
+			"nestedFieldArray.value_long", externalId,
 			_runAndAssertNestedRow(
 				BooleanClauseOccur.MUST,
-				_buildFilter("eq", "externalId", "99999"), "externalId"));
+				_buildFilter("eq", "externalId", externalId), "externalId"));
 
 		_setUpObjectField(
 			ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
 			ObjectFieldConstants.DB_TYPE_DOUBLE, "priority");
 
+		String priority = String.valueOf(RandomTestUtil.randomDouble());
+
 		_assertTermQuery(
-			"nestedFieldArray.value_double", "3.14",
+			"nestedFieldArray.value_double", priority,
 			_runAndAssertNestedRow(
-				BooleanClauseOccur.MUST, _buildFilter("eq", "priority", "3.14"),
-				"priority"));
+				BooleanClauseOccur.MUST,
+				_buildFilter("eq", "priority", priority), "priority"));
 
 		_setUpObjectField(
 			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 			ObjectFieldConstants.DB_TYPE_STRING, "title");
 
+		String title = RandomTestUtil.randomString();
+
 		_assertTermQuery(
-			"nestedFieldArray.value_text", "keyword",
+			"nestedFieldArray.value_text", title,
 			_runAndAssertNestedRow(
-				BooleanClauseOccur.MUST, _buildFilter("eq", "title", "keyword"),
+				BooleanClauseOccur.MUST, _buildFilter("eq", "title", title),
 				"title"));
 
 		_assertTermQuery(
-			"nestedFieldArray.value_text", "keyword",
+			"nestedFieldArray.value_text", title,
 			_runAndAssertNestedRow(
 				BooleanClauseOccur.MUST_NOT,
-				_buildFilter("not-eq", "title", "keyword"), "title"));
+				_buildFilter("not-eq", "title", title), "title"));
 
 		ObjectField subtitleObjectField = _setUpObjectField(
 			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
@@ -286,11 +305,13 @@ public class AssetListFiltersUtilTest {
 			true
 		);
 
+		String subtitle = RandomTestUtil.randomString();
+
 		_assertTermQuery(
-			"nestedFieldArray.value_en_US", "keyword",
+			"nestedFieldArray.value_en_US", subtitle,
 			_runAndAssertNestedRow(
 				BooleanClauseOccur.MUST,
-				_buildFilter("eq", "subtitle", "keyword"), "subtitle"));
+				_buildFilter("eq", "subtitle", subtitle), "subtitle"));
 	}
 
 	@Test
@@ -350,10 +371,12 @@ public class AssetListFiltersUtilTest {
 			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 			ObjectFieldConstants.DB_TYPE_STRING, "creator");
 
+		String userName = RandomTestUtil.randomString();
+
 		_assertTermQuery(
-			"userName", "Alice",
+			"userName", userName,
 			_runAndAssertCommonFieldRow(
-				_buildFilter("eq", "creator", "Alice")));
+				_buildFilter("eq", "creator", userName)));
 
 		_setUpMetadataObjectField(
 			ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
@@ -579,16 +602,18 @@ public class AssetListFiltersUtilTest {
 			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 			ObjectFieldConstants.DB_TYPE_STRING, "title");
 
+		String title = RandomTestUtil.randomString();
+
 		Query containsQuery = _runAndAssertNestedRow(
-			BooleanClauseOccur.MUST,
-			_buildFilter("contains", "title", "keyword"), "title");
+			BooleanClauseOccur.MUST, _buildFilter("contains", "title", title),
+			"title");
 
 		Assert.assertTrue(
 			containsQuery.toString(), containsQuery instanceof MatchQuery);
 
 		Query notContainsQuery = _runAndAssertNestedRow(
 			BooleanClauseOccur.MUST_NOT,
-			_buildFilter("not-contains", "title", "keyword"), "title");
+			_buildFilter("not-contains", "title", title), "title");
 
 		Assert.assertTrue(
 			notContainsQuery.toString(),
@@ -597,7 +622,7 @@ public class AssetListFiltersUtilTest {
 		Query containsWithQuantifierQuery = _runAndAssertNestedRow(
 			BooleanClauseOccur.MUST,
 			_buildFilter(
-				"contains", "title", "keyword"
+				"contains", "title", title
 			).put(
 				"quantifier", "any"
 			),

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -88,55 +88,55 @@ public class AssetListFiltersUtilTest {
 	@Test
 	public void testHandlesCommonFieldOperators() {
 		_assertMatchQuery(
+			"localized_title_en_US", "Apple",
 			_runAndAssertCommonFieldRow(
-				_buildCommonFieldFilter("eq", "title", "Apple")),
-			"localized_title_en_US", "Apple");
+				_buildCommonFieldFilter("eq", "title", "Apple")));
 		_assertMatchQuery(
+			"localized_title_en_US", "App",
 			_runAndAssertCommonFieldRow(
-				_buildCommonFieldFilter("contains", "title", "App")),
-			"localized_title_en_US", "App");
+				_buildCommonFieldFilter("contains", "title", "App")));
 
 		_assertTermQuery(
+			"userName", "Alice",
 			_runAndAssertCommonFieldRow(
-				_buildCommonFieldFilter("eq", "userName", "Alice")),
-			"userName", "Alice");
+				_buildCommonFieldFilter("eq", "userName", "Alice")));
 		_assertWildcardQuery(
+			"userName", "*Alice*",
 			_runAndAssertNegatedCommonFieldRow(
-				_buildCommonFieldFilter("not-contains", "userName", "Alice")),
-			"userName", "*Alice*");
+				_buildCommonFieldFilter("not-contains", "userName", "Alice")));
 
 		_assertTermQuery(
+			"viewCount", "5",
 			_runAndAssertCommonFieldRow(
-				_buildCommonFieldFilter("eq", "viewCount", "5")),
-			"viewCount", "5");
+				_buildCommonFieldFilter("eq", "viewCount", "5")));
 		_assertTermQuery(
+			"status", "0",
 			_runAndAssertNegatedCommonFieldRow(
-				_buildCommonFieldFilter("not-eq", "status", "0")),
-			"status", "0");
+				_buildCommonFieldFilter("not-eq", "status", "0")));
 
 		_assertTermRangeQuery(
+			"priority", false, false, "0.5", null,
 			_runAndAssertCommonFieldRow(
-				_buildCommonFieldFilter("gt", "priority", "0.5")),
-			"priority", "0.5", null, false, false);
+				_buildCommonFieldFilter("gt", "priority", "0.5")));
 
 		_assertTermRangeQuery(
+			"modified", true, true, "20260115000000", "20260115235959",
 			_runAndAssertCommonFieldRow(
-				_buildCommonFieldFilter("eq", "modified", "2026-01-15")),
-			"modified", "20260115000000", "20260115235959", true, true);
+				_buildCommonFieldFilter("eq", "modified", "2026-01-15")));
 		_assertTermRangeQuery(
+			"modified", true, true, "20260115000000", "20260115235959",
 			_runAndAssertNegatedCommonFieldRow(
-				_buildCommonFieldFilter("not-eq", "modified", "2026-01-15")),
-			"modified", "20260115000000", "20260115235959", true, true);
+				_buildCommonFieldFilter("not-eq", "modified", "2026-01-15")));
 		_assertTermRangeQuery(
+			"createDate", false, false, "20260115235959", null,
 			_runAndAssertCommonFieldRow(
-				_buildCommonFieldFilter("gt", "createDate", "2026-01-15")),
-			"createDate", "20260115235959", null, false, false);
+				_buildCommonFieldFilter("gt", "createDate", "2026-01-15")));
 		_assertTermRangeQuery(
+			"modified", true, true, "20260115000000", "20260120235959",
 			_runAndAssertCommonFieldRow(
 				_buildCommonFieldFilterWithJSONArrayValue(
 					"between", "modified",
-					JSONUtil.putAll("2026-01-15", "2026-01-20"))),
-			"modified", "20260115000000", "20260120235959", true, true);
+					JSONUtil.putAll("2026-01-15", "2026-01-20"))));
 
 		BooleanClause[] booleanClauses =
 			AssetListFiltersUtil.getFiltersBooleanClauses(
@@ -151,132 +151,130 @@ public class AssetListFiltersUtilTest {
 	@Test
 	public void testHandlesDateAndDateTimeOperators() {
 		_setUpObjectField(
-			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
-			ObjectFieldConstants.DB_TYPE_DATE);
+			ObjectFieldConstants.BUSINESS_TYPE_DATE,
+			ObjectFieldConstants.DB_TYPE_DATE, "dueDate");
 
 		_assertTermRangeQuery(
+			"nestedFieldArray.value_date", true, true, "20260115000000",
+			"20260115235959",
 			_runAndAssertNestedRow(
-				"dueDate", _buildFilter("eq", "dueDate", "2026-01-15"),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_date", "20260115000000", "20260115235959",
-			true, true);
+				BooleanClauseOccur.MUST,
+				_buildFilter("eq", "dueDate", "2026-01-15"), "dueDate"));
 
 		_assertTermRangeQuery(
+			"nestedFieldArray.value_date", false, false, "20260115235959", null,
 			_runAndAssertNestedRow(
-				"dueDate", _buildFilter("gt", "dueDate", "2026-01-15"),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_date", "20260115235959", null, false,
-			false);
+				BooleanClauseOccur.MUST,
+				_buildFilter("gt", "dueDate", "2026-01-15"), "dueDate"));
 
 		_assertTermRangeQuery(
+			"nestedFieldArray.value_date", true, false, "20260115000000", null,
 			_runAndAssertNestedRow(
-				"dueDate", _buildFilter("ge", "dueDate", "2026-01-15"),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_date", "20260115000000", null, true, false);
+				BooleanClauseOccur.MUST,
+				_buildFilter("ge", "dueDate", "2026-01-15"), "dueDate"));
 
 		_assertTermRangeQuery(
+			"nestedFieldArray.value_date", false, false, null, "20260115000000",
 			_runAndAssertNestedRow(
-				"dueDate", _buildFilter("lt", "dueDate", "2026-01-15"),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_date", null, "20260115000000", false,
-			false);
+				BooleanClauseOccur.MUST,
+				_buildFilter("lt", "dueDate", "2026-01-15"), "dueDate"));
 
 		_assertTermRangeQuery(
+			"nestedFieldArray.value_date", false, true, null, "20260115235959",
 			_runAndAssertNestedRow(
-				"dueDate", _buildFilter("le", "dueDate", "2026-01-15"),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_date", null, "20260115235959", false, true);
+				BooleanClauseOccur.MUST,
+				_buildFilter("le", "dueDate", "2026-01-15"), "dueDate"));
 
 		_assertTermRangeQuery(
+			"nestedFieldArray.value_date", true, true, "20260115000000",
+			"20260120235959",
 			_runAndAssertNestedRow(
-				"dueDate",
+				BooleanClauseOccur.MUST,
 				_buildFilterWithJSONArrayValue(
 					"between", "dueDate",
 					JSONUtil.putAll("2026-01-15", "2026-01-20")),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_date", "20260115000000", "20260120235959",
-			true, true);
+				"dueDate"));
 
 		_setUpObjectField(
-			"reminderAt", ObjectFieldConstants.BUSINESS_TYPE_DATE_TIME,
-			ObjectFieldConstants.DB_TYPE_DATE_TIME);
+			ObjectFieldConstants.BUSINESS_TYPE_DATE_TIME,
+			ObjectFieldConstants.DB_TYPE_DATE_TIME, "reminderAt");
 
 		_assertTermRangeQuery(
+			"nestedFieldArray.value_date", true, true, "20260115103000",
+			"20260115103059",
 			_runAndAssertNestedRow(
-				"reminderAt",
+				BooleanClauseOccur.MUST,
 				_buildFilter("eq", "reminderAt", "2026-01-15 10:30"),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_date", "20260115103000", "20260115103059",
-			true, true);
+				"reminderAt"));
 	}
 
 	@Test
 	public void testHandlesEqualityOperators() {
 		_setUpObjectField(
-			"visible", ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN,
-			ObjectFieldConstants.DB_TYPE_BOOLEAN);
+			ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN,
+			ObjectFieldConstants.DB_TYPE_BOOLEAN, "visible");
 
 		_assertTermQuery(
+			"nestedFieldArray.value_boolean", "true",
 			_runAndAssertNestedRow(
-				"visible", _buildFilter("eq", "visible", "true"),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_boolean", "true");
+				BooleanClauseOccur.MUST, _buildFilter("eq", "visible", "true"),
+				"visible"));
 
 		_setUpObjectField(
-			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
-			ObjectFieldConstants.DB_TYPE_INTEGER);
+			ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
+			ObjectFieldConstants.DB_TYPE_INTEGER, "viewCount");
 
 		_assertTermQuery(
+			"nestedFieldArray.value_integer", "5",
 			_runAndAssertNestedRow(
-				"viewCount", _buildFilter("eq", "viewCount", "5"),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_integer", "5");
+				BooleanClauseOccur.MUST, _buildFilter("eq", "viewCount", "5"),
+				"viewCount"));
 
 		_assertTermQuery(
+			"nestedFieldArray.value_integer", "5",
 			_runAndAssertNestedRow(
-				"viewCount", _buildFilter("not-eq", "viewCount", "5"),
-				BooleanClauseOccur.MUST_NOT),
-			"nestedFieldArray.value_integer", "5");
+				BooleanClauseOccur.MUST_NOT,
+				_buildFilter("not-eq", "viewCount", "5"), "viewCount"));
 
 		_setUpObjectField(
-			"externalId", ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
-			ObjectFieldConstants.DB_TYPE_LONG);
+			ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
+			ObjectFieldConstants.DB_TYPE_LONG, "externalId");
 
 		_assertTermQuery(
+			"nestedFieldArray.value_long", "99999",
 			_runAndAssertNestedRow(
-				"externalId", _buildFilter("eq", "externalId", "99999"),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_long", "99999");
+				BooleanClauseOccur.MUST,
+				_buildFilter("eq", "externalId", "99999"), "externalId"));
 
 		_setUpObjectField(
-			"priority", ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
-			ObjectFieldConstants.DB_TYPE_DOUBLE);
+			ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
+			ObjectFieldConstants.DB_TYPE_DOUBLE, "priority");
 
 		_assertTermQuery(
+			"nestedFieldArray.value_double", "3.14",
 			_runAndAssertNestedRow(
-				"priority", _buildFilter("eq", "priority", "3.14"),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_double", "3.14");
+				BooleanClauseOccur.MUST, _buildFilter("eq", "priority", "3.14"),
+				"priority"));
 
 		_setUpObjectField(
-			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-			ObjectFieldConstants.DB_TYPE_STRING);
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, "title");
 
 		_assertTermQuery(
+			"nestedFieldArray.value_text", "keyword",
 			_runAndAssertNestedRow(
-				"title", _buildFilter("eq", "title", "keyword"),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_text", "keyword");
+				BooleanClauseOccur.MUST, _buildFilter("eq", "title", "keyword"),
+				"title"));
 
 		_assertTermQuery(
+			"nestedFieldArray.value_text", "keyword",
 			_runAndAssertNestedRow(
-				"title", _buildFilter("not-eq", "title", "keyword"),
-				BooleanClauseOccur.MUST_NOT),
-			"nestedFieldArray.value_text", "keyword");
+				BooleanClauseOccur.MUST_NOT,
+				_buildFilter("not-eq", "title", "keyword"), "title"));
 
 		ObjectField localizedSubtitle = _setUpObjectField(
-			"subtitle", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-			ObjectFieldConstants.DB_TYPE_STRING);
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, "subtitle");
 
 		Mockito.when(
 			localizedSubtitle.isLocalized()
@@ -285,10 +283,10 @@ public class AssetListFiltersUtilTest {
 		);
 
 		_assertTermQuery(
+			"nestedFieldArray.value_en_US", "keyword",
 			_runAndAssertNestedRow(
-				"subtitle", _buildFilter("eq", "subtitle", "keyword"),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_en_US", "keyword");
+				BooleanClauseOccur.MUST,
+				_buildFilter("eq", "subtitle", "keyword"), "subtitle"));
 	}
 
 	@Test
@@ -296,94 +294,94 @@ public class AssetListFiltersUtilTest {
 		_setUpKeywordTextObjectField("learnDocumentation");
 
 		_assertWildcardQuery(
+			"nestedFieldArray.value_keyword", "*alpha*",
 			_runAndAssertNestedRow(
-				"learnDocumentation",
+				BooleanClauseOccur.MUST,
 				_buildFilter("contains", "learnDocumentation", "Alpha"),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_keyword", "*alpha*");
+				"learnDocumentation"));
 
 		_assertWildcardQuery(
+			"nestedFieldArray.value_keyword", "*alpha*",
 			_runAndAssertNestedRow(
-				"learnDocumentation",
+				BooleanClauseOccur.MUST_NOT,
 				_buildFilter("not-contains", "learnDocumentation", "Alpha"),
-				BooleanClauseOccur.MUST_NOT),
-			"nestedFieldArray.value_keyword", "*alpha*");
+				"learnDocumentation"));
 
 		_assertTermQuery(
+			"nestedFieldArray.value_keyword", "alpha",
 			_runAndAssertNestedRow(
-				"learnDocumentation",
+				BooleanClauseOccur.MUST,
 				_buildFilter("eq", "learnDocumentation", "Alpha"),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_keyword", "alpha");
+				"learnDocumentation"));
 	}
 
 	@Test
 	public void testHandlesNumericRangeOperators() {
 		_setUpObjectField(
-			"viewCount", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
-			ObjectFieldConstants.DB_TYPE_INTEGER);
+			ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
+			ObjectFieldConstants.DB_TYPE_INTEGER, "viewCount");
 
 		_assertTermRangeQuery(
+			"nestedFieldArray.value_integer", false, false, "5", null,
 			_runAndAssertNestedRow(
-				"viewCount", _buildFilter("gt", "viewCount", "5"),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_integer", "5", null, false, false);
+				BooleanClauseOccur.MUST, _buildFilter("gt", "viewCount", "5"),
+				"viewCount"));
 
 		_assertTermRangeQuery(
+			"nestedFieldArray.value_integer", true, false, "5", null,
 			_runAndAssertNestedRow(
-				"viewCount", _buildFilter("ge", "viewCount", "5"),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_integer", "5", null, true, false);
+				BooleanClauseOccur.MUST, _buildFilter("ge", "viewCount", "5"),
+				"viewCount"));
 
 		_assertTermRangeQuery(
+			"nestedFieldArray.value_integer", false, false, null, "5",
 			_runAndAssertNestedRow(
-				"viewCount", _buildFilter("lt", "viewCount", "5"),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_integer", null, "5", false, false);
+				BooleanClauseOccur.MUST, _buildFilter("lt", "viewCount", "5"),
+				"viewCount"));
 
 		_assertTermRangeQuery(
+			"nestedFieldArray.value_integer", false, true, null, "5",
 			_runAndAssertNestedRow(
-				"viewCount", _buildFilter("le", "viewCount", "5"),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_integer", null, "5", false, true);
+				BooleanClauseOccur.MUST, _buildFilter("le", "viewCount", "5"),
+				"viewCount"));
 
 		_assertTermRangeQuery(
+			"nestedFieldArray.value_integer", true, true, "5", "10",
 			_runAndAssertNestedRow(
-				"viewCount",
+				BooleanClauseOccur.MUST,
 				_buildFilterWithJSONArrayValue(
 					"between", "viewCount", JSONUtil.putAll("5", "10")),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_integer", "5", "10", true, true);
+				"viewCount"));
 
 		_setUpObjectField(
-			"priority", ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
-			ObjectFieldConstants.DB_TYPE_DOUBLE);
+			ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
+			ObjectFieldConstants.DB_TYPE_DOUBLE, "priority");
 
 		_assertTermRangeQuery(
+			"nestedFieldArray.value_double", false, false, "3.14", null,
 			_runAndAssertNestedRow(
-				"priority", _buildFilter("gt", "priority", "3.14"),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_double", "3.14", null, false, false);
+				BooleanClauseOccur.MUST, _buildFilter("gt", "priority", "3.14"),
+				"priority"));
 
 		_assertTermRangeQuery(
+			"nestedFieldArray.value_double", true, true, "1.0", "5.0",
 			_runAndAssertNestedRow(
-				"priority",
+				BooleanClauseOccur.MUST,
 				_buildFilterWithJSONArrayValue(
 					"between", "priority", JSONUtil.putAll("1.0", "5.0")),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_double", "1.0", "5.0", true, true);
+				"priority"));
 
 		_setUpObjectField(
-			"externalId", ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
-			ObjectFieldConstants.DB_TYPE_LONG);
+			ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
+			ObjectFieldConstants.DB_TYPE_LONG, "externalId");
 
 		_assertTermRangeQuery(
+			"nestedFieldArray.value_long", true, true, "100", "200",
 			_runAndAssertNestedRow(
-				"externalId",
+				BooleanClauseOccur.MUST,
 				_buildFilterWithJSONArrayValue(
 					"between", "externalId", JSONUtil.putAll("100", "200")),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_long", "100", "200", true, true);
+				"externalId"));
 	}
 
 	@Test
@@ -391,8 +389,9 @@ public class AssetListFiltersUtilTest {
 		_setUpPicklistObjectField("status");
 
 		_assertPicklistBooleanQuery(
+			BooleanClauseOccur.SHOULD,
 			_runAndAssertNestedRow(
-				"status",
+				BooleanClauseOccur.MUST,
 				_buildFilterWithJSONArrayValue(
 					"contains", "status",
 					JSONUtil.putAll(
@@ -401,12 +400,13 @@ public class AssetListFiltersUtilTest {
 				).put(
 					"quantifier", "any"
 				),
-				BooleanClauseOccur.MUST),
-			BooleanClauseOccur.SHOULD, "approved", "draft");
+				"status"),
+			"approved", "draft");
 
 		_assertPicklistBooleanQuery(
+			BooleanClauseOccur.MUST,
 			_runAndAssertNestedRow(
-				"status",
+				BooleanClauseOccur.MUST,
 				_buildFilterWithJSONArrayValue(
 					"contains", "status",
 					JSONUtil.putAll(
@@ -415,21 +415,23 @@ public class AssetListFiltersUtilTest {
 				).put(
 					"quantifier", "all"
 				),
-				BooleanClauseOccur.MUST),
-			BooleanClauseOccur.MUST, "approved", "draft");
+				"status"),
+			"approved", "draft");
 
 		_assertPicklistBooleanQuery(
+			BooleanClauseOccur.SHOULD,
 			_runAndAssertNestedRow(
-				"status",
+				BooleanClauseOccur.MUST,
 				_buildFilterWithJSONArrayValue(
 					"contains", "status",
 					JSONUtil.putAll(_picklistValueJSONObject("approved"))),
-				BooleanClauseOccur.MUST),
-			BooleanClauseOccur.SHOULD, "approved");
+				"status"),
+			"approved");
 
 		_assertPicklistBooleanQuery(
+			BooleanClauseOccur.SHOULD,
 			_runAndAssertNestedRow(
-				"status",
+				BooleanClauseOccur.MUST_NOT,
 				_buildFilterWithJSONArrayValue(
 					"not-contains", "status",
 					JSONUtil.putAll(
@@ -438,20 +440,21 @@ public class AssetListFiltersUtilTest {
 				).put(
 					"quantifier", "any"
 				),
-				BooleanClauseOccur.MUST_NOT),
-			BooleanClauseOccur.SHOULD, "approved", "draft");
+				"status"),
+			"approved", "draft");
 
 		_assertPicklistBooleanQuery(
+			BooleanClauseOccur.SHOULD,
 			_runAndAssertNestedRow(
-				"status",
+				BooleanClauseOccur.MUST,
 				_buildFilterWithJSONArrayValue(
 					"contains", "status",
 					JSONUtil.putAll(_picklistValueJSONObject("Approved"))
 				).put(
 					"quantifier", "any"
 				),
-				BooleanClauseOccur.MUST),
-			BooleanClauseOccur.SHOULD, "approved");
+				"status"),
+			"approved");
 
 		BooleanClause[] booleanClauses =
 			AssetListFiltersUtil.getFiltersBooleanClauses(
@@ -471,8 +474,8 @@ public class AssetListFiltersUtilTest {
 	@Test
 	public void testHandlesRelativeDateOperators() {
 		_setUpObjectField(
-			"dueDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
-			ObjectFieldConstants.DB_TYPE_DATE);
+			ObjectFieldConstants.BUSINESS_TYPE_DATE,
+			ObjectFieldConstants.DB_TYPE_DATE, "dueDate");
 
 		String lastYearLowerTerm = _runRelativeDateGeLowerTerm("last-year");
 		String nextMonthLowerTerm = _runRelativeDateGeLowerTerm("next-month");
@@ -510,42 +513,42 @@ public class AssetListFiltersUtilTest {
 		Assert.assertTrue(nowLowerTerm.compareTo(nextMonthLowerTerm) < 0);
 
 		_assertTermRangeQuery(
+			"nestedFieldArray.value_date", false, true, null,
+			format.format(new Date()) + "235959",
 			_runAndAssertNestedRow(
-				"dueDate", _buildFilter("le", "dueDate", "now"),
-				BooleanClauseOccur.MUST),
-			"nestedFieldArray.value_date", null,
-			format.format(new Date()) + "235959", false, true);
+				BooleanClauseOccur.MUST, _buildFilter("le", "dueDate", "now"),
+				"dueDate"));
 	}
 
 	@Test
 	public void testHandlesTextContainsOperators() {
 		_setUpObjectField(
-			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-			ObjectFieldConstants.DB_TYPE_STRING);
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, "title");
 
 		Query containsQuery = _runAndAssertNestedRow(
-			"title", _buildFilter("contains", "title", "keyword"),
-			BooleanClauseOccur.MUST);
+			BooleanClauseOccur.MUST,
+			_buildFilter("contains", "title", "keyword"), "title");
 
 		Assert.assertTrue(
 			containsQuery.toString(), containsQuery instanceof MatchQuery);
 
 		Query notContainsQuery = _runAndAssertNestedRow(
-			"title", _buildFilter("not-contains", "title", "keyword"),
-			BooleanClauseOccur.MUST_NOT);
+			BooleanClauseOccur.MUST_NOT,
+			_buildFilter("not-contains", "title", "keyword"), "title");
 
 		Assert.assertTrue(
 			notContainsQuery.toString(),
 			notContainsQuery instanceof MatchQuery);
 
 		Query containsWithQuantifierQuery = _runAndAssertNestedRow(
-			"title",
+			BooleanClauseOccur.MUST,
 			_buildFilter(
 				"contains", "title", "keyword"
 			).put(
 				"quantifier", "any"
 			),
-			BooleanClauseOccur.MUST);
+			"title");
 
 		Assert.assertTrue(
 			containsWithQuantifierQuery.toString(),
@@ -571,25 +574,26 @@ public class AssetListFiltersUtilTest {
 	@Test
 	public void testRoutesMetadataObjectFieldsToCommonFieldPath() {
 		_setUpMetadataObjectField(
-			"modifiedDate", ObjectFieldConstants.BUSINESS_TYPE_DATE,
-			ObjectFieldConstants.DB_TYPE_DATE);
+			ObjectFieldConstants.BUSINESS_TYPE_DATE,
+			ObjectFieldConstants.DB_TYPE_DATE, "modifiedDate");
 
 		_assertTermRangeQuery(
+			"modified", true, true, "20260115000000", "20260115235959",
 			_runAndAssertCommonFieldRow(
-				_buildFilter("eq", "modifiedDate", "2026-01-15")),
-			"modified", "20260115000000", "20260115235959", true, true);
+				_buildFilter("eq", "modifiedDate", "2026-01-15")));
 
 		_setUpMetadataObjectField(
-			"creator", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-			ObjectFieldConstants.DB_TYPE_STRING);
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, "creator");
 
 		_assertTermQuery(
-			_runAndAssertCommonFieldRow(_buildFilter("eq", "creator", "Alice")),
-			"userName", "Alice");
+			"userName", "Alice",
+			_runAndAssertCommonFieldRow(
+				_buildFilter("eq", "creator", "Alice")));
 
 		_setUpMetadataObjectField(
-			"id", ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
-			ObjectFieldConstants.DB_TYPE_LONG);
+			ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
+			ObjectFieldConstants.DB_TYPE_LONG, "id");
 
 		BooleanClause[] booleanClauses =
 			AssetListFiltersUtil.getFiltersBooleanClauses(
@@ -639,7 +643,7 @@ public class AssetListFiltersUtilTest {
 	}
 
 	private void _assertMatchQuery(
-		Query query, String expectedField, String expectedValue) {
+		String expectedField, String expectedValue, Query query) {
 
 		Assert.assertTrue(query.toString(), query instanceof MatchQuery);
 
@@ -650,8 +654,8 @@ public class AssetListFiltersUtilTest {
 	}
 
 	private Query _assertNestedRow(
-		BooleanClause[] booleanClauses, int rowIndex, String propertyName,
-		BooleanClauseOccur expectedValueOccur) {
+		BooleanClause[] booleanClauses, BooleanClauseOccur expectedValueOccur,
+		String propertyName, int rowIndex) {
 
 		Assert.assertEquals(
 			Arrays.toString(booleanClauses), 1, booleanClauses.length);
@@ -730,7 +734,7 @@ public class AssetListFiltersUtilTest {
 	}
 
 	private void _assertPicklistBooleanQuery(
-		Query query, BooleanClauseOccur expectedInnerOccur,
+		BooleanClauseOccur expectedInnerOccur, Query query,
 		String... expectedValues) {
 
 		Assert.assertTrue(query.toString(), query instanceof BooleanQuery);
@@ -751,15 +755,15 @@ public class AssetListFiltersUtilTest {
 				).getBooleanClauseOccur());
 
 			_assertTermQuery(
+				"nestedFieldArray.value_keyword", expectedValues[i],
 				innerBooleanClauses.get(
 					i
-				).getClause(),
-				"nestedFieldArray.value_keyword", expectedValues[i]);
+				).getClause());
 		}
 	}
 
 	private void _assertTermQuery(
-		Query query, String expectedField, String expectedValue) {
+		String expectedField, String expectedValue, Query query) {
 
 		Assert.assertTrue(query.toString(), query instanceof TermQuery);
 
@@ -776,9 +780,9 @@ public class AssetListFiltersUtilTest {
 	}
 
 	private void _assertTermRangeQuery(
-		Query query, String expectedField, String expectedLower,
-		String expectedUpper, boolean expectedIncludesLower,
-		boolean expectedIncludesUpper) {
+		String expectedField, boolean expectedIncludesLower,
+		boolean expectedIncludesUpper, String expectedLower,
+		String expectedUpper, Query query) {
 
 		Assert.assertTrue(query.toString(), query instanceof TermRangeQuery);
 
@@ -794,7 +798,7 @@ public class AssetListFiltersUtilTest {
 	}
 
 	private void _assertWildcardQuery(
-		Query query, String expectedField, String expectedValue) {
+		String expectedField, String expectedValue, Query query) {
 
 		Assert.assertTrue(query.toString(), query instanceof WildcardQuery);
 
@@ -932,21 +936,21 @@ public class AssetListFiltersUtilTest {
 	}
 
 	private Query _runAndAssertNestedRow(
-		String propertyName, JSONObject filterJSONObject,
-		BooleanClauseOccur expectedValueOccur) {
+		BooleanClauseOccur expectedValueOccur, JSONObject filterJSONObject,
+		String propertyName) {
 
 		BooleanClause[] booleanClauses =
 			AssetListFiltersUtil.getFiltersBooleanClauses(
 				_COMPANY_ID, JSONUtil.putAll(filterJSONObject), LocaleUtil.US);
 
 		return _assertNestedRow(
-			booleanClauses, 0, propertyName, expectedValueOccur);
+			booleanClauses, expectedValueOccur, propertyName, 0);
 	}
 
 	private String _runRelativeDateGeLowerTerm(String value) {
 		Query query = _runAndAssertNestedRow(
-			"dueDate", _buildFilter("ge", "dueDate", value),
-			BooleanClauseOccur.MUST);
+			BooleanClauseOccur.MUST, _buildFilter("ge", "dueDate", value),
+			"dueDate");
 
 		Assert.assertTrue(query.toString(), query instanceof TermRangeQuery);
 
@@ -957,8 +961,8 @@ public class AssetListFiltersUtilTest {
 
 	private ObjectField _setUpKeywordTextObjectField(String name) {
 		ObjectField objectField = _setUpObjectField(
-			name, ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-			ObjectFieldConstants.DB_TYPE_STRING);
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, name);
 
 		Mockito.when(
 			objectField.isIndexedAsKeyword()
@@ -986,9 +990,9 @@ public class AssetListFiltersUtilTest {
 	}
 
 	private ObjectField _setUpMetadataObjectField(
-		String name, String businessType, String dbType) {
+		String businessType, String dbType, String name) {
 
-		ObjectField objectField = _setUpObjectField(name, businessType, dbType);
+		ObjectField objectField = _setUpObjectField(businessType, dbType, name);
 
 		Mockito.when(
 			objectField.isMetadata()
@@ -1000,7 +1004,7 @@ public class AssetListFiltersUtilTest {
 	}
 
 	private ObjectField _setUpObjectField(
-		String name, String businessType, String dbType) {
+		String businessType, String dbType, String name) {
 
 		ObjectField objectField = Mockito.mock(ObjectField.class);
 
@@ -1058,8 +1062,8 @@ public class AssetListFiltersUtilTest {
 
 	private ObjectField _setUpPicklistObjectField(String name) {
 		ObjectField objectField = _setUpObjectField(
-			name, ObjectFieldConstants.BUSINESS_TYPE_PICKLIST,
-			ObjectFieldConstants.DB_TYPE_STRING);
+			ObjectFieldConstants.BUSINESS_TYPE_PICKLIST,
+			ObjectFieldConstants.DB_TYPE_STRING, name);
 
 		Mockito.when(
 			objectField.getListTypeDefinitionId()

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -185,6 +185,25 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
+	public void testTextContainsIgnoresQuantifierOnTextField() {
+		_stubObjectField(
+			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING);
+
+		JSONObject filterJSONObject = _buildFilter(
+			"contains", "title", "keyword"
+		).put(
+			"quantifier", "any"
+		);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"title", filterJSONObject, BooleanClauseOccur.MUST);
+
+		Assert.assertTrue(
+			valueQuery.toString(), valueQuery instanceof MatchQuery);
+	}
+
+	@Test
 	public void testTextEqBuildsTermQuery() {
 		_stubObjectField(
 			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
@@ -195,6 +214,20 @@ public class AssetListFiltersUtilTest {
 			BooleanClauseOccur.MUST);
 
 		_assertTermQuery(valueQuery, "nestedFieldArray.value_text", "keyword");
+	}
+
+	@Test
+	public void testTextNotContainsWrapsMatchQueryInMustNot() {
+		_stubObjectField(
+			"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING);
+
+		Query valueQuery = _runAndAssertNestedRow(
+			"title", _buildFilter("not-contains", "title", "keyword"),
+			BooleanClauseOccur.MUST_NOT);
+
+		Assert.assertTrue(
+			valueQuery.toString(), valueQuery instanceof MatchQuery);
 	}
 
 	@Test

--- a/modules/apps/asset/asset-list-test/build.gradle
+++ b/modules/apps/asset/asset-list-test/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:journal:journal-api")
 	testIntegrationImplementation project(":apps:journal:journal-test-util")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
+	testIntegrationImplementation project(":apps:list-type:list-type-api")
 	testIntegrationImplementation project(":apps:object:object-api")
 	testIntegrationImplementation project(":apps:object:object-test-util")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -33,6 +33,7 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -61,7 +62,6 @@ import com.liferay.segments.constants.SegmentsEntryConstants;
 
 import java.io.Serializable;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -627,17 +627,11 @@ public class AssetListAssetEntryProviderFiltersTest {
 				null, null, StringPool.BLANK, StringPool.BLANK,
 				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
-		List<Long> actualClassPKs = new ArrayList<>();
+		List<Long> actualClassPKs = TransformUtil.transform(
+			infoPage.getPageItems(), AssetEntry::getClassPK);
 
-		for (AssetEntry assetEntry : infoPage.getPageItems()) {
-			actualClassPKs.add(assetEntry.getClassPK());
-		}
-
-		List<Long> expectedClassPKs = new ArrayList<>();
-
-		for (ObjectEntry objectEntry : expectedObjectEntries) {
-			expectedClassPKs.add(objectEntry.getObjectEntryId());
-		}
+		List<Long> expectedClassPKs = TransformUtil.transformToList(
+			expectedObjectEntries, ObjectEntry::getObjectEntryId);
 
 		Assert.assertEquals(
 			actualClassPKs.toString(), expectedClassPKs.size(),
@@ -718,13 +712,8 @@ public class AssetListAssetEntryProviderFiltersTest {
 				StringPool.BLANK, StringPool.BLANK, QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS);
 
-		List<Long> classPKs = new ArrayList<>();
-
-		for (AssetEntry assetEntry : infoPage.getPageItems()) {
-			classPKs.add(assetEntry.getClassPK());
-		}
-
-		return classPKs;
+		return TransformUtil.transform(
+			infoPage.getPageItems(), AssetEntry::getClassPK);
 	}
 
 	private JSONObject _picklistFilter(

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -6,23 +6,40 @@
 package com.liferay.asset.list.asset.entry.provider.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
 import com.liferay.asset.list.asset.entry.provider.AssetListAssetEntryProvider;
 import com.liferay.asset.list.model.AssetListEntry;
 import com.liferay.asset.list.service.AssetListEntryLocalService;
 import com.liferay.asset.list.test.util.AssetListTestUtil;
+import com.liferay.info.pagination.InfoPage;
+import com.liferay.list.type.entry.util.ListTypeEntryUtil;
+import com.liferay.list.type.model.ListTypeDefinition;
+import com.liferay.list.type.service.ListTypeDefinitionLocalService;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
@@ -33,7 +50,13 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.segments.constants.SegmentsEntryConstants;
 
+import java.io.Serializable;
+
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -53,41 +76,133 @@ public class AssetListAssetEntryProviderFiltersTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			PermissionCheckerMethodTestRule.INSTANCE);
+			PermissionCheckerMethodTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
+
+		_listTypeDefinition = _addListTypeDefinition();
+
 		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
 			Arrays.asList(
 				ObjectFieldUtil.createObjectField(
+					_listTypeDefinition.getListTypeDefinitionId(),
+					ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST,
+					null, ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+					"Categories", "categories", false, false),
+				ObjectFieldUtil.createObjectField(
+					_listTypeDefinition.getListTypeDefinitionId(),
+					ObjectFieldConstants.BUSINESS_TYPE_PICKLIST, null,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+					"Category", "category", false, false),
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_DATE,
+					ObjectFieldConstants.DB_TYPE_DATE, true, false, null,
+					"Due Date", "dueDate", false),
+				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
-					ObjectFieldConstants.DB_TYPE_INTEGER,
-					RandomTestUtil.randomString(), "priority"),
+					ObjectFieldConstants.DB_TYPE_INTEGER, true, false, null,
+					"Priority", "priority", false),
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_DATE_TIME,
+					ObjectFieldConstants.DB_TYPE_DATE_TIME, true, false, null,
+					"Start Time", "startTime", false),
 				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-					ObjectFieldConstants.DB_TYPE_STRING,
-					RandomTestUtil.randomString(), "title")));
+					ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+					"Title", "title", false)),
+			ObjectDefinitionConstants.SCOPE_SITE);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testDateRangeFilters() throws Exception {
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"dueDate", "2026-01-15"
+			).build());
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"dueDate", "2026-06-15"
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_filter(
+					"dueDate", "between",
+					JSONUtil.putAll("2026-01-01", "2026-03-01"))),
+			objectEntry1);
+
+		ObjectEntry objectEntry3 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"startTime", "2026-01-15 10:30"
+			).build());
+
+		_addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"startTime", "2026-06-15 10:30"
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_filter(
+					"startTime", "between",
+					JSONUtil.putAll(
+						"2026-01-15 00:00", "2026-01-15 23:59"))),
+			objectEntry3);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testEqualityFilters() throws Exception {
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"priority", 1
+			).put(
+				"title", "alpha"
+			).build());
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"priority", 2
+			).put(
+				"title", "beta"
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(_filter("title", "eq", "alpha")),
+			objectEntry1);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(_filter("title", "not-eq", "alpha")),
+			objectEntry2);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(_filter("priority", "eq", "2")),
+			objectEntry2);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(_filter("priority", "not-eq", "2")),
+			objectEntry1);
 	}
 
 	@FeatureFlag(enable = false, value = "LPD-74731")
 	@Test
-	public void testGetAssetEntryQueryWithFiltersWhenFeatureFlagDisabled()
+	public void testFiltersAreIgnoredWhenFeatureFlagDisabled()
 		throws Exception {
 
+		JSONArray filtersJSONArray = JSONUtil.putAll(
+			JSONUtil.put(
+				"classNameId",
+				_portal.getClassNameId(_objectDefinition.getClassName())
+			).put(
+				"classTypeId", _objectDefinition.getObjectDefinitionId()
+			).put(
+				"propertyName", "title"
+			).put(
+				"value", "keyword"
+			));
+
 		AssetListEntry assetListEntry = _addDynamicAssetListEntryWithFilters(
-			JSONUtil.putAll(
-				JSONUtil.put(
-					"classNameId",
-					_portal.getClassNameId(_objectDefinition.getClassName())
-				).put(
-					"classTypeId", _objectDefinition.getObjectDefinitionId()
-				).put(
-					"propertyName", RandomTestUtil.randomString()
-				).put(
-					"value", RandomTestUtil.randomString()
-				)
-			).toString());
+			filtersJSONArray.toString());
 
 		AssetEntryQuery assetEntryQuery =
 			_assetListAssetEntryProvider.getAssetEntryQuery(
@@ -99,49 +214,51 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
 	@Test
-	public void testGetAssetEntryQueryWithFiltersWhenFeatureFlagEnabled()
+	public void testFiltersArePropagatedAsAttributeWhenFeatureFlagEnabled()
 		throws Exception {
 
+		JSONArray filtersJSONArray = JSONUtil.putAll(
+			JSONUtil.put(
+				"classNameId",
+				_portal.getClassNameId(_objectDefinition.getClassName())
+			).put(
+				"classTypeId", _objectDefinition.getObjectDefinitionId()
+			).put(
+				"operatorName", "contains"
+			).put(
+				"propertyName", "title"
+			).put(
+				"value", "keyword"
+			),
+			JSONUtil.put(
+				"classNameId",
+				_portal.getClassNameId(_objectDefinition.getClassName())
+			).put(
+				"classTypeId", _objectDefinition.getObjectDefinitionId()
+			).put(
+				"operatorName", "eq"
+			).put(
+				"propertyName", "priority"
+			).put(
+				"value", "1"
+			));
+
 		AssetListEntry assetListEntry = _addDynamicAssetListEntryWithFilters(
-			JSONUtil.putAll(
-				JSONUtil.put(
-					"classNameId",
-					_portal.getClassNameId(_objectDefinition.getClassName())
-				).put(
-					"classTypeId", _objectDefinition.getObjectDefinitionId()
-				).put(
-					"operatorName", RandomTestUtil.randomString()
-				).put(
-					"propertyName", "title"
-				).put(
-					"value", "keyword"
-				),
-				JSONUtil.put(
-					"classNameId",
-					_portal.getClassNameId(_objectDefinition.getClassName())
-				).put(
-					"classTypeId", _objectDefinition.getObjectDefinitionId()
-				).put(
-					"operatorName", RandomTestUtil.randomString()
-				).put(
-					"propertyName", RandomTestUtil.randomString()
-				).put(
-					"value", RandomTestUtil.randomString()
-				)
-			).toString());
+			filtersJSONArray.toString());
 
 		AssetEntryQuery assetEntryQuery =
 			_assetListAssetEntryProvider.getAssetEntryQuery(
 				assetListEntry, new long[] {SegmentsEntryConstants.ID_DEFAULT},
 				null);
 
-		JSONArray filtersJSONArray = (JSONArray)assetEntryQuery.getAttribute(
+		JSONArray actualJSONArray = (JSONArray)assetEntryQuery.getAttribute(
 			"filters");
 
+		Assert.assertNotNull(actualJSONArray);
 		Assert.assertEquals(
-			filtersJSONArray.toString(), 2, filtersJSONArray.length());
+			actualJSONArray.toString(), 2, actualJSONArray.length());
 
-		JSONObject jsonObject = filtersJSONArray.getJSONObject(0);
+		JSONObject jsonObject = actualJSONArray.getJSONObject(0);
 
 		Assert.assertEquals("title", jsonObject.getString("propertyName"));
 		Assert.assertEquals("keyword", jsonObject.getString("value"));
@@ -154,7 +271,7 @@ public class AssetListAssetEntryProviderFiltersTest {
 	@Test
 	public void testGetAssetEntryQueryWithInvalidFilters() throws Exception {
 		AssetListEntry assetListEntry = _addDynamicAssetListEntryWithFilters(
-			RandomTestUtil.randomString());
+			"not-a-json-array");
 
 		AssetEntryQuery assetEntryQuery =
 			_assetListAssetEntryProvider.getAssetEntryQuery(
@@ -166,7 +283,40 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
 	@Test
-	public void testGetAssetEntryQueryWithoutFilters() throws Exception {
+	public void testMultipleFiltersJoinedWithMust() throws Exception {
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"priority", 5
+			).put(
+				"title", "match"
+			).build());
+
+		_addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"priority", 1
+			).put(
+				"title", "match"
+			).build());
+
+		_addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"priority", 5
+			).put(
+				"title", "other"
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_filter("title", "contains", "match"),
+				_filter("priority", "eq", "5")),
+			objectEntry1);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testNoFiltersAttributeWhenTypeSettingsHasNoFilters()
+		throws Exception {
+
 		AssetListEntry assetListEntry = _addDynamicAssetListEntryWithFilters(
 			null);
 
@@ -178,8 +328,118 @@ public class AssetListAssetEntryProviderFiltersTest {
 		Assert.assertNull(assetEntryQuery.getAttribute("filters"));
 	}
 
-	private AssetListEntry _addDynamicAssetListEntryWithFilters(
-			String filtersJSON)
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testNumericRangeFilters() throws Exception {
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"priority", 1
+			).build());
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"priority", 5
+			).build());
+		ObjectEntry objectEntry3 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"priority", 10
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(_filter("priority", "gt", "5")),
+			objectEntry3);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(_filter("priority", "ge", "5")),
+			objectEntry2, objectEntry3);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(_filter("priority", "lt", "5")),
+			objectEntry1);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(_filter("priority", "le", "5")),
+			objectEntry1, objectEntry2);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_filter("priority", "between", JSONUtil.putAll("4", "11"))),
+			objectEntry2, objectEntry3);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testPicklistFilters() throws Exception {
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"category", _LIST_TYPE_ENTRY_KEY_1
+			).build());
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"category", _LIST_TYPE_ENTRY_KEY_2
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_picklistFilter("category", "any", _LIST_TYPE_ENTRY_KEY_1)),
+			objectEntry1);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_picklistFilter(
+					"category", "any", _LIST_TYPE_ENTRY_KEY_1,
+					_LIST_TYPE_ENTRY_KEY_2)),
+			objectEntry1, objectEntry2);
+
+		ObjectEntry objectEntry3 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"categories",
+				(Serializable)Arrays.asList(
+					_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2)
+			).build());
+		ObjectEntry objectEntry4 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"categories",
+				(Serializable)Arrays.asList(
+					_LIST_TYPE_ENTRY_KEY_2, _LIST_TYPE_ENTRY_KEY_3)
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_picklistFilter("categories", "any", _LIST_TYPE_ENTRY_KEY_1)),
+			objectEntry3);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_picklistFilter("categories", "any", _LIST_TYPE_ENTRY_KEY_3)),
+			objectEntry4);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_picklistFilter(
+					"categories", "all", _LIST_TYPE_ENTRY_KEY_1,
+					_LIST_TYPE_ENTRY_KEY_2)),
+			objectEntry3);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_picklistFilter("categories", "all", _LIST_TYPE_ENTRY_KEY_2)),
+			objectEntry3, objectEntry4);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testTextContainsFilters() throws Exception {
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"title", "liferay platform"
+			).build());
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"title", "other content"
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(_filter("title", "contains", "liferay")),
+			objectEntry1);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_filter("title", "not-contains", "liferay")),
+			objectEntry2);
+	}
+
+	private AssetListEntry _addDynamicAssetListEntryWithFilters(String filters)
 		throws Exception {
 
 		AssetListEntry assetListEntry = AssetListTestUtil.addAssetListEntry(
@@ -194,9 +454,9 @@ public class AssetListAssetEntryProviderFiltersTest {
 					_portal.getClassNameId(_objectDefinition.getClassName()))
 			);
 
-		if (filtersJSON != null) {
+		if (filters != null) {
 			unicodePropertiesWrapper = unicodePropertiesWrapper.put(
-				"filters", filtersJSON);
+				"filters", filters);
 		}
 
 		UnicodeProperties typeSettingsUnicodeProperties =
@@ -211,6 +471,124 @@ public class AssetListAssetEntryProviderFiltersTest {
 			assetListEntry.getAssetListEntryId());
 	}
 
+	private ListTypeDefinition _addListTypeDefinition() throws Exception {
+		return _listTypeDefinitionLocalService.addListTypeDefinition(
+			null, TestPropsValues.getUserId(),
+			Collections.singletonMap(LocaleUtil.US, RandomTestUtil.randomString()),
+			false,
+			Arrays.asList(
+				ListTypeEntryUtil.createListTypeEntry(
+					_LIST_TYPE_ENTRY_KEY_1,
+					Collections.singletonMap(
+						LocaleUtil.US, _LIST_TYPE_ENTRY_KEY_1)),
+				ListTypeEntryUtil.createListTypeEntry(
+					_LIST_TYPE_ENTRY_KEY_2,
+					Collections.singletonMap(
+						LocaleUtil.US, _LIST_TYPE_ENTRY_KEY_2)),
+				ListTypeEntryUtil.createListTypeEntry(
+					_LIST_TYPE_ENTRY_KEY_3,
+					Collections.singletonMap(
+						LocaleUtil.US, _LIST_TYPE_ENTRY_KEY_3))),
+			new ServiceContext());
+	}
+
+	private ObjectEntry _addObjectEntry(Map<String, Serializable> values)
+		throws Exception {
+
+		return _objectEntryLocalService.addObjectEntry(
+			_group.getGroupId(), TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null, values,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private void _assertFilteredClassPKs(
+			JSONArray filtersJSONArray, ObjectEntry... expectedObjectEntries)
+		throws Exception {
+
+		AssetListEntry assetListEntry = _addDynamicAssetListEntryWithFilters(
+			filtersJSONArray.toString());
+
+		InfoPage<AssetEntry> infoPage =
+			_assetListAssetEntryProvider.getAssetEntriesInfoPage(
+				assetListEntry, new long[] {SegmentsEntryConstants.ID_DEFAULT},
+				null, null, StringPool.BLANK, StringPool.BLANK,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		List<Long> actualClassPKs = new ArrayList<>();
+
+		for (AssetEntry assetEntry : infoPage.getPageItems()) {
+			actualClassPKs.add(assetEntry.getClassPK());
+		}
+
+		List<Long> expectedClassPKs = new ArrayList<>();
+
+		for (ObjectEntry objectEntry : expectedObjectEntries) {
+			expectedClassPKs.add(objectEntry.getObjectEntryId());
+		}
+
+		Assert.assertEquals(
+			actualClassPKs.toString(), expectedClassPKs.size(),
+			actualClassPKs.size());
+		Assert.assertTrue(
+			actualClassPKs.toString(),
+			actualClassPKs.containsAll(expectedClassPKs));
+	}
+
+	private JSONArray _buildFiltersJSONArray(JSONObject... filterJSONObjects) {
+		return JSONUtil.putAll((Object[])filterJSONObjects);
+	}
+
+	private JSONObject _filter(
+		String propertyName, String operatorName, Object value) {
+
+		return JSONUtil.put(
+			"classNameId",
+			_portal.getClassNameId(_objectDefinition.getClassName())
+		).put(
+			"classTypeId", _objectDefinition.getObjectDefinitionId()
+		).put(
+			"operatorName", operatorName
+		).put(
+			"propertyName", propertyName
+		).put(
+			"value", value
+		);
+	}
+
+	private JSONObject _picklistFilter(
+		String propertyName, String quantifier, String... keys) {
+
+		JSONObject[] valueJSONObjects = new JSONObject[keys.length];
+
+		for (int i = 0; i < keys.length; i++) {
+			valueJSONObjects[i] = JSONUtil.put("value", keys[i]);
+		}
+
+		return JSONUtil.put(
+			"classNameId",
+			_portal.getClassNameId(_objectDefinition.getClassName())
+		).put(
+			"classTypeId", _objectDefinition.getObjectDefinitionId()
+		).put(
+			"operatorName", "contains"
+		).put(
+			"propertyName", propertyName
+		).put(
+			"quantifier", quantifier
+		).put(
+			"value", JSONUtil.putAll((Object[])valueJSONObjects)
+		);
+	}
+
+	private static final String _LIST_TYPE_ENTRY_KEY_1 = "key1";
+
+	private static final String _LIST_TYPE_ENTRY_KEY_2 = "key2";
+
+	private static final String _LIST_TYPE_ENTRY_KEY_3 = "key3";
+
 	@Inject
 	private AssetListAssetEntryProvider _assetListAssetEntryProvider;
 
@@ -221,7 +599,16 @@ public class AssetListAssetEntryProviderFiltersTest {
 	private Group _group;
 
 	@DeleteAfterTestRun
+	private ListTypeDefinition _listTypeDefinition;
+
+	@Inject
+	private ListTypeDefinitionLocalService _listTypeDefinitionLocalService;
+
+	@DeleteAfterTestRun
 	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
 
 	@Inject
 	private Portal _portal;

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -217,7 +217,7 @@ public class AssetListAssetEntryProviderFiltersTest {
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
 				_filter(
-					"dueDate", "between",
+					"between", "dueDate",
 					JSONUtil.putAll("2026-01-01", "2026-03-01"))),
 			objectEntry1);
 
@@ -234,7 +234,7 @@ public class AssetListAssetEntryProviderFiltersTest {
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
 				_filter(
-					"startTime", "between",
+					"between", "startTime",
 					JSONUtil.putAll("2026-01-15 00:00", "2026-01-15 23:59"))),
 			objectEntry3);
 	}
@@ -256,16 +256,16 @@ public class AssetListAssetEntryProviderFiltersTest {
 			).build());
 
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("title", "eq", "alpha")),
+			_buildFiltersJSONArray(_filter("eq", "title", "alpha")),
 			objectEntry1);
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("title", "not-eq", "alpha")),
+			_buildFiltersJSONArray(_filter("not-eq", "title", "alpha")),
 			objectEntry2);
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("priority", "eq", "2")),
+			_buildFiltersJSONArray(_filter("eq", "priority", "2")),
 			objectEntry2);
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("priority", "not-eq", "2")),
+			_buildFiltersJSONArray(_filter("not-eq", "priority", "2")),
 			objectEntry1);
 	}
 
@@ -380,11 +380,11 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_filter("learnDocumentation", "contains", "alpha")),
+				_filter("contains", "learnDocumentation", "alpha")),
 			objectEntry1);
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_filter("learnDocumentation", "not-contains", "alpha")),
+				_filter("not-contains", "learnDocumentation", "alpha")),
 			objectEntry2);
 	}
 
@@ -414,8 +414,8 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_filter("title", "contains", "match"),
-				_filter("priority", "eq", "5")),
+				_filter("contains", "title", "match"),
+				_filter("eq", "priority", "5")),
 			objectEntry1);
 	}
 
@@ -453,21 +453,21 @@ public class AssetListAssetEntryProviderFiltersTest {
 			).build());
 
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("priority", "gt", "5")),
+			_buildFiltersJSONArray(_filter("gt", "priority", "5")),
 			objectEntry3);
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("priority", "ge", "5")),
+			_buildFiltersJSONArray(_filter("ge", "priority", "5")),
 			objectEntry2, objectEntry3);
 
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("priority", "lt", "5")),
+			_buildFiltersJSONArray(_filter("lt", "priority", "5")),
 			objectEntry1);
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("priority", "le", "5")),
+			_buildFiltersJSONArray(_filter("le", "priority", "5")),
 			objectEntry1, objectEntry2);
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_filter("priority", "between", JSONUtil.putAll("4", "11"))),
+				_filter("between", "priority", JSONUtil.putAll("4", "11"))),
 			objectEntry2, objectEntry3);
 	}
 
@@ -540,10 +540,10 @@ public class AssetListAssetEntryProviderFiltersTest {
 			).build());
 
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("title", "contains", "liferay")),
+			_buildFiltersJSONArray(_filter("contains", "title", "liferay")),
 			objectEntry1);
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("title", "not-contains", "liferay")),
+			_buildFiltersJSONArray(_filter("not-contains", "title", "liferay")),
 			objectEntry2);
 	}
 
@@ -675,7 +675,7 @@ public class AssetListAssetEntryProviderFiltersTest {
 	}
 
 	private JSONObject _filter(
-		String propertyName, String operatorName, Object value) {
+		String operatorName, String propertyName, Object value) {
 
 		return JSONUtil.put(
 			"classNameId",

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -180,21 +180,24 @@ public class AssetListAssetEntryProviderFiltersTest {
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
 	@Test
 	public void testCommonFieldFiltersMatchAcrossAssetTypes() throws Exception {
+		String title = RandomTestUtil.randomString();
+
 		ObjectEntry objectEntry = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
-				"title", "crossfilter"
+				"title", title
 			).build());
 
 		JournalArticle journalArticle = JournalTestUtil.addArticle(
 			_group.getGroupId(),
-			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, 0, "crossfilter",
-			StringPool.BLANK, "content", LocaleUtil.US, false, true,
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, 0, title,
+			StringPool.BLANK, RandomTestUtil.randomString(), LocaleUtil.US,
+			false, true,
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 
 		List<Long> actualClassPKs = _getFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_commonFieldFilter("contains", "title", "crossfilter")));
+				_commonFieldFilter("contains", "title", title)));
 
 		Assert.assertEquals(
 			actualClassPKs.toString(), 2, actualClassPKs.size());
@@ -339,7 +342,6 @@ public class AssetListAssetEntryProviderFiltersTest {
 		JSONArray actualJSONArray = (JSONArray)assetEntryQuery.getAttribute(
 			"filters");
 
-		Assert.assertNotNull(actualJSONArray);
 		Assert.assertEquals(
 			actualJSONArray.toString(), 2, actualJSONArray.length());
 
@@ -741,11 +743,14 @@ public class AssetListAssetEntryProviderFiltersTest {
 		);
 	}
 
-	private static final String _LIST_TYPE_ENTRY_KEY_1 = "key1";
+	private static final String _LIST_TYPE_ENTRY_KEY_1 =
+		RandomTestUtil.randomString();
 
-	private static final String _LIST_TYPE_ENTRY_KEY_2 = "key2";
+	private static final String _LIST_TYPE_ENTRY_KEY_2 =
+		RandomTestUtil.randomString();
 
-	private static final String _LIST_TYPE_ENTRY_KEY_3 = "key3";
+	private static final String _LIST_TYPE_ENTRY_KEY_3 =
+		RandomTestUtil.randomString();
 
 	@Inject
 	private AssetListAssetEntryProvider _assetListAssetEntryProvider;

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -146,7 +146,9 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
 	@Test
-	public void testCommonFieldFilters() throws Exception {
+	public void testGetAssetEntriesInfoPageWithCommonFieldFilters()
+		throws Exception {
+
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
 				"title", "alpha"
@@ -179,7 +181,9 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
 	@Test
-	public void testCommonFieldFiltersMatchAcrossAssetTypes() throws Exception {
+	public void testGetAssetEntriesInfoPageWithCommonFieldFiltersAcrossAssetTypes()
+		throws Exception {
+
 		String title = RandomTestUtil.randomString();
 
 		ObjectEntry objectEntry = _addObjectEntry(
@@ -211,7 +215,9 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
 	@Test
-	public void testDateRangeFilters() throws Exception {
+	public void testGetAssetEntriesInfoPageWithDateRangeFilters()
+		throws Exception {
+
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
 				"dueDate", "2026-01-15"
@@ -244,7 +250,9 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
 	@Test
-	public void testEqualityFilters() throws Exception {
+	public void testGetAssetEntriesInfoPageWithEqualityFilters()
+		throws Exception {
+
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
 				"priority", 1
@@ -272,9 +280,184 @@ public class AssetListAssetEntryProviderFiltersTest {
 			objectEntry1);
 	}
 
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testGetAssetEntriesInfoPageWithKeywordTextContainsFilters()
+		throws Exception {
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"learnDocumentation", "I like alpha"
+			).build());
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"learnDocumentation", "other content"
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_filter("contains", "learnDocumentation", "alpha")),
+			objectEntry1);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_filter("not-contains", "learnDocumentation", "alpha")),
+			objectEntry2);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testGetAssetEntriesInfoPageWithMultipleFiltersJoinedWithMust()
+		throws Exception {
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"priority", 5
+			).put(
+				"title", "match"
+			).build());
+
+		_addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"priority", 1
+			).put(
+				"title", "match"
+			).build());
+
+		_addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"priority", 5
+			).put(
+				"title", "other"
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_filter("contains", "title", "match"),
+				_filter("eq", "priority", "5")),
+			objectEntry1);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testGetAssetEntriesInfoPageWithNumericRangeFilters()
+		throws Exception {
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"priority", 1
+			).build());
+
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"priority", 5
+			).build());
+		ObjectEntry objectEntry3 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"priority", 10
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(_filter("gt", "priority", "5")),
+			objectEntry3);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(_filter("ge", "priority", "5")),
+			objectEntry2, objectEntry3);
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(_filter("lt", "priority", "5")),
+			objectEntry1);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(_filter("le", "priority", "5")),
+			objectEntry1, objectEntry2);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_filter("between", "priority", JSONUtil.putAll("4", "11"))),
+			objectEntry2, objectEntry3);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testGetAssetEntriesInfoPageWithPicklistFilters()
+		throws Exception {
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"category", _LIST_TYPE_ENTRY_KEY_1
+			).build());
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"category", _LIST_TYPE_ENTRY_KEY_2
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_picklistFilter("category", "any", _LIST_TYPE_ENTRY_KEY_1)),
+			objectEntry1);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_picklistFilter(
+					"category", "any", _LIST_TYPE_ENTRY_KEY_1,
+					_LIST_TYPE_ENTRY_KEY_2)),
+			objectEntry1, objectEntry2);
+
+		ObjectEntry objectEntry3 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"categories",
+				(Serializable)Arrays.asList(
+					_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2)
+			).build());
+		ObjectEntry objectEntry4 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"categories",
+				(Serializable)Arrays.asList(
+					_LIST_TYPE_ENTRY_KEY_2, _LIST_TYPE_ENTRY_KEY_3)
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_picklistFilter("categories", "any", _LIST_TYPE_ENTRY_KEY_1)),
+			objectEntry3);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_picklistFilter("categories", "any", _LIST_TYPE_ENTRY_KEY_3)),
+			objectEntry4);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_picklistFilter(
+					"categories", "all", _LIST_TYPE_ENTRY_KEY_1,
+					_LIST_TYPE_ENTRY_KEY_2)),
+			objectEntry3);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_picklistFilter("categories", "all", _LIST_TYPE_ENTRY_KEY_2)),
+			objectEntry3, objectEntry4);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testGetAssetEntriesInfoPageWithTextContainsFilters()
+		throws Exception {
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"title", "liferay platform"
+			).build());
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"title", "other content"
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(_filter("contains", "title", "liferay")),
+			objectEntry1);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(_filter("not-contains", "title", "liferay")),
+			objectEntry2);
+	}
+
 	@FeatureFlag(enable = false, value = "LPD-74731")
 	@Test
-	public void testFiltersAreIgnoredWhenFeatureFlagDisabled()
+	public void testGetAssetEntryQueryWithFiltersWhenFeatureFlagDisabled()
 		throws Exception {
 
 		JSONArray filtersJSONArray = JSONUtil.putAll(
@@ -302,7 +485,7 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
 	@Test
-	public void testFiltersArePropagatedAsAttributeWhenFeatureFlagEnabled()
+	public void testGetAssetEntryQueryWithFiltersWhenFeatureFlagEnabled()
 		throws Exception {
 
 		JSONArray filtersJSONArray = JSONUtil.putAll(
@@ -370,62 +553,7 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
 	@Test
-	public void testKeywordTextContainsFilters() throws Exception {
-		ObjectEntry objectEntry1 = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"learnDocumentation", "I like alpha"
-			).build());
-		ObjectEntry objectEntry2 = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"learnDocumentation", "other content"
-			).build());
-
-		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(
-				_filter("contains", "learnDocumentation", "alpha")),
-			objectEntry1);
-		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(
-				_filter("not-contains", "learnDocumentation", "alpha")),
-			objectEntry2);
-	}
-
-	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
-	@Test
-	public void testMultipleFiltersJoinedWithMust() throws Exception {
-		ObjectEntry objectEntry1 = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"priority", 5
-			).put(
-				"title", "match"
-			).build());
-
-		_addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"priority", 1
-			).put(
-				"title", "match"
-			).build());
-
-		_addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"priority", 5
-			).put(
-				"title", "other"
-			).build());
-
-		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(
-				_filter("contains", "title", "match"),
-				_filter("eq", "priority", "5")),
-			objectEntry1);
-	}
-
-	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
-	@Test
-	public void testNoFiltersAttributeWhenTypeSettingsHasNoFilters()
-		throws Exception {
-
+	public void testGetAssetEntryQueryWithoutFilters() throws Exception {
 		AssetListEntry assetListEntry = _addDynamicAssetListEntryWithFilters(
 			null);
 
@@ -435,118 +563,6 @@ public class AssetListAssetEntryProviderFiltersTest {
 				null);
 
 		Assert.assertNull(assetEntryQuery.getAttribute("filters"));
-	}
-
-	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
-	@Test
-	public void testNumericRangeFilters() throws Exception {
-		ObjectEntry objectEntry1 = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"priority", 1
-			).build());
-
-		ObjectEntry objectEntry2 = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"priority", 5
-			).build());
-		ObjectEntry objectEntry3 = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"priority", 10
-			).build());
-
-		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("gt", "priority", "5")),
-			objectEntry3);
-		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("ge", "priority", "5")),
-			objectEntry2, objectEntry3);
-
-		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("lt", "priority", "5")),
-			objectEntry1);
-		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("le", "priority", "5")),
-			objectEntry1, objectEntry2);
-		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(
-				_filter("between", "priority", JSONUtil.putAll("4", "11"))),
-			objectEntry2, objectEntry3);
-	}
-
-	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
-	@Test
-	public void testPicklistFilters() throws Exception {
-		ObjectEntry objectEntry1 = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"category", _LIST_TYPE_ENTRY_KEY_1
-			).build());
-		ObjectEntry objectEntry2 = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"category", _LIST_TYPE_ENTRY_KEY_2
-			).build());
-
-		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(
-				_picklistFilter("category", "any", _LIST_TYPE_ENTRY_KEY_1)),
-			objectEntry1);
-		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(
-				_picklistFilter(
-					"category", "any", _LIST_TYPE_ENTRY_KEY_1,
-					_LIST_TYPE_ENTRY_KEY_2)),
-			objectEntry1, objectEntry2);
-
-		ObjectEntry objectEntry3 = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"categories",
-				(Serializable)Arrays.asList(
-					_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2)
-			).build());
-		ObjectEntry objectEntry4 = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"categories",
-				(Serializable)Arrays.asList(
-					_LIST_TYPE_ENTRY_KEY_2, _LIST_TYPE_ENTRY_KEY_3)
-			).build());
-
-		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(
-				_picklistFilter("categories", "any", _LIST_TYPE_ENTRY_KEY_1)),
-			objectEntry3);
-		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(
-				_picklistFilter("categories", "any", _LIST_TYPE_ENTRY_KEY_3)),
-			objectEntry4);
-		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(
-				_picklistFilter(
-					"categories", "all", _LIST_TYPE_ENTRY_KEY_1,
-					_LIST_TYPE_ENTRY_KEY_2)),
-			objectEntry3);
-		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(
-				_picklistFilter("categories", "all", _LIST_TYPE_ENTRY_KEY_2)),
-			objectEntry3, objectEntry4);
-	}
-
-	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
-	@Test
-	public void testTextContainsFilters() throws Exception {
-		ObjectEntry objectEntry1 = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"title", "liferay platform"
-			).build());
-		ObjectEntry objectEntry2 = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"title", "other content"
-			).build());
-
-		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("contains", "title", "liferay")),
-			objectEntry1);
-		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("not-contains", "title", "liferay")),
-			objectEntry2);
 	}
 
 	private AssetListEntry _addDynamicAssetListEntryWithFilters(

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -547,7 +547,8 @@ public class AssetListAssetEntryProviderFiltersTest {
 			objectEntry2);
 	}
 
-	private AssetListEntry _addDynamicAssetListEntryWithFilters(String filters)
+	private AssetListEntry _addDynamicAssetListEntryWithFilters(
+			String filtersJSON)
 		throws Exception {
 
 		AssetListEntry assetListEntry = AssetListTestUtil.addAssetListEntry(
@@ -562,9 +563,9 @@ public class AssetListAssetEntryProviderFiltersTest {
 					_portal.getClassNameId(_objectDefinition.getClassName()))
 			);
 
-		if (filters != null) {
+		if (filtersJSON != null) {
 			unicodePropertiesWrapper = unicodePropertiesWrapper.put(
-				"filters", filters);
+				"filters", filtersJSON);
 		}
 
 		UnicodeProperties typeSettingsUnicodeProperties =

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -13,6 +13,9 @@ import com.liferay.asset.list.model.AssetListEntry;
 import com.liferay.asset.list.service.AssetListEntryLocalService;
 import com.liferay.asset.list.test.util.AssetListTestUtil;
 import com.liferay.info.pagination.InfoPage;
+import com.liferay.journal.constants.JournalFolderConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.list.type.entry.util.ListTypeEntryUtil;
 import com.liferay.list.type.model.ListTypeDefinition;
 import com.liferay.list.type.service.ListTypeDefinitionLocalService;
@@ -23,8 +26,11 @@ import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectFieldSetting;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringPool;
@@ -127,6 +133,77 @@ public class AssetListAssetEntryProviderFiltersTest {
 					ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
 					"Title", "title", false)),
 			ObjectDefinitionConstants.SCOPE_SITE);
+
+		ObjectField titleObjectField =
+			_objectFieldLocalService.fetchObjectField(
+				_objectDefinition.getObjectDefinitionId(), "title");
+
+		_objectDefinition =
+			_objectDefinitionLocalService.updateTitleObjectFieldId(
+				_objectDefinition.getObjectDefinitionId(),
+				titleObjectField.getObjectFieldId());
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testCommonFieldFilters() throws Exception {
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"title", "alpha"
+			).build());
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"title", "beta"
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(_commonFieldFilter("title", "eq", "alpha")),
+			objectEntry1);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_commonFieldFilter("title", "contains", "alpha")),
+			objectEntry1);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_commonFieldFilter("title", "not-contains", "alpha")),
+			objectEntry2);
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_commonFieldFilter("createDate", "gt", "2000-01-01")),
+			objectEntry1, objectEntry2);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_commonFieldFilter("createDate", "lt", "2000-01-01")));
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testCommonFieldFiltersMatchAcrossAssetTypes() throws Exception {
+		ObjectEntry objectEntry = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"title", "crossfilter"
+			).build());
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, 0, "crossfilter",
+			StringPool.BLANK, "content", LocaleUtil.US, false, true,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		List<Long> actualClassPKs = _getFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_commonFieldFilter("title", "contains", "crossfilter")));
+
+		Assert.assertEquals(
+			actualClassPKs.toString(), 2, actualClassPKs.size());
+		Assert.assertTrue(
+			actualClassPKs.toString(),
+			actualClassPKs.containsAll(
+				Arrays.asList(
+					objectEntry.getObjectEntryId(),
+					journalArticle.getResourcePrimKey())));
 	}
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
@@ -573,6 +650,18 @@ public class AssetListAssetEntryProviderFiltersTest {
 		return JSONUtil.putAll((Object[])filterJSONObjects);
 	}
 
+	private JSONObject _commonFieldFilter(
+		String propertyName, String operatorName, Object value) {
+
+		return JSONUtil.put(
+			"operatorName", operatorName
+		).put(
+			"propertyName", propertyName
+		).put(
+			"value", value
+		);
+	}
+
 	private ObjectFieldSetting _createObjectFieldSetting(
 		String name, String value) {
 
@@ -600,6 +689,41 @@ public class AssetListAssetEntryProviderFiltersTest {
 		).put(
 			"value", value
 		);
+	}
+
+	private List<Long> _getFilteredClassPKs(JSONArray filtersJSONArray)
+		throws Exception {
+
+		AssetListEntry assetListEntry = AssetListTestUtil.addAssetListEntry(
+			_group.getGroupId(), 0);
+
+		_assetListEntryLocalService.updateAssetListEntryTypeSettings(
+			assetListEntry.getAssetListEntryId(),
+			SegmentsEntryConstants.ID_DEFAULT,
+			UnicodePropertiesBuilder.create(
+				true
+			).put(
+				"anyAssetType", "true"
+			).put(
+				"filters", filtersJSONArray.toString()
+			).build(
+			).toString());
+
+		InfoPage<AssetEntry> infoPage =
+			_assetListAssetEntryProvider.getAssetEntriesInfoPage(
+				_assetListEntryLocalService.getAssetListEntry(
+					assetListEntry.getAssetListEntryId()),
+				new long[] {SegmentsEntryConstants.ID_DEFAULT}, null, null,
+				StringPool.BLANK, StringPool.BLANK, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS);
+
+		List<Long> classPKs = new ArrayList<>();
+
+		for (AssetEntry assetEntry : infoPage.getPageItems()) {
+			classPKs.add(assetEntry.getClassPK());
+		}
+
+		return classPKs;
 	}
 
 	private JSONObject _picklistFilter(
@@ -652,7 +776,13 @@ public class AssetListAssetEntryProviderFiltersTest {
 	private ObjectDefinition _objectDefinition;
 
 	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ObjectFieldLocalService _objectFieldLocalService;
 
 	@Inject
 	private ObjectFieldSettingLocalService _objectFieldSettingLocalService;

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -19,10 +19,13 @@ import com.liferay.list.type.service.ListTypeDefinitionLocalService;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectFieldSetting;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -102,13 +105,23 @@ public class AssetListAssetEntryProviderFiltersTest {
 					ObjectFieldConstants.DB_TYPE_DATE, true, false, null,
 					"Due Date", "dueDate", false),
 				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+					"Learn Documentation", "learnDocumentation", false),
+				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
 					ObjectFieldConstants.DB_TYPE_INTEGER, true, false, null,
 					"Priority", "priority", false),
 				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_DATE_TIME,
 					ObjectFieldConstants.DB_TYPE_DATE_TIME, true, false, null,
-					"Start Time", "startTime", false),
+					"Start Time", "startTime",
+					Collections.singletonList(
+						_createObjectFieldSetting(
+							ObjectFieldSettingConstants.NAME_TIME_STORAGE,
+							ObjectFieldSettingConstants.
+								VALUE_USE_INPUT_AS_ENTERED)),
+					false),
 				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 					ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
@@ -122,10 +135,6 @@ public class AssetListAssetEntryProviderFiltersTest {
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
 				"dueDate", "2026-01-15"
-			).build());
-		ObjectEntry objectEntry2 = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"dueDate", "2026-06-15"
 			).build());
 
 		_assertFilteredClassPKs(
@@ -149,8 +158,7 @@ public class AssetListAssetEntryProviderFiltersTest {
 			_buildFiltersJSONArray(
 				_filter(
 					"startTime", "between",
-					JSONUtil.putAll(
-						"2026-01-15 00:00", "2026-01-15 23:59"))),
+					JSONUtil.putAll("2026-01-15 00:00", "2026-01-15 23:59"))),
 			objectEntry3);
 	}
 
@@ -283,6 +291,28 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
 	@Test
+	public void testKeywordTextContainsFilters() throws Exception {
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"learnDocumentation", "I like alpha"
+			).build());
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"learnDocumentation", "other content"
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_filter("learnDocumentation", "contains", "alpha")),
+			objectEntry1);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_filter("learnDocumentation", "not-contains", "alpha")),
+			objectEntry2);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
 	public void testMultipleFiltersJoinedWithMust() throws Exception {
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
@@ -335,6 +365,7 @@ public class AssetListAssetEntryProviderFiltersTest {
 			HashMapBuilder.<String, Serializable>put(
 				"priority", 1
 			).build());
+
 		ObjectEntry objectEntry2 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
 				"priority", 5
@@ -350,6 +381,7 @@ public class AssetListAssetEntryProviderFiltersTest {
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(_filter("priority", "ge", "5")),
 			objectEntry2, objectEntry3);
+
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(_filter("priority", "lt", "5")),
 			objectEntry1);
@@ -434,8 +466,7 @@ public class AssetListAssetEntryProviderFiltersTest {
 			_buildFiltersJSONArray(_filter("title", "contains", "liferay")),
 			objectEntry1);
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(
-				_filter("title", "not-contains", "liferay")),
+			_buildFiltersJSONArray(_filter("title", "not-contains", "liferay")),
 			objectEntry2);
 	}
 
@@ -474,7 +505,8 @@ public class AssetListAssetEntryProviderFiltersTest {
 	private ListTypeDefinition _addListTypeDefinition() throws Exception {
 		return _listTypeDefinitionLocalService.addListTypeDefinition(
 			null, TestPropsValues.getUserId(),
-			Collections.singletonMap(LocaleUtil.US, RandomTestUtil.randomString()),
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
 			false,
 			Arrays.asList(
 				ListTypeEntryUtil.createListTypeEntry(
@@ -539,6 +571,18 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 	private JSONArray _buildFiltersJSONArray(JSONObject... filterJSONObjects) {
 		return JSONUtil.putAll((Object[])filterJSONObjects);
+	}
+
+	private ObjectFieldSetting _createObjectFieldSetting(
+		String name, String value) {
+
+		ObjectFieldSetting objectFieldSetting =
+			_objectFieldSettingLocalService.createObjectFieldSetting(0L);
+
+		objectFieldSetting.setName(name);
+		objectFieldSetting.setValue(value);
+
+		return objectFieldSetting;
 	}
 
 	private JSONObject _filter(
@@ -609,6 +653,9 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ObjectFieldSettingLocalService _objectFieldSettingLocalService;
 
 	@Inject
 	private Portal _portal;

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -157,24 +157,24 @@ public class AssetListAssetEntryProviderFiltersTest {
 			).build());
 
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_commonFieldFilter("title", "eq", "alpha")),
+			_buildFiltersJSONArray(_commonFieldFilter("eq", "title", "alpha")),
 			objectEntry1);
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_commonFieldFilter("title", "contains", "alpha")),
+				_commonFieldFilter("contains", "title", "alpha")),
 			objectEntry1);
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_commonFieldFilter("title", "not-contains", "alpha")),
+				_commonFieldFilter("not-contains", "title", "alpha")),
 			objectEntry2);
 
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_commonFieldFilter("createDate", "gt", "2000-01-01")),
+				_commonFieldFilter("gt", "createDate", "2000-01-01")),
 			objectEntry1, objectEntry2);
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_commonFieldFilter("createDate", "lt", "2000-01-01")));
+				_commonFieldFilter("lt", "createDate", "2000-01-01")));
 	}
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
@@ -194,7 +194,7 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 		List<Long> actualClassPKs = _getFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_commonFieldFilter("title", "contains", "crossfilter")));
+				_commonFieldFilter("contains", "title", "crossfilter")));
 
 		Assert.assertEquals(
 			actualClassPKs.toString(), 2, actualClassPKs.size());
@@ -651,7 +651,7 @@ public class AssetListAssetEntryProviderFiltersTest {
 	}
 
 	private JSONObject _commonFieldFilter(
-		String propertyName, String operatorName, Object value) {
+		String operatorName, String propertyName, Object value) {
 
 		return JSONUtil.put(
 			"operatorName", operatorName

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -100,28 +100,28 @@ public class AssetListAssetEntryProviderFiltersTest {
 					_listTypeDefinition.getListTypeDefinitionId(),
 					ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST,
 					null, ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
-					"Categories", "categories", false, false),
+					RandomTestUtil.randomString(), "categories", false, false),
 				ObjectFieldUtil.createObjectField(
 					_listTypeDefinition.getListTypeDefinitionId(),
 					ObjectFieldConstants.BUSINESS_TYPE_PICKLIST, null,
 					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
-					"Category", "category", false, false),
+					RandomTestUtil.randomString(), "category", false, false),
 				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_DATE,
 					ObjectFieldConstants.DB_TYPE_DATE, true, false, null,
-					"Due Date", "dueDate", false),
+					RandomTestUtil.randomString(), "dueDate", false),
 				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
-					"Learn Documentation", "learnDocumentation", false),
+					RandomTestUtil.randomString(), "learnDocumentation", false),
 				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
 					ObjectFieldConstants.DB_TYPE_INTEGER, true, false, null,
-					"Priority", "priority", false),
+					RandomTestUtil.randomString(), "priority", false),
 				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_DATE_TIME,
 					ObjectFieldConstants.DB_TYPE_DATE_TIME, true, false, null,
-					"Start Time", "startTime",
+					RandomTestUtil.randomString(), "startTime",
 					Collections.singletonList(
 						_createObjectFieldSetting(
 							ObjectFieldSettingConstants.NAME_TIME_STORAGE,
@@ -131,7 +131,7 @@ public class AssetListAssetEntryProviderFiltersTest {
 				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 					ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-					"Title", "title", false)),
+					RandomTestUtil.randomString(), "title", false)),
 			ObjectDefinitionConstants.SCOPE_SITE);
 
 		ObjectField titleObjectField =

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -51,6 +51,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.test.rule.FeatureFlag;
@@ -149,25 +150,28 @@ public class AssetListAssetEntryProviderFiltersTest {
 	public void testGetAssetEntriesInfoPageWithCommonFieldFilters()
 		throws Exception {
 
+		String title1 = RandomTestUtil.randomString();
+
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
-				"title", "alpha"
+				"title", title1
 			).build());
+
 		ObjectEntry objectEntry2 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
-				"title", "beta"
+				"title", RandomTestUtil.randomString()
 			).build());
 
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_commonFieldFilter("eq", "title", "alpha")),
+			_buildFiltersJSONArray(_commonFieldFilter("eq", "title", title1)),
 			objectEntry1);
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_commonFieldFilter("contains", "title", "alpha")),
+				_commonFieldFilter("contains", "title", title1)),
 			objectEntry1);
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_commonFieldFilter("not-contains", "title", "alpha")),
+				_commonFieldFilter("not-contains", "title", title1)),
 			objectEntry2);
 
 		_assertFilteredClassPKs(
@@ -253,30 +257,37 @@ public class AssetListAssetEntryProviderFiltersTest {
 	public void testGetAssetEntriesInfoPageWithEqualityFilters()
 		throws Exception {
 
+		int priority = RandomTestUtil.randomInt();
+
+		String title = StringUtil.toLowerCase(RandomTestUtil.randomString());
+
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
-				"priority", 1
+				"priority", RandomTestUtil.randomInt()
 			).put(
-				"title", "alpha"
+				"title", title
 			).build());
+
 		ObjectEntry objectEntry2 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
-				"priority", 2
+				"priority", priority
 			).put(
-				"title", "beta"
+				"title", RandomTestUtil.randomString()
 			).build());
 
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("eq", "title", "alpha")),
+			_buildFiltersJSONArray(_filter("eq", "title", title)),
 			objectEntry1);
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("not-eq", "title", "alpha")),
+			_buildFiltersJSONArray(_filter("not-eq", "title", title)),
 			objectEntry2);
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("eq", "priority", "2")),
+			_buildFiltersJSONArray(
+				_filter("eq", "priority", String.valueOf(priority))),
 			objectEntry2);
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("not-eq", "priority", "2")),
+			_buildFiltersJSONArray(
+				_filter("not-eq", "priority", String.valueOf(priority))),
 			objectEntry1);
 	}
 
@@ -285,22 +296,25 @@ public class AssetListAssetEntryProviderFiltersTest {
 	public void testGetAssetEntriesInfoPageWithKeywordTextContainsFilters()
 		throws Exception {
 
+		String keyword = RandomTestUtil.randomString();
+
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
-				"learnDocumentation", "I like alpha"
+				"learnDocumentation", keyword
 			).build());
+
 		ObjectEntry objectEntry2 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
-				"learnDocumentation", "other content"
+				"learnDocumentation", RandomTestUtil.randomString()
 			).build());
 
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_filter("contains", "learnDocumentation", "alpha")),
+				_filter("contains", "learnDocumentation", keyword)),
 			objectEntry1);
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_filter("not-contains", "learnDocumentation", "alpha")),
+				_filter("not-contains", "learnDocumentation", keyword)),
 			objectEntry2);
 	}
 
@@ -309,31 +323,34 @@ public class AssetListAssetEntryProviderFiltersTest {
 	public void testGetAssetEntriesInfoPageWithMultipleFiltersJoinedWithMust()
 		throws Exception {
 
+		String matchTitle = RandomTestUtil.randomString();
+		int priority = RandomTestUtil.randomInt();
+
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
-				"priority", 5
+				"priority", priority
 			).put(
-				"title", "match"
+				"title", matchTitle
 			).build());
 
 		_addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
-				"priority", 1
+				"priority", RandomTestUtil.randomInt()
 			).put(
-				"title", "match"
+				"title", matchTitle
 			).build());
 
 		_addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
-				"priority", 5
+				"priority", priority
 			).put(
-				"title", "other"
+				"title", RandomTestUtil.randomString()
 			).build());
 
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_filter("contains", "title", "match"),
-				_filter("eq", "priority", "5")),
+				_filter("contains", "title", matchTitle),
+				_filter("eq", "priority", String.valueOf(priority))),
 			objectEntry1);
 	}
 
@@ -342,36 +359,46 @@ public class AssetListAssetEntryProviderFiltersTest {
 	public void testGetAssetEntriesInfoPageWithNumericRangeFilters()
 		throws Exception {
 
+		int priority2 = RandomTestUtil.randomInt(101, 200);
+		int priority3 = RandomTestUtil.randomInt(201, 300);
+
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
-				"priority", 1
+				"priority", RandomTestUtil.randomInt(1, 100)
 			).build());
 
 		ObjectEntry objectEntry2 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
-				"priority", 5
+				"priority", priority2
 			).build());
 		ObjectEntry objectEntry3 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
-				"priority", 10
+				"priority", priority3
 			).build());
 
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("gt", "priority", "5")),
+			_buildFiltersJSONArray(
+				_filter("gt", "priority", String.valueOf(priority2))),
 			objectEntry3);
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("ge", "priority", "5")),
+			_buildFiltersJSONArray(
+				_filter("ge", "priority", String.valueOf(priority2))),
 			objectEntry2, objectEntry3);
 
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("lt", "priority", "5")),
+			_buildFiltersJSONArray(
+				_filter("lt", "priority", String.valueOf(priority2))),
 			objectEntry1);
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("le", "priority", "5")),
+			_buildFiltersJSONArray(
+				_filter("le", "priority", String.valueOf(priority2))),
 			objectEntry1, objectEntry2);
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_filter("between", "priority", JSONUtil.putAll("4", "11"))),
+				_filter(
+					"between", "priority",
+					JSONUtil.putAll(
+						String.valueOf(priority2), String.valueOf(priority3)))),
 			objectEntry2, objectEntry3);
 	}
 
@@ -438,20 +465,23 @@ public class AssetListAssetEntryProviderFiltersTest {
 	public void testGetAssetEntriesInfoPageWithTextContainsFilters()
 		throws Exception {
 
+		String title = RandomTestUtil.randomString();
+
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
-				"title", "liferay platform"
+				"title", title
 			).build());
+
 		ObjectEntry objectEntry2 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
-				"title", "other content"
+				"title", RandomTestUtil.randomString()
 			).build());
 
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("contains", "title", "liferay")),
+			_buildFiltersJSONArray(_filter("contains", "title", title)),
 			objectEntry1);
 		_assertFilteredClassPKs(
-			_buildFiltersJSONArray(_filter("not-contains", "title", "liferay")),
+			_buildFiltersJSONArray(_filter("not-contains", "title", title)),
 			objectEntry2);
 	}
 
@@ -469,7 +499,7 @@ public class AssetListAssetEntryProviderFiltersTest {
 			).put(
 				"propertyName", "title"
 			).put(
-				"value", "keyword"
+				"value", RandomTestUtil.randomString()
 			));
 
 		AssetListEntry assetListEntry = _addDynamicAssetListEntryWithFilters(
@@ -488,6 +518,9 @@ public class AssetListAssetEntryProviderFiltersTest {
 	public void testGetAssetEntryQueryWithFiltersWhenFeatureFlagEnabled()
 		throws Exception {
 
+		String propertyName = RandomTestUtil.randomString();
+		String value = RandomTestUtil.randomString();
+
 		JSONArray filtersJSONArray = JSONUtil.putAll(
 			JSONUtil.put(
 				"classNameId",
@@ -497,9 +530,9 @@ public class AssetListAssetEntryProviderFiltersTest {
 			).put(
 				"operatorName", "contains"
 			).put(
-				"propertyName", "title"
+				"propertyName", propertyName
 			).put(
-				"value", "keyword"
+				"value", value
 			),
 			JSONUtil.put(
 				"classNameId",
@@ -509,9 +542,9 @@ public class AssetListAssetEntryProviderFiltersTest {
 			).put(
 				"operatorName", "eq"
 			).put(
-				"propertyName", "priority"
+				"propertyName", RandomTestUtil.randomString()
 			).put(
-				"value", "1"
+				"value", String.valueOf(RandomTestUtil.randomInt())
 			));
 
 		AssetListEntry assetListEntry = _addDynamicAssetListEntryWithFilters(
@@ -530,8 +563,8 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 		JSONObject jsonObject = actualJSONArray.getJSONObject(0);
 
-		Assert.assertEquals("title", jsonObject.getString("propertyName"));
-		Assert.assertEquals("keyword", jsonObject.getString("value"));
+		Assert.assertEquals(propertyName, jsonObject.getString("propertyName"));
+		Assert.assertEquals(value, jsonObject.getString("value"));
 		Assert.assertEquals(
 			_portal.getClassNameId(_objectDefinition.getClassName()),
 			jsonObject.getLong("classNameId"));

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -541,7 +541,7 @@ public class AssetListAssetEntryProviderFiltersTest {
 	@Test
 	public void testGetAssetEntryQueryWithInvalidFilters() throws Exception {
 		AssetListEntry assetListEntry = _addDynamicAssetListEntryWithFilters(
-			"not-a-json-array");
+			RandomTestUtil.randomString());
 
 		AssetEntryQuery assetEntryQuery =
 			_assetListAssetEntryProvider.getAssetEntryQuery(

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
@@ -1083,14 +1083,14 @@ public class EditAssetListDisplayContext {
 	}
 
 	public JSONArray getTypePropertiesJSONArray() {
-		long[] classNameIds = new long[0];
-		long[] classTypeIds = new long[0];
-
 		boolean anyAssetType = GetterUtil.getBoolean(
 			_unicodeProperties.getProperty(
 				"anyAssetType", Boolean.TRUE.toString()));
 		String selectionStyle = _unicodeProperties.getProperty(
 			"selectionStyle", "dynamic");
+
+		long[] classNameIds = new long[0];
+		long[] classTypeIds = new long[0];
 
 		if (!anyAssetType && !selectionStyle.equals("manual")) {
 			classNameIds = getClassNameIds();

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
@@ -236,6 +236,10 @@ public class AssetListTypePropertiesUtil {
 	}
 
 	private static String _toType(String businessType) {
+		if (businessType == null) {
+			return null;
+		}
+
 		if (businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN)) {
 			return "boolean";
 		}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -120,6 +120,29 @@ public class ObjectEntryModelDocumentContributor
 		fieldArray.addField(field);
 	}
 
+	private void _addMultiValuedKeywordField(
+		FieldArray fieldArray, String fieldName, String[] values) {
+
+		if (ArrayUtil.isEmpty(values)) {
+			return;
+		}
+
+		Field field = new Field("");
+
+		field.addField(new Field("fieldName", fieldName));
+		field.addField(new Field("valueFieldName", "value_keyword"));
+
+		String[] keywordValues = new String[values.length];
+
+		for (int i = 0; i < values.length; i++) {
+			keywordValues[i] = StringUtil.lowerCase(values[i]);
+		}
+
+		field.addField(new Field("value_keyword", keywordValues));
+
+		fieldArray.addField(field);
+	}
+
 	private void _appendToContent(
 		ObjectContentHelper objectContentHelper, String locale,
 		String objectFieldName, String valueString) {
@@ -206,11 +229,30 @@ public class ObjectEntryModelDocumentContributor
 		}
 		else if (StringUtil.equals(
 					objectField.getBusinessType(),
-					ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST) &&
-				 (fieldValue instanceof List)) {
+					ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST)) {
 
-			fieldValue = ListUtil.toString(
-				(List)fieldValue, (String)null, StringPool.COMMA_AND_SPACE);
+			String valueString = null;
+
+			if (fieldValue instanceof List) {
+				valueString = ListUtil.toString(
+					(List)fieldValue, (String)null, StringPool.COMMA_AND_SPACE);
+			}
+			else {
+				valueString = String.valueOf(fieldValue);
+			}
+
+			if (objectField.isIndexedAsKeyword()) {
+				_addMultiValuedKeywordField(
+					fieldArray, fieldName,
+					StringUtil.split(valueString, StringPool.COMMA_AND_SPACE));
+
+				_appendToContent(
+					objectContentHelper, locale, fieldName, valueString);
+
+				return;
+			}
+
+			fieldValue = valueString;
 		}
 		else if (StringUtil.equals(
 					objectField.getBusinessType(),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93003

## What Is Being Fixed

This addresses review feedback (BChan/Gemini) on the common-field filter query work for asset lists. The changes are test-and-readability cleanups on top of the already-merged feature; no runtime behavior changes.

## How It Is Being Fixed

In AssetListFiltersUtil, range-operator blocks and helper parameters are ordered alphabetically, a single-instance BooleanClauseOccur is named after its type, the picklist query declares its accumulator and quantifier per the burrito/declare-near-use conventions, _normalizeDateValue parameters are ordered alphabetically, and the single-use date format is inlined as a local. The test classes assign chained calls on non-fluent types to named locals, replace mapped-list loops with TransformUtil, drop a redundant assertNotNull, randomize unasserted hardcoded test values via RandomTestUtil, and name test methods after the method under test with a scenario qualifier.

## PR Check

**pr-check: PASS** — tested on `19219f4ab72b9baa7cdba7bca89b86e4a882d51d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS (no consumers) |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "19219f4ab72b9baa7cdba7bca89b86e4a882d51d"} -->
