### PR TITLE
PR2 LPD-88609 Add numeric range object field filters

### DIFF
--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -23,7 +23,9 @@ import com.liferay.portal.kernel.search.MatchQuery;
 import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.TermQuery;
+import com.liferay.portal.kernel.search.TermRangeQuery;
 import com.liferay.portal.kernel.search.WildcardQuery;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -169,7 +171,7 @@ public class AssetListFiltersUtil {
 
 		String subfield = _getSubfield(locale, objectField);
 
-		Query query = _toValueQuery(operatorName, subfield, value);
+		Query query = _toValueQuery(jsonObject, operatorName, subfield, value);
 
 		if (query == null) {
 			return null;
@@ -193,8 +195,53 @@ public class AssetListFiltersUtil {
 		return new NestedQuery("nestedFieldArray", booleanQuery);
 	}
 
+	private static Query _toRangeQuery(
+		JSONObject filterJSONObject, String operatorName, String subfield) {
+
+		if (operatorName.equals("between")) {
+			JSONArray valueJSONArray = filterJSONObject.getJSONArray("value");
+
+			if ((valueJSONArray == null) || (valueJSONArray.length() < 2)) {
+				return null;
+			}
+
+			String lowerTerm = GetterUtil.getString(
+				valueJSONArray.getString(0), null);
+			String upperTerm = GetterUtil.getString(
+				valueJSONArray.getString(1), null);
+
+			return new TermRangeQuery(
+				subfield, lowerTerm, upperTerm, true, true);
+		}
+
+		String value = filterJSONObject.getString("value");
+
+		if (Validator.isNull(value)) {
+			return null;
+		}
+
+		if (operatorName.equals("ge")) {
+			return new TermRangeQuery(subfield, value, null, true, false);
+		}
+
+		if (operatorName.equals("gt")) {
+			return new TermRangeQuery(subfield, value, null, false, false);
+		}
+
+		if (operatorName.equals("le")) {
+			return new TermRangeQuery(subfield, null, value, false, true);
+		}
+
+		if (operatorName.equals("lt")) {
+			return new TermRangeQuery(subfield, null, value, false, false);
+		}
+
+		return null;
+	}
+
 	private static Query _toValueQuery(
-		String operatorName, String subfield, String value) {
+		JSONObject filterJSONObject, String operatorName, String subfield,
+		String value) {
 
 		if ((operatorName.equals("contains") ||
 			 operatorName.equals("not-contains")) &&
@@ -204,6 +251,13 @@ public class AssetListFiltersUtil {
 				subfield,
 				StringPool.STAR + StringUtil.toLowerCase(value) +
 					StringPool.STAR);
+		}
+
+		if (operatorName.equals("between") || operatorName.equals("ge") ||
+			operatorName.equals("gt") || operatorName.equals("le") ||
+			operatorName.equals("lt")) {
+
+			return _toRangeQuery(filterJSONObject, operatorName, subfield);
 		}
 
 		if (subfield.endsWith(".value_keyword")) {

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -510,12 +510,12 @@ public class AssetListFiltersUtilTest {
 		TermRangeQuery termRangeQuery = (TermRangeQuery)query;
 
 		Assert.assertEquals(expectedField, termRangeQuery.getField());
+		Assert.assertEquals(expectedLowerTerm, termRangeQuery.getLowerTerm());
+		Assert.assertEquals(expectedUpperTerm, termRangeQuery.getUpperTerm());
 		Assert.assertEquals(
 			expectedIncludesLower, termRangeQuery.includesLower());
 		Assert.assertEquals(
 			expectedIncludesUpper, termRangeQuery.includesUpper());
-		Assert.assertEquals(expectedLowerTerm, termRangeQuery.getLowerTerm());
-		Assert.assertEquals(expectedUpperTerm, termRangeQuery.getUpperTerm());
 	}
 
 	private void _assertWildcardQuery(

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -91,7 +91,7 @@ public class AssetListFiltersUtilTest {
 
 		_assertTermQuery(
 			"nestedFieldArray.value_boolean", "true",
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject("eq", booleanFieldName, "true"),
 				booleanFieldName));
@@ -106,7 +106,7 @@ public class AssetListFiltersUtilTest {
 
 		_assertTermQuery(
 			"nestedFieldArray.value_double", doubleFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject("eq", doubleFieldName, doubleFieldValue),
 				doubleFieldName));
@@ -121,14 +121,14 @@ public class AssetListFiltersUtilTest {
 
 		_assertTermQuery(
 			"nestedFieldArray.value_integer", integerFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"eq", integerFieldName, integerFieldValue),
 				integerFieldName));
 		_assertTermQuery(
 			"nestedFieldArray.value_integer", integerFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST_NOT,
 				_buildFilterJSONObject(
 					"not-eq", integerFieldName, integerFieldValue),
@@ -148,7 +148,7 @@ public class AssetListFiltersUtilTest {
 
 		_assertTermQuery(
 			"nestedFieldArray.value_keyword", "alpha",
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject("eq", keywordTextFieldName, "Alpha"),
 				keywordTextFieldName));
@@ -169,7 +169,7 @@ public class AssetListFiltersUtilTest {
 
 		_assertTermQuery(
 			"nestedFieldArray.value_en_US", localizedTextFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"eq", localizedTextFieldName, localizedTextFieldValue),
@@ -185,7 +185,7 @@ public class AssetListFiltersUtilTest {
 
 		_assertTermQuery(
 			"nestedFieldArray.value_long", longFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"eq", longIntegerFieldName, longFieldValue),
@@ -201,13 +201,13 @@ public class AssetListFiltersUtilTest {
 
 		_assertTermQuery(
 			"nestedFieldArray.value_text", textFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject("eq", textFieldName, textFieldValue),
 				textFieldName));
 		_assertTermQuery(
 			"nestedFieldArray.value_text", textFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST_NOT,
 				_buildFilterJSONObject("not-eq", textFieldName, textFieldValue),
 				textFieldName));
@@ -245,14 +245,14 @@ public class AssetListFiltersUtilTest {
 
 		_assertWildcardQuery(
 			"nestedFieldArray.value_keyword", "*alpha*",
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"contains", keywordTextFieldName, "Alpha"),
 				keywordTextFieldName));
 		_assertWildcardQuery(
 			"nestedFieldArray.value_keyword", "*alpha*",
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST_NOT,
 				_buildFilterJSONObject(
 					"not-contains", keywordTextFieldName, "Alpha"),
@@ -273,7 +273,7 @@ public class AssetListFiltersUtilTest {
 		_assertTermRangeQuery(
 			"nestedFieldArray.value_double", true, true, doubleLowerFieldValue,
 			doubleUpperFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"between", doubleFieldName,
@@ -286,7 +286,7 @@ public class AssetListFiltersUtilTest {
 		_assertTermRangeQuery(
 			"nestedFieldArray.value_double", false, false, doubleFieldValue,
 			null,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject("gt", doubleFieldName, doubleFieldValue),
 				doubleFieldName));
@@ -303,7 +303,7 @@ public class AssetListFiltersUtilTest {
 		_assertTermRangeQuery(
 			"nestedFieldArray.value_integer", true, true,
 			integerLowerFieldValue, integerUpperFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"between", integerFieldName,
@@ -316,7 +316,7 @@ public class AssetListFiltersUtilTest {
 		_assertTermRangeQuery(
 			"nestedFieldArray.value_integer", true, false, integerFieldValue,
 			null,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"ge", integerFieldName, integerFieldValue),
@@ -324,7 +324,7 @@ public class AssetListFiltersUtilTest {
 		_assertTermRangeQuery(
 			"nestedFieldArray.value_integer", false, false, integerFieldValue,
 			null,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"gt", integerFieldName, integerFieldValue),
@@ -332,7 +332,7 @@ public class AssetListFiltersUtilTest {
 		_assertTermRangeQuery(
 			"nestedFieldArray.value_integer", false, true, null,
 			integerFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"le", integerFieldName, integerFieldValue),
@@ -340,7 +340,7 @@ public class AssetListFiltersUtilTest {
 		_assertTermRangeQuery(
 			"nestedFieldArray.value_integer", false, false, null,
 			integerFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"lt", integerFieldName, integerFieldValue),
@@ -358,7 +358,7 @@ public class AssetListFiltersUtilTest {
 		_assertTermRangeQuery(
 			"nestedFieldArray.value_long", true, true, longLowerFieldValue,
 			longUpperFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"between", longIntegerFieldName,
@@ -376,7 +376,7 @@ public class AssetListFiltersUtilTest {
 
 		String textFieldValue = RandomTestUtil.randomString();
 
-		Query containsQuery = _assertNestedRowAndGetQuery(
+		Query containsQuery = _assertNestedQuery(
 			BooleanClauseOccur.MUST,
 			_buildFilterJSONObject("contains", textFieldName, textFieldValue),
 			textFieldName);
@@ -384,7 +384,7 @@ public class AssetListFiltersUtilTest {
 		Assert.assertTrue(
 			containsQuery.toString(), containsQuery instanceof MatchQuery);
 
-		Query containsWithQuantifierQuery = _assertNestedRowAndGetQuery(
+		Query containsWithQuantifierQuery = _assertNestedQuery(
 			BooleanClauseOccur.MUST,
 			_buildFilterJSONObject(
 				"contains", textFieldName, textFieldValue
@@ -397,7 +397,7 @@ public class AssetListFiltersUtilTest {
 			containsWithQuantifierQuery.toString(),
 			containsWithQuantifierQuery instanceof MatchQuery);
 
-		Query notContainsQuery = _assertNestedRowAndGetQuery(
+		Query notContainsQuery = _assertNestedQuery(
 			BooleanClauseOccur.MUST_NOT,
 			_buildFilterJSONObject(
 				"not-contains", textFieldName, textFieldValue),
@@ -408,7 +408,7 @@ public class AssetListFiltersUtilTest {
 			notContainsQuery instanceof MatchQuery);
 	}
 
-	private Query _assertNestedRowAndGetQuery(
+	private Query _assertNestedQuery(
 		BooleanClauseOccur expectedBooleanClauseOccur,
 		JSONObject filterJSONObject, String propertyName) {
 
@@ -419,34 +419,36 @@ public class AssetListFiltersUtilTest {
 		Assert.assertEquals(
 			Arrays.toString(booleanClauses), 1, booleanClauses.length);
 
-		BooleanClause<?> outerBooleanClause = booleanClauses[0];
+		BooleanClause<?> filtersBooleanClause = booleanClauses[0];
 
 		Assert.assertEquals(
 			BooleanClauseOccur.MUST,
-			outerBooleanClause.getBooleanClauseOccur());
+			filtersBooleanClause.getBooleanClauseOccur());
 
-		BooleanQuery outerBooleanQuery =
-			(BooleanQuery)outerBooleanClause.getClause();
+		BooleanQuery filtersBooleanQuery =
+			(BooleanQuery)filtersBooleanClause.getClause();
 
-		List<BooleanClause<Query>> rowBooleanClauses =
-			outerBooleanQuery.clauses();
+		List<BooleanClause<Query>> filterBooleanClauses =
+			filtersBooleanQuery.clauses();
 
-		BooleanClause<Query> rowBooleanClause = rowBooleanClauses.get(0);
+		BooleanClause<Query> filterBooleanClause = filterBooleanClauses.get(0);
 
-		NestedQuery nestedQuery = (NestedQuery)rowBooleanClause.getClause();
+		NestedQuery nestedQuery = (NestedQuery)filterBooleanClause.getClause();
 
 		Assert.assertEquals("nestedFieldArray", nestedQuery.getPath());
 
-		BooleanQuery innerBooleanQuery = (BooleanQuery)nestedQuery.getQuery();
+		BooleanQuery nestedFieldBooleanQuery =
+			(BooleanQuery)nestedQuery.getQuery();
 
-		List<BooleanClause<Query>> innerBooleanClauses =
-			innerBooleanQuery.clauses();
+		List<BooleanClause<Query>> nestedFieldBooleanClauses =
+			nestedFieldBooleanQuery.clauses();
 
 		Assert.assertEquals(
-			innerBooleanClauses.toString(), 3, innerBooleanClauses.size());
+			nestedFieldBooleanClauses.toString(), 3,
+			nestedFieldBooleanClauses.size());
 
-		BooleanClause<Query> fieldNameBooleanClause = innerBooleanClauses.get(
-			0);
+		BooleanClause<Query> fieldNameBooleanClause =
+			nestedFieldBooleanClauses.get(0);
 
 		TermQuery fieldNameTermQuery =
 			(TermQuery)fieldNameBooleanClause.getClause();
@@ -462,7 +464,7 @@ public class AssetListFiltersUtilTest {
 			fieldNameBooleanClause.getBooleanClauseOccur());
 
 		BooleanClause<Query> valueFieldNameBooleanClause =
-			innerBooleanClauses.get(1);
+			nestedFieldBooleanClauses.get(1);
 
 		TermQuery valueFieldNameTermQuery =
 			(TermQuery)valueFieldNameBooleanClause.getClause();
@@ -478,7 +480,8 @@ public class AssetListFiltersUtilTest {
 			BooleanClauseOccur.MUST,
 			valueFieldNameBooleanClause.getBooleanClauseOccur());
 
-		BooleanClause<Query> valueBooleanClause = innerBooleanClauses.get(2);
+		BooleanClause<Query> valueBooleanClause = nestedFieldBooleanClauses.get(
+			2);
 
 		Assert.assertEquals(
 			expectedBooleanClauseOccur,

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -591,6 +591,15 @@ public class AssetListFiltersUtilTest {
 			_CLASS_TYPE_ID
 		);
 
+		_objectDefinitionLocalServiceUtilMockedStatic.when(
+			() ->
+				ObjectDefinitionLocalServiceUtil.
+					fetchObjectDefinitionByClassName(
+						_COMPANY_ID, "com.liferay.test.Class" + _CLASS_NAME_ID)
+		).thenReturn(
+			objectDefinition
+		);
+
 		ObjectField objectField = Mockito.mock(ObjectField.class);
 
 		Mockito.when(
@@ -609,15 +618,6 @@ public class AssetListFiltersUtilTest {
 			objectField.getName()
 		).thenReturn(
 			fieldName
-		);
-
-		_objectDefinitionLocalServiceUtilMockedStatic.when(
-			() ->
-				ObjectDefinitionLocalServiceUtil.
-					fetchObjectDefinitionByClassName(
-						_COMPANY_ID, "com.liferay.test.Class" + _CLASS_NAME_ID)
-		).thenReturn(
-			objectDefinition
 		);
 
 		_objectFieldLocalServiceUtilMockedStatic.when(

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -10,6 +10,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldLocalServiceUtil;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -21,6 +22,7 @@ import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.QueryTerm;
 import com.liferay.portal.kernel.search.TermQuery;
+import com.liferay.portal.kernel.search.TermRangeQuery;
 import com.liferay.portal.kernel.search.WildcardQuery;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -258,6 +260,113 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
+	public void testFilterQueriesWithNumericRangeOperators() {
+		String doubleFieldName = RandomTestUtil.randomString();
+
+		_setUpObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
+			ObjectFieldConstants.DB_TYPE_DOUBLE, doubleFieldName);
+
+		String doubleLowerFieldValue = "1.5";
+		String doubleUpperFieldValue = "2.5";
+
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_double", true, true, doubleLowerFieldValue,
+			doubleUpperFieldValue,
+			_assertNestedRowAndGetQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"between", doubleFieldName,
+					JSONUtil.putAll(
+						doubleLowerFieldValue, doubleUpperFieldValue)),
+				doubleFieldName));
+
+		String doubleFieldValue = String.valueOf(RandomTestUtil.randomDouble());
+
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_double", false, false, doubleFieldValue,
+			null,
+			_assertNestedRowAndGetQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject("gt", doubleFieldName, doubleFieldValue),
+				doubleFieldName));
+
+		String integerFieldName = RandomTestUtil.randomString();
+
+		_setUpObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
+			ObjectFieldConstants.DB_TYPE_INTEGER, integerFieldName);
+
+		String integerLowerFieldValue = "1";
+		String integerUpperFieldValue = "2";
+
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_integer", true, true,
+			integerLowerFieldValue, integerUpperFieldValue,
+			_assertNestedRowAndGetQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"between", integerFieldName,
+					JSONUtil.putAll(
+						integerLowerFieldValue, integerUpperFieldValue)),
+				integerFieldName));
+
+		String integerFieldValue = String.valueOf(RandomTestUtil.randomInt());
+
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_integer", true, false, integerFieldValue,
+			null,
+			_assertNestedRowAndGetQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"ge", integerFieldName, integerFieldValue),
+				integerFieldName));
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_integer", false, false, integerFieldValue,
+			null,
+			_assertNestedRowAndGetQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"gt", integerFieldName, integerFieldValue),
+				integerFieldName));
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_integer", false, true, null,
+			integerFieldValue,
+			_assertNestedRowAndGetQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"le", integerFieldName, integerFieldValue),
+				integerFieldName));
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_integer", false, false, null,
+			integerFieldValue,
+			_assertNestedRowAndGetQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"lt", integerFieldName, integerFieldValue),
+				integerFieldName));
+
+		String longIntegerFieldName = RandomTestUtil.randomString();
+
+		_setUpObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
+			ObjectFieldConstants.DB_TYPE_LONG, longIntegerFieldName);
+
+		String longLowerFieldValue = "1";
+		String longUpperFieldValue = "2";
+
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_long", true, true, longLowerFieldValue,
+			longUpperFieldValue,
+			_assertNestedRowAndGetQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"between", longIntegerFieldName,
+					JSONUtil.putAll(longLowerFieldValue, longUpperFieldValue)),
+				longIntegerFieldName));
+	}
+
+	@Test
 	public void testFilterQueriesWithTextContainsOperators() {
 		String textFieldName = RandomTestUtil.randomString();
 
@@ -391,6 +500,24 @@ public class AssetListFiltersUtilTest {
 		Assert.assertEquals(expectedValue, queryTerm.getValue());
 	}
 
+	private void _assertTermRangeQuery(
+		String expectedField, boolean expectedIncludesLower,
+		boolean expectedIncludesUpper, String expectedLowerTerm,
+		String expectedUpperTerm, Query query) {
+
+		Assert.assertTrue(query.toString(), query instanceof TermRangeQuery);
+
+		TermRangeQuery termRangeQuery = (TermRangeQuery)query;
+
+		Assert.assertEquals(expectedField, termRangeQuery.getField());
+		Assert.assertEquals(
+			expectedIncludesLower, termRangeQuery.includesLower());
+		Assert.assertEquals(
+			expectedIncludesUpper, termRangeQuery.includesUpper());
+		Assert.assertEquals(expectedLowerTerm, termRangeQuery.getLowerTerm());
+		Assert.assertEquals(expectedUpperTerm, termRangeQuery.getUpperTerm());
+	}
+
 	private void _assertWildcardQuery(
 		String expectedField, String expectedValue, Query query) {
 
@@ -402,6 +529,22 @@ public class AssetListFiltersUtilTest {
 
 		Assert.assertEquals(expectedField, queryTerm.getField());
 		Assert.assertEquals(expectedValue, queryTerm.getValue());
+	}
+
+	private JSONObject _buildFilterJSONObject(
+		String operatorName, String propertyName, JSONArray valueJSONArray) {
+
+		return JSONUtil.put(
+			"classNameId", _CLASS_NAME_ID
+		).put(
+			"classTypeId", _CLASS_TYPE_ID
+		).put(
+			"operatorName", operatorName
+		).put(
+			"propertyName", propertyName
+		).put(
+			"value", valueJSONArray
+		);
 	}
 
 	private JSONObject _buildFilterJSONObject(

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -217,6 +217,65 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
 	@Test
+	public void testGetAssetEntriesInfoPageWithNumericRangeFilters()
+		throws Exception {
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_INTEGER, RandomTestUtil.randomInt(1, 100)
+			).build());
+
+		int priority1 = RandomTestUtil.randomInt(101, 200);
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildFilterJSONObject(
+					"lt", _OBJECT_FIELD_NAME_INTEGER,
+					String.valueOf(priority1))),
+			objectEntry1);
+
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_INTEGER, priority1
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildFilterJSONObject(
+					"le", _OBJECT_FIELD_NAME_INTEGER,
+					String.valueOf(priority1))),
+			objectEntry1, objectEntry2);
+
+		int priority2 = RandomTestUtil.randomInt(201, 300);
+
+		ObjectEntry objectEntry3 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_INTEGER, priority2
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildFilterJSONObject(
+					"between", _OBJECT_FIELD_NAME_INTEGER,
+					JSONUtil.putAll(
+						String.valueOf(priority1), String.valueOf(priority2)))),
+			objectEntry2, objectEntry3);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildFilterJSONObject(
+					"ge", _OBJECT_FIELD_NAME_INTEGER,
+					String.valueOf(priority1))),
+			objectEntry2, objectEntry3);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildFilterJSONObject(
+					"gt", _OBJECT_FIELD_NAME_INTEGER,
+					String.valueOf(priority1))),
+			objectEntry3);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
 	public void testGetAssetEntriesInfoPageWithTextContainsFilters()
 		throws Exception {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88609

## What Is Being Fixed

Adds numeric range operators (between, ge, gt, le, lt) for object-field filters on dynamic asset list collections. This is part of a series of scoped PRs split from a larger change (per review feedback). It is **stacked on the contains PR #2077** (already forwarded, not yet in this fork's master), so the diff below includes its two "contains" commits — the numeric-range delta for review is the two "numeric range" commits.

## How It Is Being Fixed

_toValueQuery routes the range operators to a new _toRangeQuery helper that builds a TermRangeQuery: between reads a two-element JSON array for the lower and upper bounds, while ge/gt/le/lt set a single bound with the appropriate inclusivity. Unit tests assert the resulting query shapes and integration tests verify end-to-end filtering against real object entries. Date, relative-date, and picklist operators follow in subsequent stacked PRs.

## PR Check

**pr-check: PASS** — tested on `c34a9c223df385b45ac96dd48a3863067d6847f6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c34a9c223df385b45ac96dd48a3863067d6847f6"} -->


