### PR TITLE
LPD-96032 Fix custom facet date range in non-English locales

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/FacetUtil.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/FacetUtil.js
@@ -9,6 +9,14 @@ const FACET_TERM_CLASS = 'facet-term';
 
 const FACET_TERM_SELECTED_CLASS = 'facet-term-selected';
 
+function _getInputDate(form, prefix) {
+	const yearInput = form.querySelector(`[id$=${prefix}Year]`);
+	const monthInput = form.querySelector(`[id$=${prefix}Month]`);
+	const dayInput = form.querySelector(`[id$=${prefix}Day]`);
+
+	return new Date(yearInput.value, monthInput.value, dayInput.value);
+}
+
 /**
  * Gets the ID by checking the `data-term-id` attribute and then `id` if
  * `data-term-id` is not defined.
@@ -19,6 +27,14 @@ const FACET_TERM_SELECTED_CLASS = 'facet-term-selected';
  */
 function _getTermId(term) {
 	return term.dataset.termId || term.id;
+}
+
+function _toISODateString(date) {
+	const localDate = new Date(date);
+
+	localDate.setMinutes(date.getMinutes() - date.getTimezoneOffset());
+
+	return localDate.toISOString().split('T')[0];
 }
 
 /**
@@ -176,14 +192,11 @@ export const FacetUtil = {
 			);
 
 			if (fromValue && toValue) {
-				endDate = new Date(toValue);
-				startDate = new Date(fromValue);
+				startDate = _getInputDate(form, 'from');
+				endDate = _getInputDate(form, 'to');
 			}
 
-			return [
-				startDate.toISOString().split('T')[0],
-				endDate.toISOString().split('T')[0],
-			];
+			return [_toISODateString(startDate), _toISODateString(endDate)];
 		}
 		else {
 			return termId;

--- a/modules/apps/portal-search/portal-search-web/test/js/FacetUtil.js
+++ b/modules/apps/portal-search/portal-search-web/test/js/FacetUtil.js
@@ -5,7 +5,46 @@
 
 import {FacetUtil} from '../../src/main/resources/META-INF/resources/js/FacetUtil';
 
+function createForm(values) {
+	return {
+		querySelector: (selector) =>
+			selector in values ? {value: values[selector]} : null,
+	};
+}
+
 describe('FacetUtil', () => {
+	describe('getSelectedTerm()', () => {
+		it('derives a date range from the locale-independent hidden inputs', () => {
+			const form = createForm({
+				'.aggregation-type': 'dateRange',
+				'[id$=fromDay]': '24',
+				'[id$=fromInput]': '24/6/26',
+				'[id$=fromMonth]': '5',
+				'[id$=fromYear]': '2026',
+				'[id$=toDay]': '25',
+				'[id$=toInput]': '25/6/26',
+				'[id$=toMonth]': '5',
+				'[id$=toYear]': '2026',
+			});
+
+			expect(
+				FacetUtil.getSelectedTerm('custom-range', form, true)
+			).toEqual(['2026-06-24', '2026-06-25']);
+		});
+
+		it('returns the raw numeric bounds for a non-date range', () => {
+			const form = createForm({
+				'.aggregation-type': 'range',
+				'[id$=fromInput]': '10',
+				'[id$=toInput]': '20',
+			});
+
+			expect(
+				FacetUtil.getSelectedTerm('custom-range', form, true)
+			).toEqual(['10', '20']);
+		});
+	});
+
 	describe('queryParameterAndUpdateValue()', () => {
 		let originalQuerySelector;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96032

## What Is Being Fixed

In a non-English, day-first locale (Spanish, French, Portuguese), the Custom Facet widget configured with a Date Range aggregation cannot apply a custom range. Clicking the custom-range facet term disables the whole facet and throws `RangeError: Invalid time value`. Because `changeSelection` disables every facet term up front and only re-enables them after the page navigates, the exception leaves the facet permanently greyed out and unusable.

## How It Is Being Fixed

`FacetUtil.getSelectedTerm` built the range by parsing the date picker's visible text input with `new Date(value)`. That input holds a locale `SHORT`-formatted string (e.g. `25/6/26`), which `new Date` cannot parse outside English locales, producing an `Invalid Date` whose `toISOString()` throws. The fix instead reads the locale-independent day, month, and year hidden inputs rendered by the `liferay-ui:input-date` tag and builds the date with `new Date(year, month, day)` — the same source the working "Search" button already uses via the date picker's `getDate()`. Formatting reuses the timezone-offset adjustment so the local calendar date survives the UTC conversion.

## PR Check

**pr-check: PASS** — tested on `2a83606955db55a61eb28f5e7349ce53b05d0492`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "2a83606955db55a61eb28f5e7349ce53b05d0492"} -->
