### PR TITLE
LPD-97767 Fix Elasticsearch 8 Connections page reporting 0 nodes

### DIFF
--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/information/ElasticsearchSearchEngineInformation.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/information/ElasticsearchSearchEngineInformation.java
@@ -7,20 +7,17 @@ package com.liferay.portal.search.elasticsearch8.internal.information;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchVersionInfo;
-import co.elastic.clients.elasticsearch._types.Time;
 import co.elastic.clients.elasticsearch._types.TimeUnit;
 import co.elastic.clients.elasticsearch.core.InfoResponse;
-import co.elastic.clients.elasticsearch.nodes.ElasticsearchNodesClient;
-import co.elastic.clients.elasticsearch.nodes.NodesInfoRequest;
-import co.elastic.clients.elasticsearch.nodes.NodesInfoResponse;
-import co.elastic.clients.elasticsearch.nodes.info.NodeInfo;
+import co.elastic.clients.json.JsonpDeserializer;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.search.elasticsearch8.configuration.ElasticsearchConnectionConfiguration;
@@ -39,13 +36,16 @@ import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
 import com.liferay.portal.search.engine.adapter.cluster.HealthClusterRequest;
 import com.liferay.portal.search.engine.adapter.cluster.HealthClusterResponse;
 
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Dictionary;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.osgi.service.cm.Configuration;
@@ -365,6 +365,28 @@ public class ElasticsearchSearchEngineInformation
 		}
 	}
 
+	private JsonObject _getNodesInfoJsonObject(
+			ElasticsearchClient elasticsearchClient)
+		throws Exception {
+
+		ElasticsearchTransport elasticsearchTransport =
+			elasticsearchClient._transport();
+
+		JsonValue jsonValue = elasticsearchTransport.performRequest(
+			null,
+			new SimpleEndpoint<Object, JsonValue>(
+				"es/nodes.info", nodesInfoRequest -> "GET",
+				nodesInfoRequest -> "/_nodes",
+				nodesInfoRequest -> Collections.emptyMap(),
+				nodesInfoRequest -> Collections.singletonMap(
+					"timeout", "10000" + TimeUnit.Milliseconds.jsonValue()),
+				nodesInfoRequest -> Collections.emptyMap(), false,
+				JsonpDeserializer.jsonValueDeserializer()),
+			null);
+
+		return jsonValue.asJsonObject();
+	}
+
 	private Version _getServerVersion() throws Exception {
 		String serverVersionString = _getServerVersionString();
 
@@ -392,42 +414,37 @@ public class ElasticsearchSearchEngineInformation
 			Set<String> labels, ElasticsearchClient elasticsearchClient)
 		throws Exception {
 
-		ElasticsearchNodesClient elasticsearchNodesClient =
-			elasticsearchClient.nodes();
+		JsonObject jsonObject = _getNodesInfoJsonObject(elasticsearchClient);
 
-		NodesInfoResponse nodesInfoResponse = elasticsearchNodesClient.info(
-			NodesInfoRequest.of(
-				nodesInforequest -> nodesInforequest.timeout(
-					Time.of(
-						time -> time.time(
-							"10000" + TimeUnit.Milliseconds.jsonValue())))));
-
-		String clusterName = GetterUtil.getString(
-			nodesInfoResponse.clusterName());
-
-		connectionInformationBuilder.clusterName(clusterName);
-
-		Map<String, NodeInfo> nodeInfos = nodesInfoResponse.nodes();
+		connectionInformationBuilder.clusterName(
+			jsonObject.getString("cluster_name", StringPool.BLANK));
 
 		List<NodeInformation> nodeInformationList = new ArrayList<>();
 
-		for (Map.Entry<String, NodeInfo> entry : nodeInfos.entrySet()) {
-			NodeInfo nodeInfo = entry.getValue();
+		JsonObject nodesJsonObject = jsonObject.getJsonObject("nodes");
 
-			NodeInformationBuilder nodeInformationBuilder =
-				nodeInformationBuilderFactory.getNodeInformationBuilder();
+		if (nodesJsonObject != null) {
+			for (String nodeId : nodesJsonObject.keySet()) {
+				JsonObject nodeJsonObject = nodesJsonObject.getJsonObject(
+					nodeId);
 
-			nodeInformationBuilder.name(nodeInfo.name());
+				NodeInformationBuilder nodeInformationBuilder =
+					nodeInformationBuilderFactory.getNodeInformationBuilder();
 
-			Version version = Version.parseVersion(nodeInfo.version());
+				nodeInformationBuilder.name(
+					nodeJsonObject.getString("name", StringPool.BLANK));
 
-			nodeInformationBuilder.version(version.toString());
+				Version version = Version.parseVersion(
+					nodeJsonObject.getString("version", StringPool.BLANK));
 
-			if (version.getMajor() == 7) {
-				labels.add("deprecated");
+				nodeInformationBuilder.version(version.toString());
+
+				if (version.getMajor() == 7) {
+					labels.add("deprecated");
+				}
+
+				nodeInformationList.add(nodeInformationBuilder.build());
 			}
-
-			nodeInformationList.add(nodeInformationBuilder.build());
 		}
 
 		connectionInformationBuilder.nodeInformationList(nodeInformationList);

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/information/ElasticsearchSearchEngineInformationTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/information/ElasticsearchSearchEngineInformationTest.java
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.elasticsearch8.internal.information;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.search.elasticsearch8.internal.configuration.ElasticsearchConfigurationWrapper;
+import com.liferay.portal.search.elasticsearch8.internal.connection.ElasticsearchConnectionFixture;
+import com.liferay.portal.search.elasticsearch8.internal.connection.ElasticsearchConnectionManager;
+import com.liferay.portal.search.internal.engine.ConnectionInformationBuilderFactoryImpl;
+import com.liferay.portal.search.internal.engine.NodeInformationBuilderFactoryImpl;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Selena Aungst
+ */
+public class ElasticsearchSearchEngineInformationTest {
+
+	@ClassRule
+	public static LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		ElasticsearchConnectionFixture elasticsearchConnectionFixture =
+			ElasticsearchConnectionFixture.builder(
+			).clusterName(
+				_CLUSTER_NAME
+			).build();
+
+		elasticsearchConnectionFixture.createNode();
+
+		_elasticsearchConnectionFixture = elasticsearchConnectionFixture;
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_elasticsearchConnectionFixture.destroyNode();
+	}
+
+	@Before
+	public void setUp() {
+		ElasticsearchConnectionManager elasticsearchConnectionManager =
+			Mockito.mock(ElasticsearchConnectionManager.class);
+
+		Mockito.when(
+			elasticsearchConnectionManager.getElasticsearchClient()
+		).thenReturn(
+			_elasticsearchConnectionFixture.getElasticsearchClient()
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			_elasticsearchSearchEngineInformation,
+			"connectionInformationBuilderFactory",
+			new ConnectionInformationBuilderFactoryImpl());
+		ReflectionTestUtil.setFieldValue(
+			_elasticsearchSearchEngineInformation,
+			"elasticsearchConfigurationWrapper",
+			Mockito.mock(ElasticsearchConfigurationWrapper.class));
+		ReflectionTestUtil.setFieldValue(
+			_elasticsearchSearchEngineInformation,
+			"elasticsearchConnectionManager", elasticsearchConnectionManager);
+		ReflectionTestUtil.setFieldValue(
+			_elasticsearchSearchEngineInformation,
+			"nodeInformationBuilderFactory",
+			new NodeInformationBuilderFactoryImpl());
+	}
+
+	@Test
+	public void testGetNodesString() {
+		String nodesString =
+			_elasticsearchSearchEngineInformation.getNodesString();
+
+		Assert.assertTrue(
+			nodesString, nodesString.startsWith(_CLUSTER_NAME + ": ["));
+		Assert.assertTrue(nodesString, nodesString.endsWith(")]"));
+	}
+
+	private static final String _CLUSTER_NAME =
+		"ElasticsearchSearchEngineInformationTest";
+
+	private static ElasticsearchConnectionFixture
+		_elasticsearchConnectionFixture;
+
+	private final ElasticsearchSearchEngineInformation
+		_elasticsearchSearchEngineInformation =
+			new ElasticsearchSearchEngineInformation();
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97767

## What Is Being Fixed

On Control Panel → Configuration → Search → Connections, the Elasticsearch connection displays as healthy but reports 0 nodes, and the log records `[es/nodes.info] Failed to decode response`. The Elasticsearch 8 connector deserializes the Nodes Info response into the typed `NodesInfoResponse`, whose generated model marks certain node settings as required (for example `NodeInfoAction.destructiveRequiresName` and `NodeInfoXpackLicense.selfGenerated`). Elasticsearch only emits those settings when they are explicitly configured, so a valid cluster that sets a sibling setting (such as `action.auto_create_index`) without the one the client expects makes the client reject the entire response, leaving the page unable to list any nodes.

## How It Is Being Fixed

Rather than binding the response to the strict typed model, the connector now reads the Nodes Info response as raw JSON through `JsonpDeserializer.jsonValueDeserializer()` and extracts only the fields the Connections page needs: the cluster name and each node's name and version. This mirrors the fix already applied to the OpenSearch connector in LPD-84891 and makes node reporting tolerant of optional settings the typed model would otherwise require. A unit test runs against an embedded node (whose settings omit `destructive_requires_name`) and asserts the node list is still returned.

## PR Check

**pr-check: PASS** — tested on `3be570b04d8cd031e68f3b56c1c0c1b0002c79d1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3be570b04d8cd031e68f3b56c1c0c1b0002c79d1"} -->
