### PR TITLE
LPD-98237 Recompute blueprint configuration entry on import

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/dto/v1_0/util/ElementInstanceUtil.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/dto/v1_0/util/ElementInstanceUtil.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.search.experiences.rest.dto.v1_0.ElementDefinition;
 import com.liferay.search.experiences.rest.dto.v1_0.ElementInstance;
 import com.liferay.search.experiences.rest.dto.v1_0.SXPElement;
 
@@ -45,23 +46,47 @@ public class ElementInstanceUtil {
 			return null;
 		}
 
-		ConfigurationUtil.unpack(elementInstance.getConfigurationEntry());
+		Object customSXPElement = null;
 
-		SXPElement sxpElement = elementInstance.getSxpElement();
+		Map<String, Object> uiConfigurationValues =
+			elementInstance.getUiConfigurationValues();
 
-		if (sxpElement != null) {
-			elementInstance.setSxpElement(
-				() -> SXPElementUtil.unpack(sxpElement));
+		if (MapUtil.isNotEmpty(uiConfigurationValues)) {
+			customSXPElement = uiConfigurationValues.get("sxpElement");
 		}
 
-		if (MapUtil.isNotEmpty(elementInstance.getUiConfigurationValues())) {
-			Map<String, Object> values1 =
-				elementInstance.getUiConfigurationValues();
+		if (customSXPElement instanceof String) {
+			SXPElement sxpElement = SXPElementUtil.toSXPElement(
+				(String)customSXPElement);
 
-			Map<String, Object> values2 = new HashMap<>(values1);
+			elementInstance.setSxpElement(() -> sxpElement);
 
-			values2.forEach(
-				(name, value) -> values1.put(name, UnpackUtil.unpack(value)));
+			ElementDefinition elementDefinition =
+				sxpElement.getElementDefinition();
+
+			if (elementDefinition != null) {
+				elementInstance.setConfigurationEntry(
+					elementDefinition::getConfiguration);
+			}
+		}
+		else {
+			SXPElement sxpElement = elementInstance.getSxpElement();
+
+			if (sxpElement != null) {
+				elementInstance.setSxpElement(
+					() -> SXPElementUtil.unpack(sxpElement));
+			}
+		}
+
+		ConfigurationUtil.unpack(elementInstance.getConfigurationEntry());
+
+		if (MapUtil.isNotEmpty(uiConfigurationValues)) {
+			Map<String, Object> unpackedUiConfigurationValues = new HashMap<>(
+				uiConfigurationValues);
+
+			unpackedUiConfigurationValues.forEach(
+				(name, value) -> uiConfigurationValues.put(
+					name, UnpackUtil.unpack(value)));
 		}
 
 		return elementInstance;

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/test/java/com/liferay/search/experiences/rest/dto/v1_0/util/ElementInstanceUtilTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/test/java/com/liferay/search/experiences/rest/dto/v1_0/util/ElementInstanceUtilTest.java
@@ -1,0 +1,103 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.search.experiences.rest.dto.v1_0.util;
+
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.search.experiences.rest.dto.v1_0.ElementInstance;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Selena Aungst
+ */
+public class ElementInstanceUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testUnpackCustomSXPElementRecomputesConfigurationEntry()
+		throws Exception {
+
+		ElementInstance elementInstance = ElementInstanceUtil.unpack(
+			ElementInstance.unsafeToDTO(
+				JSONUtil.put(
+					"configurationEntry",
+					_createConfigurationJSONObject(_INCORRECT_VALUE)
+				).put(
+					"sxpElement", _createSXPElementJSONObject(_INCORRECT_VALUE)
+				).put(
+					"uiConfigurationValues",
+					JSONUtil.put(
+						"sxpElement",
+						String.valueOf(
+							_createSXPElementJSONObject(_CORRECT_VALUE)))
+				).toString()));
+
+		String configurationEntry = String.valueOf(
+			elementInstance.getConfigurationEntry());
+
+		Assert.assertTrue(
+			configurationEntry, configurationEntry.contains(_CORRECT_VALUE));
+		Assert.assertFalse(
+			configurationEntry, configurationEntry.contains(_INCORRECT_VALUE));
+	}
+
+	private JSONObject _createClauseJSONObject(String value) {
+		return JSONUtil.put(
+			"context", "query"
+		).put(
+			"occur", "filter"
+		).put(
+			"query",
+			JSONUtil.put(
+				"terms",
+				JSONUtil.put(
+					"groupAssetCategoryExternalReferenceCodes",
+					JSONUtil.putAll(value)))
+		);
+	}
+
+	private JSONObject _createConfigurationJSONObject(String value) {
+		return JSONUtil.put(
+			"queryConfiguration",
+			JSONUtil.put(
+				"queryEntries",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"clauses",
+						JSONUtil.putAll(_createClauseJSONObject(value))))));
+	}
+
+	private JSONObject _createSXPElementJSONObject(String value) {
+		return JSONUtil.put(
+			"elementDefinition",
+			JSONUtil.put(
+				"category", "filter"
+			).put(
+				"configuration", _createConfigurationJSONObject(value)
+			).put(
+				"icon", "filter"
+			)
+		).put(
+			"title_i18n", JSONUtil.put("en_US", "Filter by Category")
+		);
+	}
+
+	private static final String _CORRECT_VALUE = RandomTestUtil.randomString();
+
+	private static final String _INCORRECT_VALUE =
+		RandomTestUtil.randomString();
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98237

## What Is Being Fixed

After deploying a site initializer client extension, fragments backed by a Blueprint Collection Provider return no results until the blueprint is opened in Search Experiences and re-saved with no changes. Importing a blueprint persisted the client-supplied compiled query (`configurationEntry`) verbatim instead of recomputing it from `uiConfigurationValues` the way the admin UI does on save. For a custom-JSON element the correct query lives only in `uiConfigurationValues.sxpElement`, so the persisted `configurationEntry` could hold stale or unresolved values that match nothing.

## How It Is Being Fixed

`ElementInstanceUtil.unpack` — the normalization step every blueprint write path funnels through — now detects a custom-JSON element (an `sxpElement` entry in `uiConfigurationValues`), re-derives the `SXPElement` from it with `SXPElementUtil.toSXPElement`, and recomputes `configurationEntry` from its element definition. This mirrors the client-side `parseCustomSXPElement`/`replaceTemplateVariable`, so importing a blueprint yields the same query as saving it, and blueprints imported before the fix self-heal when read. The change only activates for custom-JSON elements, leaving standard elements untouched.

## PR Check

**pr-check: PASS** — tested on `3ffb4935a7f80f013829a46e452992150f60b517`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3ffb4935a7f80f013829a46e452992150f60b517"} -->
