### PR TITLE
LPD-98598 Sync OpenSearch 2 field mappings with Elasticsearch 8

### DIFF
--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/resources/META-INF/mappings/index-mappings.json
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/resources/META-INF/mappings/index-mappings.json
@@ -43,6 +43,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "ar",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_ar_[A-Z]{2}_sortable\\b|\\w+_ar_[A-Z]{2}_\\w+_sortable\\b",
@@ -59,6 +60,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "bg",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_bg_[A-Z]{2}_sortable\\b|\\w+_bg_[A-Z]{2}_\\w+_sortable\\b",
@@ -75,6 +77,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "ca",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_ca_[A-Z]{2}_sortable\\b|\\w+_ca_[A-Z]{2}_\\w+_sortable\\b",
@@ -91,6 +94,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "cs",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_cs_[A-Z]{2}_sortable\\b|\\w+_cs_[A-Z]{2}_\\w+_sortable\\b",
@@ -107,6 +111,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "da",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_da_[A-Z]{2}_sortable\\b|\\w+_da_[A-Z]{2}_\\w+_sortable\\b",
@@ -117,12 +122,14 @@
 		{
 			"template_string_sortable_de_AT": {
 				"mapping": {
+					"country": "AT",
 					"fields": {
 						"keyword_lowercase": {
 							"normalizer": "lowercase",
 							"type": "keyword"
 						}
 					},
+					"language": "de",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_de_AT_sortable\\b|\\w+_de_AT_\\w+_sortable\\b",
@@ -139,6 +146,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "de",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_de_[A-Z]{2}_sortable\\b|\\w+_de_[A-Z]{2}_\\w+_sortable\\b",
@@ -155,6 +163,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "el",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_el_[A-Z]{2}_sortable\\b|\\w+_el_[A-Z]{2}_\\w+_sortable\\b",
@@ -171,6 +180,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "en",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_en_[A-Z]{2}_sortable\\b|\\w+_en_[A-Z]{2}_\\w+_sortable\\b",
@@ -187,6 +197,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "es",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_es_[A-Z]{2}_sortable\\b|\\w+_es_[A-Z]{2}_\\w+_sortable\\b",
@@ -203,6 +214,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "et",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_et_[A-Z]{2}_sortable\\b|\\w+_et_[A-Z]{2}_\\w+_sortable\\b",
@@ -219,6 +231,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "eu",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_eu_[A-Z]{2}_sortable\\b|\\w+_eu_[A-Z]{2}_\\w+_sortable\\b",
@@ -235,6 +248,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "fa",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_fa_[A-Z]{2}_sortable\\b|\\w+_fa_[A-Z]{2}_\\w+_sortable\\b",
@@ -251,6 +265,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "fi",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_fi_[A-Z]{2}_sortable\\b|\\w+_fi_[A-Z]{2}_\\w+_sortable\\b",
@@ -261,12 +276,14 @@
 		{
 			"template_string_sortable_fr_CA": {
 				"mapping": {
+					"country": "CA",
 					"fields": {
 						"keyword_lowercase": {
 							"normalizer": "lowercase",
 							"type": "keyword"
 						}
 					},
+					"language": "fr",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_fr_CA_sortable\\b|\\w+_fr_CA_\\w+_sortable\\b",
@@ -283,6 +300,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "fr",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_fr_[A-Z]{2}_sortable\\b|\\w+_fr_[A-Z]{2}_\\w+_sortable\\b",
@@ -299,6 +317,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "gl",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_gl_[A-Z]{2}_sortable\\b|\\w+_gl_[A-Z]{2}_\\w+_sortable\\b",
@@ -315,6 +334,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "hi",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_hi_[A-Z]{2}_sortable\\b|\\w+_hi_[A-Z]{2}_\\w+_sortable\\b",
@@ -331,6 +351,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "hr",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_hr_[A-Z]{2}_sortable\\b|\\w+_hr_[A-Z]{2}_\\w+_sortable\\b",
@@ -347,6 +368,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "hu",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_hu_[A-Z]{2}_sortable\\b|\\w+_hu_[A-Z]{2}_\\w+_sortable\\b",
@@ -363,6 +385,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "hy",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_hy_[A-Z]{2}_sortable\\b|\\w+_hy_[A-Z]{2}_\\w+_sortable\\b",
@@ -379,6 +402,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "in",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_in_[A-Z]{2}_sortable\\b|\\w+_in_[A-Z]{2}_\\w+_sortable\\b",
@@ -395,6 +419,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "it",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_it_[A-Z]{2}_sortable\\b|\\w+_it_[A-Z]{2}_\\w+_sortable\\b",
@@ -411,6 +436,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "ja",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_ja_[A-Z]{2}_sortable\\b|\\w+_ja_[A-Z]{2}_\\w+_sortable\\b",
@@ -427,6 +453,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "kk",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_kk_[A-Z]{2}_sortable\\b|\\w+_kk_[A-Z]{2}_\\w+_sortable\\b",
@@ -443,6 +470,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "ko",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_ko_[A-Z]{2}_sortable\\b|\\w+_ko_[A-Z]{2}_\\w+_sortable\\b",
@@ -459,6 +487,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "lo",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_lo_[A-Z]{2}_sortable\\b|\\w+_lo_[A-Z]{2}_\\w+_sortable\\b",
@@ -475,6 +504,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "lt",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_lt_[A-Z]{2}_sortable\\b|\\w+_lt_[A-Z]{2}_\\w+_sortable\\b",
@@ -491,6 +521,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "ms",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_ms_[A-Z]{2}_sortable\\b|\\w+_ms_[A-Z]{2}_\\w+_sortable\\b",
@@ -507,6 +538,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "nb",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_nb_[A-Z]{2}_sortable\\b|\\w+_nb_[A-Z]{2}_\\w+_sortable\\b",
@@ -523,6 +555,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "nl",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_nl_[A-Z]{2}_sortable\\b|\\w+_nl_[A-Z]{2}_\\w+_sortable\\b",
@@ -539,6 +572,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "no",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_no_[A-Z]{2}_sortable\\b|\\w+_no_[A-Z]{2}_\\w+_sortable\\b",
@@ -555,6 +589,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "pl",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_pl_[A-Z]{2}_sortable\\b|\\w+_pl_[A-Z]{2}_\\w+_sortable\\b",
@@ -571,6 +606,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "pt",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_pt_[A-Z]{2}_sortable\\b|\\w+_pt_[A-Z]{2}_\\w+_sortable\\b",
@@ -587,6 +623,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "ro",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_ro_[A-Z]{2}_sortable\\b|\\w+_ro_[A-Z]{2}_\\w+_sortable\\b",
@@ -603,6 +640,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "ru",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_ru_[A-Z]{2}_sortable\\b|\\w+_ru_[A-Z]{2}_\\w+_sortable\\b",
@@ -619,6 +657,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "sk",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_sk_[A-Z]{2}_sortable\\b|\\w+_sk_[A-Z]{2}_\\w+_sortable\\b",
@@ -635,6 +674,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "sl",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_sl_[A-Z]{2}_sortable\\b|\\w+_sl_[A-Z]{2}_\\w+_sortable\\b",
@@ -651,6 +691,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "sr",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_sr_[A-Z]{2}_sortable\\b|\\w+_sr_[A-Z]{2}_\\w+_sortable\\b",
@@ -667,6 +708,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "sv",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_sv_[A-Z]{2}_sortable\\b|\\w+_sv_[A-Z]{2}_\\w+_sortable\\b",
@@ -683,6 +725,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "ta",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_ta_[A-Z]{2}_sortable\\b|\\w+_ta_[A-Z]{2}_\\w+_sortable\\b",
@@ -699,6 +742,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "th",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_th_[A-Z]{2}_sortable\\b|\\w+_th_[A-Z]{2}_\\w+_sortable\\b",
@@ -715,6 +759,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "tr",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_tr_[A-Z]{2}_sortable\\b|\\w+_tr_[A-Z]{2}_\\w+_sortable\\b",
@@ -731,6 +776,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "uk",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_uk_[A-Z]{2}_sortable\\b|\\w+_uk_[A-Z]{2}_\\w+_sortable\\b",
@@ -747,6 +793,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "vi",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_vi_[A-Z]{2}_sortable\\b|\\w+_vi_[A-Z]{2}_\\w+_sortable\\b",
@@ -763,6 +810,7 @@
 							"type": "keyword"
 						}
 					},
+					"language": "zh",
 					"type": "icu_collation_keyword"
 				},
 				"match": "\\w+_zh_[A-Z]{2}_sortable\\b|\\w+_zh_[A-Z]{2}_\\w+_sortable\\b",
@@ -1398,6 +1446,9 @@
 			"type": "keyword"
 		},
 		"assetVocabularyIds": {
+			"type": "keyword"
+		},
+		"classExternalReferenceCode": {
 			"type": "keyword"
 		},
 		"classTypeId": {

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/resources/com/liferay/portal/search/opensearch2/internal/index/OpenSearchIndexInformationTest-testGetFieldMappings.json
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/resources/com/liferay/portal/search/opensearch2/internal/index/OpenSearchIndexInformationTest-testGetFieldMappings.json
@@ -45,6 +45,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "ar",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_ar_[A-Z]{2}_sortable\\b|\\w+_ar_[A-Z]{2}_\\w+_sortable\\b",
@@ -61,6 +62,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "bg",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_bg_[A-Z]{2}_sortable\\b|\\w+_bg_[A-Z]{2}_\\w+_sortable\\b",
@@ -77,6 +79,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "ca",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_ca_[A-Z]{2}_sortable\\b|\\w+_ca_[A-Z]{2}_\\w+_sortable\\b",
@@ -93,6 +96,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "cs",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_cs_[A-Z]{2}_sortable\\b|\\w+_cs_[A-Z]{2}_\\w+_sortable\\b",
@@ -109,6 +113,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "da",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_da_[A-Z]{2}_sortable\\b|\\w+_da_[A-Z]{2}_\\w+_sortable\\b",
@@ -119,12 +124,14 @@
 				{
 					"template_string_sortable_de_AT": {
 						"mapping": {
+							"country": "AT",
 							"fields": {
 								"keyword_lowercase": {
 									"normalizer": "lowercase",
 									"type": "keyword"
 								}
 							},
+							"language": "de",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_de_AT_sortable\\b|\\w+_de_AT_\\w+_sortable\\b",
@@ -141,6 +148,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "de",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_de_[A-Z]{2}_sortable\\b|\\w+_de_[A-Z]{2}_\\w+_sortable\\b",
@@ -157,6 +165,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "el",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_el_[A-Z]{2}_sortable\\b|\\w+_el_[A-Z]{2}_\\w+_sortable\\b",
@@ -173,6 +182,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "en",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_en_[A-Z]{2}_sortable\\b|\\w+_en_[A-Z]{2}_\\w+_sortable\\b",
@@ -189,6 +199,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "es",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_es_[A-Z]{2}_sortable\\b|\\w+_es_[A-Z]{2}_\\w+_sortable\\b",
@@ -205,6 +216,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "et",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_et_[A-Z]{2}_sortable\\b|\\w+_et_[A-Z]{2}_\\w+_sortable\\b",
@@ -221,6 +233,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "eu",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_eu_[A-Z]{2}_sortable\\b|\\w+_eu_[A-Z]{2}_\\w+_sortable\\b",
@@ -237,6 +250,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "fa",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_fa_[A-Z]{2}_sortable\\b|\\w+_fa_[A-Z]{2}_\\w+_sortable\\b",
@@ -253,6 +267,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "fi",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_fi_[A-Z]{2}_sortable\\b|\\w+_fi_[A-Z]{2}_\\w+_sortable\\b",
@@ -263,12 +278,14 @@
 				{
 					"template_string_sortable_fr_CA": {
 						"mapping": {
+							"country": "CA",
 							"fields": {
 								"keyword_lowercase": {
 									"normalizer": "lowercase",
 									"type": "keyword"
 								}
 							},
+							"language": "fr",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_fr_CA_sortable\\b|\\w+_fr_CA_\\w+_sortable\\b",
@@ -285,6 +302,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "fr",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_fr_[A-Z]{2}_sortable\\b|\\w+_fr_[A-Z]{2}_\\w+_sortable\\b",
@@ -301,6 +319,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "gl",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_gl_[A-Z]{2}_sortable\\b|\\w+_gl_[A-Z]{2}_\\w+_sortable\\b",
@@ -317,6 +336,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "hi",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_hi_[A-Z]{2}_sortable\\b|\\w+_hi_[A-Z]{2}_\\w+_sortable\\b",
@@ -333,6 +353,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "hr",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_hr_[A-Z]{2}_sortable\\b|\\w+_hr_[A-Z]{2}_\\w+_sortable\\b",
@@ -349,6 +370,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "hu",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_hu_[A-Z]{2}_sortable\\b|\\w+_hu_[A-Z]{2}_\\w+_sortable\\b",
@@ -365,6 +387,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "hy",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_hy_[A-Z]{2}_sortable\\b|\\w+_hy_[A-Z]{2}_\\w+_sortable\\b",
@@ -381,6 +404,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "in",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_in_[A-Z]{2}_sortable\\b|\\w+_in_[A-Z]{2}_\\w+_sortable\\b",
@@ -397,6 +421,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "it",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_it_[A-Z]{2}_sortable\\b|\\w+_it_[A-Z]{2}_\\w+_sortable\\b",
@@ -413,6 +438,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "ja",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_ja_[A-Z]{2}_sortable\\b|\\w+_ja_[A-Z]{2}_\\w+_sortable\\b",
@@ -429,6 +455,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "kk",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_kk_[A-Z]{2}_sortable\\b|\\w+_kk_[A-Z]{2}_\\w+_sortable\\b",
@@ -445,6 +472,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "ko",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_ko_[A-Z]{2}_sortable\\b|\\w+_ko_[A-Z]{2}_\\w+_sortable\\b",
@@ -461,6 +489,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "lo",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_lo_[A-Z]{2}_sortable\\b|\\w+_lo_[A-Z]{2}_\\w+_sortable\\b",
@@ -477,6 +506,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "lt",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_lt_[A-Z]{2}_sortable\\b|\\w+_lt_[A-Z]{2}_\\w+_sortable\\b",
@@ -493,6 +523,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "ms",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_ms_[A-Z]{2}_sortable\\b|\\w+_ms_[A-Z]{2}_\\w+_sortable\\b",
@@ -509,6 +540,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "nb",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_nb_[A-Z]{2}_sortable\\b|\\w+_nb_[A-Z]{2}_\\w+_sortable\\b",
@@ -525,6 +557,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "nl",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_nl_[A-Z]{2}_sortable\\b|\\w+_nl_[A-Z]{2}_\\w+_sortable\\b",
@@ -541,6 +574,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "no",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_no_[A-Z]{2}_sortable\\b|\\w+_no_[A-Z]{2}_\\w+_sortable\\b",
@@ -557,6 +591,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "pl",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_pl_[A-Z]{2}_sortable\\b|\\w+_pl_[A-Z]{2}_\\w+_sortable\\b",
@@ -573,6 +608,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "pt",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_pt_[A-Z]{2}_sortable\\b|\\w+_pt_[A-Z]{2}_\\w+_sortable\\b",
@@ -589,6 +625,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "ro",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_ro_[A-Z]{2}_sortable\\b|\\w+_ro_[A-Z]{2}_\\w+_sortable\\b",
@@ -605,6 +642,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "ru",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_ru_[A-Z]{2}_sortable\\b|\\w+_ru_[A-Z]{2}_\\w+_sortable\\b",
@@ -621,6 +659,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "sk",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_sk_[A-Z]{2}_sortable\\b|\\w+_sk_[A-Z]{2}_\\w+_sortable\\b",
@@ -637,6 +676,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "sl",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_sl_[A-Z]{2}_sortable\\b|\\w+_sl_[A-Z]{2}_\\w+_sortable\\b",
@@ -653,6 +693,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "sr",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_sr_[A-Z]{2}_sortable\\b|\\w+_sr_[A-Z]{2}_\\w+_sortable\\b",
@@ -669,6 +710,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "sv",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_sv_[A-Z]{2}_sortable\\b|\\w+_sv_[A-Z]{2}_\\w+_sortable\\b",
@@ -685,6 +727,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "ta",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_ta_[A-Z]{2}_sortable\\b|\\w+_ta_[A-Z]{2}_\\w+_sortable\\b",
@@ -701,6 +744,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "th",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_th_[A-Z]{2}_sortable\\b|\\w+_th_[A-Z]{2}_\\w+_sortable\\b",
@@ -717,6 +761,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "tr",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_tr_[A-Z]{2}_sortable\\b|\\w+_tr_[A-Z]{2}_\\w+_sortable\\b",
@@ -733,6 +778,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "uk",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_uk_[A-Z]{2}_sortable\\b|\\w+_uk_[A-Z]{2}_\\w+_sortable\\b",
@@ -749,6 +795,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "vi",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_vi_[A-Z]{2}_sortable\\b|\\w+_vi_[A-Z]{2}_\\w+_sortable\\b",
@@ -765,6 +812,7 @@
 									"type": "keyword"
 								}
 							},
+							"language": "zh",
 							"type": "icu_collation_keyword"
 						},
 						"match": "\\w+_zh_[A-Z]{2}_sortable\\b|\\w+_zh_[A-Z]{2}_\\w+_sortable\\b",
@@ -1409,6 +1457,9 @@
 					"type": "keyword"
 				},
 				"assetVocabularyIds": {
+					"type": "keyword"
+				},
+				"classExternalReferenceCode": {
 					"type": "keyword"
 				},
 				"classTypeId": {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98598

## What Is Being Fixed

- The OpenSearch 2 connector's index field mappings had drifted from the Elasticsearch 8 reference connector.
- The `icu_collation_keyword` sortable templates were missing their per-language `language` (and `country`) collation parameters, so locale-aware sorting did not match Elasticsearch 8.
- The `classExternalReferenceCode` keyword field was absent from the mappings.

## How It Is Being Fixed

- Add the `language` collation parameter (plus `country` for `de-AT` and `fr-CA`) to every `icu_collation_keyword` sortable template in `index-mappings.json`, and add the `classExternalReferenceCode` keyword field, bringing the file in line with Elasticsearch 8.
- Update the `OpenSearchIndexInformationTest.testGetFieldMappings` expected fixture, since the engine echoes these collation parameters and the new field back through `getFieldMappings`.

## Why Are There No Tests?

- This is a data-only sync of the field-mapping definitions with the Elasticsearch 8 connector. It is covered by the existing `OpenSearchIndexInformationTest.testGetFieldMappings`, whose expected fixture is updated in this PR and was verified against a real OpenSearch 2.19.0 node (with the `analysis-icu`, `analysis-kuromoji`, and `analysis-smartcn` plugins).

## PR Check

**pr-check: PASS** — tested on `bb65956888bb14ade6da5ac5998be013ae515951`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "bb65956888bb14ade6da5ac5998be013ae515951"} -->
