### PR TITLE
LPD-96296 Show CMS content in a collection filtered by a tag

### DIFF
--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
@@ -51,6 +51,7 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
@@ -971,6 +972,37 @@ public class AssetListAssetEntryProviderImpl
 		return searchContext;
 	}
 
+	private long[] _getReferencedModelsGroupIds(long[] groupIds) {
+		for (long groupId : groupIds) {
+			Group group = _groupLocalService.fetchGroup(groupId);
+
+			if (group == null) {
+				continue;
+			}
+
+			int depotEntryType = GetterUtil.getInteger(
+				group.getTypeSettingsProperty("depotEntryType"));
+
+			if ((depotEntryType != DepotConstants.TYPE_SPACE) ||
+				!FeatureFlagManagerUtil.isEnabled(
+					group.getCompanyId(), "LPD-17564")) {
+
+				continue;
+			}
+
+			Group cmsGroup = _groupLocalService.fetchGroup(
+				group.getCompanyId(), GroupConstants.CMS);
+
+			if (cmsGroup != null) {
+				return ArrayUtil.append(groupIds, cmsGroup.getGroupId());
+			}
+
+			break;
+		}
+
+		return groupIds;
+	}
+
 	private void _setCategoriesAndTagsAndKeywords(
 		AssetEntryQuery assetEntryQuery, UnicodeProperties unicodeProperties,
 		long[] overrideAllAssetCategoryIds, String[] overrideAllAssetTagNames,
@@ -1072,8 +1104,10 @@ public class AssetListAssetEntryProviderImpl
 			allAssetTagNames = overrideAllAssetTagNames;
 		}
 
-		long[] groupIds = GetterUtil.getLongValues(
-			StringUtil.split(unicodeProperties.getProperty("groupIds", null)));
+		long[] groupIds = _getReferencedModelsGroupIds(
+			GetterUtil.getLongValues(
+				StringUtil.split(
+					unicodeProperties.getProperty("groupIds", null))));
 
 		for (String assetTagName : allAssetTagNames) {
 			long[] allAssetTagIds = _assetTagLocalService.getTagIds(

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/collectionDisplay.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/collectionDisplay.spec.ts
@@ -303,11 +303,6 @@ test(
 		pageEditorPage,
 		site,
 	}) => {
-		test.fail(
-			true,
-			'Fails due to LPD-96296: a tag-filtered collection returns no CMS content on the published page'
-		);
-
 		const space = await createSpace(apiHelpers);
 
 		const tag = `tag${getRandomString()}`.toLowerCase();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96296

## What Is Being Fixed

When CMS content from a Space is shown on a DXP page through a Collection Display fragment, a dynamic collection filtered by a tag returned no items — the published page showed an empty collection even though the content carried that tag. Filtering the same collection by a category or by content type worked correctly; only the tag filter came back empty.

## How It Is Being Fixed

CMS asset tags are scoped to the company's CMS group rather than to the Space the content lives in, but the dynamic collection provider resolved the configured tag names to tag IDs using only the Space group persisted in the collection scope. The names never matched a tag in that group, so the tag filter was dropped and the collection failed to show the tagged CMS content. Categories were unaffected because they are stored and matched by ID.

AssetListAssetEntryProviderImpl now augments the group IDs used for tag-name resolution with the company's CMS group whenever a Space is in the collection scope, mirroring the injection the collection editor already performs in EditAssetListDisplayContext.getReferencedModelsGroupIds. The query scope itself is left untouched, so no extra content is pulled in — only tag names now resolve against the group where CMS tags actually live.

The previously skipped faithful test (TC-7.d in collectionDisplay.spec.ts), kept failing pending this fix, is enabled so it now asserts that a tag-filtered collection shows only the tagged CMS content.

## PR Check

**pr-check: PASS** — tested on `cc6e090ed05f790584e5a8d9a2320392456d1ba6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "cc6e090ed05f790584e5a8d9a2320392456d1ba6"} -->
