### PR TITLE
LPD-98110 Bump OpenSearch 2 connector marketplace version to 2.2.0

### DIFF
--- a/modules/.releng/dxp/apps/portal-search-opensearch2/app.properties
+++ b/modules/.releng/dxp/apps/portal-search-opensearch2/app.properties
@@ -1,4 +1,4 @@
 app.marketplace.id=233702113
 app.marketplace.title=Liferay Connector to OpenSearch 2
-app.marketplace.version=2.1.0
+app.marketplace.version=2.2.0
 app.portal.build=7413


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98110

## What Is Being Fixed

The release-engineering metadata for the "Liferay Connector to OpenSearch 2" app still records marketplace version 2.1.0 on master, which lags the intended connector release.

## How It Is Being Fixed

Update `app.marketplace.version` from 2.1.0 to 2.2.0 in `modules/.releng/dxp/apps/portal-search-opensearch2/app.properties`, so the release tooling publishes the OpenSearch 2 connector under version 2.2.0.

## PR Check

**pr-check: PASS** — tested on `1da738e719d8aec85b73bcc52ba05f5cf98d8d3a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "1da738e719d8aec85b73bcc52ba05f5cf98d8d3a"} -->
