### PR TITLE
LPD-98935 Require Update permission to edit a Search Blueprint

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPBlueprintsDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPBlueprintsDisplayContext.java
@@ -95,7 +95,7 @@ public class ViewSXPBlueprintsDisplayContext {
 				).buildString(),
 				"pencil", "edit",
 				LanguageUtil.get(_sxpRequestHelper.getRequest(), "edit"), "get",
-				"get", "link"),
+				"update", "link"),
 			new FDSActionDropdownItem(
 				"#", "book", "enableAsACollectionProvider",
 				LanguageUtil.get(

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/test/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPBlueprintsDisplayContextTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/test/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPBlueprintsDisplayContextTest.java
@@ -1,0 +1,91 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.search.experiences.web.internal.blueprint.admin.display.context;
+
+import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Selena Aungst
+ */
+public class ViewSXPBlueprintsDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		LanguageUtil languageUtil = new LanguageUtil();
+
+		languageUtil.setLanguage(Mockito.mock(Language.class));
+
+		Mockito.when(
+			LanguageUtil.get(
+				Mockito.any(HttpServletRequest.class), Mockito.anyString())
+		).thenAnswer(
+			invocation -> invocation.getArgument(1)
+		);
+	}
+
+	@Test
+	public void testGetFDSActionDropdownItemsEditActionPermissionKeyIsUpdate()
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, Mockito.mock(ThemeDisplay.class));
+
+		ViewSXPBlueprintsDisplayContext viewSXPBlueprintsDisplayContext =
+			Mockito.spy(
+				new ViewSXPBlueprintsDisplayContext(
+					mockHttpServletRequest,
+					Mockito.mock(ModelResourcePermission.class)));
+
+		Mockito.doReturn(
+			new MockLiferayPortletURL()
+		).when(
+			viewSXPBlueprintsDisplayContext
+		).getPortletURL();
+
+		List<FDSActionDropdownItem> fdsActionDropdownItems =
+			viewSXPBlueprintsDisplayContext.getFDSActionDropdownItems();
+
+		FDSActionDropdownItem fdsActionDropdownItem =
+			fdsActionDropdownItems.get(0);
+
+		Map<String, String> data =
+			(Map<String, String>)fdsActionDropdownItem.get("data");
+
+		Assert.assertEquals("edit", data.get("id"));
+		Assert.assertEquals("update", data.get("permissionKey"));
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98935

## What Is Being Fixed

In the Search Blueprints admin, a user with only the View permission on a Blueprint was still shown the Edit action in the list. They could open the editor and modify fields, and the missing permission was only enforced at save time, where it returned an error. This exposed an edit affordance that did not reflect the user's real capabilities.

## How It Is Being Fixed

The Blueprint list's Edit action was keyed to the View permission instead of Update, so it appeared for any user who could view a Blueprint. The action is now keyed to Update, matching how the Delete and Copy actions already behave, so view-only users no longer see it. This follows the existing pattern where the editor screen itself is not gated (mirroring the Elements view) and the mutating operation remains enforced at the service layer. A unit test asserts the Edit action's permission key.

## PR Check

**pr-check: PASS** — tested on `f789b933173812ebb3f07857bbc41af1ccce7b48`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f789b933173812ebb3f07857bbc41af1ccce7b48"} -->
