### PR TITLE
LPD-96889 Ignore dueDate in SearchResult REST DATE_TIME tests

### DIFF
--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
@@ -1553,7 +1553,8 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 	private static final String[] _IGNORED_ENTITY_FIELD_NAMES = {
 		"cmpAssignTo", "cmpDueDate", "cmpState", "cmsRoot", "cmsSection",
 		"extension", "dateDisplay", "dateExpiration", "datePublish",
-		"dateReview", "folderId", "objectDefinitionExternalReferenceCode",
+		"dateReview", "dueDate", "folderId",
+		"objectDefinitionExternalReferenceCode",
 		"objectFolderExternalReferenceCode", "rootDescendantNode"
 	};
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96889

## What Is Being Fixed

- Two integration tests, `testGetSearchPageWithSortDateTime` and `testGetSearchPageWithFilterDateTimeEquals`, started failing after LPD-94976 (commit `06b4a5004`, "fix workflow task status, assignee, and due date filters") added a `dueDate` `DateTimeEntityField` to `SearchResultEntityModel`.
- These generated Vulcan tests iterate over every DATE_TIME entity field the model advertises and set/read a matching property on the `SearchResult` DTO.
- `dueDate` is a filter-only search field with no corresponding DTO property, so the sort test threw `NoSuchMethodException` (no `setDueDate`) and the filter test threw `IllegalArgumentException: Invalid entity field dueDate`.

## How It Is Being Fixed

- Add `dueDate` to the test's `_IGNORED_ENTITY_FIELD_NAMES`, matching the existing treatment of the sibling filter-only date fields `cmpDueDate`, `cmpAssignTo`, and `cmpState` (LPD-76148, LPD-77235).
- This excludes `dueDate` from the generated DATE_TIME round-trip assertions while leaving the LPD-94976 product change intact.
- Both tests were reproduced failing locally and confirmed green after the change.

## Why Are There No Tests?

This is a test-only fix that restores two existing integration tests to green; the tests themselves are the coverage. The product behavior added by LPD-94976 is unchanged.

## PR Check

**pr-check: PASS** — tested on `6f11928b8675e5fbe1e9b275f7e8487b70030010`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6f11928b8675e5fbe1e9b275f7e8487b70030010"} -->
