### PR TITLE
LPD-97816 Link document search suggestions to the destination page

### DIFF
--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SuggestionResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SuggestionResourceImpl.java
@@ -79,15 +79,26 @@ public class SuggestionResourceImpl extends BaseSuggestionResourceImpl {
 
 		Layout layout = _layoutLocalService.getLayout(plid);
 
+		if (Validator.isNotNull(destinationFriendlyURL)) {
+			if (!StringUtil.startsWith(
+					destinationFriendlyURL, CharPool.SLASH)) {
+
+				destinationFriendlyURL = StringPool.SLASH.concat(
+					destinationFriendlyURL);
+			}
+
+			Layout destinationLayout = _fetchLayoutByFriendlyURL(
+				layout.getGroupId(), destinationFriendlyURL);
+
+			if (destinationLayout != null) {
+				layout = destinationLayout;
+			}
+		}
+
 		ThemeDisplay themeDisplay = _createThemeDisplay(currentURL, layout);
 
 		LiferayRenderRequest liferayRenderRequest = _createLiferayRenderRequest(
 			layout, themeDisplay);
-
-		if (!StringUtil.startsWith(destinationFriendlyURL, CharPool.SLASH)) {
-			destinationFriendlyURL = StringPool.SLASH.concat(
-				destinationFriendlyURL);
-		}
 
 		return Page.of(
 			transform(
@@ -245,6 +256,18 @@ public class SuggestionResourceImpl extends BaseSuggestionResourceImpl {
 		themeDisplay.setUser(contextUser);
 
 		return themeDisplay;
+	}
+
+	private Layout _fetchLayoutByFriendlyURL(long groupId, String friendlyURL) {
+		Layout layout = _layoutLocalService.fetchLayoutByFriendlyURL(
+			groupId, false, friendlyURL);
+
+		if (layout != null) {
+			return layout;
+		}
+
+		return _layoutLocalService.fetchLayoutByFriendlyURL(
+			groupId, true, friendlyURL);
 	}
 
 	@Reference

--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SuggestionResourceTest.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SuggestionResourceTest.java
@@ -68,6 +68,7 @@ public class SuggestionResourceTest extends BaseSuggestionResourceTestCase {
 	public void testPostSuggestionsPage() throws Exception {
 		_testPostSuggestionsPageWithBasicSuggestionsContributor();
 		_testPostSuggestionsPageWithBasicSuggestionsContributorWithAssetSearchSummary();
+		_testPostSuggestionsPageWithBasicSuggestionsContributorWithDestinationLayout();
 		_testPostSuggestionsPageWithBasicSuggestionsContributorWithEverythingScope();
 		_testPostSuggestionsPageWithBasicSuggestionsContributorWithGroupERCScope();
 		_testPostSuggestionsPageWithBasicSuggestionsContributorWithThisSiteScope();
@@ -199,6 +200,44 @@ public class SuggestionResourceTest extends BaseSuggestionResourceTestCase {
 		Assert.assertEquals(
 			_journalArticle.getDescription(_locale),
 			suggestionAttributesJSONObject.get("assetSearchSummary"));
+	}
+
+	private void _testPostSuggestionsPageWithBasicSuggestionsContributorWithDestinationLayout()
+		throws Exception {
+
+		Layout destinationLayout = LayoutTestUtil.addTypePortletLayout(
+			testGroup);
+
+		Page<SuggestionsContributorResults> page = _postSuggestionsPage(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/web/guest/home",
+			destinationLayout.getFriendlyURL(), null, "q", _layout.getPlid(),
+			null, _journalArticle.getArticleId(),
+			new SuggestionsContributorConfiguration[] {
+				new SuggestionsContributorConfiguration() {
+					{
+						contributorName = "basic";
+						displayGroupName = "Suggestions";
+					}
+				}
+			});
+
+		SuggestionsContributorResults suggestionsContributorResults =
+			page.fetchFirstItem();
+
+		Suggestion[] suggestions =
+			suggestionsContributorResults.getSuggestions();
+
+		JSONObject suggestionAttributesJSONObject =
+			JSONFactoryUtil.createJSONObject(
+				String.valueOf(suggestions[0].getAttributes()));
+
+		String assetURL = suggestionAttributesJSONObject.getString("assetURL");
+
+		Assert.assertTrue(
+			assetURL,
+			assetURL.contains(destinationLayout.getFriendlyURL()) ||
+			assetURL.contains("p_l_id=" + destinationLayout.getPlid()));
 	}
 
 	private void _testPostSuggestionsPageWithBasicSuggestionsContributorWithEverythingScope()


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97816

## What Is Being Fixed

When a guest user selects a document from the Search Bar suggestions dropdown, the portal shows "You do not have the roles required to access this portlet." instead of opening the document. The suggestion link is built against the current page (the one hosting the Search Bar), targeting the Search Results portlet on a page where a guest has no access to it. Opening the same public document from the Search Results page works, so the failure is specific to the URL the suggestions feature generates. This has been the behavior since the suggestions dropdown was introduced.

## How It Is Being Fixed

The suggestions endpoint already receives the destination search page's friendly URL but never uses it to resolve the layout the suggestion link is built against — it always uses the current page's plid. This change resolves the destination layout from that friendly URL (mirroring the resolution the Search Bar web layer already performs) and builds the theme display and render request against it, so the generated link targets the Search Results portlet on the destination page, where a guest can open the document. When the destination cannot be resolved, it falls back to the current layout, preserving existing behavior.

## PR Check

**pr-check: PASS** — tested on `e5ca23f1b9e103d52f9da1cd65bd80671ea82ade`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e5ca23f1b9e103d52f9da1cd65bd80671ea82ade"} -->
