### PR TITLE
LPD-75968 Skip stale-doc version conflicts on SYNC reindex (engine-adapter)

### DIFF
--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/index/SyncReindexManagerImpl.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/index/SyncReindexManagerImpl.java
@@ -83,6 +83,8 @@ public class SyncReindexManagerImpl implements SyncReindexManager {
 		DeleteByQueryDocumentRequest deleteByQueryDocumentRequest =
 			new DeleteByQueryDocumentRequest(booleanQuery, indexName);
 
+		deleteByQueryDocumentRequest.setProceedOnConflicts(true);
+
 		_searchEngineAdapter.execute(deleteByQueryDocumentRequest);
 	}
 

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/document/DeleteByQueryDocumentRequestExecutor.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/document/DeleteByQueryDocumentRequestExecutor.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.search.elasticsearch8.internal.search.engine.adapter.document;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.Conflicts;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryResponse;
@@ -62,6 +63,10 @@ public class DeleteByQueryDocumentRequestExecutor {
 				new Query(
 					ElasticsearchQueryVisitor.INSTANCE.translate(
 						deleteByQueryDocumentRequest.getQuery())));
+		}
+
+		if (deleteByQueryDocumentRequest.isProceedOnConflicts()) {
+			builder.conflicts(Conflicts.Proceed);
 		}
 
 		builder.refresh(deleteByQueryDocumentRequest.isRefresh());

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/document/DeleteByQueryDocumentRequestExecutorTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/document/DeleteByQueryDocumentRequestExecutorTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.search.elasticsearch8.internal.search.engine.adapter.document;
 
+import co.elastic.clients.elasticsearch._types.Conflicts;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
 
 import com.liferay.portal.kernel.search.BooleanQuery;
@@ -45,6 +46,30 @@ public class DeleteByQueryDocumentRequestExecutorTest {
 	@Test
 	public void testDocumentRequestTranslationWithNoRefresh() {
 		doTestDocumentRequestTranslation(false);
+	}
+
+	@Test
+	public void testDocumentRequestTranslationWithProceedOnConflicts() {
+		BooleanQuery booleanQuery = new BooleanQuery();
+
+		booleanQuery.addExactTerm(_FIELD_NAME, true);
+
+		DeleteByQueryDocumentRequest deleteByQueryDocumentRequest =
+			new DeleteByQueryDocumentRequest(
+				booleanQuery, new String[] {_INDEX_NAME});
+
+		deleteByQueryDocumentRequest.setProceedOnConflicts(true);
+
+		DeleteByQueryDocumentRequestExecutor
+			deleteByQueryDocumentRequestExecutor =
+				new DeleteByQueryDocumentRequestExecutor(_elasticsearchFixture);
+
+		DeleteByQueryRequest deleteByQueryRequest =
+			deleteByQueryDocumentRequestExecutor.createDeleteByQueryRequest(
+				deleteByQueryDocumentRequest);
+
+		Assert.assertEquals(
+			Conflicts.Proceed, deleteByQueryRequest.conflicts());
 	}
 
 	@Test

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/index/SyncReindexManagerImpl.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/index/SyncReindexManagerImpl.java
@@ -61,8 +61,12 @@ public class SyncReindexManagerImpl implements SyncReindexManager {
 		booleanQuery.addFilterQueryClauses(
 			_getTimeStampFilterBooleanQuery(date));
 
-		_searchEngineAdapter.execute(
-			new DeleteByQueryDocumentRequest(booleanQuery, indexName));
+		DeleteByQueryDocumentRequest deleteByQueryDocumentRequest =
+			new DeleteByQueryDocumentRequest(booleanQuery, indexName);
+
+		deleteByQueryDocumentRequest.setProceedOnConflicts(true);
+
+		_searchEngineAdapter.execute(deleteByQueryDocumentRequest);
 	}
 
 	private TermsQuery _getEntryClassNamesFilterQuery(

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/document/DeleteByQueryDocumentRequestExecutor.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/document/DeleteByQueryDocumentRequestExecutor.java
@@ -14,6 +14,7 @@ import com.liferay.portal.search.opensearch2.internal.legacy.query.OpenSearchQue
 import java.io.IOException;
 
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.Conflicts;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.DeleteByQueryRequest;
 import org.opensearch.client.opensearch.core.DeleteByQueryResponse;
@@ -62,6 +63,10 @@ public class DeleteByQueryDocumentRequestExecutor {
 				new Query(
 					OpenSearchQueryVisitor.INSTANCE.translate(
 						deleteByQueryDocumentRequest.getQuery())));
+		}
+
+		if (deleteByQueryDocumentRequest.isProceedOnConflicts()) {
+			builder.conflicts(Conflicts.Proceed);
 		}
 
 		builder.refresh(deleteByQueryDocumentRequest.isRefresh());

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/document/DeleteByQueryDocumentRequestExecutorTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/document/DeleteByQueryDocumentRequestExecutorTest.java
@@ -17,6 +17,7 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import org.opensearch.client.opensearch._types.Conflicts;
 import org.opensearch.client.opensearch.core.DeleteByQueryRequest;
 
 /**
@@ -36,6 +37,31 @@ public class DeleteByQueryDocumentRequestExecutorTest
 	@Test
 	public void testDocumentRequestTranslationWithNoRefresh() {
 		doTestDocumentRequestTranslation(false);
+	}
+
+	@Test
+	public void testDocumentRequestTranslationWithProceedOnConflicts() {
+		BooleanQuery booleanQuery = new BooleanQuery();
+
+		booleanQuery.addExactTerm(_FIELD_NAME, true);
+
+		DeleteByQueryDocumentRequest deleteByQueryDocumentRequest =
+			new DeleteByQueryDocumentRequest(
+				booleanQuery, new String[] {TEST_INDEX_NAME});
+
+		deleteByQueryDocumentRequest.setProceedOnConflicts(true);
+
+		DeleteByQueryDocumentRequestExecutor
+			deleteByQueryDocumentRequestExecutor =
+				new DeleteByQueryDocumentRequestExecutor(
+					openSearchConnectionManager);
+
+		DeleteByQueryRequest deleteByQueryRequest =
+			deleteByQueryDocumentRequestExecutor.createDeleteByQueryRequest(
+				deleteByQueryDocumentRequest);
+
+		Assert.assertEquals(
+			Conflicts.Proceed, deleteByQueryRequest.conflicts());
 	}
 
 	@Test

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search Engine Adapter API
 Bundle-SymbolicName: com.liferay.portal.search.engine.adapter.api
-Bundle-Version: 7.1.1
+Bundle-Version: 7.2.0
 Export-Package:\
 	com.liferay.portal.search.engine.adapter,\
 	com.liferay.portal.search.engine.adapter.ccr,\

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/DeleteByQueryDocumentRequest.java
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/DeleteByQueryDocumentRequest.java
@@ -63,12 +63,20 @@ public class DeleteByQueryDocumentRequest
 		return _query;
 	}
 
+	public boolean isProceedOnConflicts() {
+		return _proceedOnConflicts;
+	}
+
 	public boolean isRefresh() {
 		return _refresh;
 	}
 
 	public boolean isWaitForCompletion() {
 		return _waitForCompletion;
+	}
+
+	public void setProceedOnConflicts(boolean proceedOnConflicts) {
+		_proceedOnConflicts = proceedOnConflicts;
 	}
 
 	public void setRefresh(boolean refresh) {
@@ -81,6 +89,7 @@ public class DeleteByQueryDocumentRequest
 
 	private final String[] _indexNames;
 	private final Query _portalSearchQuery;
+	private boolean _proceedOnConflicts;
 	private final com.liferay.portal.kernel.search.Query _query;
 	private boolean _refresh;
 	private boolean _waitForCompletion;

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/resources/com/liferay/portal/search/engine/adapter/document/packageinfo
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/resources/com/liferay/portal/search/engine/adapter/document/packageinfo
@@ -1,1 +1,1 @@
-version 5.1.0
+version 5.2.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-75968

## What Is Being Fixed

A SYNC reindex racing against concurrent writes triggers Elasticsearch `version_conflict_engine_exception` when the stale-document sweep hits a document that was re-indexed after the sweep captured its version. The failure surfaces as a reindex error even though nothing meaningful is wrong — the concurrent writer already put the document in the right state.

## How It Is Being Fixed

`DeleteByQueryDocumentRequest` grows an additive `setProceedOnConflicts(boolean)` flag (default `false`, backward-compatible with every existing caller). The Elasticsearch 8 executor honours the flag by setting `builder.conflicts(Conflicts.Proceed)` on the underlying `DeleteByQueryRequest`, which tells ES to skip conflicting documents instead of aborting the batch. `SyncReindexManagerImpl` opts in by calling `setProceedOnConflicts(true)` on its stale-document sweep, so the SYNC reindex path survives concurrent writes without failing. The bnd `Bundle-Version` and `packageinfo` are bumped MINOR (`7.1.1 → 7.2.0`) to reflect the additive API change.

## PR Check

**pr-check: PASS** — tested on `6ff5f0f20c4ec019c9cd1197d78eba53ed346c0c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6ff5f0f20c4ec019c9cd1197d78eba53ed346c0c"} -->
