### PR TITLE
PR4 LPD-88609 Add picklist multi-value object field filters

### DIFF
--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.MatchAllQuery;
 import com.liferay.portal.kernel.search.MatchQuery;
 import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
@@ -36,6 +37,7 @@ import java.text.Format;
 
 import java.util.Calendar;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -52,19 +54,36 @@ public class AssetListFiltersUtil {
 
 		BooleanQuery booleanQuery = new BooleanQuery();
 
+		boolean hasMustClause = false;
+
 		for (int i = 0; i < filtersJSONArray.length(); i++) {
+			JSONObject jsonObject = filtersJSONArray.getJSONObject(i);
+
 			NestedQuery nestedQuery = _toNestedQuery(
-				companyId, filtersJSONArray.getJSONObject(i), locale);
+				companyId, jsonObject, locale);
 
 			if (nestedQuery == null) {
 				continue;
 			}
 
-			booleanQuery.add(nestedQuery, BooleanClauseOccur.MUST);
+			if (_isNegatedOperator(
+					jsonObject.getString("operatorName", "contains"))) {
+
+				booleanQuery.add(nestedQuery, BooleanClauseOccur.MUST_NOT);
+			}
+			else {
+				booleanQuery.add(nestedQuery, BooleanClauseOccur.MUST);
+
+				hasMustClause = true;
+			}
 		}
 
 		if (!booleanQuery.hasClauses()) {
 			return new BooleanClause[0];
+		}
+
+		if (!hasMustClause) {
+			booleanQuery.add(new MatchAllQuery(), BooleanClauseOccur.MUST);
 		}
 
 		return new BooleanClause[] {
@@ -258,12 +277,41 @@ public class AssetListFiltersUtil {
 				"nestedFieldArray.valueFieldName",
 				subfield.substring(subfield.indexOf(CharPool.PERIOD) + 1)),
 			BooleanClauseOccur.MUST);
-		booleanQuery.add(
-			query,
-			_isNegatedOperator(operatorName) ? BooleanClauseOccur.MUST_NOT :
-				BooleanClauseOccur.MUST);
+		booleanQuery.add(query, BooleanClauseOccur.MUST);
 
 		return new NestedQuery("nestedFieldArray", booleanQuery);
+	}
+
+	private static Query _toPicklistQuery(
+		JSONObject filterJSONObject, String subfield) {
+
+		JSONArray valueJSONArray = filterJSONObject.getJSONArray("value");
+
+		if (JSONUtil.isEmpty(valueJSONArray)) {
+			return null;
+		}
+
+		BooleanClauseOccur booleanClauseOccur = BooleanClauseOccur.SHOULD;
+
+		String quantifier = filterJSONObject.getString("quantifier");
+
+		if (Objects.equals(quantifier, "all")) {
+			booleanClauseOccur = BooleanClauseOccur.MUST;
+		}
+
+		BooleanQuery booleanQuery = new BooleanQuery();
+
+		for (int i = 0; i < valueJSONArray.length(); i++) {
+			JSONObject itemJSONObject = valueJSONArray.getJSONObject(i);
+
+			String value = StringUtil.toLowerCase(
+				itemJSONObject.getString("value"));
+
+			booleanQuery.add(
+				new TermQuery(subfield, value), booleanClauseOccur);
+		}
+
+		return booleanQuery;
 	}
 
 	private static Query _toRangeQuery(
@@ -340,14 +388,19 @@ public class AssetListFiltersUtil {
 		JSONObject filterJSONObject, ObjectField objectField,
 		String operatorName, String subfield, String value) {
 
-		if ((operatorName.equals("contains") ||
-			 operatorName.equals("not-contains")) &&
-			subfield.endsWith(".value_keyword")) {
+		if (operatorName.equals("contains") ||
+			operatorName.equals("not-contains")) {
 
-			return new WildcardQuery(
-				subfield,
-				StringPool.STAR + StringUtil.toLowerCase(value) +
-					StringPool.STAR);
+			if (objectField.getListTypeDefinitionId() != 0) {
+				return _toPicklistQuery(filterJSONObject, subfield);
+			}
+
+			if (subfield.endsWith(".value_keyword")) {
+				return new WildcardQuery(
+					subfield,
+					StringPool.STAR + StringUtil.toLowerCase(value) +
+						StringPool.STAR);
+			}
 		}
 
 		if (operatorName.equals("between") || operatorName.equals("ge") ||

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -204,15 +204,7 @@ public class AssetListFiltersUtilTest {
 
 		String keywordTextFieldName = RandomTestUtil.randomString();
 
-		ObjectField keywordObjectField = _setUpObjectField(
-			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-			ObjectFieldConstants.DB_TYPE_STRING, keywordTextFieldName);
-
-		Mockito.when(
-			keywordObjectField.isIndexedAsKeyword()
-		).thenReturn(
-			true
-		);
+		_setUpKeywordTextObjectField(keywordTextFieldName);
 
 		_assertTermQuery(
 			"nestedFieldArray.value_keyword", "alpha",
@@ -249,14 +241,15 @@ public class AssetListFiltersUtilTest {
 			ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
 			ObjectFieldConstants.DB_TYPE_LONG, longIntegerFieldName);
 
-		String longFieldValue = String.valueOf(RandomTestUtil.randomLong());
+		String longIntegerFieldValue = String.valueOf(
+			RandomTestUtil.randomLong());
 
 		_assertTermQuery(
-			"nestedFieldArray.value_long", longFieldValue,
+			"nestedFieldArray.value_long", longIntegerFieldValue,
 			_assertNestedQuery(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject(
-					"eq", longIntegerFieldName, longFieldValue),
+					"eq", longIntegerFieldName, longIntegerFieldValue),
 				longIntegerFieldName));
 
 		String textFieldName = RandomTestUtil.randomString();
@@ -301,15 +294,7 @@ public class AssetListFiltersUtilTest {
 	public void testFilterQueriesWithKeywordTextContainsOperators() {
 		String keywordTextFieldName = RandomTestUtil.randomString();
 
-		ObjectField keywordObjectField = _setUpObjectField(
-			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-			ObjectFieldConstants.DB_TYPE_STRING, keywordTextFieldName);
-
-		Mockito.when(
-			keywordObjectField.isIndexedAsKeyword()
-		).thenReturn(
-			true
-		);
+		_setUpKeywordTextObjectField(keywordTextFieldName);
 
 		_assertWildcardQuery(
 			"nestedFieldArray.value_keyword", "*alpha*",
@@ -432,6 +417,92 @@ public class AssetListFiltersUtilTest {
 					"between", longIntegerFieldName,
 					JSONUtil.putAll(longLowerFieldValue, longUpperFieldValue)),
 				longIntegerFieldName));
+	}
+
+	@Test
+	public void testFilterQueriesWithPicklistMultiValueOperators() {
+		String picklistFieldName = RandomTestUtil.randomString();
+
+		_setUpPicklistObjectField(picklistFieldName);
+
+		_assertPicklistBooleanQuery(
+			BooleanClauseOccur.MUST,
+			_assertNestedQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"contains", picklistFieldName,
+					JSONUtil.putAll(
+						_buildPicklistValueJSONObject("approved"),
+						_buildPicklistValueJSONObject("draft"))
+				).put(
+					"quantifier", "all"
+				),
+				picklistFieldName),
+			"approved", "draft");
+		_assertPicklistBooleanQuery(
+			BooleanClauseOccur.SHOULD,
+			_assertNestedQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"contains", picklistFieldName,
+					JSONUtil.putAll(_buildPicklistValueJSONObject("Approved"))
+				).put(
+					"quantifier", "any"
+				),
+				picklistFieldName),
+			"approved");
+		_assertPicklistBooleanQuery(
+			BooleanClauseOccur.SHOULD,
+			_assertNestedQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"contains", picklistFieldName,
+					JSONUtil.putAll(_buildPicklistValueJSONObject("approved"))),
+				picklistFieldName),
+			"approved");
+		_assertPicklistBooleanQuery(
+			BooleanClauseOccur.SHOULD,
+			_assertNestedQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"contains", picklistFieldName,
+					JSONUtil.putAll(
+						_buildPicklistValueJSONObject("approved"),
+						_buildPicklistValueJSONObject("draft"))
+				).put(
+					"quantifier", "any"
+				),
+				picklistFieldName),
+			"approved", "draft");
+		_assertPicklistBooleanQuery(
+			BooleanClauseOccur.SHOULD,
+			_assertNestedQuery(
+				BooleanClauseOccur.MUST_NOT,
+				_buildFilterJSONObject(
+					"not-contains", picklistFieldName,
+					JSONUtil.putAll(
+						_buildPicklistValueJSONObject("approved"),
+						_buildPicklistValueJSONObject("draft"))
+				).put(
+					"quantifier", "any"
+				),
+				picklistFieldName),
+			"approved", "draft");
+
+		BooleanClause[] booleanClauses =
+			AssetListFiltersUtil.getFiltersBooleanClauses(
+				_COMPANY_ID,
+				JSONUtil.putAll(
+					_buildFilterJSONObject(
+						"contains", picklistFieldName,
+						JSONFactoryUtil.createJSONArray()
+					).put(
+						"quantifier", "any"
+					)),
+				LocaleUtil.US);
+
+		Assert.assertEquals(
+			Arrays.toString(booleanClauses), 0, booleanClauses.length);
 	}
 
 	@Test
@@ -574,6 +645,10 @@ public class AssetListFiltersUtilTest {
 
 		BooleanClause<Query> filterBooleanClause = filterBooleanClauses.get(0);
 
+		Assert.assertEquals(
+			expectedBooleanClauseOccur,
+			filterBooleanClause.getBooleanClauseOccur());
+
 		NestedQuery nestedQuery = (NestedQuery)filterBooleanClause.getClause();
 
 		Assert.assertEquals("nestedFieldArray", nestedQuery.getPath());
@@ -601,10 +676,39 @@ public class AssetListFiltersUtilTest {
 			nestedFieldBooleanClauses.get(2);
 
 		Assert.assertEquals(
-			expectedBooleanClauseOccur,
+			BooleanClauseOccur.MUST,
 			nestedFieldBooleanClause.getBooleanClauseOccur());
 
 		return nestedFieldBooleanClause.getClause();
+	}
+
+	private void _assertPicklistBooleanQuery(
+		BooleanClauseOccur expectedBooleanClauseOccur, Query query,
+		String... expectedValues) {
+
+		Assert.assertTrue(query.toString(), query instanceof BooleanQuery);
+
+		BooleanQuery booleanQuery = (BooleanQuery)query;
+
+		List<BooleanClause<Query>> nestedFieldBooleanClauses =
+			booleanQuery.clauses();
+
+		Assert.assertEquals(
+			nestedFieldBooleanClauses.toString(), expectedValues.length,
+			nestedFieldBooleanClauses.size());
+
+		for (int i = 0; i < expectedValues.length; i++) {
+			BooleanClause<Query> booleanClause = nestedFieldBooleanClauses.get(
+				i);
+
+			Assert.assertEquals(
+				expectedBooleanClauseOccur,
+				booleanClause.getBooleanClauseOccur());
+
+			_assertTermQuery(
+				"nestedFieldArray.value_keyword", expectedValues[i],
+				booleanClause.getClause());
+		}
 	}
 
 	private void _assertTermQuery(
@@ -630,12 +734,12 @@ public class AssetListFiltersUtilTest {
 		TermRangeQuery termRangeQuery = (TermRangeQuery)query;
 
 		Assert.assertEquals(expectedField, termRangeQuery.getField());
-		Assert.assertEquals(expectedLowerTerm, termRangeQuery.getLowerTerm());
-		Assert.assertEquals(expectedUpperTerm, termRangeQuery.getUpperTerm());
 		Assert.assertEquals(
 			expectedIncludesLower, termRangeQuery.includesLower());
 		Assert.assertEquals(
 			expectedIncludesUpper, termRangeQuery.includesUpper());
+		Assert.assertEquals(expectedLowerTerm, termRangeQuery.getLowerTerm());
+		Assert.assertEquals(expectedUpperTerm, termRangeQuery.getUpperTerm());
 	}
 
 	private void _assertWildcardQuery(
@@ -683,6 +787,14 @@ public class AssetListFiltersUtilTest {
 		);
 	}
 
+	private JSONObject _buildPicklistValueJSONObject(String value) {
+		return JSONUtil.put(
+			"label", value
+		).put(
+			"value", value
+		);
+	}
+
 	private String _resolveRelativeDateLowerTerm(
 		String propertyName, String value) {
 
@@ -695,6 +807,18 @@ public class AssetListFiltersUtilTest {
 		TermRangeQuery termRangeQuery = (TermRangeQuery)query;
 
 		return termRangeQuery.getLowerTerm();
+	}
+
+	private void _setUpKeywordTextObjectField(String name) {
+		ObjectField objectField = _setUpObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, name);
+
+		Mockito.when(
+			objectField.isIndexedAsKeyword()
+		).thenReturn(
+			true
+		);
 	}
 
 	private void _setUpLocalizationUtil() {
@@ -725,15 +849,6 @@ public class AssetListFiltersUtilTest {
 			_CLASS_TYPE_ID
 		);
 
-		_objectDefinitionLocalServiceUtilMockedStatic.when(
-			() ->
-				ObjectDefinitionLocalServiceUtil.
-					fetchObjectDefinitionByClassName(
-						_COMPANY_ID, "com.liferay.test.Class" + _CLASS_NAME_ID)
-		).thenReturn(
-			objectDefinition
-		);
-
 		ObjectField objectField = Mockito.mock(ObjectField.class);
 
 		Mockito.when(
@@ -754,6 +869,15 @@ public class AssetListFiltersUtilTest {
 			fieldName
 		);
 
+		_objectDefinitionLocalServiceUtilMockedStatic.when(
+			() ->
+				ObjectDefinitionLocalServiceUtil.
+					fetchObjectDefinitionByClassName(
+						_COMPANY_ID, "com.liferay.test.Class" + _CLASS_NAME_ID)
+		).thenReturn(
+			objectDefinition
+		);
+
 		_objectFieldLocalServiceUtilMockedStatic.when(
 			() -> ObjectFieldLocalServiceUtil.fetchObjectField(
 				_CLASS_TYPE_ID, fieldName)
@@ -768,6 +892,24 @@ public class AssetListFiltersUtilTest {
 		);
 
 		return objectField;
+	}
+
+	private void _setUpPicklistObjectField(String fieldName) {
+		ObjectField objectField = _setUpObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_PICKLIST,
+			ObjectFieldConstants.DB_TYPE_STRING, fieldName);
+
+		Mockito.when(
+			objectField.getListTypeDefinitionId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			objectField.isIndexedAsKeyword()
+		).thenReturn(
+			true
+		);
 	}
 
 	private static final long _CLASS_NAME_ID = RandomTestUtil.randomLong();

--- a/modules/apps/asset/asset-list-test/build.gradle
+++ b/modules/apps/asset/asset-list-test/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:journal:journal-api")
 	testIntegrationImplementation project(":apps:journal:journal-test-util")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
+	testIntegrationImplementation project(":apps:list-type:list-type-api")
 	testIntegrationImplementation project(":apps:object:object-api")
 	testIntegrationImplementation project(":apps:object:object-test-util")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -13,6 +13,9 @@ import com.liferay.asset.list.model.AssetListEntry;
 import com.liferay.asset.list.service.AssetListEntryLocalService;
 import com.liferay.asset.list.test.util.AssetListTestUtil;
 import com.liferay.info.pagination.InfoPage;
+import com.liferay.list.type.entry.util.ListTypeEntryUtil;
+import com.liferay.list.type.model.ListTypeDefinition;
+import com.liferay.list.type.service.ListTypeDefinitionLocalService;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
@@ -31,6 +34,7 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
@@ -39,6 +43,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -82,6 +87,8 @@ public class AssetListAssetEntryProviderFiltersTest {
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
 
+		_listTypeDefinition = _addListTypeDefinition();
+
 		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
 			Arrays.asList(
 				ObjectFieldUtil.createObjectField(
@@ -113,7 +120,19 @@ public class AssetListAssetEntryProviderFiltersTest {
 					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 					ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_TEXT,
-					false)),
+					false),
+				ObjectFieldUtil.createObjectField(
+					_listTypeDefinition.getListTypeDefinitionId(),
+					ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST,
+					null, ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+					RandomTestUtil.randomString(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, false, false),
+				ObjectFieldUtil.createObjectField(
+					_listTypeDefinition.getListTypeDefinitionId(),
+					ObjectFieldConstants.BUSINESS_TYPE_PICKLIST, null,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_PICKLIST,
+					false, false)),
 			ObjectDefinitionConstants.SCOPE_SITE);
 	}
 
@@ -271,6 +290,43 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
 	@Test
+	public void testGetAssetEntriesInfoPageWithNegationFiltersIncludeFieldAbsentEntries()
+		throws Exception {
+
+		String title = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_TEXT, title
+			).build());
+
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_INTEGER, RandomTestUtil.randomInt()
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildFilterJSONObject(
+					"not-eq", _OBJECT_FIELD_NAME_TEXT, title)),
+			objectEntry2);
+
+		String keyword = RandomTestUtil.randomString();
+
+		_addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_KEYWORD, keyword
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildFilterJSONObject(
+					"not-contains", _OBJECT_FIELD_NAME_KEYWORD, keyword)),
+			objectEntry1, objectEntry2);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
 	public void testGetAssetEntriesInfoPageWithNumericRangeFilters()
 		throws Exception {
 
@@ -278,6 +334,7 @@ public class AssetListAssetEntryProviderFiltersTest {
 			HashMapBuilder.<String, Serializable>put(
 				_OBJECT_FIELD_NAME_INTEGER, RandomTestUtil.randomInt(1, 100)
 			).build());
+
 		int priority1 = RandomTestUtil.randomInt(101, 200);
 
 		_assertFilteredClassPKs(
@@ -325,6 +382,77 @@ public class AssetListAssetEntryProviderFiltersTest {
 					"gt", _OBJECT_FIELD_NAME_INTEGER,
 					String.valueOf(priority1))),
 			objectEntry3);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testGetAssetEntriesInfoPageWithPicklistFilters()
+		throws Exception {
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_PICKLIST, _LIST_TYPE_ENTRY_KEY_1
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildPicklistFilter(
+					_OBJECT_FIELD_NAME_PICKLIST, "any",
+					_LIST_TYPE_ENTRY_KEY_1)),
+			objectEntry1);
+
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_PICKLIST, _LIST_TYPE_ENTRY_KEY_2
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildPicklistFilter(
+					_OBJECT_FIELD_NAME_PICKLIST, "any", _LIST_TYPE_ENTRY_KEY_1,
+					_LIST_TYPE_ENTRY_KEY_2)),
+			objectEntry1, objectEntry2);
+
+		ObjectEntry objectEntry3 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				(Serializable)Arrays.asList(
+					_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2)
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildPicklistFilter(
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, "all",
+					_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2)),
+			objectEntry3);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildPicklistFilter(
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, "any",
+					_LIST_TYPE_ENTRY_KEY_1)),
+			objectEntry3);
+
+		ObjectEntry objectEntry4 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				(Serializable)Arrays.asList(
+					_LIST_TYPE_ENTRY_KEY_2, _LIST_TYPE_ENTRY_KEY_3)
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildPicklistFilter(
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, "all",
+					_LIST_TYPE_ENTRY_KEY_2)),
+			objectEntry3, objectEntry4);
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildPicklistFilter(
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, "any",
+					_LIST_TYPE_ENTRY_KEY_3)),
+			objectEntry4);
 	}
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
@@ -503,6 +631,28 @@ public class AssetListAssetEntryProviderFiltersTest {
 			assetListEntry.getAssetListEntryId());
 	}
 
+	private ListTypeDefinition _addListTypeDefinition() throws Exception {
+		return _listTypeDefinitionLocalService.addListTypeDefinition(
+			null, TestPropsValues.getUserId(),
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			false,
+			Arrays.asList(
+				ListTypeEntryUtil.createListTypeEntry(
+					_LIST_TYPE_ENTRY_KEY_1,
+					Collections.singletonMap(
+						LocaleUtil.US, _LIST_TYPE_ENTRY_KEY_1)),
+				ListTypeEntryUtil.createListTypeEntry(
+					_LIST_TYPE_ENTRY_KEY_2,
+					Collections.singletonMap(
+						LocaleUtil.US, _LIST_TYPE_ENTRY_KEY_2)),
+				ListTypeEntryUtil.createListTypeEntry(
+					_LIST_TYPE_ENTRY_KEY_3,
+					Collections.singletonMap(
+						LocaleUtil.US, _LIST_TYPE_ENTRY_KEY_3))),
+			new ServiceContext());
+	}
+
 	private ObjectEntry _addObjectEntry(Map<String, Serializable> values)
 		throws Exception {
 
@@ -563,6 +713,28 @@ public class AssetListAssetEntryProviderFiltersTest {
 		return JSONUtil.putAll((Object[])filterJSONObjects);
 	}
 
+	private JSONObject _buildPicklistFilter(
+		String propertyName, String quantifier, String... keys) {
+
+		return JSONUtil.put(
+			"classNameId",
+			_portal.getClassNameId(_objectDefinition.getClassName())
+		).put(
+			"classTypeId", _objectDefinition.getObjectDefinitionId()
+		).put(
+			"operatorName", "contains"
+		).put(
+			"propertyName", propertyName
+		).put(
+			"quantifier", quantifier
+		).put(
+			"value",
+			JSONUtil.putAll(
+				(Object[])TransformUtil.transform(
+					keys, key -> JSONUtil.put("value", key), JSONObject.class))
+		);
+	}
+
 	private ObjectFieldSetting _createObjectFieldSetting(
 		String name, String value) {
 
@@ -574,6 +746,15 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 		return objectFieldSetting;
 	}
+
+	private static final String _LIST_TYPE_ENTRY_KEY_1 =
+		RandomTestUtil.randomString();
+
+	private static final String _LIST_TYPE_ENTRY_KEY_2 =
+		RandomTestUtil.randomString();
+
+	private static final String _LIST_TYPE_ENTRY_KEY_3 =
+		RandomTestUtil.randomString();
 
 	private static final String _OBJECT_FIELD_NAME_DATE =
 		"xDate" + RandomTestUtil.randomString();
@@ -587,6 +768,12 @@ public class AssetListAssetEntryProviderFiltersTest {
 	private static final String _OBJECT_FIELD_NAME_KEYWORD =
 		"xKeyword" + RandomTestUtil.randomString();
 
+	private static final String _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST =
+		"xCategories" + RandomTestUtil.randomString();
+
+	private static final String _OBJECT_FIELD_NAME_PICKLIST =
+		"xCategory" + RandomTestUtil.randomString();
+
 	private static final String _OBJECT_FIELD_NAME_TEXT =
 		"xText" + RandomTestUtil.randomString();
 
@@ -598,6 +785,12 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@DeleteAfterTestRun
+	private ListTypeDefinition _listTypeDefinition;
+
+	@Inject
+	private ListTypeDefinitionLocalService _listTypeDefinitionLocalService;
 
 	@DeleteAfterTestRun
 	private ObjectDefinition _objectDefinition;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88609

## What Is Being Fixed

Adds the picklist (single and multi-value) operator for object-field filters on dynamic asset list collections. This is the last in a series of scoped PRs split from a larger change (per review feedback). It is **stacked on the date PR #2069** (which chains back through the numeric range PR #2068 and the contains PR #2077), so the diff below includes those predecessors' commits — the picklist delta for review is the two "picklist multi-value" commits.

## How It Is Being Fixed

When a filtered object field is backed by a list type definition, the contains and not-contains operators route to a new _toPicklistQuery helper that builds a keyword TermQuery per selected value, joined with SHOULD for the any quantifier and MUST for the all quantifier. Unit tests assert the resulting boolean query shapes and integration tests verify end-to-end filtering against real object entries backed by a list type definition. This completes the object-field filter operator set.

## PR Check

**pr-check: PASS** — tested on `9662e6ba2476cfb79c49b5b447da1bccea467a38`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "9662e6ba2476cfb79c49b5b447da1bccea467a38"} -->


