### PR TITLE
LPD-96569 Prevent highlight snippet duplication for localized fields

### DIFF
--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/response/SearchResponseTranslator.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/response/SearchResponseTranslator.java
@@ -156,9 +156,14 @@ public class SearchResponseTranslator {
 			fragments, StringPool.TRIPLE_PERIOD);
 
 		if (document.getField(snippetName) != null) {
+			String existingSnippetValue = document.get(snippetName);
+
+			if (snippetValue.equals(existingSnippetValue)) {
+				return;
+			}
+
 			snippetValue = StringBundler.concat(
-				document.get(snippetName), StringPool.TRIPLE_PERIOD,
-				snippetValue);
+				existingSnippetValue, StringPool.TRIPLE_PERIOD, snippetValue);
 		}
 
 		document.add(new Field(snippetName, snippetValue));

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/response/SearchResponseTranslatorTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/response/SearchResponseTranslatorTest.java
@@ -1,0 +1,128 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.elasticsearch8.internal.search.response;
+
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
+import co.elastic.clients.elasticsearch.core.search.InnerHitsResult;
+import co.elastic.clients.json.JsonData;
+
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentImpl;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.LocalizationUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.util.LocalizationImpl;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Prathima Shreenath
+ */
+public class SearchResponseTranslatorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		LocalizationUtil localizationUtil = new LocalizationUtil();
+
+		localizationUtil.setLocalization(new LocalizationImpl());
+	}
+
+	@Test
+	public void testAddSnippetsConcatenatesDistinctInnerHitFragments() {
+		String fieldName = RandomTestUtil.randomString();
+
+		Document document = _addSnippets(
+			_createHit(
+				fieldName, Collections.singletonList("alpha"),
+				_createInnerHitsResult(
+					_createHit(
+						fieldName, Collections.singletonList("gamma"), null))));
+
+		Assert.assertEquals(
+			"alpha...gamma", document.get("snippet_" + fieldName));
+	}
+
+	@Test
+	public void testAddSnippetsDoesNotDuplicateBaseAndLocalizedField() {
+		String fieldName = RandomTestUtil.randomString();
+
+		String localizedFieldName = Field.getLocalizedName(
+			LocaleUtil.US, fieldName);
+
+		List<String> fragments = Collections.singletonList(
+			"<liferay-hl>alpha</liferay-hl> beta");
+
+		Hit.Builder<JsonData> builder = new Hit.Builder<>();
+
+		builder.highlight(fieldName, fragments);
+		builder.highlight(localizedFieldName, fragments);
+		builder.index("0");
+
+		Document document = _addSnippets(builder.build());
+
+		Assert.assertEquals(
+			"<liferay-hl>alpha</liferay-hl> beta",
+			document.get("snippet_" + localizedFieldName));
+	}
+
+	private Document _addSnippets(Hit<JsonData> hit) {
+		Document document = new DocumentImpl();
+
+		ReflectionTestUtil.invoke(
+			new SearchResponseTranslator(), "_addSnippets",
+			new Class<?>[] {Document.class, Hit.class, Locale.class}, document,
+			hit, LocaleUtil.US);
+
+		return document;
+	}
+
+	private Hit<JsonData> _createHit(
+		String fieldName, List<String> fragments,
+		InnerHitsResult innerHitsResult) {
+
+		Hit.Builder<JsonData> builder = new Hit.Builder<>();
+
+		builder.highlight(fieldName, fragments);
+		builder.index("0");
+
+		if (innerHitsResult != null) {
+			builder.innerHits(RandomTestUtil.randomString(), innerHitsResult);
+		}
+
+		return builder.build();
+	}
+
+	private InnerHitsResult _createInnerHitsResult(Hit<JsonData> hit) {
+		HitsMetadata.Builder<JsonData> hitsMetadataBuilder =
+			new HitsMetadata.Builder<>();
+
+		hitsMetadataBuilder.hits(Collections.singletonList(hit));
+
+		InnerHitsResult.Builder builder = new InnerHitsResult.Builder();
+
+		builder.hits(hitsMetadataBuilder.build());
+
+		return builder.build();
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96569

## What Is Being Fixed

After the Elasticsearch 7 to 8 migration, highlight-enabled searches return a duplicated snippet for the search-locale variant of a localized field. The snippet comes back as the fragment repeated and joined by an ellipsis, e.g. `<liferay-hl>alpha</liferay-hl> beta...<liferay-hl>alpha</liferay-hl> beta` instead of `<liferay-hl>alpha</liferay-hl> beta`. This breaks the highlight integration tests in Blogs, Documents and Media, and Wiki (`testSearchWithHighlightEnabled`, `testSingleEntryClassSearchWithHighlightEnabled`).

## Root Cause

A highlight-enabled search requests highlighting on both the base field and the localized field, so the query carries both `content` and `content_en_US` (same for `title` and `description`). Both exist in the index as text fields and both match, so `hit.highlight()` returns both keys.

Iterating `hit.highlight()`, both keys collapse onto the same snippet name `snippet_content_en_US`:

- `content` resolves through `Field.getLocalizedName(locale, "content")` to `content_en_US`, whose fragments are present, and writes `snippet_content_en_US`.
- `content_en_US` resolves to `content_en_US_en_US`, misses, falls back to `content_en_US`, and writes the same snippet a second time.

Before LPD-75868 the second write simply overwrote the first (`DocumentImpl.add` is put-by-name), so the duplicate was invisible. LPD-75868 changed the second write from overwrite to concatenate, turning the identical write into `X...X`. Only the search-locale variant duplicates because `getLocalizedName` always resolves the bare field to the search locale; every other locale stays clean.

## How It Is Being Fixed

`SearchResponseTranslator` now skips appending a snippet fragment that is identical to the value already stored under the same snippet name. This suppresses the duplicate while still concatenating genuinely distinct fragments, such as `nestedFieldArray` object-entry values.

## How To Run The Tests

Unit:

cd modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl && gradlew test --tests "SearchResponseTranslatorTest"

Integration:

cd modules/apps/blogs/blogs-test && gradlew testIntegration --tests "BlogsEntrySearchRequestBuilderHighlightTest.testSearchWithHighlightEnabled" --tests "BlogsEntrySearchRequestBuilderHighlightTest.testSingleEntryClassSearchWithHighlightEnabled"
