### PR TITLE
LPD-95760 Prevent blank search page when resolved experience is empty

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchRequestImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchRequestImpl.java
@@ -11,8 +11,11 @@ import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.search.DisplayTerms;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
@@ -289,13 +292,51 @@ public class PortletSharedSearchRequestImpl
 	private Set<String> _getSegmentExperiencePortletIds(
 		Layout layout, long segmentsExperienceId) {
 
+		Set<String> segmentExperiencePortletIds =
+			_getSegmentExperiencePortletIds(
+				layout.getGroupId(), segmentsExperienceId, layout.getPlid());
+
+		if (!segmentExperiencePortletIds.isEmpty()) {
+			return segmentExperiencePortletIds;
+		}
+
+		long defaultSegmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				layout.getPlid());
+
+		if (defaultSegmentsExperienceId == segmentsExperienceId) {
+			return segmentExperiencePortletIds;
+		}
+
+		// A resolved segments experience that contributes no widgets points to
+		// a stale or unresolved experience rather than an intentionally empty
+		// one. Fall back to the page's default segments experience so the
+		// shared search still gathers the page's widgets, such as Search
+		// Options, instead of silently rendering an empty page.
+
+		if (_log.isWarnEnabled()) {
+			_log.warn(
+				StringBundler.concat(
+					"Segments experience ", segmentsExperienceId,
+					" contributed no widgets to the shared search for layout ",
+					layout.getPlid(),
+					", falling back to default segments experience ",
+					defaultSegmentsExperienceId));
+		}
+
+		return _getSegmentExperiencePortletIds(
+			layout.getGroupId(), defaultSegmentsExperienceId, layout.getPlid());
+	}
+
+	private Set<String> _getSegmentExperiencePortletIds(
+		long groupId, long segmentsExperienceId, long plid) {
+
 		Set<String> segmentExperiencePortletIds = new HashSet<>();
 
 		for (FragmentEntryLink fragmentEntryLink :
 				_fragmentEntryLinkLocalService.
 					getFragmentEntryLinksBySegmentsExperienceId(
-						layout.getGroupId(), segmentsExperienceId,
-						layout.getPlid())) {
+						groupId, segmentsExperienceId, plid)) {
 
 			segmentExperiencePortletIds.addAll(
 				_portletRegistry.getFragmentEntryLinkPortletIds(
@@ -326,6 +367,9 @@ public class PortletSharedSearchRequestImpl
 		return new PortletSharedSearchResponseImpl(
 			searchResponseImpl, portletSharedRequestHelper);
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		PortletSharedSearchRequestImpl.class);
 
 	@Reference
 	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchRequestImplTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchRequestImplTest.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchRequest;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import java.util.List;
 import java.util.Set;
@@ -45,6 +46,77 @@ public class PortletSharedSearchRequestImplTest {
 				"_getSegmentExperiencePortletIds",
 				new Class<?>[] {Layout.class, long.class},
 				Mockito.mock(Layout.class), RandomTestUtil.randomLong()));
+	}
+
+	@Test
+	public void testGetSegmentExperiencePortletIdsWhenResolvedExperienceIsEmpty() {
+		long groupId = RandomTestUtil.randomLong();
+		long plid = RandomTestUtil.randomLong();
+		long defaultSegmentsExperienceId = RandomTestUtil.randomLong();
+		long segmentsExperienceId = RandomTestUtil.randomLong();
+
+		FragmentEntryLinkLocalService fragmentEntryLinkLocalService =
+			Mockito.mock(FragmentEntryLinkLocalService.class);
+
+		Mockito.doReturn(
+			List.of()
+		).when(
+			fragmentEntryLinkLocalService
+		).getFragmentEntryLinksBySegmentsExperienceId(
+			groupId, segmentsExperienceId, plid
+		);
+
+		Mockito.doReturn(
+			List.of(_mockFragmentEntryLink("searchOptions"))
+		).when(
+			fragmentEntryLinkLocalService
+		).getFragmentEntryLinksBySegmentsExperienceId(
+			groupId, defaultSegmentsExperienceId, plid
+		);
+
+		SegmentsExperienceLocalService segmentsExperienceLocalService =
+			Mockito.mock(SegmentsExperienceLocalService.class);
+
+		Mockito.doReturn(
+			defaultSegmentsExperienceId
+		).when(
+			segmentsExperienceLocalService
+		).fetchDefaultSegmentsExperienceId(
+			plid
+		);
+
+		PortletSharedSearchRequest portletSharedSearchRequest =
+			new PortletSharedSearchRequestImpl();
+
+		ReflectionTestUtil.setFieldValue(
+			portletSharedSearchRequest, "_fragmentEntryLinkLocalService",
+			fragmentEntryLinkLocalService);
+		ReflectionTestUtil.setFieldValue(
+			portletSharedSearchRequest, "_portletRegistry", _portletRegistry);
+		ReflectionTestUtil.setFieldValue(
+			portletSharedSearchRequest, "_segmentsExperienceLocalService",
+			segmentsExperienceLocalService);
+
+		Layout layout = Mockito.mock(Layout.class);
+
+		Mockito.doReturn(
+			groupId
+		).when(
+			layout
+		).getGroupId();
+
+		Mockito.doReturn(
+			plid
+		).when(
+			layout
+		).getPlid();
+
+		Assert.assertEquals(
+			Set.of("searchOptions_INSTANCE_rdna"),
+			ReflectionTestUtil.<Set<String>>invoke(
+				portletSharedSearchRequest, "_getSegmentExperiencePortletIds",
+				new Class<?>[] {Layout.class, long.class}, layout,
+				segmentsExperienceId));
 	}
 
 	private FragmentEntryLink _mockFragmentEntryLink(String portletName) {


### PR DESCRIPTION
DRAFT PR
---
This is being moved to the backlog, I am just sending what I have so far for visibility when this is able to be worked on again. 
---
https://liferay.atlassian.net/browse/LPD-95760

## What Is Being Fixed

Content search pages (Search Bar, Search Results, Facets, Search Options) can render blank on initial load — only the Search Bar, with no results or facets — even when "Allow Empty Searches" is enabled. A content page's shared search gathers its widgets per request from the resolved segments experience; when that resolution yields an experience that contributes no widgets, the Search Options widget is never gathered, emptySearchEnabled defaults to false, and the empty query short-circuits in SearcherImpl before Elasticsearch is queried, leaving results and facets empty. There is no error and no log, which makes it hard to diagnose.

## How It Is Being Fixed

When the resolved segments experience contributes no widgets to a content page's shared search, PortletSharedSearchRequestImpl now falls back to the page's default segments experience before gathering contributors, so a present, enabled Search Options widget is no longer lost to a resolution miss. The fallback triggers only when the resolved experience yields zero widgets and differs from the default, so legitimately configured experiences are untouched. A warning is logged when the fallback fires so the condition is no longer silent.
