### PR TITLE
LPD-95481 Preserve the parent on root Blueprint clauses

### DIFF
--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/search/CommonSearchRequestBuilderAssembler.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/search/CommonSearchRequestBuilderAssembler.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.elasticsearch8.internal.aggregation.ElasticsearchAggregationVisitor;
 import com.liferay.portal.search.elasticsearch8.internal.aggregation.ElasticsearchPipelineAggregationVisitor;
 import com.liferay.portal.search.elasticsearch8.internal.facet.FacetTranslator;
@@ -235,7 +236,10 @@ public class CommonSearchRequestBuilderAssembler {
 				additiveComplexQueryParts.add(complexQueryPart);
 			}
 			else {
-				if (complexQueryPart.isRootClause() && query1.isBool()) {
+				if (complexQueryPart.isRootClause() &&
+					Validator.isBlank(complexQueryPart.getParent()) &&
+					query1.isBool()) {
+
 					query1 = _combine(query1.bool(), complexQueryPart);
 				}
 				else {

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/search/CommonSearchRequestBuilderAssemblerImplTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/search/CommonSearchRequestBuilderAssemblerImplTest.java
@@ -461,6 +461,35 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 	}
 
 	@Test
+	public void testRootClauseWithParentNestsUnderNamedParentQuery()
+		throws Exception {
+
+		_index("alpha 1", "JournalArticle");
+		_index("alpha 2", "DLFileEntry");
+		_index("bravo 1", "DLFileEntry");
+
+		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
+
+		BooleanQuery booleanQuery = new BooleanQuery();
+
+		booleanQuery.add(
+			new MatchQuery("title", "alpha"), BooleanClauseOccur.MUST);
+
+		searchSearchRequest.setQuery(booleanQuery);
+
+		_assertSearch(searchSearchRequest, "alpha 1", "alpha 2");
+
+		_addPartNamed("parent_query", "must", searchSearchRequest);
+
+		_addPartRootWithParent(
+			"should", "parent_query",
+			QueriesUtil.term("entryClassName", "DLFileEntry"),
+			searchSearchRequest);
+
+		_assertSearch(searchSearchRequest, "alpha 2");
+	}
+
+	@Test
 	public void testRootOnlyAppliedWhenMainQueryIsBooleanFilterOccur()
 		throws Exception {
 
@@ -592,6 +621,21 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 				).build()));
 	}
 
+	private void _addPartNamed(
+		String name, String occur, SearchSearchRequest searchSearchRequest) {
+
+		searchSearchRequest.addComplexQueryParts(
+			Arrays.asList(
+				_complexQueryPartBuilderFactory.builder(
+				).name(
+					name
+				).occur(
+					occur
+				).query(
+					QueriesUtil.booleanQuery()
+				).build()));
+	}
+
 	private void _addPartRoot(
 		String occur, Query query, SearchSearchRequest searchSearchRequest) {
 
@@ -600,6 +644,24 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 				_complexQueryPartBuilderFactory.builder(
 				).occur(
 					occur
+				).query(
+					query
+				).rootClause(
+					true
+				).build()));
+	}
+
+	private void _addPartRootWithParent(
+		String occur, String parent, Query query,
+		SearchSearchRequest searchSearchRequest) {
+
+		searchSearchRequest.addComplexQueryParts(
+			Arrays.asList(
+				_complexQueryPartBuilderFactory.builder(
+				).occur(
+					occur
+				).parent(
+					parent
 				).query(
 					query
 				).rootClause(

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/search/CommonSearchRequestBuilderAssembler.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/search/CommonSearchRequestBuilderAssembler.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.engine.adapter.search.BaseSearchRequest;
 import com.liferay.portal.search.filter.ComplexQueryBuilder;
 import com.liferay.portal.search.filter.ComplexQueryPart;
@@ -216,7 +217,10 @@ public class CommonSearchRequestBuilderAssembler {
 				additiveComplexQueryParts.add(complexQueryPart);
 			}
 			else {
-				if (complexQueryPart.isRootClause() && query1.isBool()) {
+				if (complexQueryPart.isRootClause() &&
+					Validator.isBlank(complexQueryPart.getParent()) &&
+					query1.isBool()) {
+
 					query1 = _combine(query1.bool(), complexQueryPart);
 				}
 				else {

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/search/CommonSearchRequestBuilderAssemblerImplTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/search/CommonSearchRequestBuilderAssemblerImplTest.java
@@ -463,6 +463,35 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 	}
 
 	@Test
+	public void testRootClauseWithParentNestsUnderNamedParentQuery()
+		throws Exception {
+
+		_index("alpha 1", "JournalArticle");
+		_index("alpha 2", "DLFileEntry");
+		_index("bravo 1", "DLFileEntry");
+
+		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
+
+		BooleanQuery booleanQuery = new BooleanQuery();
+
+		booleanQuery.add(
+			new MatchQuery("title", "alpha"), BooleanClauseOccur.MUST);
+
+		searchSearchRequest.setQuery(booleanQuery);
+
+		_assertSearch(searchSearchRequest, "alpha 1", "alpha 2");
+
+		_addPartNamed("parent_query", "must", searchSearchRequest);
+
+		_addPartRootWithParent(
+			"should", "parent_query",
+			QueriesUtil.term("entryClassName", "DLFileEntry"),
+			searchSearchRequest);
+
+		_assertSearch(searchSearchRequest, "alpha 2");
+	}
+
+	@Test
 	public void testRootOnlyAppliedWhenMainQueryIsBooleanFilterOccur()
 		throws Exception {
 
@@ -594,6 +623,21 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 				).build()));
 	}
 
+	private void _addPartNamed(
+		String name, String occur, SearchSearchRequest searchSearchRequest) {
+
+		searchSearchRequest.addComplexQueryParts(
+			Arrays.asList(
+				_complexQueryPartBuilderFactory.builder(
+				).name(
+					name
+				).occur(
+					occur
+				).query(
+					QueriesUtil.booleanQuery()
+				).build()));
+	}
+
 	private void _addPartRoot(
 		String occur, Query query, SearchSearchRequest searchSearchRequest) {
 
@@ -602,6 +646,24 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 				_complexQueryPartBuilderFactory.builder(
 				).occur(
 					occur
+				).query(
+					query
+				).rootClause(
+					true
+				).build()));
+	}
+
+	private void _addPartRootWithParent(
+		String occur, String parent, Query query,
+		SearchSearchRequest searchSearchRequest) {
+
+		searchSearchRequest.addComplexQueryParts(
+			Arrays.asList(
+				_complexQueryPartBuilderFactory.builder(
+				).occur(
+					occur
+				).parent(
+					parent
 				).query(
 					query
 				).rootClause(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95481

## What Is Being Fixed

A Search Blueprint clause that declares a `parent` pointing at a named query (such as a Custom Filter widget named `parent_query`) is not nested under that parent on 2026.Q1.0 — the clause is flattened into the base query and the named parent query comes out empty. The same configuration nested correctly on 7.3 U36.

## How It Is Being Fixed

The search-engine adapter `CommonSearchRequestBuilderAssembler` has a shortcut that merges a root clause directly into the base bool query when the base query is a bool. That merge path (`buildPart()`) builds only the clause's own query and ignores its `parent`/`name`, so every Blueprint clause — which carries `rootClause=true` since LPS-126703 — had its `parent` dropped whenever the base query was a bool. The fix guards the shortcut with `Validator.isBlank(complexQueryPart.getParent())`, so a clause that declares an explicit parent falls through to `ComplexQueryBuilder`, where the parent is resolved and the clause nests under its named parent query. The same guard is applied to both the Elasticsearch 8 and OpenSearch 2 adapters. Clauses without a parent keep taking the shortcut, so the LPS-126703 behavior is unchanged. Each adapter gets an integration test asserting a parented root clause nests instead of flattening.

## PR Check

**pr-check: PASS** — tested on `8eee8e5e13feddf78dc35b1ae7f096410a2bb95e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "8eee8e5e13feddf78dc35b1ae7f096410a2bb95e"} -->
