### PR TITLE
LPD-99907 portal-search-elasticsearch8-test: Capture expected warning

### DIFF
--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-test/src/testIntegration/java/com/liferay/portal/search/elasticsearch8/internal/upgrade/v1_0_0/test/ElasticsearchConfigurationUpgradeProcessTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-test/src/testIntegration/java/com/liferay/portal/search/elasticsearch8/internal/upgrade/v1_0_0/test/ElasticsearchConfigurationUpgradeProcessTest.java
@@ -13,11 +13,15 @@ import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.search.elasticsearch8.configuration.ElasticsearchConfiguration;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import java.util.Dictionary;
+import java.util.List;
 import java.util.Objects;
 
 import org.junit.After;
@@ -99,7 +103,22 @@ public class ElasticsearchConfigurationUpgradeProcessTest {
 	public void testUpgrade() throws Exception {
 		UpgradeProcess upgradeProcess = _getUpgradeProcess();
 
-		upgradeProcess.upgrade();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME_UPGRADE_PROCESS, LoggerTestUtil.WARN)) {
+
+			upgradeProcess.upgrade();
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			LogEntry logEntry = logEntries.get(0);
+
+			String logEntryMessage = logEntry.getMessage();
+
+			Assert.assertTrue(
+				logEntryMessage.contains(
+					"Elasticsearch 7 configuration detected. Attempting to " +
+						"migrate properties to Elasticsearch 8."));
+		}
 
 		Configuration configuration = _getConfiguration(
 			ElasticsearchConfiguration.class.getName());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99907

## What Is Being Fixed

`PortalLogAssertorTest#testScanXMLLog` fails an entire modules integration batch when it finds any WARN, ERROR, or FATAL event in the portal XML log, and it keeps no whitelist. Testray case result 503364464 on build `[master] ci:test:search - 8030`, batch `modules-integration-postgresql163/0/14`, failed with:

```
PortalLogAssertorTest#testScanXMLLog: Elasticsearch 7 configuration detected. Attempting to migrate properties to Elasticsearch 8. Manual updates to the configuration may be
```

`ElasticsearchConfigurationUpgradeProcessTest` writes properties to the Elasticsearch 7 pid in its setup so the upgrade process has something to migrate. The process then correctly warns that it detected an Elasticsearch 7 configuration, but nothing captured the logger, so the warning propagated to the portal appenders and landed in the XML log, failing the batch for every other test sharing it. The leak dates to `0bbcbcb8685cc` ("LPD-79131 Add test") on 2026-02-12, and LPD-95375 recorded the same warning on sibling batch `postgresql163/0/19` in June without diagnosing it.

## How It Is Being Fixed

Wrapping the upgrade call in a `LogCapture` from `LoggerTestUtil.configureLog4JLogger` creates a dedicated Log4j config for the upgrade process logger and clears its additivity for the duration of the block, so the warning reaches the capture instead of propagating to the root appenders that own the XML file. Asserting the captured message makes the suppression deliberate rather than a silent mute, and means a future reword of the warning surfaces here instead of quietly changing behavior. The warning itself stays in place in product code, where it is correct guidance for anyone actually migrating from Elasticsearch 7 to Elasticsearch 8.

Two limits are worth flagging for review. The change has been compiled but not exercised against a running portal, so the suppression rests on `Log4jConfigUtil.setLevel` creating an exact-name `LoggerConfig` and the capture then clearing additivity, matching the existing `CategoryFacetPortletUpgradeProcessTest` precedent. And the capture silences one logger only, so any warning from the connection or observer classes that the setup provokes by setting `clusterName` to `alpha` uses a different logger and is untouched.

## PR Check

**pr-check: PASS** — tested on `e6033f49d28a419ea903502c710eb2b32fa07e8e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "e6033f49d28a419ea903502c710eb2b32fa07e8e"} -->
