### PR TITLE
LPD-96225 Restore partial title search for CMS and object entries

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/FieldQueryBuilderFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/FieldQueryBuilderFactoryImpl.java
@@ -28,7 +28,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Rodrigo Paulino
  */
 @Component(
-	property = {"description.fields=description", "title.fields=name|title"},
+	property = {
+		"description.fields=description",
+		"title.fields=name|objectEntryTitle|title"
+	},
 	service = FieldQueryBuilderFactory.class
 )
 public class FieldQueryBuilderFactoryImpl implements FieldQueryBuilderFactory {
@@ -85,6 +88,6 @@ public class FieldQueryBuilderFactoryImpl implements FieldQueryBuilderFactory {
 	private volatile Collection<String> _descriptionFieldNames =
 		Collections.singleton("description");
 	private volatile Collection<String> _titleFieldNames = new HashSet<>(
-		Arrays.asList("name", "title"));
+		Arrays.asList("name", "objectEntryTitle", "title"));
 
 }

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/field/FieldQueryBuilderFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/field/FieldQueryBuilderFactoryImpl.java
@@ -28,7 +28,8 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"description.fields=content|description", "title.fields=name|title"
+		"description.fields=content|description",
+		"title.fields=name|objectEntryTitle|title"
 	},
 	service = FieldQueryBuilderFactory.class
 )
@@ -86,6 +87,6 @@ public class FieldQueryBuilderFactoryImpl implements FieldQueryBuilderFactory {
 	private volatile Collection<String> _descriptionFieldNames = Arrays.asList(
 		"content", "description");
 	private volatile Collection<String> _titleFieldNames = new HashSet<>(
-		Arrays.asList("name", "title"));
+		Arrays.asList("name", "objectEntryTitle", "title"));
 
 }

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/analysis/FieldQueryBuilderFactoryImplTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/analysis/FieldQueryBuilderFactoryImplTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/analysis/FieldQueryBuilderFactoryImplTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/analysis/FieldQueryBuilderFactoryImplTest.java
@@ -1,0 +1,108 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.internal.analysis;
+
+import com.liferay.portal.kernel.search.query.QueryPreProcessConfiguration;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Rodrigo Guedes de Souza
+ */
+public class FieldQueryBuilderFactoryImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_fieldQueryBuilderFactoryImpl = new FieldQueryBuilderFactoryImpl();
+
+		_fieldQueryBuilderFactoryImpl.descriptionFieldQueryBuilder =
+			_descriptionFieldQueryBuilder;
+		_fieldQueryBuilderFactoryImpl.queryPreProcessConfiguration =
+			_queryPreProcessConfiguration;
+		_fieldQueryBuilderFactoryImpl.substringFieldQueryBuilder =
+			_substringFieldQueryBuilder;
+		_fieldQueryBuilderFactoryImpl.titleFieldQueryBuilder =
+			_titleFieldQueryBuilder;
+
+		Mockito.when(
+			_queryPreProcessConfiguration.isSubstringSearchAlways(
+				Mockito.anyString())
+		).thenReturn(
+			false
+		);
+	}
+
+	@Test
+	public void testGetQueryBuilderDescriptionField() {
+		Assert.assertSame(
+			_descriptionFieldQueryBuilder,
+			_fieldQueryBuilderFactoryImpl.getQueryBuilder("description"));
+	}
+
+	@Test
+	public void testGetQueryBuilderObjectEntryTitleFields() {
+		Assert.assertSame(
+			_titleFieldQueryBuilder,
+			_fieldQueryBuilderFactoryImpl.getQueryBuilder("objectEntryTitle"));
+		Assert.assertSame(
+			_titleFieldQueryBuilder,
+			_fieldQueryBuilderFactoryImpl.getQueryBuilder(
+				"objectEntryTitle_en_US"));
+	}
+
+	@Test
+	public void testGetQueryBuilderSubstringField() {
+		Mockito.when(
+			_queryPreProcessConfiguration.isSubstringSearchAlways("extension")
+		).thenReturn(
+			true
+		);
+
+		Assert.assertSame(
+			_substringFieldQueryBuilder,
+			_fieldQueryBuilderFactoryImpl.getQueryBuilder("extension"));
+	}
+
+	@Test
+	public void testGetQueryBuilderTitleFields() {
+		Assert.assertSame(
+			_titleFieldQueryBuilder,
+			_fieldQueryBuilderFactoryImpl.getQueryBuilder("name"));
+		Assert.assertSame(
+			_titleFieldQueryBuilder,
+			_fieldQueryBuilderFactoryImpl.getQueryBuilder("title"));
+	}
+
+	@Test
+	public void testGetQueryBuilderUnmappedField() {
+		Assert.assertNull(
+			_fieldQueryBuilderFactoryImpl.getQueryBuilder(
+				"objectEntryContent"));
+	}
+
+	private final DescriptionFieldQueryBuilder _descriptionFieldQueryBuilder =
+		Mockito.mock(DescriptionFieldQueryBuilder.class);
+	private FieldQueryBuilderFactoryImpl _fieldQueryBuilderFactoryImpl;
+	private final QueryPreProcessConfiguration _queryPreProcessConfiguration =
+		Mockito.mock(QueryPreProcessConfiguration.class);
+	private final SubstringFieldQueryBuilder _substringFieldQueryBuilder =
+		Mockito.mock(SubstringFieldQueryBuilder.class);
+	private final TitleFieldQueryBuilder _titleFieldQueryBuilder = Mockito.mock(
+		TitleFieldQueryBuilder.class);
+
+}

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/query/field/FieldQueryBuilderFactoryImplTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/query/field/FieldQueryBuilderFactoryImplTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/query/field/FieldQueryBuilderFactoryImplTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/query/field/FieldQueryBuilderFactoryImplTest.java
@@ -1,0 +1,111 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.internal.query.field;
+
+import com.liferay.portal.search.query.field.FieldQueryBuilder;
+import com.liferay.portal.search.query.field.QueryPreProcessConfiguration;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Rodrigo Guedes de Souza
+ */
+public class FieldQueryBuilderFactoryImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_fieldQueryBuilderFactoryImpl = new FieldQueryBuilderFactoryImpl();
+
+		_fieldQueryBuilderFactoryImpl.descriptionFieldQueryBuilder =
+			_descriptionFieldQueryBuilder;
+		_fieldQueryBuilderFactoryImpl.queryPreProcessConfiguration =
+			_queryPreProcessConfiguration;
+		_fieldQueryBuilderFactoryImpl.substringFieldQueryBuilder =
+			_substringFieldQueryBuilder;
+		_fieldQueryBuilderFactoryImpl.titleFieldQueryBuilder =
+			_titleFieldQueryBuilder;
+
+		Mockito.when(
+			_queryPreProcessConfiguration.isSubstringSearchAlways(
+				Mockito.anyString())
+		).thenReturn(
+			false
+		);
+	}
+
+	@Test
+	public void testGetQueryBuilderDescriptionFields() {
+		Assert.assertSame(
+			_descriptionFieldQueryBuilder,
+			_fieldQueryBuilderFactoryImpl.getQueryBuilder("content"));
+		Assert.assertSame(
+			_descriptionFieldQueryBuilder,
+			_fieldQueryBuilderFactoryImpl.getQueryBuilder("description"));
+	}
+
+	@Test
+	public void testGetQueryBuilderObjectEntryTitleFields() {
+		Assert.assertSame(
+			_titleFieldQueryBuilder,
+			_fieldQueryBuilderFactoryImpl.getQueryBuilder("objectEntryTitle"));
+		Assert.assertSame(
+			_titleFieldQueryBuilder,
+			_fieldQueryBuilderFactoryImpl.getQueryBuilder(
+				"objectEntryTitle_en_US"));
+	}
+
+	@Test
+	public void testGetQueryBuilderSubstringField() {
+		Mockito.when(
+			_queryPreProcessConfiguration.isSubstringSearchAlways("extension")
+		).thenReturn(
+			true
+		);
+
+		Assert.assertSame(
+			_substringFieldQueryBuilder,
+			_fieldQueryBuilderFactoryImpl.getQueryBuilder("extension"));
+	}
+
+	@Test
+	public void testGetQueryBuilderTitleFields() {
+		Assert.assertSame(
+			_titleFieldQueryBuilder,
+			_fieldQueryBuilderFactoryImpl.getQueryBuilder("name"));
+		Assert.assertSame(
+			_titleFieldQueryBuilder,
+			_fieldQueryBuilderFactoryImpl.getQueryBuilder("title"));
+	}
+
+	@Test
+	public void testGetQueryBuilderUnmappedField() {
+		Assert.assertNull(
+			_fieldQueryBuilderFactoryImpl.getQueryBuilder("objectEntryId"));
+	}
+
+	private final FieldQueryBuilder _descriptionFieldQueryBuilder =
+		Mockito.mock(FieldQueryBuilder.class);
+	private FieldQueryBuilderFactoryImpl _fieldQueryBuilderFactoryImpl;
+	private final QueryPreProcessConfiguration _queryPreProcessConfiguration =
+		Mockito.mock(QueryPreProcessConfiguration.class);
+	private final FieldQueryBuilder _substringFieldQueryBuilder = Mockito.mock(
+		FieldQueryBuilder.class);
+	private final FieldQueryBuilder _titleFieldQueryBuilder = Mockito.mock(
+		FieldQueryBuilder.class);
+
+}

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/transformFDSBulkActions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/transformFDSBulkActions.spec.ts
@@ -10,13 +10,14 @@ import {loginTest} from '../../../fixtures/loginTest';
 import {ApiHelpers} from '../../../helpers/ApiHelpers';
 import getRandomString from '../../../utils/getRandomString';
 import {performLoginViaApi} from '../../../utils/performLogin';
+import {AssetsPage} from '../main/pages/AssetsPage';
 import {DataSetPage} from '../main/pages/DataSetPage';
 import {cmsPagesTest} from './fixtures/cmsPagesTest';
 
 const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
 
 const APPLICATION_NAME = 'cms/basic-documents';
-const FILE_COUNT = 12;
+const FILE_COUNT = 2;
 
 const SPACE_NAME = 'Default';
 
@@ -24,13 +25,22 @@ const VALID_IMAGE_FILE_BASE64 =
 	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAAApJREFUCNdjYAAAAAIAAeIhvDMAAAAASUVORK5CYII=';
 
 let createdEntryIds: number[];
-let titlePrefix: string;
+let singleTokenPrefix: string;
+let multiTokenPrefix: string;
 
-async function openBulkActionMenu(page: Page) {
-	await page
-		.getByTestId('visualization-mode-table')
-		.getByLabel('Actions')
-		.click();
+async function createFile(apiHelpers: ApiHelpers, title: string) {
+	return apiHelpers.objectEntry.postObjectEntry(
+		{
+			file: {
+				fileBase64: VALID_IMAGE_FILE_BASE64,
+				name: `${title}.png`,
+			},
+			objectEntryFolderExternalReferenceCode: 'L_FILES',
+			title,
+		},
+		APPLICATION_NAME,
+		SPACE_NAME
+	);
 }
 
 async function expectBulkActionVisible(page: Page, action: string) {
@@ -45,15 +55,35 @@ async function expectBulkActionVisible(page: Page, action: string) {
 	}).toPass({timeout: 5000});
 }
 
-async function selectRow(page: Page, title: string, checked: boolean) {
-	const checkbox = page.getByLabel(`Select ${title}`, {exact: true});
+async function openBulkActionMenu(page: Page) {
+	await page
+		.getByTestId('visualization-mode-table')
+		.getByLabel('Actions')
+		.click();
+}
 
-	if (checked) {
-		await checkbox.check();
+async function searchSelectAndExpectDelete(
+	assetsPage: AssetsPage,
+	page: Page,
+	search: string,
+	titles: string[]
+) {
+	await assetsPage.gotoFiles();
+	await assetsPage.changeVisualizationMode('Table');
+
+	const dataSetPage = new DataSetPage(page);
+
+	await dataSetPage.search(search);
+
+	for (const title of titles) {
+		await selectRow(page, title);
 	}
-	else {
-		await checkbox.uncheck();
-	}
+
+	await expectBulkActionVisible(page, 'Delete');
+}
+
+async function selectRow(page: Page, title: string) {
+	await page.getByLabel(`Select ${title}`, {exact: true}).check();
 }
 
 test.describe(
@@ -67,26 +97,24 @@ test.describe(
 
 			const setupApiHelpers = new ApiHelpers(page);
 
-			titlePrefix = `bulkfilter_${getRandomString().replace(/-/g, '')}`;
+			singleTokenPrefix = `singleToken_${getRandomString().replace(/-/g, '')}`;
+			multiTokenPrefix = `multiToken_${getRandomString().replace(/-/g, '')}`;
 
 			const createdEntries: ObjectEntry[] = [];
 
 			for (let i = 0; i < FILE_COUNT; i++) {
-				const title = `${titlePrefix} ${i}`;
-				const entry = await setupApiHelpers.objectEntry.postObjectEntry(
-					{
-						file: {
-							fileBase64: VALID_IMAGE_FILE_BASE64,
-							name: `${title}.png`,
-						},
-						objectEntryFolderExternalReferenceCode: 'L_FILES',
-						title,
-					},
-					APPLICATION_NAME,
-					SPACE_NAME
+				createdEntries.push(
+					await createFile(
+						setupApiHelpers,
+						`${singleTokenPrefix}_${i}`
+					)
 				);
-
-				createdEntries.push(entry);
+				createdEntries.push(
+					await createFile(
+						setupApiHelpers,
+						`${multiTokenPrefix} ${i}`
+					)
+				);
 			}
 
 			createdEntryIds = createdEntries.map((entry) => entry.id);
@@ -116,31 +144,40 @@ test.describe(
 			assetsPage,
 			page,
 		}) => {
-			await assetsPage.gotoFiles();
-			await assetsPage.changeVisualizationMode('Table');
-
-			const dataSetPage = new DataSetPage(page);
-
-			await dataSetPage.search(`${titlePrefix} 0`);
-			await selectRow(page, `${titlePrefix} 0`, true);
-
-			await expectBulkActionVisible(page, 'Delete');
+			await searchSelectAndExpectDelete(
+				assetsPage,
+				page,
+				`${singleTokenPrefix}_0`,
+				[`${singleTokenPrefix}_0`]
+			);
 		});
 
-		test('shows Delete in the bulk menu when multiple items are selected', async ({
-			assetsPage,
-			page,
-		}) => {
-			await assetsPage.gotoFiles();
-			await assetsPage.changeVisualizationMode('Table');
+		test(
+			'shows Delete in the bulk menu when multiple items are found by a ' +
+				'partial title',
+			{tag: '@LPD-96225'},
+			async ({assetsPage, page}) => {
+				await searchSelectAndExpectDelete(
+					assetsPage,
+					page,
+					singleTokenPrefix,
+					[`${singleTokenPrefix}_0`, `${singleTokenPrefix}_1`]
+				);
+			}
+		);
 
-			const dataSetPage = new DataSetPage(page);
-
-			await dataSetPage.search(titlePrefix);
-			await selectRow(page, `${titlePrefix} 0`, true);
-			await selectRow(page, `${titlePrefix} 1`, true);
-
-			await expectBulkActionVisible(page, 'Delete');
-		});
+		test(
+			'shows Delete in the bulk menu when multiple items are found by a ' +
+				'whole word in a multi-word title',
+			{tag: '@LPD-96225'},
+			async ({assetsPage, page}) => {
+				await searchSelectAndExpectDelete(
+					assetsPage,
+					page,
+					multiTokenPrefix,
+					[`${multiTokenPrefix} 0`, `${multiTokenPrefix} 1`]
+				);
+			}
+		);
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96225

## What Is Being Fixed

In the CMS Files view, object entries could no longer be found by a partial title search. Object entries index their title under the `objectEntryTitle` field, but the search field-query builders only treated `name` and `title` as title fields. Partial (substring/wildcard) title query building was therefore never applied to `objectEntryTitle`, so object entries fell back to whole-word matching and dropped out of partial-title search results.

## How It Is Being Fixed

The `objectEntryTitle` field is added to the title field set in both `FieldQueryBuilderFactoryImpl` implementations — the one under `internal.analysis` and the one under `internal.query.field` — updating both the `title.fields` component property and the corresponding `_titleFieldNames` collection. This lets the partial-title query builder apply to the object entry title field alongside `name` and `title`, restoring partial title search for CMS and object entries. New `FieldQueryBuilderFactoryImplTest` unit tests in each package lock in the title and description field configuration, and the CMS Files Playwright test `transformFDSBulkActions.spec.ts` is extended to cover both partial and whole-word title search.

## PR Check

**pr-check: PASS** — tested on `b5f15c7b843f8cfe215e54ffb8ffede486830fb2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b5f15c7b843f8cfe215e54ffb8ffede486830fb2"} -->
