### PR TITLE
LPD-97635 Allow server-admin-web to start without Elasticsearch

### DIFF
--- a/modules/apps/server/server-admin-web/bnd.bnd
+++ b/modules/apps/server/server-admin-web/bnd.bnd
@@ -1,6 +1,10 @@
 Bundle-Name: Liferay Server Admin Web
 Bundle-SymbolicName: com.liferay.server.admin.web
-Bundle-Version: 5.0.109
+Bundle-Version: 5.0.110
 DynamicImport-Package: *
+Import-Package:\
+	com.liferay.portal.search.elasticsearch8.configuration;resolution:=optional,\
+	\
+	*
 Web-ContextPath: /server-admin-web
 -dsannotations-options: inherit

--- a/modules/apps/server/server-admin-web/package.json
+++ b/modules/apps/server/server-admin-web/package.json
@@ -19,5 +19,5 @@
 		"format": "node-scripts format",
 		"test": "node-scripts test"
 	},
-	"version": "5.0.109"
+	"version": "5.0.110"
 }

--- a/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/production/readiness/ProductionReadinessCheckUtil.java
+++ b/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/production/readiness/ProductionReadinessCheckUtil.java
@@ -611,7 +611,7 @@ public class ProductionReadinessCheckUtil {
 			productionModeEnabled =
 				elasticsearchConfiguration.productionModeEnabled();
 		}
-		catch (Exception exception) {
+		catch (Exception | NoClassDefFoundError exception) {
 			if (_log.isWarnEnabled()) {
 				_log.warn(exception);
 			}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97635

## What Is Being Fixed

The `LocalFile.Collections#ViewUsagesOfCollectionFromSite` functional test on the OpenSearch2 routine failed because the portal threw exceptions during startup:

```
org.osgi.framework.BundleException: Could not resolve module: com.liferay.server.admin.web [1018]
  Unresolved requirement: Import-Package: com.liferay.portal.search.elasticsearch8.configuration; version="1.1.0"
```

`portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/collections/Collections.testcase`

Commit `821551904e065` ("LPD-94870 Add search engine connectivity production readiness rule") added a production readiness check that statically references `ElasticsearchConfiguration`, which made bnd emit a mandatory `Import-Package` on `com.liferay.portal.search.elasticsearch8.configuration`. In environments where the Elasticsearch API bundle is not deployed, such as OpenSearch2, `com.liferay.server.admin.web` could no longer resolve and the portal failed to start, so every functional test on that routine failed during startup.

## How It Is Being Fixed

Marking the import optional in `bnd.bnd` lets the bundle resolve without the Elasticsearch configuration package, and broadening the catch clause in `_checkSidecarDetection` to `NoClassDefFoundError` keeps the check from throwing when the configuration class is absent at runtime. When Elasticsearch is deployed the import wires normally and behavior is unchanged. Verified against the generated bundle manifest: the entry went from `elasticsearch8.configuration;version="1.1"` (mandatory) to `elasticsearch8.configuration;resolution:=optional;version="1.1"`.

- `modules/apps/server/server-admin-web/bnd.bnd`
- `modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/production/readiness/ProductionReadinessCheckUtil.java`

## Why Are There No Tests?

The fix is an OSGi bundle-resolution directive (making an import optional). It is verified by inspecting the generated bundle manifest, and cannot be meaningfully exercised by a unit or integration test without provisioning an OpenSearch2-only runtime where the Elasticsearch API bundle is absent — which is exactly the CI functional environment that already covers it.

## PR Check

**pr-check: PASS** — tested on `d94dee2f988ddef13a406c5023bf8894c9921efe`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Cross-Module Compile | PASS |
| Integration Test Compile | PASS |
| Per-Module Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "d94dee2f988ddef13a406c5023bf8894c9921efe"} -->
