### PR TITLE
LPD-98952 Isolate IndexFactoryTest from a leaked company ID registry

### DIFF
--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/index/IndexFactoryTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/index/IndexFactoryTest.java
@@ -28,6 +28,7 @@ import com.liferay.portal.search.elasticsearch8.internal.configuration.Elasticse
 import com.liferay.portal.search.elasticsearch8.internal.connection.ElasticsearchFixture;
 import com.liferay.portal.search.elasticsearch8.internal.connection.IndexName;
 import com.liferay.portal.search.elasticsearch8.internal.document.SingleFieldFixture;
+import com.liferay.portal.search.elasticsearch8.internal.index.util.IndexFactoryCompanyIdRegistryUtil;
 import com.liferay.portal.search.elasticsearch8.internal.query.QueryFactories;
 import com.liferay.portal.search.elasticsearch8.internal.util.ResourceUtil;
 import com.liferay.portal.search.spi.index.configuration.contributor.CompanyIndexConfigurationContributor;
@@ -84,6 +85,12 @@ public class IndexFactoryTest {
 
 	@Before
 	public void setUp() throws Exception {
+		for (long companyId :
+				IndexFactoryCompanyIdRegistryUtil.getCompanyIds()) {
+
+			IndexFactoryCompanyIdRegistryUtil.unregisterCompanyId(companyId);
+		}
+
 		_indexFactoryFixture = new IndexFactoryFixture(
 			_elasticsearchFixture, testName.getMethodName());
 

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/ElasticsearchSearchEngineBackupTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/ElasticsearchSearchEngineBackupTest.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.elasticsearch8.internal.ElasticsearchSearchEngine;
 import com.liferay.portal.search.elasticsearch8.internal.connection.ElasticsearchConnectionFixture;
+import com.liferay.portal.search.elasticsearch8.internal.index.util.IndexFactoryCompanyIdRegistryUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.io.IOException;
@@ -71,6 +72,12 @@ public class ElasticsearchSearchEngineBackupTest {
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		_elasticsearchSearchEngineFixture.tearDown();
+
+		for (long companyId :
+				IndexFactoryCompanyIdRegistryUtil.getCompanyIds()) {
+
+			IndexFactoryCompanyIdRegistryUtil.unregisterCompanyId(companyId);
+		}
 	}
 
 	@Test

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/ElasticsearchSearchEngineReconnectTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/ElasticsearchSearchEngineReconnectTest.java
@@ -10,6 +10,7 @@ import com.liferay.portal.search.elasticsearch8.internal.ElasticsearchSearchEngi
 import com.liferay.portal.search.elasticsearch8.internal.connection.ElasticsearchConnection;
 import com.liferay.portal.search.elasticsearch8.internal.connection.ElasticsearchConnectionFixture;
 import com.liferay.portal.search.elasticsearch8.internal.connection.ElasticsearchConnectionManager;
+import com.liferay.portal.search.elasticsearch8.internal.index.util.IndexFactoryCompanyIdRegistryUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import org.junit.AfterClass;
@@ -46,6 +47,12 @@ public class ElasticsearchSearchEngineReconnectTest {
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		_elasticsearchSearchEngineFixture.tearDown();
+
+		for (long companyId :
+				IndexFactoryCompanyIdRegistryUtil.getCompanyIds()) {
+
+			IndexFactoryCompanyIdRegistryUtil.unregisterCompanyId(companyId);
+		}
 	}
 
 	@Test

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/index/IndexFactoryTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/index/IndexFactoryTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.search.opensearch2.internal.configuration.OpenSearchCo
 import com.liferay.portal.search.opensearch2.internal.configuration.OpenSearchConfigurationWrapperImpl;
 import com.liferay.portal.search.opensearch2.internal.connection.IndexName;
 import com.liferay.portal.search.opensearch2.internal.document.SingleFieldFixture;
+import com.liferay.portal.search.opensearch2.internal.index.util.IndexFactoryCompanyIdRegistryUtil;
 import com.liferay.portal.search.opensearch2.internal.query.QueryFactories;
 import com.liferay.portal.search.opensearch2.internal.util.ResourceUtil;
 import com.liferay.portal.search.spi.index.configuration.contributor.CompanyIndexConfigurationContributor;
@@ -75,6 +76,12 @@ public class IndexFactoryTest extends BaseOpenSearchTestCase {
 
 	@Before
 	public void setUp() throws Exception {
+		for (long companyId :
+				IndexFactoryCompanyIdRegistryUtil.getCompanyIds()) {
+
+			IndexFactoryCompanyIdRegistryUtil.unregisterCompanyId(companyId);
+		}
+
 		_indexFactoryFixture = new IndexFactoryFixture(
 			testName.getMethodName(), openSearchConnectionManager);
 

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/search/engine/OpenSearchSearchEngineBackupTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/search/engine/OpenSearchSearchEngineBackupTest.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.opensearch2.internal.BaseOpenSearchTestCase;
 import com.liferay.portal.search.opensearch2.internal.OpenSearchSearchEngine;
 import com.liferay.portal.search.opensearch2.internal.OpenSearchTestRule;
+import com.liferay.portal.search.opensearch2.internal.index.util.IndexFactoryCompanyIdRegistryUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.io.IOException;
@@ -67,6 +68,12 @@ public class OpenSearchSearchEngineBackupTest extends BaseOpenSearchTestCase {
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		_openSearchSearchEngineFixture.tearDown();
+
+		for (long companyId :
+				IndexFactoryCompanyIdRegistryUtil.getCompanyIds()) {
+
+			IndexFactoryCompanyIdRegistryUtil.unregisterCompanyId(companyId);
+		}
 	}
 
 	@Test

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/search/engine/OpenSearchSearchEngineReconnectTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/search/engine/OpenSearchSearchEngineReconnectTest.java
@@ -11,6 +11,7 @@ import com.liferay.portal.search.opensearch2.internal.OpenSearchTestRule;
 import com.liferay.portal.search.opensearch2.internal.connection.OpenSearchConnection;
 import com.liferay.portal.search.opensearch2.internal.connection.OpenSearchConnectionManager;
 import com.liferay.portal.search.opensearch2.internal.connection.TestOpenSearchConnectionManager;
+import com.liferay.portal.search.opensearch2.internal.index.util.IndexFactoryCompanyIdRegistryUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import org.junit.AfterClass;
@@ -46,6 +47,12 @@ public class OpenSearchSearchEngineReconnectTest {
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		_openSearchSearchEngineFixture.tearDown();
+
+		for (long companyId :
+				IndexFactoryCompanyIdRegistryUtil.getCompanyIds()) {
+
+			IndexFactoryCompanyIdRegistryUtil.unregisterCompanyId(companyId);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98952

Continuation of brianchandotcom/liferay-portal#179003.

## What Is Being Fixed

`IndexFactoryTest` in both `portal-search-elasticsearch8-impl` and `portal-search-opensearch2-impl` fails on the `ci:test:search` routine but passes locally. Each module's unit tests share one process-wide search node and static registry across classes in CI's shared-JVM batch, whereas Gradle forks a JVM per class locally. `*SearchEngineReconnectTest` and `*SearchEngineBackupTest` call `SearchEngine.initialize`, which registers a company ID in the static `IndexFactoryCompanyIdRegistryUtil` and never removes it. Since `LPD-88080` made `IndexFactory`'s constructor iterate that registry directly — instead of through `CompanyLocalService.forEachCompanyId`, a no-op against the test's mock — the leaked ID makes the constructor pre-create a default index, so `IndexFactoryTest`'s own settings, mappings, and listener configuration is skipped and its assertions fail.

## How It Is Being Fixed

Test-only changes in both modules. The search engine tests now unregister the company IDs they registered in `tearDownClass`, so they no longer leak into the shared registry. `IndexFactoryTest` now clears the registry in `setUp`, so it cannot inherit stale company IDs from any earlier test sharing the JVM. Verified for elasticsearch8 in a shared JVM with a leaking class running first: `IndexFactoryTest` fails the exact 13 methods without the fix and passes all 24 with it. The opensearch2 change is the identical fix applied to the mirrored classes.

## Why Are There No Tests?

The change fixes existing tests (test isolation); no product code changed, so no new tests are warranted.

## PR Check

**pr-check: PASS** — tested on `dbd261366cbbac458f6eb1c82a21e44df096dafc`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS (elasticsearch8 run locally; opensearch2 unit tests require an OpenSearch node and run in CI) |

<!-- pr-check {"result": "success", "sha": "dbd261366cbbac458f6eb1c82a21e44df096dafc"} -->
