### PR TITLE
LPD-97685 portal-search-elasticsearch8-impl: Fix missing fieldName after LPD-96569

### DIFF
--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/response/SearchResponseTranslatorTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/response/SearchResponseTranslatorTest.java
@@ -69,9 +69,9 @@ public class SearchResponseTranslatorTest {
 		List<String> fragments = Collections.singletonList(
 			"<liferay-hl>alpha</liferay-hl> beta");
 
-		builder.highlight(fieldName, fragments);
-
 		String fieldName = RandomTestUtil.randomString();
+
+		builder.highlight(fieldName, fragments);
 
 		String localizedFieldName = Field.getLocalizedName(
 			LocaleUtil.US, fieldName);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97685

## Failing Tests

`com.liferay.portal.search.elasticsearch8.internal.aggregation.bucket.DateHistogramAggregationTest` and all other `com.liferay.portal.search.elasticsearch8.internal` tests

```
testRun: :apps:portal-search-elasticsearch8:portal-search-elasticsearch8-impl:test was not executed. Please check the logs for details.
```

## Root Cause

Commit `03d4659f` ("LPD-96569 As used") reordered `testAddSnippetsDoesNotDuplicateBaseAndLocalizedField` in `SearchResponseTranslatorTest`, moving the `String fieldName = RandomTestUtil.randomString();` declaration below its first use in `builder.highlight(fieldName, fragments)`. That is a use-before-declaration compile error, so the entire `portal-search-elasticsearch8-impl` test source set stopped compiling and no unit test in the module — including `DateHistogramAggregationTest` — was executed.

## Fix

Declare `fieldName` immediately before its first use so the test source set compiles again. The reported test then runs and passes along with the rest of the module's unit tests.

- `modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/response/SearchResponseTranslatorTest.java`

## Why Are There No Tests?

This change only reorders two lines within an existing unit test to restore compilation. There is no product-code change to cover, and the fix is validated by the previously failing tests now compiling and passing.

## PR Check

**pr-check: PASS** — tested on `5d533ebfc89b1d1107fa447924b9b62991b1f4a4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5d533ebfc89b1d1107fa447924b9b62991b1f4a4"} -->
