### PR TITLE
PR 3 LPD-88609 Add date and relative date object field filters

### DIFF
--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -25,12 +25,18 @@ import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.TermQuery;
 import com.liferay.portal.kernel.search.TermRangeQuery;
 import com.liferay.portal.kernel.search.WildcardQuery;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.text.Format;
+
+import java.util.Calendar;
 import java.util.Locale;
+import java.util.Set;
 
 /**
  * @author Joshua Cords
@@ -136,6 +142,11 @@ public class AssetListFiltersUtil {
 		return "nestedFieldArray.value_text";
 	}
 
+	private static boolean _isDateTimeField(ObjectField objectField) {
+		return ObjectFieldConstants.DB_TYPE_DATE_TIME.equals(
+			objectField.getDBType());
+	}
+
 	private static boolean _isNegatedOperator(String operatorName) {
 		if (operatorName.equals("not-contains") ||
 			operatorName.equals("not-eq")) {
@@ -144,6 +155,65 @@ public class AssetListFiltersUtil {
 		}
 
 		return false;
+	}
+
+	private static String _resolveRelativeDateValue(String value) {
+		if (!_relativeDateValues.contains(value)) {
+			return null;
+		}
+
+		Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyyMMddHHmmss");
+
+		Calendar calendar = Calendar.getInstance();
+
+		calendar.set(Calendar.MILLISECOND, 0);
+		calendar.set(Calendar.MINUTE, 0);
+		calendar.set(Calendar.SECOND, 0);
+
+		if (value.equals("last-year") || value.equals("past-year")) {
+			calendar.add(Calendar.YEAR, -1);
+		}
+		else if (value.equals("next-month")) {
+			calendar.add(Calendar.MONTH, 1);
+		}
+		else if (value.equals("past-24-hours") || value.equals("past-day")) {
+			calendar.add(Calendar.DAY_OF_MONTH, -1);
+		}
+		else if (value.equals("past-month")) {
+			calendar.add(Calendar.MONTH, -1);
+		}
+		else if (value.equals("past-week")) {
+			calendar.add(Calendar.DAY_OF_MONTH, -7);
+		}
+
+		return format.format(calendar.getTime());
+	}
+
+	private static String _toDateTerm(
+		boolean dateTimeField, boolean upperBound, String value) {
+
+		if (Validator.isNull(value)) {
+			return null;
+		}
+
+		String relativeDateValue = _resolveRelativeDateValue(value);
+
+		if (relativeDateValue != null) {
+			value = relativeDateValue;
+		}
+
+		String digits = value.replaceAll("[^0-9]", "");
+
+		if (dateTimeField) {
+			String padded = digits + "000000000000";
+
+			return padded.substring(0, 12) + (upperBound ? "59" : "00");
+		}
+
+		String padded = digits + "00000000";
+
+		return padded.substring(0, 8) + (upperBound ? "235959" : "000000");
 	}
 
 	private static NestedQuery _toNestedQuery(
@@ -171,7 +241,8 @@ public class AssetListFiltersUtil {
 
 		String subfield = _getSubfield(locale, objectField);
 
-		Query query = _toValueQuery(jsonObject, operatorName, subfield, value);
+		Query query = _toValueQuery(
+			jsonObject, objectField, operatorName, subfield, value);
 
 		if (query == null) {
 			return null;
@@ -196,7 +267,16 @@ public class AssetListFiltersUtil {
 	}
 
 	private static Query _toRangeQuery(
-		JSONObject filterJSONObject, String operatorName, String subfield) {
+		JSONObject filterJSONObject, ObjectField objectField,
+		String operatorName, String subfield) {
+
+		boolean dateField = subfield.endsWith(".value_date");
+
+		boolean dateTimeField = false;
+
+		if (dateField && _isDateTimeField(objectField)) {
+			dateTimeField = true;
+		}
 
 		if (operatorName.equals("between")) {
 			JSONArray valueJSONArray = filterJSONObject.getJSONArray("value");
@@ -210,6 +290,11 @@ public class AssetListFiltersUtil {
 			String upperTerm = GetterUtil.getString(
 				valueJSONArray.getString(1), null);
 
+			if (dateField) {
+				lowerTerm = _toDateTerm(dateTimeField, false, lowerTerm);
+				upperTerm = _toDateTerm(dateTimeField, true, upperTerm);
+			}
+
 			return new TermRangeQuery(
 				subfield, lowerTerm, upperTerm, true, true);
 		}
@@ -221,27 +306,39 @@ public class AssetListFiltersUtil {
 		}
 
 		if (operatorName.equals("ge")) {
-			return new TermRangeQuery(subfield, value, null, true, false);
+			String lowerTerm =
+				dateField ? _toDateTerm(dateTimeField, false, value) : value;
+
+			return new TermRangeQuery(subfield, lowerTerm, null, true, false);
 		}
 
 		if (operatorName.equals("gt")) {
-			return new TermRangeQuery(subfield, value, null, false, false);
+			String lowerTerm =
+				dateField ? _toDateTerm(dateTimeField, true, value) : value;
+
+			return new TermRangeQuery(subfield, lowerTerm, null, false, false);
 		}
 
 		if (operatorName.equals("le")) {
-			return new TermRangeQuery(subfield, null, value, false, true);
+			String upperTerm =
+				dateField ? _toDateTerm(dateTimeField, true, value) : value;
+
+			return new TermRangeQuery(subfield, null, upperTerm, false, true);
 		}
 
 		if (operatorName.equals("lt")) {
-			return new TermRangeQuery(subfield, null, value, false, false);
+			String upperTerm =
+				dateField ? _toDateTerm(dateTimeField, false, value) : value;
+
+			return new TermRangeQuery(subfield, null, upperTerm, false, false);
 		}
 
 		return null;
 	}
 
 	private static Query _toValueQuery(
-		JSONObject filterJSONObject, String operatorName, String subfield,
-		String value) {
+		JSONObject filterJSONObject, ObjectField objectField,
+		String operatorName, String subfield, String value) {
 
 		if ((operatorName.equals("contains") ||
 			 operatorName.equals("not-contains")) &&
@@ -257,7 +354,18 @@ public class AssetListFiltersUtil {
 			operatorName.equals("gt") || operatorName.equals("le") ||
 			operatorName.equals("lt")) {
 
-			return _toRangeQuery(filterJSONObject, operatorName, subfield);
+			return _toRangeQuery(
+				filterJSONObject, objectField, operatorName, subfield);
+		}
+
+		if ((operatorName.equals("eq") || operatorName.equals("not-eq")) &&
+			subfield.endsWith(".value_date")) {
+
+			boolean dateTimeField = _isDateTimeField(objectField);
+
+			return new TermRangeQuery(
+				subfield, _toDateTerm(dateTimeField, false, value),
+				_toDateTerm(dateTimeField, true, value), true, true);
 		}
 
 		if (subfield.endsWith(".value_keyword")) {
@@ -275,5 +383,9 @@ public class AssetListFiltersUtil {
 
 		return new MatchQuery(subfield, value);
 	}
+
+	private static final Set<String> _relativeDateValues = SetUtil.fromArray(
+		"last-year", "next-month", "now", "past-24-hours", "past-day",
+		"past-month", "past-week", "past-year");
 
 }

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -23,7 +23,9 @@ import com.liferay.portal.kernel.search.MatchQuery;
 import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.TermQuery;
+import com.liferay.portal.kernel.search.TermRangeQuery;
 import com.liferay.portal.kernel.search.WildcardQuery;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -169,7 +171,7 @@ public class AssetListFiltersUtil {
 
 		String subfield = _getSubfield(locale, objectField);
 
-		Query query = _toValueQuery(operatorName, subfield, value);
+		Query query = _toValueQuery(jsonObject, operatorName, subfield, value);
 
 		if (query == null) {
 			return null;
@@ -193,8 +195,53 @@ public class AssetListFiltersUtil {
 		return new NestedQuery("nestedFieldArray", booleanQuery);
 	}
 
+	private static Query _toRangeQuery(
+		JSONObject filterJSONObject, String operatorName, String subfield) {
+
+		if (operatorName.equals("between")) {
+			JSONArray valueJSONArray = filterJSONObject.getJSONArray("value");
+
+			if ((valueJSONArray == null) || (valueJSONArray.length() < 2)) {
+				return null;
+			}
+
+			String lowerTerm = GetterUtil.getString(
+				valueJSONArray.getString(0), null);
+			String upperTerm = GetterUtil.getString(
+				valueJSONArray.getString(1), null);
+
+			return new TermRangeQuery(
+				subfield, lowerTerm, upperTerm, true, true);
+		}
+
+		String value = filterJSONObject.getString("value");
+
+		if (Validator.isNull(value)) {
+			return null;
+		}
+
+		if (operatorName.equals("ge")) {
+			return new TermRangeQuery(subfield, value, null, true, false);
+		}
+
+		if (operatorName.equals("gt")) {
+			return new TermRangeQuery(subfield, value, null, false, false);
+		}
+
+		if (operatorName.equals("le")) {
+			return new TermRangeQuery(subfield, null, value, false, true);
+		}
+
+		if (operatorName.equals("lt")) {
+			return new TermRangeQuery(subfield, null, value, false, false);
+		}
+
+		return null;
+	}
+
 	private static Query _toValueQuery(
-		String operatorName, String subfield, String value) {
+		JSONObject filterJSONObject, String operatorName, String subfield,
+		String value) {
 
 		if ((operatorName.equals("contains") ||
 			 operatorName.equals("not-contains")) &&
@@ -204,6 +251,13 @@ public class AssetListFiltersUtil {
 				subfield,
 				StringPool.STAR + StringUtil.toLowerCase(value) +
 					StringPool.STAR);
+		}
+
+		if (operatorName.equals("between") || operatorName.equals("ge") ||
+			operatorName.equals("gt") || operatorName.equals("le") ||
+			operatorName.equals("lt")) {
+
+			return _toRangeQuery(filterJSONObject, operatorName, subfield);
 		}
 
 		if (subfield.endsWith(".value_keyword")) {

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -91,7 +91,7 @@ public class AssetListFiltersUtilTest {
 
 		_assertTermQuery(
 			"nestedFieldArray.value_boolean", "true",
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject("eq", booleanFieldName, "true"),
 				booleanFieldName));
@@ -106,7 +106,7 @@ public class AssetListFiltersUtilTest {
 
 		_assertTermQuery(
 			"nestedFieldArray.value_double", doubleFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject("eq", doubleFieldName, doubleFieldValue),
 				doubleFieldName));
@@ -121,14 +121,14 @@ public class AssetListFiltersUtilTest {
 
 		_assertTermQuery(
 			"nestedFieldArray.value_integer", integerFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"eq", integerFieldName, integerFieldValue),
 				integerFieldName));
 		_assertTermQuery(
 			"nestedFieldArray.value_integer", integerFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST_NOT,
 				_buildFilterJSONObject(
 					"not-eq", integerFieldName, integerFieldValue),
@@ -148,7 +148,7 @@ public class AssetListFiltersUtilTest {
 
 		_assertTermQuery(
 			"nestedFieldArray.value_keyword", "alpha",
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject("eq", keywordTextFieldName, "Alpha"),
 				keywordTextFieldName));
@@ -169,7 +169,7 @@ public class AssetListFiltersUtilTest {
 
 		_assertTermQuery(
 			"nestedFieldArray.value_en_US", localizedTextFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"eq", localizedTextFieldName, localizedTextFieldValue),
@@ -185,7 +185,7 @@ public class AssetListFiltersUtilTest {
 
 		_assertTermQuery(
 			"nestedFieldArray.value_long", longFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"eq", longIntegerFieldName, longFieldValue),
@@ -201,13 +201,13 @@ public class AssetListFiltersUtilTest {
 
 		_assertTermQuery(
 			"nestedFieldArray.value_text", textFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject("eq", textFieldName, textFieldValue),
 				textFieldName));
 		_assertTermQuery(
 			"nestedFieldArray.value_text", textFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST_NOT,
 				_buildFilterJSONObject("not-eq", textFieldName, textFieldValue),
 				textFieldName));
@@ -245,14 +245,14 @@ public class AssetListFiltersUtilTest {
 
 		_assertWildcardQuery(
 			"nestedFieldArray.value_keyword", "*alpha*",
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"contains", keywordTextFieldName, "Alpha"),
 				keywordTextFieldName));
 		_assertWildcardQuery(
 			"nestedFieldArray.value_keyword", "*alpha*",
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST_NOT,
 				_buildFilterJSONObject(
 					"not-contains", keywordTextFieldName, "Alpha"),
@@ -273,7 +273,7 @@ public class AssetListFiltersUtilTest {
 		_assertTermRangeQuery(
 			"nestedFieldArray.value_double", true, true, doubleLowerFieldValue,
 			doubleUpperFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"between", doubleFieldName,
@@ -286,7 +286,7 @@ public class AssetListFiltersUtilTest {
 		_assertTermRangeQuery(
 			"nestedFieldArray.value_double", false, false, doubleFieldValue,
 			null,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject("gt", doubleFieldName, doubleFieldValue),
 				doubleFieldName));
@@ -303,7 +303,7 @@ public class AssetListFiltersUtilTest {
 		_assertTermRangeQuery(
 			"nestedFieldArray.value_integer", true, true,
 			integerLowerFieldValue, integerUpperFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"between", integerFieldName,
@@ -316,7 +316,7 @@ public class AssetListFiltersUtilTest {
 		_assertTermRangeQuery(
 			"nestedFieldArray.value_integer", true, false, integerFieldValue,
 			null,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"ge", integerFieldName, integerFieldValue),
@@ -324,7 +324,7 @@ public class AssetListFiltersUtilTest {
 		_assertTermRangeQuery(
 			"nestedFieldArray.value_integer", false, false, integerFieldValue,
 			null,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"gt", integerFieldName, integerFieldValue),
@@ -332,7 +332,7 @@ public class AssetListFiltersUtilTest {
 		_assertTermRangeQuery(
 			"nestedFieldArray.value_integer", false, true, null,
 			integerFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"le", integerFieldName, integerFieldValue),
@@ -340,7 +340,7 @@ public class AssetListFiltersUtilTest {
 		_assertTermRangeQuery(
 			"nestedFieldArray.value_integer", false, false, null,
 			integerFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"lt", integerFieldName, integerFieldValue),
@@ -358,7 +358,7 @@ public class AssetListFiltersUtilTest {
 		_assertTermRangeQuery(
 			"nestedFieldArray.value_long", true, true, longLowerFieldValue,
 			longUpperFieldValue,
-			_assertNestedRowAndGetQuery(
+			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
 					"between", longIntegerFieldName,
@@ -376,7 +376,7 @@ public class AssetListFiltersUtilTest {
 
 		String textFieldValue = RandomTestUtil.randomString();
 
-		Query containsQuery = _assertNestedRowAndGetQuery(
+		Query containsQuery = _assertNestedQuery(
 			BooleanClauseOccur.MUST,
 			_buildFilterJSONObject("contains", textFieldName, textFieldValue),
 			textFieldName);
@@ -384,7 +384,7 @@ public class AssetListFiltersUtilTest {
 		Assert.assertTrue(
 			containsQuery.toString(), containsQuery instanceof MatchQuery);
 
-		Query containsWithQuantifierQuery = _assertNestedRowAndGetQuery(
+		Query containsWithQuantifierQuery = _assertNestedQuery(
 			BooleanClauseOccur.MUST,
 			_buildFilterJSONObject(
 				"contains", textFieldName, textFieldValue
@@ -397,7 +397,7 @@ public class AssetListFiltersUtilTest {
 			containsWithQuantifierQuery.toString(),
 			containsWithQuantifierQuery instanceof MatchQuery);
 
-		Query notContainsQuery = _assertNestedRowAndGetQuery(
+		Query notContainsQuery = _assertNestedQuery(
 			BooleanClauseOccur.MUST_NOT,
 			_buildFilterJSONObject(
 				"not-contains", textFieldName, textFieldValue),
@@ -408,7 +408,22 @@ public class AssetListFiltersUtilTest {
 			notContainsQuery instanceof MatchQuery);
 	}
 
-	private Query _assertNestedRowAndGetQuery(
+	private QueryTerm _assertNestedFieldQueryTerm(
+		BooleanClause<Query> booleanClause, String expectedField) {
+
+		Assert.assertEquals(
+			BooleanClauseOccur.MUST, booleanClause.getBooleanClauseOccur());
+
+		TermQuery termQuery = (TermQuery)booleanClause.getClause();
+
+		QueryTerm queryTerm = termQuery.getQueryTerm();
+
+		Assert.assertEquals(expectedField, queryTerm.getField());
+
+		return queryTerm;
+	}
+
+	private Query _assertNestedQuery(
 		BooleanClauseOccur expectedBooleanClauseOccur,
 		JSONObject filterJSONObject, String propertyName) {
 
@@ -419,72 +434,51 @@ public class AssetListFiltersUtilTest {
 		Assert.assertEquals(
 			Arrays.toString(booleanClauses), 1, booleanClauses.length);
 
-		BooleanClause<?> outerBooleanClause = booleanClauses[0];
+		BooleanClause<?> filtersBooleanClause = booleanClauses[0];
 
 		Assert.assertEquals(
 			BooleanClauseOccur.MUST,
-			outerBooleanClause.getBooleanClauseOccur());
+			filtersBooleanClause.getBooleanClauseOccur());
 
-		BooleanQuery outerBooleanQuery =
-			(BooleanQuery)outerBooleanClause.getClause();
+		BooleanQuery filtersBooleanQuery =
+			(BooleanQuery)filtersBooleanClause.getClause();
 
-		List<BooleanClause<Query>> rowBooleanClauses =
-			outerBooleanQuery.clauses();
+		List<BooleanClause<Query>> filterBooleanClauses =
+			filtersBooleanQuery.clauses();
 
-		BooleanClause<Query> rowBooleanClause = rowBooleanClauses.get(0);
+		BooleanClause<Query> filterBooleanClause = filterBooleanClauses.get(0);
 
-		NestedQuery nestedQuery = (NestedQuery)rowBooleanClause.getClause();
+		NestedQuery nestedQuery = (NestedQuery)filterBooleanClause.getClause();
 
 		Assert.assertEquals("nestedFieldArray", nestedQuery.getPath());
 
-		BooleanQuery innerBooleanQuery = (BooleanQuery)nestedQuery.getQuery();
+		BooleanQuery nestedFieldBooleanQuery =
+			(BooleanQuery)nestedQuery.getQuery();
 
-		List<BooleanClause<Query>> innerBooleanClauses =
-			innerBooleanQuery.clauses();
-
-		Assert.assertEquals(
-			innerBooleanClauses.toString(), 3, innerBooleanClauses.size());
-
-		BooleanClause<Query> fieldNameBooleanClause = innerBooleanClauses.get(
-			0);
-
-		TermQuery fieldNameTermQuery =
-			(TermQuery)fieldNameBooleanClause.getClause();
-
-		QueryTerm fieldNameQueryTerm = fieldNameTermQuery.getQueryTerm();
+		List<BooleanClause<Query>> nestedFieldBooleanClauses =
+			nestedFieldBooleanQuery.clauses();
 
 		Assert.assertEquals(
-			"nestedFieldArray.fieldName", fieldNameQueryTerm.getField());
-		Assert.assertEquals(propertyName, fieldNameQueryTerm.getValue());
+			nestedFieldBooleanClauses.toString(), 3,
+			nestedFieldBooleanClauses.size());
 
-		Assert.assertEquals(
-			BooleanClauseOccur.MUST,
-			fieldNameBooleanClause.getBooleanClauseOccur());
+		QueryTerm nestedFieldQueryTerm = _assertNestedFieldQueryTerm(
+			nestedFieldBooleanClauses.get(0), "nestedFieldArray.fieldName");
 
-		BooleanClause<Query> valueFieldNameBooleanClause =
-			innerBooleanClauses.get(1);
+		Assert.assertEquals(propertyName, nestedFieldQueryTerm.getValue());
 
-		TermQuery valueFieldNameTermQuery =
-			(TermQuery)valueFieldNameBooleanClause.getClause();
+		_assertNestedFieldQueryTerm(
+			nestedFieldBooleanClauses.get(1),
+			"nestedFieldArray.valueFieldName");
 
-		QueryTerm valueFieldNameQueryTerm =
-			valueFieldNameTermQuery.getQueryTerm();
-
-		Assert.assertEquals(
-			"nestedFieldArray.valueFieldName",
-			valueFieldNameQueryTerm.getField());
-
-		Assert.assertEquals(
-			BooleanClauseOccur.MUST,
-			valueFieldNameBooleanClause.getBooleanClauseOccur());
-
-		BooleanClause<Query> valueBooleanClause = innerBooleanClauses.get(2);
+		BooleanClause<Query> nestedFieldBooleanClause =
+			nestedFieldBooleanClauses.get(2);
 
 		Assert.assertEquals(
 			expectedBooleanClauseOccur,
-			valueBooleanClause.getBooleanClauseOccur());
+			nestedFieldBooleanClause.getBooleanClauseOccur());
 
-		return valueBooleanClause.getClause();
+		return nestedFieldBooleanClause.getClause();
 	}
 
 	private void _assertTermQuery(

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -34,7 +34,10 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.util.FastDateFormatFactoryImpl;
 
+import java.text.Format;
+
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 
 import org.junit.AfterClass;
@@ -79,6 +82,71 @@ public class AssetListFiltersUtilTest {
 		_portalUtilMockedStatic.reset();
 
 		_setUpLocalizationUtil();
+	}
+
+	@Test
+	public void testFilterQueriesWithDateAndDateTimeOperators() {
+		String dateFieldName = RandomTestUtil.randomString();
+
+		_setUpObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_DATE,
+			ObjectFieldConstants.DB_TYPE_DATE, dateFieldName);
+
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_date", true, true, "20260115000000",
+			"20260120235959",
+			_assertNestedQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"between", dateFieldName,
+					JSONUtil.putAll("2026-01-15", "2026-01-20")),
+				dateFieldName));
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_date", true, true, "20260115000000",
+			"20260115235959",
+			_assertNestedQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject("eq", dateFieldName, "2026-01-15"),
+				dateFieldName));
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_date", true, false, "20260115000000", null,
+			_assertNestedQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject("ge", dateFieldName, "2026-01-15"),
+				dateFieldName));
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_date", false, false, "20260115235959", null,
+			_assertNestedQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject("gt", dateFieldName, "2026-01-15"),
+				dateFieldName));
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_date", false, true, null, "20260115235959",
+			_assertNestedQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject("le", dateFieldName, "2026-01-15"),
+				dateFieldName));
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_date", false, false, null, "20260115000000",
+			_assertNestedQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject("lt", dateFieldName, "2026-01-15"),
+				dateFieldName));
+
+		String dateTimeFieldName = RandomTestUtil.randomString();
+
+		_setUpObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_DATE_TIME,
+			ObjectFieldConstants.DB_TYPE_DATE_TIME, dateTimeFieldName);
+
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_date", true, true, "20260115103000",
+			"20260115103059",
+			_assertNestedQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"eq", dateTimeFieldName, "2026-01-15 10:30"),
+				dateTimeFieldName));
 	}
 
 	@Test
@@ -367,6 +435,64 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
+	public void testFilterQueriesWithRelativeDateOperators() {
+		String dateFieldName = RandomTestUtil.randomString();
+
+		_setUpObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_DATE,
+			ObjectFieldConstants.DB_TYPE_DATE, dateFieldName);
+
+		String lastYearLowerTerm = _resolveRelativeDateLowerTerm(
+			dateFieldName, "last-year");
+		String nextMonthLowerTerm = _resolveRelativeDateLowerTerm(
+			dateFieldName, "next-month");
+		String nowLowerTerm = _resolveRelativeDateLowerTerm(
+			dateFieldName, "now");
+		String past24HoursLowerTerm = _resolveRelativeDateLowerTerm(
+			dateFieldName, "past-24-hours");
+		String pastDayLowerTerm = _resolveRelativeDateLowerTerm(
+			dateFieldName, "past-day");
+		String pastMonthLowerTerm = _resolveRelativeDateLowerTerm(
+			dateFieldName, "past-month");
+		String pastWeekLowerTerm = _resolveRelativeDateLowerTerm(
+			dateFieldName, "past-week");
+		String pastYearLowerTerm = _resolveRelativeDateLowerTerm(
+			dateFieldName, "past-year");
+
+		for (String lowerTerm :
+				new String[] {
+					lastYearLowerTerm, nextMonthLowerTerm, nowLowerTerm,
+					past24HoursLowerTerm, pastDayLowerTerm, pastMonthLowerTerm,
+					pastWeekLowerTerm, pastYearLowerTerm
+				}) {
+
+			Assert.assertEquals(lowerTerm, 14, lowerTerm.length());
+			Assert.assertTrue(lowerTerm, lowerTerm.endsWith("000000"));
+		}
+
+		Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyyMMdd");
+
+		Assert.assertEquals(format.format(new Date()) + "000000", nowLowerTerm);
+
+		Assert.assertEquals(lastYearLowerTerm, pastYearLowerTerm);
+		Assert.assertEquals(past24HoursLowerTerm, pastDayLowerTerm);
+		Assert.assertTrue(nowLowerTerm.compareTo(nextMonthLowerTerm) < 0);
+		Assert.assertTrue(pastDayLowerTerm.compareTo(nowLowerTerm) < 0);
+		Assert.assertTrue(pastMonthLowerTerm.compareTo(pastWeekLowerTerm) < 0);
+		Assert.assertTrue(pastWeekLowerTerm.compareTo(pastDayLowerTerm) < 0);
+		Assert.assertTrue(pastYearLowerTerm.compareTo(pastMonthLowerTerm) < 0);
+
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_date", false, true, null,
+			format.format(new Date()) + "235959",
+			_assertNestedQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject("le", dateFieldName, "now"),
+				dateFieldName));
+	}
+
+	@Test
 	public void testFilterQueriesWithTextContainsOperators() {
 		String textFieldName = RandomTestUtil.randomString();
 
@@ -555,6 +681,20 @@ public class AssetListFiltersUtilTest {
 		).put(
 			"value", value
 		);
+	}
+
+	private String _resolveRelativeDateLowerTerm(
+		String propertyName, String value) {
+
+		Query query = _assertNestedQuery(
+			BooleanClauseOccur.MUST,
+			_buildFilterJSONObject("ge", propertyName, value), propertyName);
+
+		Assert.assertTrue(query.toString(), query instanceof TermRangeQuery);
+
+		TermRangeQuery termRangeQuery = (TermRangeQuery)query;
+
+		return termRangeQuery.getLowerTerm();
 	}
 
 	private void _setUpLocalizationUtil() {

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -510,12 +510,12 @@ public class AssetListFiltersUtilTest {
 		TermRangeQuery termRangeQuery = (TermRangeQuery)query;
 
 		Assert.assertEquals(expectedField, termRangeQuery.getField());
+		Assert.assertEquals(expectedLowerTerm, termRangeQuery.getLowerTerm());
+		Assert.assertEquals(expectedUpperTerm, termRangeQuery.getUpperTerm());
 		Assert.assertEquals(
 			expectedIncludesLower, termRangeQuery.includesLower());
 		Assert.assertEquals(
 			expectedIncludesUpper, termRangeQuery.includesUpper());
-		Assert.assertEquals(expectedLowerTerm, termRangeQuery.getLowerTerm());
-		Assert.assertEquals(expectedUpperTerm, termRangeQuery.getUpperTerm());
 	}
 
 	private void _assertWildcardQuery(

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -591,6 +591,15 @@ public class AssetListFiltersUtilTest {
 			_CLASS_TYPE_ID
 		);
 
+		_objectDefinitionLocalServiceUtilMockedStatic.when(
+			() ->
+				ObjectDefinitionLocalServiceUtil.
+					fetchObjectDefinitionByClassName(
+						_COMPANY_ID, "com.liferay.test.Class" + _CLASS_NAME_ID)
+		).thenReturn(
+			objectDefinition
+		);
+
 		ObjectField objectField = Mockito.mock(ObjectField.class);
 
 		Mockito.when(
@@ -609,15 +618,6 @@ public class AssetListFiltersUtilTest {
 			objectField.getName()
 		).thenReturn(
 			fieldName
-		);
-
-		_objectDefinitionLocalServiceUtilMockedStatic.when(
-			() ->
-				ObjectDefinitionLocalServiceUtil.
-					fetchObjectDefinitionByClassName(
-						_COMPANY_ID, "com.liferay.test.Class" + _CLASS_NAME_ID)
-		).thenReturn(
-			objectDefinition
 		);
 
 		_objectFieldLocalServiceUtilMockedStatic.when(

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -10,6 +10,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldLocalServiceUtil;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -21,6 +22,7 @@ import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.QueryTerm;
 import com.liferay.portal.kernel.search.TermQuery;
+import com.liferay.portal.kernel.search.TermRangeQuery;
 import com.liferay.portal.kernel.search.WildcardQuery;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -258,6 +260,113 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
+	public void testFilterQueriesWithNumericRangeOperators() {
+		String doubleFieldName = RandomTestUtil.randomString();
+
+		_setUpObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
+			ObjectFieldConstants.DB_TYPE_DOUBLE, doubleFieldName);
+
+		String doubleLowerFieldValue = "1.5";
+		String doubleUpperFieldValue = "2.5";
+
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_double", true, true, doubleLowerFieldValue,
+			doubleUpperFieldValue,
+			_assertNestedRowAndGetQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"between", doubleFieldName,
+					JSONUtil.putAll(
+						doubleLowerFieldValue, doubleUpperFieldValue)),
+				doubleFieldName));
+
+		String doubleFieldValue = String.valueOf(RandomTestUtil.randomDouble());
+
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_double", false, false, doubleFieldValue,
+			null,
+			_assertNestedRowAndGetQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject("gt", doubleFieldName, doubleFieldValue),
+				doubleFieldName));
+
+		String integerFieldName = RandomTestUtil.randomString();
+
+		_setUpObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
+			ObjectFieldConstants.DB_TYPE_INTEGER, integerFieldName);
+
+		String integerLowerFieldValue = "1";
+		String integerUpperFieldValue = "2";
+
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_integer", true, true,
+			integerLowerFieldValue, integerUpperFieldValue,
+			_assertNestedRowAndGetQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"between", integerFieldName,
+					JSONUtil.putAll(
+						integerLowerFieldValue, integerUpperFieldValue)),
+				integerFieldName));
+
+		String integerFieldValue = String.valueOf(RandomTestUtil.randomInt());
+
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_integer", true, false, integerFieldValue,
+			null,
+			_assertNestedRowAndGetQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"ge", integerFieldName, integerFieldValue),
+				integerFieldName));
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_integer", false, false, integerFieldValue,
+			null,
+			_assertNestedRowAndGetQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"gt", integerFieldName, integerFieldValue),
+				integerFieldName));
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_integer", false, true, null,
+			integerFieldValue,
+			_assertNestedRowAndGetQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"le", integerFieldName, integerFieldValue),
+				integerFieldName));
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_integer", false, false, null,
+			integerFieldValue,
+			_assertNestedRowAndGetQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"lt", integerFieldName, integerFieldValue),
+				integerFieldName));
+
+		String longIntegerFieldName = RandomTestUtil.randomString();
+
+		_setUpObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
+			ObjectFieldConstants.DB_TYPE_LONG, longIntegerFieldName);
+
+		String longLowerFieldValue = "1";
+		String longUpperFieldValue = "2";
+
+		_assertTermRangeQuery(
+			"nestedFieldArray.value_long", true, true, longLowerFieldValue,
+			longUpperFieldValue,
+			_assertNestedRowAndGetQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"between", longIntegerFieldName,
+					JSONUtil.putAll(longLowerFieldValue, longUpperFieldValue)),
+				longIntegerFieldName));
+	}
+
+	@Test
 	public void testFilterQueriesWithTextContainsOperators() {
 		String textFieldName = RandomTestUtil.randomString();
 
@@ -391,6 +500,24 @@ public class AssetListFiltersUtilTest {
 		Assert.assertEquals(expectedValue, queryTerm.getValue());
 	}
 
+	private void _assertTermRangeQuery(
+		String expectedField, boolean expectedIncludesLower,
+		boolean expectedIncludesUpper, String expectedLowerTerm,
+		String expectedUpperTerm, Query query) {
+
+		Assert.assertTrue(query.toString(), query instanceof TermRangeQuery);
+
+		TermRangeQuery termRangeQuery = (TermRangeQuery)query;
+
+		Assert.assertEquals(expectedField, termRangeQuery.getField());
+		Assert.assertEquals(
+			expectedIncludesLower, termRangeQuery.includesLower());
+		Assert.assertEquals(
+			expectedIncludesUpper, termRangeQuery.includesUpper());
+		Assert.assertEquals(expectedLowerTerm, termRangeQuery.getLowerTerm());
+		Assert.assertEquals(expectedUpperTerm, termRangeQuery.getUpperTerm());
+	}
+
 	private void _assertWildcardQuery(
 		String expectedField, String expectedValue, Query query) {
 
@@ -402,6 +529,22 @@ public class AssetListFiltersUtilTest {
 
 		Assert.assertEquals(expectedField, queryTerm.getField());
 		Assert.assertEquals(expectedValue, queryTerm.getValue());
+	}
+
+	private JSONObject _buildFilterJSONObject(
+		String operatorName, String propertyName, JSONArray valueJSONArray) {
+
+		return JSONUtil.put(
+			"classNameId", _CLASS_NAME_ID
+		).put(
+			"classTypeId", _CLASS_TYPE_ID
+		).put(
+			"operatorName", operatorName
+		).put(
+			"propertyName", propertyName
+		).put(
+			"value", valueJSONArray
+		);
 	}
 
 	private JSONObject _buildFilterJSONObject(

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -217,6 +217,65 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
 	@Test
+	public void testGetAssetEntriesInfoPageWithNumericRangeFilters()
+		throws Exception {
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_INTEGER, RandomTestUtil.randomInt(1, 100)
+			).build());
+
+		int priority1 = RandomTestUtil.randomInt(101, 200);
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildFilterJSONObject(
+					"lt", _OBJECT_FIELD_NAME_INTEGER,
+					String.valueOf(priority1))),
+			objectEntry1);
+
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_INTEGER, priority1
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildFilterJSONObject(
+					"le", _OBJECT_FIELD_NAME_INTEGER,
+					String.valueOf(priority1))),
+			objectEntry1, objectEntry2);
+
+		int priority2 = RandomTestUtil.randomInt(201, 300);
+
+		ObjectEntry objectEntry3 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_INTEGER, priority2
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildFilterJSONObject(
+					"between", _OBJECT_FIELD_NAME_INTEGER,
+					JSONUtil.putAll(
+						String.valueOf(priority1), String.valueOf(priority2)))),
+			objectEntry2, objectEntry3);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildFilterJSONObject(
+					"ge", _OBJECT_FIELD_NAME_INTEGER,
+					String.valueOf(priority1))),
+			objectEntry2, objectEntry3);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildFilterJSONObject(
+					"gt", _OBJECT_FIELD_NAME_INTEGER,
+					String.valueOf(priority1))),
+			objectEntry3);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
 	public void testGetAssetEntriesInfoPageWithTextContainsFilters()
 		throws Exception {
 

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -16,10 +16,13 @@ import com.liferay.info.pagination.InfoPage;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectFieldSetting;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
@@ -50,6 +53,7 @@ import com.liferay.segments.constants.SegmentsEntryConstants;
 import java.io.Serializable;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -81,6 +85,21 @@ public class AssetListAssetEntryProviderFiltersTest {
 		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
 			Arrays.asList(
 				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_DATE,
+					ObjectFieldConstants.DB_TYPE_DATE, true, false, null,
+					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_DATE,
+					false),
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_DATE_TIME,
+					ObjectFieldConstants.DB_TYPE_DATE_TIME, true, false, null,
+					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_DATE_TIME,
+					Collections.singletonList(
+						_createObjectFieldSetting(
+							ObjectFieldSettingConstants.NAME_TIME_STORAGE,
+							ObjectFieldSettingConstants.
+								VALUE_USE_INPUT_AS_ENTERED)),
+					false),
+				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
 					ObjectFieldConstants.DB_TYPE_INTEGER, true, false, null,
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_INTEGER,
@@ -96,6 +115,41 @@ public class AssetListAssetEntryProviderFiltersTest {
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_TEXT,
 					false)),
 			ObjectDefinitionConstants.SCOPE_SITE);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testGetAssetEntriesInfoPageWithDateRangeFilters()
+		throws Exception {
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_DATE, "2026-01-15"
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildFilterJSONObject(
+					"between", _OBJECT_FIELD_NAME_DATE,
+					JSONUtil.putAll("2026-01-01", "2026-03-01"))),
+			objectEntry1);
+
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_DATE_TIME, "2026-01-15 10:30"
+			).build());
+
+		_addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_DATE_TIME, "2026-06-15 10:30"
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildFilterJSONObject(
+					"between", _OBJECT_FIELD_NAME_DATE_TIME,
+					JSONUtil.putAll("2026-01-15 00:00", "2026-01-15 23:59"))),
+			objectEntry2);
 	}
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
@@ -510,6 +564,24 @@ public class AssetListAssetEntryProviderFiltersTest {
 		return JSONUtil.putAll((Object[])filterJSONObjects);
 	}
 
+	private ObjectFieldSetting _createObjectFieldSetting(
+		String name, String value) {
+
+		ObjectFieldSetting objectFieldSetting =
+			_objectFieldSettingLocalService.createObjectFieldSetting(0L);
+
+		objectFieldSetting.setName(name);
+		objectFieldSetting.setValue(value);
+
+		return objectFieldSetting;
+	}
+
+	private static final String _OBJECT_FIELD_NAME_DATE =
+		"xDate" + RandomTestUtil.randomString();
+
+	private static final String _OBJECT_FIELD_NAME_DATE_TIME =
+		"xDateTime" + RandomTestUtil.randomString();
+
 	private static final String _OBJECT_FIELD_NAME_INTEGER =
 		"xInteger" + RandomTestUtil.randomString();
 
@@ -533,6 +605,9 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ObjectFieldSettingLocalService _objectFieldSettingLocalService;
 
 	@Inject
 	private Portal _portal;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88609

## What Is Being Fixed

Object-field filtering (behind the LPD-74731 feature flag) did not support date
or relative-date operators. A user could not filter a Date/DateTime object field
by a date range (`between`/`ge`/`gt`/`le`/`lt`) or by a relative value such as
`now`, `past-week`, or `next-month`.

## How It Is Being Fixed

`_toValueQuery` and `_toRangeQuery` receive the `ObjectField` so date subfields
are detected and their bounds normalized to the indexed `yyyyMMddHHmmss` term via
a new `_toDateTerm` (inclusive whole day for `Date`, boundary-aware for
`DateTime`); `_resolveRelativeDateValue` maps relative keywords to a concrete
lower bound. Unit coverage (`testFilterQueriesWithDateAndDateTimeOperators`,
`testFilterQueriesWithRelativeDateOperators`) and integration coverage
(`testGetAssetEntriesInfoPageWithDateRangeFilters`) are added.

This PR is **stacked on the numeric-range PR #2088** (not yet merged to master),
so the diff below includes that predecessor's commits — the review delta is the
two "date and relative date" commits (three asset-list files).

## PR Check

**pr-check: PASS** — tested on `ef6f601b83cb48d6ac656600a3f8c6e79bf8dcda`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ef6f601b83cb48d6ac656600a3f8c6e79bf8dcda"} -->
