### PR TITLE
LPD-93572 Fix Search Widget SEO Playwright tests for CI

### DIFF
--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutSetApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutSetApiHelper.ts
@@ -46,4 +46,30 @@ export class JSONWebServicesLayoutSetApiHelper {
 			}
 		);
 	}
+
+	async updateVirtualHosts({
+		groupId,
+		virtualHostname,
+	}: {
+		groupId: string;
+		virtualHostname: string;
+	}) {
+		const urlSearchParams = new URLSearchParams();
+
+		urlSearchParams.append('groupId', groupId);
+		urlSearchParams.append('privateLayout', false.toString());
+		urlSearchParams.append(
+			'virtualHostnames',
+			JSON.stringify({[virtualHostname]: 'en_US'})
+		);
+
+		return this.apiHelpers.post(
+			`${liferayConfig.environment.baseUrl}${this.basePath}/update-virtual-hosts`,
+			{
+				data: urlSearchParams.toString(),
+				failOnStatusCode: true,
+				headers: await this.apiHelpers.getJSONWebServicesHeaders(),
+			}
+		);
+	}
 }

--- a/modules/test/playwright/tests/portal-search-web/main/seo.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/main/seo.spec.ts
@@ -100,6 +100,7 @@ test.describe('Search Widget SEO', () => {
 	});
 
 	test('Combines contributed parameters from multiple widgets in the canonical URL @LPD-86136', async ({
+		browser,
 		layout,
 		page,
 		searchPage,
@@ -112,19 +113,28 @@ test.describe('Search Widget SEO', () => {
 			await searchPage.addPortlet('Tag Facet', 'Search');
 		});
 
-		await test.step('Visit the page with both params and assert the canonical URL keeps both', async () => {
-			await page.goto(
-				'/web/guest' +
-					layout.friendlyURL +
-					'?category=shoes&tag=running'
-			);
+		await test.step('Visit the page as a guest with both params and assert the canonical URL keeps both', async () => {
+			const guestContext = await browser.newContext();
 
-			const canonicalHref = await page
-				.locator('link[rel="canonical"]')
-				.getAttribute('href');
+			try {
+				const guestPage = await guestContext.newPage();
 
-			expect(canonicalHref).toContain('category=shoes');
-			expect(canonicalHref).toContain('tag=running');
+				await guestPage.goto(
+					'/web/guest' +
+						layout.friendlyURL +
+						'?category=shoes&tag=running'
+				);
+
+				const canonicalHref = await guestPage
+					.locator('link[rel="canonical"]')
+					.getAttribute('href');
+
+				expect(canonicalHref).toContain('category=shoes');
+				expect(canonicalHref).toContain('tag=running');
+			}
+			finally {
+				await guestContext.close();
+			}
 		});
 	});
 
@@ -169,6 +179,7 @@ test.describe('Search Widget SEO', () => {
 	});
 
 	test('Strips unrecognized query parameters from the canonical URL @LPD-86136', async ({
+		browser,
 		layout,
 		page,
 		searchPage,
@@ -179,19 +190,28 @@ test.describe('Search Widget SEO', () => {
 			await searchPage.addPortlet('Category Facet', 'Search');
 		});
 
-		await test.step('Visit the page with a recognized and an unrecognized param and assert the canonical URL keeps only the recognized one', async () => {
-			await page.goto(
-				'/web/guest' +
-					layout.friendlyURL +
-					'?category=shoes&utm_source=email'
-			);
+		await test.step('Visit the page as a guest with a recognized and an unrecognized param and assert the canonical URL keeps only the recognized one', async () => {
+			const guestContext = await browser.newContext();
 
-			const canonicalHref = await page
-				.locator('link[rel="canonical"]')
-				.getAttribute('href');
+			try {
+				const guestPage = await guestContext.newPage();
 
-			expect(canonicalHref).toContain('category=shoes');
-			expect(canonicalHref).not.toContain('utm_source');
+				await guestPage.goto(
+					'/web/guest' +
+						layout.friendlyURL +
+						'?category=shoes&utm_source=email'
+				);
+
+				const canonicalHref = await guestPage
+					.locator('link[rel="canonical"]')
+					.getAttribute('href');
+
+				expect(canonicalHref).toContain('category=shoes');
+				expect(canonicalHref).not.toContain('utm_source');
+			}
+			finally {
+				await guestContext.close();
+			}
 		});
 	});
 });

--- a/modules/test/playwright/tests/portal-search-web/main/seo.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/main/seo.spec.ts
@@ -5,10 +5,13 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {isolatedLayoutTest} from '../../../fixtures/isolatedLayoutTest';
+import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {searchPageTest} from '../../../fixtures/searchPageTest';
+import getRandomString from '../../../utils/getRandomString';
 
 const ROBOTS_META_SELECTOR = 'meta[name="robots"][content="noindex, nofollow"]';
 
@@ -21,47 +24,22 @@ export const test = mergeTests(
 	searchPageTest
 );
 
+// robots.txt resolves the site from the request Host header, so its assertions
+// need a site reachable by its own virtual host. These tests provision an
+// isolated site with a virtual host and fetch robots.txt through it, which
+// works regardless of the baseURL host (in CI the build machine's hostname).
+
+const robotsTest = mergeTests(
+	apiHelpersTest,
+	featureFlagsTest({
+		'LPD-71164': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	searchPageTest
+);
+
 test.describe('Search Widget SEO', () => {
-	test('Adds disallow entries to robots.txt when indexing is disabled @LPD-86136', async ({
-		layout,
-		page,
-		searchPage,
-	}) => {
-		await test.step('Add Category Facet widget to the page', async () => {
-			await page.goto('/web/guest' + layout.friendlyURL);
-
-			await searchPage.addPortlet('Category Facet', 'Search');
-		});
-
-		await test.step('Disable web crawler indexing on the Category Facet widget', async () => {
-			await searchPage.openSearchPortletConfiguration('Category Facet');
-
-			await searchPage.selectPortletConfigurationsCheckbox([
-				{
-					label: 'Enable Web Crawler Indexing',
-					value: false,
-				},
-			]);
-
-			await searchPage.savePortletConfiguration();
-		});
-
-		await test.step('Fetch robots.txt and assert disallow entries for the page', async () => {
-			const response = await page.request.get('/robots.txt');
-
-			expect(response.ok()).toBe(true);
-
-			const body = await response.text();
-
-			expect(body).toContain(
-				`Disallow: ${layout.friendlyURL}*?category=`
-			);
-			expect(body).toContain(
-				`Disallow: ${layout.friendlyURL}*&category=`
-			);
-		});
-	});
-
 	test('Adds noindex robots meta tag when indexing is disabled and a category is selected @LPD-86136', async ({
 		layout,
 		page,
@@ -156,28 +134,6 @@ test.describe('Search Widget SEO', () => {
 		});
 	});
 
-	test('Does not contribute disallow entries to robots.txt when indexing is enabled @LPD-86136', async ({
-		layout,
-		page,
-		searchPage,
-	}) => {
-		await test.step('Add Category Facet widget to the page', async () => {
-			await page.goto('/web/guest' + layout.friendlyURL);
-
-			await searchPage.addPortlet('Category Facet', 'Search');
-		});
-
-		await test.step('Fetch robots.txt and assert no disallow entries for the page', async () => {
-			const response = await page.request.get('/robots.txt');
-
-			expect(response.ok()).toBe(true);
-
-			const body = await response.text();
-
-			expect(body).not.toContain(layout.friendlyURL);
-		});
-	});
-
 	test('Strips unrecognized query parameters from the canonical URL @LPD-86136', async ({
 		browser,
 		layout,
@@ -214,4 +170,107 @@ test.describe('Search Widget SEO', () => {
 			}
 		});
 	});
+});
+
+robotsTest.describe('Check robots.txt', () => {
+	robotsTest(
+		'Adds disallow entries to robots.txt when indexing is disabled @LPD-86136',
+		async ({apiHelpers, page, searchPage, site}) => {
+			const virtualHostname = `${getRandomString()}.com`;
+
+			const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
+				groupId: site.id,
+				title: getRandomString(),
+			});
+
+			await apiHelpers.jsonWebServicesLayoutSet.updateVirtualHosts({
+				groupId: site.id,
+				virtualHostname,
+			});
+
+			await robotsTest.step(
+				'Add the Category Facet widget and disable web crawler indexing',
+				async () => {
+					await page.goto(
+						'/web' + site.friendlyUrlPath + layout.friendlyURL
+					);
+
+					await searchPage.addPortlet('Category Facet', 'Search');
+
+					await searchPage.openSearchPortletConfiguration(
+						'Category Facet'
+					);
+
+					await searchPage.selectPortletConfigurationsCheckbox([
+						{
+							label: 'Enable Web Crawler Indexing',
+							value: false,
+						},
+					]);
+
+					await searchPage.savePortletConfiguration();
+				}
+			);
+
+			await robotsTest.step(
+				'Fetch robots.txt through the site virtual host and assert disallow entries',
+				async () => {
+					const response = await page.request.get('/robots.txt', {
+						headers: {host: virtualHostname},
+					});
+
+					expect(response.ok()).toBe(true);
+
+					const body = await response.text();
+
+					expect(body).toContain(
+						`Disallow: ${layout.friendlyURL}*?category=`
+					);
+					expect(body).toContain(
+						`Disallow: ${layout.friendlyURL}*&category=`
+					);
+				}
+			);
+		}
+	);
+
+	robotsTest(
+		'Does not contribute disallow entries to robots.txt when indexing is enabled @LPD-86136',
+		async ({apiHelpers, page, searchPage, site}) => {
+			const virtualHostname = `${getRandomString()}.com`;
+
+			const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
+				groupId: site.id,
+				title: getRandomString(),
+			});
+
+			await apiHelpers.jsonWebServicesLayoutSet.updateVirtualHosts({
+				groupId: site.id,
+				virtualHostname,
+			});
+
+			await robotsTest.step('Add the Category Facet widget', async () => {
+				await page.goto(
+					'/web' + site.friendlyUrlPath + layout.friendlyURL
+				);
+
+				await searchPage.addPortlet('Category Facet', 'Search');
+			});
+
+			await robotsTest.step(
+				'Fetch robots.txt through the site virtual host and assert no disallow entries',
+				async () => {
+					const response = await page.request.get('/robots.txt', {
+						headers: {host: virtualHostname},
+					});
+
+					expect(response.ok()).toBe(true);
+
+					const body = await response.text();
+
+					expect(body).not.toContain(layout.friendlyURL);
+				}
+			);
+		}
+	);
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93572

## What Is Being Fixed

- The Search Widget SEO Playwright tests (`seo.spec.ts`, `@LPD-86136`) passed locally but failed in CI.
- The canonical-URL and robots-meta assertions inspected head tags that Liferay renders only for guests, yet the tests viewed the page while signed in.
- The robots.txt assertions fetched `/robots.txt` over the CI baseURL host, which matches no virtual host, so no site layout set resolved and the SEO contributions were skipped.

## How It Is Being Fixed

- The canonical/meta assertions now view the page through a guest browser context, so the guest-only head tags render.
- The robots.txt tests provision an isolated site with its own virtual host and fetch `/robots.txt` through that host, which resolves the site's layout set regardless of the baseURL host.
- Added a reusable `updateVirtualHosts` helper for assigning the site virtual host.

## PR Check

**pr-check: PASS** — tested on `29b3aa5728a07c5715f460ff88ba91813edb6360`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "29b3aa5728a07c5715f460ff88ba91813edb6360"} -->
