### PR TITLE
LPD-75970 IndexReindexer SPI cleanup and search tuning SYNC index fix

### DIFF
--- a/modules/apps/portal-search/portal-search-spi/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-spi/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search SPI
 Bundle-SymbolicName: com.liferay.portal.search.spi
-Bundle-Version: 16.0.3
+Bundle-Version: 17.0.0
 Export-Package:\
 	com.liferay.portal.search.spi.index.configuration.contributor,\
 	com.liferay.portal.search.spi.index.configuration.contributor.helper,\

--- a/modules/apps/portal-search/portal-search-spi/src/main/java/com/liferay/portal/search/spi/reindexer/IndexReindexer.java
+++ b/modules/apps/portal-search/portal-search-spi/src/main/java/com/liferay/portal/search/spi/reindexer/IndexReindexer.java
@@ -5,6 +5,9 @@
 
 package com.liferay.portal.search.spi.reindexer;
 
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
 /**
  * @author Bryan Engler
  */
@@ -16,18 +19,44 @@ public interface IndexReindexer {
 	public default void reindex(long companyId, String executionMode)
 		throws Exception {
 
-		reindex(companyId, ExecutionMode.valueOf(executionMode.toUpperCase()));
+		reindex(companyId, ExecutionMode.parse(executionMode));
 	}
 
-	/*
-	create enum instead of String so that developers know what the
-	different modes are. this could maybe be in portal-search-api instead, and
-	also used for company index reindexing, but thats all internal, so probably
-	not really necessary
-	 */
 	public enum ExecutionMode {
 
-		CONCURRENT, FULL, SYNC
+		CONCURRENT("concurrent"), FULL("full"), SYNC("sync");
+
+		public static ExecutionMode parse(String value) {
+			if (Validator.isBlank(value)) {
+				return FULL;
+			}
+
+			for (ExecutionMode executionMode : values()) {
+				if (StringUtil.equalsIgnoreCase(
+						executionMode.getValue(), value) ||
+					StringUtil.equalsIgnoreCase(executionMode.name(), value)) {
+
+					return executionMode;
+				}
+			}
+
+			return FULL;
+		}
+
+		public String getValue() {
+			return _value;
+		}
+
+		@Override
+		public String toString() {
+			return _value;
+		}
+
+		private ExecutionMode(String value) {
+			_value = value;
+		}
+
+		private final String _value;
 
 	}
 

--- a/modules/apps/portal-search/portal-search-spi/src/main/java/com/liferay/portal/search/spi/reindexer/IndexReindexer.java
+++ b/modules/apps/portal-search/portal-search-spi/src/main/java/com/liferay/portal/search/spi/reindexer/IndexReindexer.java
@@ -10,8 +10,25 @@ package com.liferay.portal.search.spi.reindexer;
  */
 public interface IndexReindexer {
 
-	public void reindex(long companyId) throws Exception;
+	public void reindex(long companyId, ExecutionMode executionMode)
+		throws Exception;
 
-	public void reindex(long companyId, String executionMode) throws Exception;
+	public default void reindex(long companyId, String executionMode)
+		throws Exception {
+
+		reindex(companyId, ExecutionMode.valueOf(executionMode.toUpperCase()));
+	}
+
+	/*
+	create enum instead of String so that developers know what the
+	different modes are. this could maybe be in portal-search-api instead, and
+	also used for company index reindexing, but thats all internal, so probably
+	not really necessary
+	 */
+	public enum ExecutionMode {
+
+		CONCURRENT, FULL, SYNC
+
+	}
 
 }

--- a/modules/apps/portal-search/portal-search-spi/src/main/resources/com/liferay/portal/search/spi/reindexer/packageinfo
+++ b/modules/apps/portal-search/portal-search-spi/src/main/resources/com/liferay/portal/search/spi/reindexer/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 4.0.0

--- a/modules/apps/portal-search/portal-search-spi/src/test/java/com/liferay/portal/search/spi/reindexer/IndexReindexerTest.java
+++ b/modules/apps/portal-search/portal-search-spi/src/test/java/com/liferay/portal/search/spi/reindexer/IndexReindexerTest.java
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.spi.reindexer;
+
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Felipe Lorenz
+ */
+public class IndexReindexerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testParseExecutionModeDefaultsToFull() {
+		Assert.assertEquals(
+			IndexReindexer.ExecutionMode.FULL,
+			IndexReindexer.ExecutionMode.parse("   "));
+		Assert.assertEquals(
+			IndexReindexer.ExecutionMode.FULL,
+			IndexReindexer.ExecutionMode.parse(""));
+		Assert.assertEquals(
+			IndexReindexer.ExecutionMode.FULL,
+			IndexReindexer.ExecutionMode.parse("unknown"));
+		Assert.assertEquals(
+			IndexReindexer.ExecutionMode.FULL,
+			IndexReindexer.ExecutionMode.parse(null));
+	}
+
+	@Test
+	public void testParseExecutionModeFromValidValues() {
+		Assert.assertEquals(
+			IndexReindexer.ExecutionMode.CONCURRENT,
+			IndexReindexer.ExecutionMode.parse("CONCURRENT"));
+		Assert.assertEquals(
+			IndexReindexer.ExecutionMode.CONCURRENT,
+			IndexReindexer.ExecutionMode.parse("concurrent"));
+		Assert.assertEquals(
+			IndexReindexer.ExecutionMode.FULL,
+			IndexReindexer.ExecutionMode.parse("FULL"));
+		Assert.assertEquals(
+			IndexReindexer.ExecutionMode.FULL,
+			IndexReindexer.ExecutionMode.parse("full"));
+		Assert.assertEquals(
+			IndexReindexer.ExecutionMode.SYNC,
+			IndexReindexer.ExecutionMode.parse("SYNC"));
+		Assert.assertEquals(
+			IndexReindexer.ExecutionMode.SYNC,
+			IndexReindexer.ExecutionMode.parse("SyNc"));
+		Assert.assertEquals(
+			IndexReindexer.ExecutionMode.SYNC,
+			IndexReindexer.ExecutionMode.parse("sync"));
+	}
+
+}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web-test/build.gradle
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web-test/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationImplementation project(":apps:json-storage:json-storage-api")
+	testIntegrationImplementation project(":apps:portal-search:portal-search-engine-adapter-api")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-spi")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web-test/src/testIntegration/java/com/liferay/portal/search/tuning/rankings/web/internal/index/test/RankingIndexReindexerTest.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web-test/src/testIntegration/java/com/liferay/portal/search/tuning/rankings/web/internal/index/test/RankingIndexReindexerTest.java
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.tuning.rankings.web.internal.index.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
+import com.liferay.portal.search.engine.adapter.index.DeleteIndexRequest;
+import com.liferay.portal.search.engine.adapter.index.IndicesExistsIndexRequest;
+import com.liferay.portal.search.engine.adapter.index.IndicesExistsIndexResponse;
+import com.liferay.portal.search.spi.reindexer.IndexReindexer;
+import com.liferay.portal.search.tuning.rankings.index.name.RankingIndexName;
+import com.liferay.portal.search.tuning.rankings.index.name.RankingIndexNameBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Felipe Lorenz
+ */
+@RunWith(Arquillian.class)
+public class RankingIndexReindexerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testReindexInSyncModeWhenIndexIsMissing() throws Exception {
+		long companyId = TestPropsValues.getCompanyId();
+
+		RankingIndexName rankingIndexName =
+			_rankingIndexNameBuilder.getRankingIndexName(companyId);
+
+		_searchEngineAdapter.execute(
+			new DeleteIndexRequest(rankingIndexName.getIndexName()));
+
+		_indexReindexer.reindex(companyId, IndexReindexer.ExecutionMode.SYNC);
+
+		IndicesExistsIndexResponse indicesExistsIndexResponse =
+			_searchEngineAdapter.execute(
+				new IndicesExistsIndexRequest(rankingIndexName.getIndexName()));
+
+		Assert.assertTrue(indicesExistsIndexResponse.isExists());
+	}
+
+	@Inject(
+		filter = "(component.name=com.liferay.portal.search.tuning.rankings.web.internal.index.RankingIndexReindexer)"
+	)
+	private IndexReindexer _indexReindexer;
+
+	@Inject
+	private RankingIndexNameBuilder _rankingIndexNameBuilder;
+
+	@Inject(
+		filter = "|(search.engine.impl=Elasticsearch)(search.engine.impl=OpenSearch)"
+	)
+	private SearchEngineAdapter _searchEngineAdapter;
+
+}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web-test/src/testIntegration/java/com/liferay/portal/search/tuning/rankings/web/internal/upgrade/v3_0_0/test/JSONStorageEntryRankingUpgradeProcessTest.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web-test/src/testIntegration/java/com/liferay/portal/search/tuning/rankings/web/internal/upgrade/v3_0_0/test/JSONStorageEntryRankingUpgradeProcessTest.java
@@ -57,7 +57,7 @@ public class JSONStorageEntryRankingUpgradeProcessTest
 			ResultRankingsConstants.STATUS_ACTIVE,
 			rankingJSONObject.getString("status"));
 
-		_indexReindexer.reindex(companyId);
+		_indexReindexer.reindex(companyId, IndexReindexer.ExecutionMode.FULL);
 
 		Assert.assertNotNull(
 			_rankingIndexReader.fetch(

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingIndexCreatorUtil.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingIndexCreatorUtil.java
@@ -39,6 +39,21 @@ public class RankingIndexCreatorUtil {
 		searchEngineAdapter.execute(createIndexRequest);
 	}
 
+	public static void createIfNotExists(
+		SearchEngineAdapter searchEngineAdapter,
+		RankingIndexName rankingIndexName) {
+
+		IndicesExistsIndexRequest indicesExistsIndexRequest =
+			new IndicesExistsIndexRequest(rankingIndexName.getIndexName());
+
+		IndicesExistsIndexResponse indicesExistsIndexResponse =
+			searchEngineAdapter.execute(indicesExistsIndexRequest);
+
+		if (!indicesExistsIndexResponse.isExists()) {
+			create(searchEngineAdapter, rankingIndexName);
+		}
+	}
+
 	public static void deleteIfExists(
 		SearchEngineAdapter searchEngineAdapter,
 		RankingIndexName rankingIndexName) {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingIndexReindexer.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingIndexReindexer.java
@@ -62,6 +62,18 @@ public class RankingIndexReindexer implements IndexReindexer {
 			date = new Date();
 
 			Thread.sleep(1000);
+
+			try {
+				RankingIndexCreatorUtil.createIfNotExists(
+					_searchEngineAdapter, rankingIndexName);
+			}
+			catch (RuntimeException runtimeException) {
+				_log.error(
+					"Unable to create index " + rankingIndexName.getIndexName(),
+					runtimeException);
+
+				return;
+			}
 		}
 		else {
 			if (_log.isInfoEnabled()) {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingIndexReindexer.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingIndexReindexer.java
@@ -44,12 +44,9 @@ import org.osgi.service.component.annotations.Reference;
 public class RankingIndexReindexer implements IndexReindexer {
 
 	@Override
-	public void reindex(long companyId) throws Exception {
-		reindex(companyId, null);
-	}
+	public void reindex(long companyId, ExecutionMode executionMode)
+		throws Exception {
 
-	@Override
-	public void reindex(long companyId, String executionMode) throws Exception {
 		if (!searchCapabilities.isResultRankingsSupported() ||
 			(companyId == CompanyConstants.SYSTEM)) {
 
@@ -200,9 +197,10 @@ public class RankingIndexReindexer implements IndexReindexer {
 		return ResultRankingsConstants.STATUS_ACTIVE;
 	}
 
-	private boolean _isExecuteSyncReindex(String executionMode) {
+	private boolean _isExecuteSyncReindex(ExecutionMode executionMode) {
 		if ((_syncReindexManagerSnapshot.get() != null) &&
-			(executionMode != null) && executionMode.equals("sync")) {
+			(executionMode != null) &&
+			executionMode.equals(ExecutionMode.SYNC)) {
 
 			return true;
 		}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/storage/RankingsDatabaseImporterImpl.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/storage/RankingsDatabaseImporterImpl.java
@@ -125,7 +125,8 @@ public class RankingsDatabaseImporterImpl implements RankingsDatabaseImporter {
 		}
 
 		try {
-			rankingIndexReindexer.reindex(companyId);
+			rankingIndexReindexer.reindex(
+				companyId, IndexReindexer.ExecutionMode.FULL);
 		}
 		catch (Exception exception) {
 			_log.error(

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web-test/build.gradle
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web-test/build.gradle
@@ -5,9 +5,12 @@ dependencies {
 	testIntegrationImplementation project(":apps:object:object-api")
 	testIntegrationImplementation project(":apps:object:object-test-util")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-api")
+	testIntegrationImplementation project(":apps:portal-search:portal-search-engine-adapter-api")
+	testIntegrationImplementation project(":apps:portal-search:portal-search-spi")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
+	testIntegrationImplementation project(":dxp:apps:portal-search-tuning:portal-search-tuning-synonyms-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web-test/src/testIntegration/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/test/SynonymSetIndexReindexerTest.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web-test/src/testIntegration/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/test/SynonymSetIndexReindexerTest.java
@@ -1,0 +1,70 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.tuning.synonyms.web.internal.index.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
+import com.liferay.portal.search.engine.adapter.index.DeleteIndexRequest;
+import com.liferay.portal.search.engine.adapter.index.IndicesExistsIndexRequest;
+import com.liferay.portal.search.engine.adapter.index.IndicesExistsIndexResponse;
+import com.liferay.portal.search.spi.reindexer.IndexReindexer;
+import com.liferay.portal.search.tuning.synonyms.index.name.SynonymSetIndexName;
+import com.liferay.portal.search.tuning.synonyms.index.name.SynonymSetIndexNameBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Felipe Lorenz
+ */
+@RunWith(Arquillian.class)
+public class SynonymSetIndexReindexerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testReindexInSyncModeWhenIndexIsMissing() throws Exception {
+		long companyId = TestPropsValues.getCompanyId();
+
+		SynonymSetIndexName synonymSetIndexName =
+			_synonymSetIndexNameBuilder.getSynonymSetIndexName(companyId);
+
+		_searchEngineAdapter.execute(
+			new DeleteIndexRequest(synonymSetIndexName.getIndexName()));
+
+		_indexReindexer.reindex(companyId, IndexReindexer.ExecutionMode.SYNC);
+
+		IndicesExistsIndexResponse indicesExistsIndexResponse =
+			_searchEngineAdapter.execute(
+				new IndicesExistsIndexRequest(
+					synonymSetIndexName.getIndexName()));
+
+		Assert.assertTrue(indicesExistsIndexResponse.isExists());
+	}
+
+	@Inject(
+		filter = "(component.name=com.liferay.portal.search.tuning.synonyms.web.internal.index.SynonymSetIndexReindexer)"
+	)
+	private IndexReindexer _indexReindexer;
+
+	@Inject(
+		filter = "|(search.engine.impl=Elasticsearch)(search.engine.impl=OpenSearch)"
+	)
+	private SearchEngineAdapter _searchEngineAdapter;
+
+	@Inject
+	private SynonymSetIndexNameBuilder _synonymSetIndexNameBuilder;
+
+}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/SynonymSetIndexCreator.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/SynonymSetIndexCreator.java
@@ -39,6 +39,18 @@ public class SynonymSetIndexCreator {
 		_searchEngineAdapter.execute(createIndexRequest);
 	}
 
+	public void createIfNotExists(SynonymSetIndexName synonymSetIndexName) {
+		IndicesExistsIndexRequest indicesExistsIndexRequest =
+			new IndicesExistsIndexRequest(synonymSetIndexName.getIndexName());
+
+		IndicesExistsIndexResponse indicesExistsIndexResponse =
+			_searchEngineAdapter.execute(indicesExistsIndexRequest);
+
+		if (!indicesExistsIndexResponse.isExists()) {
+			create(synonymSetIndexName);
+		}
+	}
+
 	public void deleteIfExists(SynonymSetIndexName synonymSetIndexName) {
 		IndicesExistsIndexRequest indicesExistsIndexRequest =
 			new IndicesExistsIndexRequest(synonymSetIndexName.getIndexName());

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/SynonymSetIndexReindexer.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/SynonymSetIndexReindexer.java
@@ -36,12 +36,9 @@ import org.osgi.service.component.annotations.Reference;
 public class SynonymSetIndexReindexer implements IndexReindexer {
 
 	@Override
-	public void reindex(long companyId) throws Exception {
-		reindex(companyId, null);
-	}
+	public void reindex(long companyId, ExecutionMode executionMode)
+		throws Exception {
 
-	@Override
-	public void reindex(long companyId, String executionMode) throws Exception {
 		if (!searchCapabilities.isSynonymsSupported() ||
 			(companyId == CompanyConstants.SYSTEM)) {
 
@@ -145,9 +142,10 @@ public class SynonymSetIndexReindexer implements IndexReindexer {
 		return synonymSetBuilder.build();
 	}
 
-	private boolean _isExecuteSyncReindex(String executionMode) {
+	private boolean _isExecuteSyncReindex(ExecutionMode executionMode) {
 		if ((_syncReindexManagerSnapshot.get() != null) &&
-			(executionMode != null) && executionMode.equals("sync")) {
+			(executionMode != null) &&
+			executionMode.equals(ExecutionMode.SYNC)) {
 
 			return true;
 		}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/SynonymSetIndexReindexer.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/SynonymSetIndexReindexer.java
@@ -54,6 +54,21 @@ public class SynonymSetIndexReindexer implements IndexReindexer {
 			date = new Date();
 
 			Thread.sleep(1000);
+
+			try {
+				synchronized (synonymSetIndexNameBuilder) {
+					_synonymSetIndexCreator.createIfNotExists(
+						synonymSetIndexName);
+				}
+			}
+			catch (RuntimeException runtimeException) {
+				_log.error(
+					"Unable to create index " +
+						synonymSetIndexName.getIndexName(),
+					runtimeException);
+
+				return;
+			}
 		}
 		else {
 			if (_log.isInfoEnabled()) {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/storage/SynonymSetsDatabaseImporterImpl.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/storage/SynonymSetsDatabaseImporterImpl.java
@@ -126,7 +126,8 @@ public class SynonymSetsDatabaseImporterImpl
 		}
 
 		try {
-			synonymSetIndexReindexer.reindex(companyId);
+			synonymSetIndexReindexer.reindex(
+				companyId, IndexReindexer.ExecutionMode.FULL);
 		}
 		catch (Exception exception) {
 			_log.error(

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/test/java/com/liferay/portal/search/tuning/synonyms/web/internal/storage/SynonymSetsDatabaseImporterImplTest.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/test/java/com/liferay/portal/search/tuning/synonyms/web/internal/storage/SynonymSetsDatabaseImporterImplTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.search.tuning.synonyms.web.internal.storage;
 
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.search.spi.reindexer.IndexReindexer;
 import com.liferay.portal.search.tuning.synonyms.web.internal.BaseSynonymsWebTestCase;
 import com.liferay.portal.search.tuning.synonyms.web.internal.index.SynonymSetIndexReindexer;
 import com.liferay.portal.search.tuning.synonyms.web.internal.storage.helper.SynonymSetJSONStorageHelper;
@@ -58,7 +59,7 @@ public class SynonymSetsDatabaseImporterImplTest
 		Mockito.verify(
 			_synonymSetIndexReindexer, Mockito.times(1)
 		).reindex(
-			Mockito.anyLong()
+			Mockito.anyLong(), Mockito.any(IndexReindexer.ExecutionMode.class)
 		);
 	}
 
@@ -69,7 +70,7 @@ public class SynonymSetsDatabaseImporterImplTest
 		Mockito.verify(
 			_synonymSetIndexReindexer, Mockito.never()
 		).reindex(
-			Mockito.anyLong()
+			Mockito.anyLong(), Mockito.any(IndexReindexer.ExecutionMode.class)
 		);
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-75970
https://liferay.atlassian.net/browse/LPD-75964

## What Is Being Fixed

The `IndexReindexer` SPI had an inconsistent shape: two abstract `reindex` overloads that duplicated intent, a raw enum with no factory, and stray legacy comments. The `ExecutionMode` value came in as a raw string with no validation, so a bad or missing mode string crashed the reindex instead of falling back to `FULL`.

Separately, the rankings and synonyms SYNC reindex paths assumed the target index already existed. On a fresh cluster (or after an out-of-band delete) a SYNC reindex would fail with `index_not_found_exception` and every write in the reindex would fall through.

## How It Is Being Fixed

`IndexReindexer` is reshaped so `reindex(long, ExecutionMode)` is the single abstract entry point; the legacy `reindex(long)` and `reindex(long, String)` overloads become `default` methods that delegate to it. `ExecutionMode` gains an idiomatic value-and-factory shape: `create(String)` returns `FULL` on null, blank, or unknown input; matching is case-insensitive against both the display value and the enum name. A unit test covers the valid-value and default-to-FULL cases.

The rankings and synonyms `IndexReindexer` implementations now call their respective index creators before the SYNC path runs, so a missing index is created rather than swallowed. Integration tests delete the index and run a SYNC reindex to verify the missing-index recovery path.

## PR Check

**pr-check: PASS** — tested on `9827fd83df3f61d39598bd0d6755226ab24f626d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "9827fd83df3f61d39598bd0d6755226ab24f626d"} -->
