### PR TITLE
LPD-98806 Show localized object entry content in result rankings

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingJSONBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingJSONBuilder.java
@@ -350,6 +350,11 @@ public class RankingJSONBuilder {
 		String content = sb.toString();
 
 		if (Validator.isBlank(content)) {
+			content = _document.getString(
+				Field.getLocalizedName(_locale, "objectEntryContent"));
+		}
+
+		if (Validator.isBlank(content)) {
 			content = _document.getString("objectEntryContent");
 		}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98806

## What Is Being Fixed

- The Search Tuning result rankings list stopped showing the content/description of CMS object entries; each row rendered the title link with no description line.
- Regression introduced by `22b8fd8008ba` (LPD-72159), which switched object entry indexing to write content into localized fields (`objectEntryContent_<locale>`) and only wrote the non-localized `objectEntryContent` field as a fallback.
- The result rankings `RankingJSONBuilder` was never updated to match and still read only the non-localized `objectEntryContent`, so for entries with localized content the description resolved to blank.

## How It Is Being Fixed

- `RankingJSONBuilder._getObjectEntryContent()` now reads the localized `objectEntryContent_<locale>` field first, falling back to the non-localized field.
- This mirrors how `_getDescription()` already resolves the localized `CONTENT` and `DESCRIPTION` fields, keeping the reader consistent with the indexer's localized-field contract.

## Why Are There No Tests?

- The behavior is covered end-to-end by the existing Playwright test `search-experiences-web/main/resultRankings.spec.ts` (`CMS Object Entries` @LPD-76602), which was failing on this regression and passes with the fix. The module's existing `RankingJSONBuilderTest` unit test also passes.

## PR Check

**pr-check: PASS** — tested on `bbe01fb7e1c922981dce460d851a27fb86a9f70c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "bbe01fb7e1c922981dce460d851a27fb86a9f70c"} -->
