### PR TITLE
LPD-100415 Render all collection sections when a subtype is not viewable

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
@@ -123,6 +123,10 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 		Long[] assetSelectedClassTypeIds = ArrayUtil.clone(editAssetListDisplayContext.getClassTypeIds(unicodeProperties, className, classTypes));
 
 		Arrays.sort(assetSelectedClassTypeIds);
+
+		long[] availableClassTypeIds = ListUtil.toLongArray(classTypes, ClassType::getClassTypeId);
+
+		Arrays.sort(availableClassTypeIds);
 	%>
 
 		<div class='asset-subtype <%= (assetSelectedClassTypeIds.length < 1) ? StringPool.BLANK : "hide" %>' data-class-name="<%= className %>" id="<portlet:namespace /><%= className %>Options">
@@ -139,6 +143,17 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 					%>
 
 						<aui:option label="<%= HtmlUtil.escapeAttribute(classType.getName()) %>" selected="<%= !anyAssetSubtype && (assetSelectedClassTypeIds.length == 1) && (assetSelectedClassTypeIds[0]).equals(classType.getClassTypeId()) && !noAssetSubtypeSelected %>" value="<%= classType.getClassTypeId() %>" />
+
+					<%
+					}
+
+					for (Long assetSelectedClassTypeId : assetSelectedClassTypeIds) {
+						if (Arrays.binarySearch(availableClassTypeIds, assetSelectedClassTypeId) >= 0) {
+							continue;
+						}
+					%>
+
+						<aui:option label="<%= String.valueOf(assetSelectedClassTypeId) %>" selected="<%= !anyAssetSubtype && (assetSelectedClassTypeIds.length == 1) && !noAssetSubtypeSelected %>" value="<%= assetSelectedClassTypeId %>" />
 
 					<%
 					}
@@ -215,7 +230,10 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 
 					subtypesRightList.add(new KeyValuePair(String.valueOf(subtypeId), HtmlUtil.escape(classType.getName())));
 				}
-				catch (NoSuchModelException nsme) {
+				catch (NoSuchModelException noSuchModelException) {
+				}
+				catch (PortalException portalException) {
+					subtypesRightList.add(new KeyValuePair(String.valueOf(subtypeId), String.valueOf(subtypeId)));
 				}
 			}
 			%>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/init.jsp
@@ -64,6 +64,7 @@ page import="com.liferay.object.service.ObjectDefinitionLocalServiceUtil" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.dao.search.SearchContainer" %><%@
 page import="com.liferay.portal.kernel.exception.NoSuchModelException" %><%@
+page import="com.liferay.portal.kernel.exception.PortalException" %><%@
 page import="com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.ClassName" %><%@

--- a/modules/test/playwright/helpers/ApiHelpers.ts
+++ b/modules/test/playwright/helpers/ApiHelpers.ts
@@ -538,6 +538,11 @@ export class DataApiHelpers extends ApiHelpers {
 			else if (item.type === 'document') {
 				await this.headlessDelivery.deleteDocument(item.id);
 			}
+			else if (item.type === 'documentDataDefinitionType') {
+				await this.headlessDelivery.deleteDocumentDataDefinitionType(
+					item.id
+				);
+			}
 			else if (item.type === 'keyword') {
 				await this.headlessAdminTaxonomy.deleteKeyword({
 					id: item.id,

--- a/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
@@ -6,7 +6,7 @@
 import * as fs from 'fs';
 
 import getRandomString from '../utils/getRandomString';
-import {ApiHelpers} from './ApiHelpers';
+import {ApiHelpers, DataApiHelpers} from './ApiHelpers';
 
 interface createSitePageProps {
 	pageDefinition?: PageDefinition;
@@ -117,6 +117,12 @@ export class HeadlessDeliveryApiHelper {
 		);
 	}
 
+	async deleteDocumentDataDefinitionType(id: string) {
+		return this.apiHelpers.delete(
+			`${this.apiHelpers.baseUrl}${this.basePath}/document-data-definition-types/${id}`
+		);
+	}
+
 	async deleteMessageBoardSection(messageBoardSectionId: string) {
 		return this.apiHelpers.delete(
 			`${this.apiHelpers.baseUrl}${this.basePath}/message-board-sections/${messageBoardSectionId}`
@@ -190,6 +196,29 @@ export class HeadlessDeliveryApiHelper {
 				failOnStatusCode: true,
 			}
 		);
+	}
+
+	async postSiteDocumentDataDefinitionType(siteId: string, name: string) {
+		const documentDataDefinitionType = await this.apiHelpers.post(
+			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}/document-data-definition-types`,
+			{
+				data: {
+					availableLanguages: ['en-US'],
+					dataDefinitionFields: [],
+					dataLayout: {},
+					name,
+				},
+			}
+		);
+
+		if (this.apiHelpers instanceof DataApiHelpers) {
+			this.apiHelpers.data.push({
+				id: documentDataDefinitionType.id,
+				type: 'documentDataDefinitionType',
+			});
+		}
+
+		return documentDataDefinitionType;
 	}
 
 	async postSiteKnowledgeBaseArticle({

--- a/modules/test/playwright/tests/asset-list-web/main/collections/dynamicCollection.spec.ts
+++ b/modules/test/playwright/tests/asset-list-web/main/collections/dynamicCollection.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {collectionsPagesTest} from '../../../../fixtures/collectionsPagesTest';
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getGlobalSite from '../../../../utils/getGlobalSite';
+import getRandomString from '../../../../utils/getRandomString';
+import {
+	performUserSwitchViaApi,
+	userData,
+} from '../../../../utils/performLogin';
+import {waitForAlert} from '../../../../utils/waitForAlert';
+
+const test = mergeTests(
+	loginTest(),
+	isolatedSiteTest,
+	dataApiHelpersTest,
+	collectionsPagesTest
+);
+
+test.describe('Source', () => {
+	test(
+		'Renders every section when the selected item subtype is not viewable',
+		{tag: '@LPD-100415'},
+		async ({apiHelpers, collectionsPage, page, site}) => {
+			const collectionName = getRandomString();
+			const documentTypeName = getRandomString();
+
+			let documentTypeId: string;
+			let screenName: string;
+
+			await test.step('Create a document type in the Global site', async () => {
+				const globalSite = await getGlobalSite(apiHelpers);
+
+				const documentType =
+					await apiHelpers.headlessDelivery.postSiteDocumentDataDefinitionType(
+						globalSite.groupId,
+						documentTypeName
+					);
+
+				documentTypeId = String(documentType.id);
+			});
+
+			await test.step('Create a dynamic collection filtered by that document type', async () => {
+				await collectionsPage.goto(site.friendlyUrlPath);
+
+				await collectionsPage.addNewDynamicCollection(collectionName);
+
+				await collectionsPage.configureSourceItemType({
+					itemSubtype: documentTypeName,
+					itemType: 'Document',
+				});
+			});
+
+			await test.step('Create a user who administers the site', async () => {
+				const user =
+					await apiHelpers.headlessAdminUser.postUserAccount();
+
+				screenName = user.alternateName || '';
+
+				userData[screenName] = {
+					name: user.givenName,
+					password: 'test',
+					surname: user.familyName,
+				};
+
+				await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
+
+				await apiHelpers.jsonWebServicesUser.answerReminderQuery(
+					user.id
+				);
+
+				const role =
+					await apiHelpers.headlessAdminUser.getRoleByName(
+						'Site Administrator'
+					);
+
+				await apiHelpers.headlessAdminUser.assignUserToSite(
+					role.id,
+					site.id,
+					user.id
+				);
+			});
+
+			await test.step('Open the collection as that user', async () => {
+				await performUserSwitchViaApi(page, screenName);
+
+				await collectionsPage.goto(site.friendlyUrlPath);
+
+				await collectionsPage.openCollection(collectionName);
+			});
+
+			await test.step('Every section is rendered', async () => {
+				for (const section of [
+					'Source',
+					'Scope',
+					'Filter',
+					'Ordering',
+				]) {
+					await expect(
+						page.getByRole('button', {name: section})
+					).toBeVisible();
+				}
+			});
+
+			await test.step('Save the collection', async () => {
+				await page.getByRole('button', {name: 'Save'}).click();
+
+				await waitForAlert(page);
+			});
+
+			await test.step('The item subtype is visible in the save', async () => {
+				await performUserSwitchViaApi(page, 'test');
+
+				await collectionsPage.goto(site.friendlyUrlPath);
+
+				await collectionsPage.openCollection(collectionName);
+
+				await expect(
+					page
+						.locator('.asset-subtype:not(.hide)')
+						.getByLabel('Item Subtype')
+				).toHaveValue(documentTypeId);
+			});
+		}
+	);
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100415

## What Is Being Fixed

Editing a collection as a non-Administrator rendered only part of the Source section. The Scope, Filter and Ordering sections were absent from the server output entirely, the item subtype selector was missing, and the section's JavaScript never loaded.

The available item subtypes are filtered by permission, but the selected item subtype is read from the type settings without filtering. When a collection is filtered by a subtype the current user cannot view — for example a document type in the Global site — resolving it raised a permission error. `source.jsp` caught only `NoSuchModelException`, so the error escaped, aborted the JSP include, and the remaining form navigator entries were never rendered.

Administrators were unaffected because they bypass permission checks.

## How It Is Being Fixed

The available item subtypes are collected up front so a selected subtype that the user cannot view is detected without invoking a permission checked lookup. Those subtypes are kept in the rendered lists rather than dropped, so the collection's configuration survives a save, and an option is emitted for them so the single subtype selection round-trips through the form.

Where a lookup is still reached — when the available list itself is unfiltered because Inline SQL Check is disabled — a permission failure is now caught and the subtype preserved. `NoSuchModelException` keeps its existing behavior of dropping the subtype, since a subtype that no longer exists should be removed; only the permission case is treated as recoverable.

A Playwright test covers the flow end to end. It creates a document type in the Global site, filters a dynamic collection by it, then opens that collection as a site administrator who cannot view the type, asserting every section renders and that the subtype survives a save. Supporting this required an update to APIHelpers for creating document types, which the Playwright suite did not have.

## PR Check

**pr-check: PASS** — tested on `7074a6efd34ccfafa3f55801126de61fb0abb880`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |

<!-- pr-check {"result": "success", "sha": "7074a6efd34ccfafa3f55801126de61fb0abb880"} -->
