### PR TITLE
LPD-97005 Fix swapped _index arguments in OpenSearch2 assembler test

### DIFF
--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/search/CommonSearchRequestBuilderAssemblerImplTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/search/CommonSearchRequestBuilderAssemblerImplTest.java
@@ -62,9 +62,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 	public void testPartsWhenAdditiveWillAppendToWhatMainQueryFindsFilterOccur()
 		throws Exception {
 
-		_index("JournalArticle", "alpha 1");
-		_index("DLFileEntry", "alpha 2");
-		_index("DLFileEntry", "bravo 1");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -87,9 +85,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 	public void testPartsWhenAdditiveWillAppendToWhatMainQueryFindsMustNotOccur()
 		throws Exception {
 
-		_index("JournalArticle", "alpha 1");
-		_index("DLFileEntry", "alpha 2");
-		_index("DLFileEntry", "bravo 1");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -112,9 +108,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 	public void testPartsWhenAdditiveWillAppendToWhatMainQueryFindsMustOccur()
 		throws Exception {
 
-		_index("JournalArticle", "alpha 1");
-		_index("DLFileEntry", "alpha 2");
-		_index("DLFileEntry", "bravo 1");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -137,9 +131,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 	public void testPartsWhenAdditiveWillAppendToWhatMainQueryFindsShouldOccur()
 		throws Exception {
 
-		_index("JournalArticle", "alpha 1");
-		_index("DLFileEntry", "alpha 2");
-		_index("DLFileEntry", "bravo 1");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -162,9 +154,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 	public void testPartsWillModifyWhatMainQueryFindsFilterOccur()
 		throws Exception {
 
-		_index("JournalArticle", "alpha 1");
-		_index("DLFileEntry", "alpha 2");
-		_index("DLFileEntry", "bravo 1");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -188,9 +178,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 	public void testPartsWillModifyWhatMainQueryFindsMustNotOccur()
 		throws Exception {
 
-		_index("JournalArticle", "alpha 1");
-		_index("DLFileEntry", "alpha 2");
-		_index("DLFileEntry", "bravo 1");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -214,9 +202,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 	public void testPartsWillModifyWhatMainQueryFindsMustOccur()
 		throws Exception {
 
-		_index("JournalArticle", "alpha 1");
-		_index("DLFileEntry", "alpha 2");
-		_index("DLFileEntry", "bravo 1");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -240,9 +226,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 	public void testPartsWillModifyWhatMainQueryFindsShouldOccur()
 		throws Exception {
 
-		_index("JournalArticle", "alpha 1");
-		_index("DLFileEntry", "alpha 2");
-		_index("DLFileEntry", "bravo 1");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -266,9 +250,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 	public void testPartsWillNarrowDownWhatMainQueryFindsFilterOccur()
 		throws Exception {
 
-		_index("JournalArticle", "alpha 1");
-		_index("DLFileEntry", "alpha 2");
-		_index("DLFileEntry", "bravo 1");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -292,9 +274,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 	public void testPartsWillNarrowDownWhatMainQueryFindsMustNotOccur()
 		throws Exception {
 
-		_index("JournalArticle", "alpha 1");
-		_index("DLFileEntry", "alpha 2");
-		_index("DLFileEntry", "bravo 1");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -318,9 +298,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 	public void testPartsWillNarrowDownWhatMainQueryFindsMustOccur()
 		throws Exception {
 
-		_index("JournalArticle", "alpha 1");
-		_index("DLFileEntry", "alpha 2");
-		_index("DLFileEntry", "bravo 1");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -344,9 +322,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 	public void testPartsWillNarrowDownWhatMainQueryFindsShouldOccur()
 		throws Exception {
 
-		_index("JournalArticle", "alpha 1");
-		_index("DLFileEntry", "alpha 2");
-		_index("DLFileEntry", "bravo 1");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -368,9 +344,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 
 	@Test
 	public void testPrecedenceOfAdditiveFilterOccur() throws Exception {
-		_index("JournalArticle", "alpha 1");
-		_index("DLFileEntry", "alpha 2");
-		_index("DLFileEntry", "bravo 1");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -392,9 +366,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 
 	@Test
 	public void testPrecedenceOfAdditiveMustNotOccur() throws Exception {
-		_index("JournalArticle", "alpha 1");
-		_index("DLFileEntry", "alpha 2");
-		_index("DLFileEntry", "bravo 1");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -416,9 +388,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 
 	@Test
 	public void testPrecedenceOfAdditiveMustOccur() throws Exception {
-		_index("JournalArticle", "alpha 1");
-		_index("DLFileEntry", "alpha 2");
-		_index("DLFileEntry", "bravo 1");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -440,9 +410,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 
 	@Test
 	public void testPrecedenceOfAdditiveShouldOccur() throws Exception {
-		_index("JournalArticle", "alpha 1");
-		_index("DLFileEntry", "alpha 2");
-		_index("DLFileEntry", "bravo 1");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -466,9 +434,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 	public void testRootClauseWithParentNestsUnderNamedParentQuery()
 		throws Exception {
 
-		_index("alpha 1", "JournalArticle");
-		_index("alpha 2", "DLFileEntry");
-		_index("bravo 1", "DLFileEntry");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -495,9 +461,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 	public void testRootOnlyAppliedWhenMainQueryIsBooleanFilterOccur()
 		throws Exception {
 
-		_index("JournalArticle", "alpha 1");
-		_index("DLFileEntry", "alpha 2");
-		_index("DLFileEntry", "bravo 1");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -516,9 +480,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 	public void testRootOnlyAppliedWhenMainQueryIsBooleanMustNotOccur()
 		throws Exception {
 
-		_index("JournalArticle", "alpha 1");
-		_index("DLFileEntry", "alpha 2");
-		_index("DLFileEntry", "bravo 1");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -537,9 +499,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 	public void testRootOnlyAppliedWhenMainQueryIsBooleanMustOccur()
 		throws Exception {
 
-		_index("JournalArticle", "alpha 1");
-		_index("DLFileEntry", "alpha 2");
-		_index("DLFileEntry", "bravo 1");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -558,9 +518,7 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 	public void testRootOnlyAppliedWhenMainQueryIsBooleanShouldOccur()
 		throws Exception {
 
-		_index("JournalArticle", "alpha 1");
-		_index("DLFileEntry", "alpha 2");
-		_index("DLFileEntry", "bravo 1");
+		_indexDocuments();
 
 		SearchSearchRequest searchSearchRequest = _createSearchSearchRequest();
 
@@ -700,6 +658,12 @@ public class CommonSearchRequestBuilderAssemblerImplTest {
 			).put(
 				"title", title
 			).build());
+	}
+
+	private void _indexDocuments() {
+		_index("DLFileEntry", "alpha 2");
+		_index("DLFileEntry", "bravo 1");
+		_index("JournalArticle", "alpha 1");
 	}
 
 	private final ComplexQueryPartBuilderFactory


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97005

## What Is Being Fixed

The unit test `testRootClauseWithParentNestsUnderNamedParentQuery`, added by
LPD-95481 to `portal-search-opensearch2-impl`, fails on the
`modules-unit-opensearch2` job. The OpenSearch2 helper is
`_index(entryClassName, title)`, but the test passes its arguments title-first
(the Elasticsearch8 convention, whose helper is `_index(title, entryClassName)`).
Documents are therefore indexed with title and entryClassName swapped — their
titles become "JournalArticle"/"DLFileEntry" instead of "alpha *" — so the first
assertion (a `title:"alpha"` match expecting "alpha 1"/"alpha 2") matches zero
documents and fails before the parent-nesting behavior is exercised. This broke
the q2 backport (BPR-90507) and contributed to closing the q1 backport (BPR-90508).

## How It Is Being Fixed

Reorder the three `_index(...)` calls in the OpenSearch2 test to className-first,
matching that module's helper signature and every other test in the file. There is
no product-code change; the `_combine` fix from LPD-95481 is correct as-is. The
Elasticsearch8 test needs no change because its helper is title-first.

## Why Are There No Tests?

This change only corrects swapped arguments in an existing unit test; there is no
product-code change, so no new test is warranted.

## PR Check

**pr-check: SKIPPED** — Trivial test-only argument-order fix; liferay-search CI will exercise it on push.

<!-- pr-check {"reason": "Trivial test-only argument-order fix; liferay-search CI will exercise it on push.", "result": "skipped", "sha": "af824698cf8125853930184f09d33f4801ec6ad2"} -->
