### PR TITLE
LPD-96979 Remove obsolete FieldMapping DTO checks from upgrade test

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/upgrade/v3_1_3/test/SXPBlueprintAndSXPElementUpgradeProcessTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/upgrade/v3_1_3/test/SXPBlueprintAndSXPElementUpgradeProcessTest.java
@@ -30,7 +30,6 @@ import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
 import com.liferay.search.experiences.constants.SXPBlueprintConstants;
 import com.liferay.search.experiences.model.SXPBlueprint;
 import com.liferay.search.experiences.model.SXPElement;
-import com.liferay.search.experiences.rest.dto.v1_0.util.ElementInstanceUtil;
 import com.liferay.search.experiences.service.SXPBlueprintLocalService;
 import com.liferay.search.experiences.service.SXPElementLocalService;
 
@@ -198,9 +197,6 @@ public class SXPBlueprintAndSXPElementUpgradeProcessTest {
 
 		String elementInstancesJSON = _readJSON("legacyFieldMappingLabel");
 
-		Assert.assertNotNull(
-			ElementInstanceUtil.toElementInstances(elementInstancesJSON));
-
 		SXPBlueprint sxpBlueprint = _sxpBlueprintLocalService.addSXPBlueprint(
 			null, TestPropsValues.getUserId(), StringPool.BLANK,
 			Collections.singletonMap(
@@ -361,9 +357,6 @@ public class SXPBlueprintAndSXPElementUpgradeProcessTest {
 			externalReferenceCode, fieldJSONObject);
 
 		String elementInstancesJSON = elementInstancesJSONArray.toString();
-
-		Assert.assertNotNull(
-			ElementInstanceUtil.toElementInstances(elementInstancesJSON));
 
 		SXPBlueprint sxpBlueprint = _sxpBlueprintLocalService.addSXPBlueprint(
 			null, TestPropsValues.getUserId(), StringPool.BLANK,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96979

## What Is Being Fixed

The v3_1_3 `SXPBlueprintAndSXPElementUpgradeProcessTest` integration test was failing on three methods — `testUpgradeHandlesLegacyFieldMappingLabel`, `testUpgradeMovesLegacyMultiselectFieldMappingsToDefaultValue`, and `testUpgradeDoesNotMoveMixedFieldMappingsToDefaultValue`. Each threw a Jackson `UnrecognizedPropertyException` on the `label` field of the `FieldMapping` DTO. LPD-28402 regenerated `FieldMapping` through `buildREST`, dropping a stale `@JsonIgnoreProperties(ignoreUnknown = true)` annotation so it now rejects unknown fields, consistent with every other Search Experiences DTO. The tests build legacy field mappings that contain `label` and `value` keys and, as a pre-upgrade precondition, read them through `ElementInstanceUtil.toElementInstances`, which now rejects the unknown `label` field.

## How It Is Being Fixed

The failing assertions were pre-upgrade preconditions that only checked whether the legacy input could be parsed into DTOs — a leniency contract that no longer exists by design and that is unrelated to what the tests verify. LPD-28402 deliberately moved multiselect `label` and `value` data into `defaultValue` rather than field mappings, and the upgrade itself operates on raw JSON rather than the DTO, so it is unaffected. This removes the two obsolete `assertNotNull(toElementInstances(...))` precondition checks and the now-unused import, leaving every meaningful upgrade assertion in place. All six methods in the class pass.

## Why Are There No Tests?

This change only removes obsolete assertions from an existing integration test; no production code changed. The test's meaningful upgrade assertions are retained, so no new coverage is warranted.

## PR Check

**pr-check: PASS** — tested on `d16642a6d3c22c6346d098a807d794becd852cce`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "d16642a6d3c22c6346d098a807d794becd852cce"} -->
