### PR TITLE
LPD-88609 Add contains operator support to object field filters

### DIFF
--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -11,6 +11,7 @@ import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldLocalServiceUtil;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -18,9 +19,11 @@ import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.MatchQuery;
 import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.TermQuery;
+import com.liferay.portal.kernel.search.WildcardQuery;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -162,9 +165,11 @@ public class AssetListFiltersUtil {
 			return null;
 		}
 
+		String operatorName = jsonObject.getString("operatorName", "contains");
+
 		String subfield = _getSubfield(locale, objectField);
 
-		Query query = _toValueQuery(subfield, value);
+		Query query = _toValueQuery(operatorName, subfield, value);
 
 		if (query == null) {
 			return null;
@@ -180,9 +185,6 @@ public class AssetListFiltersUtil {
 				"nestedFieldArray.valueFieldName",
 				subfield.substring(subfield.indexOf(CharPool.PERIOD) + 1)),
 			BooleanClauseOccur.MUST);
-
-		String operatorName = jsonObject.getString("operatorName", "contains");
-
 		booleanQuery.add(
 			query,
 			_isNegatedOperator(operatorName) ? BooleanClauseOccur.MUST_NOT :
@@ -191,12 +193,33 @@ public class AssetListFiltersUtil {
 		return new NestedQuery("nestedFieldArray", booleanQuery);
 	}
 
-	private static Query _toValueQuery(String subfield, String value) {
+	private static Query _toValueQuery(
+		String operatorName, String subfield, String value) {
+
+		if ((operatorName.equals("contains") ||
+			 operatorName.equals("not-contains")) &&
+			subfield.endsWith(".value_keyword")) {
+
+			return new WildcardQuery(
+				subfield,
+				StringPool.STAR + StringUtil.toLowerCase(value) +
+					StringPool.STAR);
+		}
+
 		if (subfield.endsWith(".value_keyword")) {
 			return new TermQuery(subfield, StringUtil.toLowerCase(value));
 		}
 
-		return new TermQuery(subfield, value);
+		if (operatorName.equals("eq") || operatorName.equals("not-eq") ||
+			subfield.endsWith(".value_boolean") ||
+			subfield.endsWith(".value_double") ||
+			subfield.endsWith(".value_integer") ||
+			subfield.endsWith(".value_long")) {
+
+			return new TermQuery(subfield, value);
+		}
+
+		return new MatchQuery(subfield, value);
 	}
 
 }

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -16,10 +16,12 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.MatchQuery;
 import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.QueryTerm;
 import com.liferay.portal.kernel.search.TermQuery;
+import com.liferay.portal.kernel.search.WildcardQuery;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
@@ -225,6 +227,78 @@ public class AssetListFiltersUtilTest {
 			Arrays.toString(booleanClauses), 0, booleanClauses.length);
 	}
 
+	@Test
+	public void testFilterQueriesWithKeywordTextContainsOperators() {
+		String keywordTextFieldName = RandomTestUtil.randomString();
+
+		ObjectField keywordObjectField = _setUpObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, keywordTextFieldName);
+
+		Mockito.when(
+			keywordObjectField.isIndexedAsKeyword()
+		).thenReturn(
+			true
+		);
+
+		_assertWildcardQuery(
+			"nestedFieldArray.value_keyword", "*alpha*",
+			_assertNestedRowAndGetQuery(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject(
+					"contains", keywordTextFieldName, "Alpha"),
+				keywordTextFieldName));
+		_assertWildcardQuery(
+			"nestedFieldArray.value_keyword", "*alpha*",
+			_assertNestedRowAndGetQuery(
+				BooleanClauseOccur.MUST_NOT,
+				_buildFilterJSONObject(
+					"not-contains", keywordTextFieldName, "Alpha"),
+				keywordTextFieldName));
+	}
+
+	@Test
+	public void testFilterQueriesWithTextContainsOperators() {
+		String textFieldName = RandomTestUtil.randomString();
+
+		_setUpObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, textFieldName);
+
+		String textFieldValue = RandomTestUtil.randomString();
+
+		Query containsQuery = _assertNestedRowAndGetQuery(
+			BooleanClauseOccur.MUST,
+			_buildFilterJSONObject("contains", textFieldName, textFieldValue),
+			textFieldName);
+
+		Assert.assertTrue(
+			containsQuery.toString(), containsQuery instanceof MatchQuery);
+
+		Query containsWithQuantifierQuery = _assertNestedRowAndGetQuery(
+			BooleanClauseOccur.MUST,
+			_buildFilterJSONObject(
+				"contains", textFieldName, textFieldValue
+			).put(
+				"quantifier", "any"
+			),
+			textFieldName);
+
+		Assert.assertTrue(
+			containsWithQuantifierQuery.toString(),
+			containsWithQuantifierQuery instanceof MatchQuery);
+
+		Query notContainsQuery = _assertNestedRowAndGetQuery(
+			BooleanClauseOccur.MUST_NOT,
+			_buildFilterJSONObject(
+				"not-contains", textFieldName, textFieldValue),
+			textFieldName);
+
+		Assert.assertTrue(
+			notContainsQuery.toString(),
+			notContainsQuery instanceof MatchQuery);
+	}
+
 	private Query _assertNestedRowAndGetQuery(
 		BooleanClauseOccur expectedBooleanClauseOccur,
 		JSONObject filterJSONObject, String propertyName) {
@@ -312,6 +386,19 @@ public class AssetListFiltersUtilTest {
 		TermQuery termQuery = (TermQuery)query;
 
 		QueryTerm queryTerm = termQuery.getQueryTerm();
+
+		Assert.assertEquals(expectedField, queryTerm.getField());
+		Assert.assertEquals(expectedValue, queryTerm.getValue());
+	}
+
+	private void _assertWildcardQuery(
+		String expectedField, String expectedValue, Query query) {
+
+		Assert.assertTrue(query.toString(), query instanceof WildcardQuery);
+
+		WildcardQuery wildcardQuery = (WildcardQuery)query;
+
+		QueryTerm queryTerm = wildcardQuery.getQueryTerm();
 
 		Assert.assertEquals(expectedField, queryTerm.getField());
 		Assert.assertEquals(expectedValue, queryTerm.getValue());

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -87,6 +87,11 @@ public class AssetListAssetEntryProviderFiltersTest {
 					false),
 				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_KEYWORD,
+					false),
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 					ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_TEXT,
 					false)),
@@ -138,6 +143,105 @@ public class AssetListAssetEntryProviderFiltersTest {
 				_buildFilterJSONObject(
 					"not-eq", _OBJECT_FIELD_NAME_INTEGER,
 					String.valueOf(priority))),
+			objectEntry2);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testGetAssetEntriesInfoPageWithKeywordTextContainsFilters()
+		throws Exception {
+
+		String keyword = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_KEYWORD, keyword
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildFilterJSONObject(
+					"contains", _OBJECT_FIELD_NAME_KEYWORD, keyword)),
+			objectEntry1);
+
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_KEYWORD, RandomTestUtil.randomString()
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildFilterJSONObject(
+					"not-contains", _OBJECT_FIELD_NAME_KEYWORD, keyword)),
+			objectEntry2);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testGetAssetEntriesInfoPageWithMultipleFiltersJoinedWithMust()
+		throws Exception {
+
+		int priority = RandomTestUtil.randomInt();
+		String title = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_INTEGER, priority
+			).put(
+				_OBJECT_FIELD_NAME_TEXT, title
+			).build());
+
+		_addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_INTEGER, RandomTestUtil.randomInt()
+			).put(
+				_OBJECT_FIELD_NAME_TEXT, title
+			).build());
+
+		_addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_INTEGER, priority
+			).put(
+				_OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildFilterJSONObject(
+					"contains", _OBJECT_FIELD_NAME_TEXT, title),
+				_buildFilterJSONObject(
+					"eq", _OBJECT_FIELD_NAME_INTEGER,
+					String.valueOf(priority))),
+			objectEntry1);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testGetAssetEntriesInfoPageWithTextContainsFilters()
+		throws Exception {
+
+		String title = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_TEXT, title
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildFilterJSONObject(
+					"contains", _OBJECT_FIELD_NAME_TEXT, title)),
+			objectEntry1);
+
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildFilterJSONObject(
+					"not-contains", _OBJECT_FIELD_NAME_TEXT, title)),
 			objectEntry2);
 	}
 
@@ -349,6 +453,9 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 	private static final String _OBJECT_FIELD_NAME_INTEGER =
 		"xInteger" + RandomTestUtil.randomString();
+
+	private static final String _OBJECT_FIELD_NAME_KEYWORD =
+		"xKeyword" + RandomTestUtil.randomString();
 
 	private static final String _OBJECT_FIELD_NAME_TEXT =
 		"xText" + RandomTestUtil.randomString();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88609

## What Is Being Fixed

Object-field filtering did not support the `contains` / `not-contains`
operators, so substring matching on keyword-indexed fields and full-text
matching on text fields was unavailable.

## How It Is Being Fixed

`AssetListFiltersUtil._toValueQuery` builds a `WildcardQuery` (`*value*`,
lowercased) for `contains` / `not-contains` on keyword-indexed fields and
falls back to a `MatchQuery` for text fields. The `eq` / `not-eq` operators
continue to use `TermQuery`.

The foundation + `eq`/`not-eq` PR (#2076) has merged; this PR rebases onto
master and adds the `contains` operator support on top of it.

## PR Check

**pr-check: PASS** — tested on `46da0d785cd4dff86243863f4efe440220d9a46c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "46da0d785cd4dff86243863f4efe440220d9a46c"} -->
