### PR TITLE
LPD-98265 Target the placed Search Results widget in suggestion links

### DIFF
--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SuggestionResourceTest.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SuggestionResourceTest.java
@@ -71,6 +71,7 @@ public class SuggestionResourceTest extends BaseSuggestionResourceTestCase {
 		_testPostSuggestionsPageWithBasicSuggestionsContributorWithDestinationLayout();
 		_testPostSuggestionsPageWithBasicSuggestionsContributorWithEverythingScope();
 		_testPostSuggestionsPageWithBasicSuggestionsContributorWithGroupERCScope();
+		_testPostSuggestionsPageWithBasicSuggestionsContributorWithSearchResultsPortlet();
 		_testPostSuggestionsPageWithBasicSuggestionsContributorWithThisSiteScope();
 		_testPostSuggestionsPageWithSXPBlueprintSuggestionsContributor();
 		_testPostSuggestionsPageWithSXPBlueprintSuggestionsContributorWithGroupERCScope();
@@ -274,6 +275,46 @@ public class SuggestionResourceTest extends BaseSuggestionResourceTestCase {
 
 		_assertSuggestionTexts(
 			page.fetchFirstItem(), _journalArticle.getTitle(_locale));
+	}
+
+	private void _testPostSuggestionsPageWithBasicSuggestionsContributorWithSearchResultsPortlet()
+		throws Exception {
+
+		Layout destinationLayout = LayoutTestUtil.addTypePortletLayout(
+			testGroup);
+
+		String searchResultsPortletId = LayoutTestUtil.addPortletToLayout(
+			destinationLayout,
+			"com_liferay_portal_search_web_search_results_portlet_" +
+				"SearchResultsPortlet");
+
+		Page<SuggestionsContributorResults> page = _postSuggestionsPage(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/web/guest/home",
+			destinationLayout.getFriendlyURL(), null, "q", _layout.getPlid(),
+			null, _journalArticle.getArticleId(),
+			new SuggestionsContributorConfiguration[] {
+				new SuggestionsContributorConfiguration() {
+					{
+						contributorName = "basic";
+						displayGroupName = "Suggestions";
+					}
+				}
+			});
+
+		SuggestionsContributorResults suggestionsContributorResults =
+			page.fetchFirstItem();
+
+		Suggestion[] suggestions =
+			suggestionsContributorResults.getSuggestions();
+
+		JSONObject suggestionAttributesJSONObject =
+			JSONFactoryUtil.createJSONObject(
+				String.valueOf(suggestions[0].getAttributes()));
+
+		String assetURL = suggestionAttributesJSONObject.getString("assetURL");
+
+		Assert.assertTrue(assetURL, assetURL.contains(searchResultsPortletId));
 	}
 
 	private void _testPostSuggestionsPageWithBasicSuggestionsContributorWithThisSiteScope()

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/asset/AssetURLViewProviderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/asset/AssetURLViewProviderImpl.java
@@ -14,9 +14,13 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutTypePortlet;
+import com.liferay.portal.kernel.model.PortletPreferences;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -48,10 +52,15 @@ public class AssetURLViewProviderImpl implements AssetURLViewProvider {
 		LiferayPortletResponse liferayPortletResponse) {
 
 		try {
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)liferayPortletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			Layout layout = themeDisplay.getLayout();
+
 			PortletURL viewContentURL =
 				PortletURLBuilder.createLiferayPortletURL(
-					liferayPortletResponse,
-					SearchResultsPortletKeys.SEARCH_RESULTS,
+					liferayPortletResponse, _getSearchResultsPortletId(layout),
 					PortletRequest.RENDER_PHASE
 				).setRedirect(
 					_portal.getCurrentURL(liferayPortletRequest)
@@ -87,16 +96,9 @@ public class AssetURLViewProviderImpl implements AssetURLViewProvider {
 				viewURL = viewContentURL.toString();
 			}
 
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)liferayPortletRequest.getAttribute(
-					WebKeys.THEME_DISPLAY);
-
-			Layout previousLayout = themeDisplay.getLayout();
-
 			return HttpComponentsUtil.addParameters(
 				viewURL, "p_l_back_url", themeDisplay.getURLCurrent(),
-				"p_l_back_url_title",
-				previousLayout.getName(themeDisplay.getLocale()));
+				"p_l_back_url_title", layout.getName(themeDisplay.getLocale()));
 		}
 		catch (Exception exception) {
 			_log.error(
@@ -109,6 +111,36 @@ public class AssetURLViewProviderImpl implements AssetURLViewProvider {
 		return StringPool.BLANK;
 	}
 
+	private String _getSearchResultsPortletId(Layout layout) {
+		if (layout.getLayoutType() instanceof LayoutTypePortlet) {
+			LayoutTypePortlet layoutTypePortlet =
+				(LayoutTypePortlet)layout.getLayoutType();
+
+			for (String portletId : layoutTypePortlet.getPortletIds()) {
+				if (SearchResultsPortletKeys.SEARCH_RESULTS.equals(
+						PortletIdCodec.decodePortletName(portletId))) {
+
+					return portletId;
+				}
+			}
+		}
+
+		for (PortletPreferences portletPreferences :
+				_portletPreferencesLocalService.getPortletPreferencesByPlid(
+					layout.getPlid())) {
+
+			String portletId = portletPreferences.getPortletId();
+
+			if (SearchResultsPortletKeys.SEARCH_RESULTS.equals(
+					PortletIdCodec.decodePortletName(portletId))) {
+
+				return portletId;
+			}
+		}
+
+		return SearchResultsPortletKeys.SEARCH_RESULTS;
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		AssetURLViewProviderImpl.class);
 
@@ -117,5 +149,8 @@ public class AssetURLViewProviderImpl implements AssetURLViewProvider {
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private PortletPreferencesLocalService _portletPreferencesLocalService;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98265

## What Is Being Fixed

A follow-up to LPD-97816. With that fix, a guest clicking a document in the Search Bar suggestions dropdown is correctly routed to the destination Search page but still sees "You do not have the roles required to access this portlet." The Search Results widget is instanceable, and the generated link targeted the generic portlet type rather than the specific widget instance placed on the page. A guest can only access the placed instance, so the permission check still failed. Opening the same document from the Search Results page works because that flow uses the placed instance.

## How It Is Being Fixed

AssetURLViewProviderImpl now resolves the Search Results widget instance placed on the layout the link is built against (the destination page, from LPD-97816) and builds the view-content URL with that full instance id, falling back to the generic portlet key when no instance is present. This mirrors the in-context result-click flow, so a guest opens the document instead of hitting the permission error.

## PR Check

**pr-check: PASS** — tested on `715d4a0f3a60b5dd576e199362ac62ae2db8c312`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "715d4a0f3a60b5dd576e199362ac62ae2db8c312"} -->
