### PR TITLE
B3 LPD-75968 Delegate to cross-writers so SYNC reindex preserves cross-writer docs

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/WorkflowMetricsIndex.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/WorkflowMetricsIndex.java
@@ -50,6 +50,19 @@ public enum WorkflowMetricsIndex {
 		WorkflowMetricsIndexNameConstants.SUFFIX_TRANSITION,
 		WorkflowMetricsIndexTypeConstants.TRANSITION_TYPE);
 
+	public static void createMissingIndexes(
+			SearchCapabilities searchCapabilities,
+			SearchEngineAdapter searchEngineAdapter,
+			IndexNameBuilder indexNameBuilder, long companyId)
+		throws PortalException {
+
+		for (WorkflowMetricsIndex workflowMetricsIndex : values()) {
+			workflowMetricsIndex.createIndex(
+				searchCapabilities, searchEngineAdapter, indexNameBuilder,
+				companyId);
+		}
+	}
+
 	public static String getIndexName(
 		IndexNameBuilder indexNameBuilder, String indexNameSuffix,
 		long companyId) {
@@ -92,7 +105,10 @@ public enum WorkflowMetricsIndex {
 			searchEngineAdapter.execute(createIndexRequest);
 		}
 		catch (Exception exception) {
-			_log.error(exception);
+			throw new PortalException(
+				"Unable to create index " +
+					getIndexName(indexNameBuilder, _indexNameSuffix, companyId),
+				exception);
 		}
 
 		return true;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/BaseWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/BaseWorkflowMetricsReindexer.java
@@ -50,6 +50,10 @@ public abstract class BaseWorkflowMetricsReindexer
 			return;
 		}
 
+		WorkflowMetricsIndex.createMissingIndexes(
+			searchCapabilities, searchEngineAdapter, indexNameBuilder,
+			companyId);
+
 		Date date = null;
 
 		WorkflowMetricsIndex workflowMetricsIndex =

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/BaseWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/BaseWorkflowMetricsReindexer.java
@@ -86,6 +86,8 @@ public abstract class BaseWorkflowMetricsReindexer
 					companyId),
 				date, Collections.emptySet());
 		}
+
+		postReindex(companyId, executionMode);
 	}
 
 	protected boolean isExecuteSyncReindex(ExecutionMode executionMode) {
@@ -97,6 +99,10 @@ public abstract class BaseWorkflowMetricsReindexer
 		}
 
 		return false;
+	}
+
+	protected void postReindex(long companyId, ExecutionMode executionMode)
+		throws Exception {
 	}
 
 	protected abstract void reindexEntities(long companyId) throws Exception;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/InstanceWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/InstanceWorkflowMetricsReindexer.java
@@ -87,6 +87,15 @@ public class InstanceWorkflowMetricsReindexer
 		actionableDynamicQuery.performActions();
 	}
 
+	@Override
+	protected void postReindex(long companyId, ExecutionMode executionMode)
+		throws Exception {
+
+		if (executionMode == ExecutionMode.FULL) {
+			_processWorkflowMetricsReindexer.reindex(companyId, executionMode);
+		}
+	}
+
 	@Reference
 	private IndexerHelper _indexerHelper;
 
@@ -99,6 +108,9 @@ public class InstanceWorkflowMetricsReindexer
 
 	@Reference
 	private KaleoInstanceLocalService _kaleoInstanceLocalService;
+
+	@Reference(target = "(workflow.metrics.reindexer.key=process)")
+	private IndexReindexer _processWorkflowMetricsReindexer;
 
 	@Reference
 	private WorkflowMetricsReindexStatusMessageSender

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/InstanceWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/InstanceWorkflowMetricsReindexer.java
@@ -91,11 +91,9 @@ public class InstanceWorkflowMetricsReindexer
 	protected void postReindex(long companyId, ExecutionMode executionMode)
 		throws Exception {
 
-		if (executionMode == ExecutionMode.FULL) {
-			_processWorkflowMetricsReindexer.reindex(companyId, executionMode);
+		_processWorkflowMetricsReindexer.reindex(companyId, executionMode);
 
-			_taskWorkflowMetricsReindexer.reindex(companyId, executionMode);
-		}
+		_taskWorkflowMetricsReindexer.reindex(companyId, executionMode);
 	}
 
 	@Reference
@@ -114,9 +112,7 @@ public class InstanceWorkflowMetricsReindexer
 	@Reference(target = "(workflow.metrics.reindexer.key=process)")
 	private IndexReindexer _processWorkflowMetricsReindexer;
 
-	@Reference(
-		target = "(component.name=com.liferay.portal.workflow.metrics.internal.search.index.reindexer.TaskWorkflowMetricsReindexer)"
-	)
+	@Reference(target = "(workflow.metrics.reindexer.key=task)")
 	private IndexReindexer _taskWorkflowMetricsReindexer;
 
 	@Reference

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/InstanceWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/InstanceWorkflowMetricsReindexer.java
@@ -37,6 +37,15 @@ public class InstanceWorkflowMetricsReindexer
 	}
 
 	@Override
+	protected void postReindex(long companyId, ExecutionMode executionMode)
+		throws Exception {
+
+		_processWorkflowMetricsReindexer.reindex(companyId, executionMode);
+
+		_taskWorkflowMetricsReindexer.reindex(companyId, executionMode);
+	}
+
+	@Override
 	protected void reindexEntities(long companyId) throws Exception {
 		ActionableDynamicQuery actionableDynamicQuery =
 			_kaleoInstanceLocalService.getActionableDynamicQuery();
@@ -85,15 +94,6 @@ public class InstanceWorkflowMetricsReindexer
 			});
 
 		actionableDynamicQuery.performActions();
-	}
-
-	@Override
-	protected void postReindex(long companyId, ExecutionMode executionMode)
-		throws Exception {
-
-		_processWorkflowMetricsReindexer.reindex(companyId, executionMode);
-
-		_taskWorkflowMetricsReindexer.reindex(companyId, executionMode);
 	}
 
 	@Reference

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/InstanceWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/InstanceWorkflowMetricsReindexer.java
@@ -93,6 +93,8 @@ public class InstanceWorkflowMetricsReindexer
 
 		if (executionMode == ExecutionMode.FULL) {
 			_processWorkflowMetricsReindexer.reindex(companyId, executionMode);
+
+			_taskWorkflowMetricsReindexer.reindex(companyId, executionMode);
 		}
 	}
 
@@ -111,6 +113,11 @@ public class InstanceWorkflowMetricsReindexer
 
 	@Reference(target = "(workflow.metrics.reindexer.key=process)")
 	private IndexReindexer _processWorkflowMetricsReindexer;
+
+	@Reference(
+		target = "(component.name=com.liferay.portal.workflow.metrics.internal.search.index.reindexer.TaskWorkflowMetricsReindexer)"
+	)
+	private IndexReindexer _taskWorkflowMetricsReindexer;
 
 	@Reference
 	private WorkflowMetricsReindexStatusMessageSender

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/NodeWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/NodeWorkflowMetricsReindexer.java
@@ -30,7 +30,10 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Rafael Praxedes
  */
-@Component(service = {IndexReindexer.class, WorkflowMetricsReindexer.class})
+@Component(
+	property = "workflow.metrics.reindexer.key=node",
+	service = {IndexReindexer.class, WorkflowMetricsReindexer.class}
+)
 public class NodeWorkflowMetricsReindexer extends BaseWorkflowMetricsReindexer {
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/ProcessWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/ProcessWorkflowMetricsReindexer.java
@@ -24,7 +24,10 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Rafael Praxedes
  */
-@Component(service = {IndexReindexer.class, WorkflowMetricsReindexer.class})
+@Component(
+	property = "workflow.metrics.reindexer.key=process",
+	service = {IndexReindexer.class, WorkflowMetricsReindexer.class}
+)
 public class ProcessWorkflowMetricsReindexer
 	extends BaseWorkflowMetricsReindexer {
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/SLAInstanceResultWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/SLAInstanceResultWorkflowMetricsReindexer.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.workflow.metrics.internal.search.index.reindexer;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalRunMode;
@@ -26,6 +27,7 @@ import com.liferay.portal.search.query.QueriesUtil;
 import com.liferay.portal.search.spi.reindexer.IndexReindexer;
 import com.liferay.portal.workflow.metrics.internal.background.task.WorkflowMetricsSLAProcessBackgroundTaskHelper;
 import com.liferay.portal.workflow.metrics.internal.search.index.SLAInstanceResultWorkflowMetricsIndexer;
+import com.liferay.portal.workflow.metrics.internal.search.index.WorkflowMetricsIndex;
 import com.liferay.portal.workflow.metrics.search.index.constants.WorkflowMetricsIndexNameConstants;
 import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexer;
 
@@ -46,6 +48,16 @@ public class SLAInstanceResultWorkflowMetricsReindexer
 
 	@Override
 	public void reindex(long companyId) throws PortalException {
+		if (!_searchCapabilities.isWorkflowMetricsSupported() ||
+			(companyId == CompanyConstants.SYSTEM)) {
+
+			return;
+		}
+
+		WorkflowMetricsIndex.createMissingIndexes(
+			_searchCapabilities, _searchEngineAdapter, _indexNameBuilder,
+			companyId);
+
 		_createDefaultDocuments(companyId);
 
 		WorkflowMetricsSLAProcessBackgroundTaskHelper

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/SLATaskResultWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/SLATaskResultWorkflowMetricsReindexer.java
@@ -5,6 +5,8 @@
 
 package com.liferay.portal.workflow.metrics.internal.search.index.reindexer;
 
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalRunMode;
 import com.liferay.portal.search.capabilities.SearchCapabilities;
@@ -23,6 +25,7 @@ import com.liferay.portal.search.query.BooleanQuery;
 import com.liferay.portal.search.query.QueriesUtil;
 import com.liferay.portal.search.spi.reindexer.IndexReindexer;
 import com.liferay.portal.workflow.metrics.internal.search.index.SLATaskResultWorkflowMetricsIndexer;
+import com.liferay.portal.workflow.metrics.internal.search.index.WorkflowMetricsIndex;
 import com.liferay.portal.workflow.metrics.search.background.task.WorkflowMetricsReindexStatusMessageSender;
 import com.liferay.portal.workflow.metrics.search.index.constants.WorkflowMetricsIndexNameConstants;
 import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexer;
@@ -45,7 +48,17 @@ public class SLATaskResultWorkflowMetricsReindexer
 	}
 
 	@Override
-	public void reindex(long companyId) {
+	public void reindex(long companyId) throws PortalException {
+		if (!_searchCapabilities.isWorkflowMetricsSupported() ||
+			(companyId == CompanyConstants.SYSTEM)) {
+
+			return;
+		}
+
+		WorkflowMetricsIndex.createMissingIndexes(
+			_searchCapabilities, _searchEngineAdapter, _indexNameBuilder,
+			companyId);
+
 		_createDefaultDocuments(companyId);
 	}
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/TaskWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/TaskWorkflowMetricsReindexer.java
@@ -29,7 +29,10 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Rafael Praxedes
  */
-@Component(service = {IndexReindexer.class, WorkflowMetricsReindexer.class})
+@Component(
+	property = "workflow.metrics.reindexer.key=task",
+	service = {IndexReindexer.class, WorkflowMetricsReindexer.class}
+)
 public class TaskWorkflowMetricsReindexer extends BaseWorkflowMetricsReindexer {
 
 	@Override
@@ -90,9 +93,7 @@ public class TaskWorkflowMetricsReindexer extends BaseWorkflowMetricsReindexer {
 	protected void postReindex(long companyId, ExecutionMode executionMode)
 		throws Exception {
 
-		if (executionMode == ExecutionMode.FULL) {
-			_nodeWorkflowMetricsReindexer.reindex(companyId, executionMode);
-		}
+		_nodeWorkflowMetricsReindexer.reindex(companyId, executionMode);
 	}
 
 	@Reference

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/TaskWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/TaskWorkflowMetricsReindexer.java
@@ -41,6 +41,13 @@ public class TaskWorkflowMetricsReindexer extends BaseWorkflowMetricsReindexer {
 	}
 
 	@Override
+	protected void postReindex(long companyId, ExecutionMode executionMode)
+		throws Exception {
+
+		_nodeWorkflowMetricsReindexer.reindex(companyId, executionMode);
+	}
+
+	@Override
 	protected void reindexEntities(long companyId) throws Exception {
 		ActionableDynamicQuery actionableDynamicQuery =
 			_kaleoTaskInstanceTokenLocalService.getActionableDynamicQuery();
@@ -87,13 +94,6 @@ public class TaskWorkflowMetricsReindexer extends BaseWorkflowMetricsReindexer {
 			});
 
 		actionableDynamicQuery.performActions();
-	}
-
-	@Override
-	protected void postReindex(long companyId, ExecutionMode executionMode)
-		throws Exception {
-
-		_nodeWorkflowMetricsReindexer.reindex(companyId, executionMode);
 	}
 
 	@Reference

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/TaskWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/TaskWorkflowMetricsReindexer.java
@@ -86,6 +86,15 @@ public class TaskWorkflowMetricsReindexer extends BaseWorkflowMetricsReindexer {
 		actionableDynamicQuery.performActions();
 	}
 
+	@Override
+	protected void postReindex(long companyId, ExecutionMode executionMode)
+		throws Exception {
+
+		if (executionMode == ExecutionMode.FULL) {
+			_nodeWorkflowMetricsReindexer.reindex(companyId, executionMode);
+		}
+	}
+
 	@Reference
 	private IndexerHelper _indexerHelper;
 
@@ -99,6 +108,9 @@ public class TaskWorkflowMetricsReindexer extends BaseWorkflowMetricsReindexer {
 	@Reference
 	private KaleoTaskInstanceTokenLocalService
 		_kaleoTaskInstanceTokenLocalService;
+
+	@Reference(target = "(workflow.metrics.reindexer.key=node)")
+	private IndexReindexer _nodeWorkflowMetricsReindexer;
 
 	@Reference
 	private TaskWorkflowMetricsIndexer _taskWorkflowMetricsIndexer;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/build.gradle
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-background-task:portal-background-task-api")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-api")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-engine-adapter-api")
+	testIntegrationImplementation project(":apps:portal-search:portal-search-spi")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:portal-security:portal-security-script-management-test-util")
 	testIntegrationImplementation project(":apps:portal-workflow:portal-workflow-api")

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/internal/search/index/test/WorkflowMetricsIndexerCrossWriterTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/internal/search/index/test/WorkflowMetricsIndexerCrossWriterTest.java
@@ -1,0 +1,166 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.workflow.metrics.service.internal.search.index.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.search.engine.adapter.index.RefreshIndexRequest;
+import com.liferay.portal.search.engine.adapter.search.CountSearchRequest;
+import com.liferay.portal.search.engine.adapter.search.CountSearchResponse;
+import com.liferay.portal.search.index.IndexNameBuilder;
+import com.liferay.portal.search.query.BooleanQuery;
+import com.liferay.portal.search.query.QueriesUtil;
+import com.liferay.portal.search.query.Query;
+import com.liferay.portal.search.spi.reindexer.IndexReindexer;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceToken;
+import com.liferay.portal.workflow.metrics.search.index.constants.WorkflowMetricsIndexNameConstants;
+import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexer;
+import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexerRegistry;
+import com.liferay.portal.workflow.metrics.service.util.BaseWorkflowMetricsIndexerTestCase;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Rodrigo Guedes de Souza
+ */
+@RunWith(Arquillian.class)
+public class WorkflowMetricsIndexerCrossWriterTest
+	extends BaseWorkflowMetricsIndexerTestCase {
+
+	@Test
+	public void testFullReindexInstancePopulatesTasksArray() throws Exception {
+		long companyId = TestPropsValues.getCompanyId();
+
+		KaleoTaskInstanceToken kaleoTaskInstanceToken =
+			addKaleoTaskInstanceToken("Review");
+
+		_reindex(companyId, "instance", IndexReindexer.ExecutionMode.FULL);
+
+		Query tasksQuery = _tasksQuery(
+			kaleoTaskInstanceToken.getKaleoTaskInstanceTokenId());
+
+		String instanceIndexName = _getIndexName(
+			companyId, WorkflowMetricsIndexNameConstants.SUFFIX_INSTANCE);
+
+		Assert.assertEquals(
+			"FULL instance reindex must repopulate the task-indexer-written " +
+				"tasks[] array",
+			1, _count(instanceIndexName, tasksQuery));
+	}
+
+	@Test
+	public void testSyncReindexPreservesInstanceIndexTemplate()
+		throws Exception {
+
+		long companyId = TestPropsValues.getCompanyId();
+
+		addKaleoTaskInstanceToken("Review");
+
+		_reindex(companyId, "instance", IndexReindexer.ExecutionMode.FULL);
+
+		String instanceIndexName = _getIndexName(
+			companyId, WorkflowMetricsIndexNameConstants.SUFFIX_INSTANCE);
+
+		long baseline = _count(instanceIndexName, _templateQuery("instanceId"));
+
+		Assert.assertTrue(
+			"Baseline must contain the process-written instanceId=0 template",
+			baseline > 0);
+
+		Thread.sleep(1100);
+
+		_reindex(companyId, "instance", IndexReindexer.ExecutionMode.SYNC);
+
+		Assert.assertEquals(
+			"SYNC instance reindex must not strand the process-written " +
+				"instanceId=0 template",
+			baseline, _count(instanceIndexName, _templateQuery("instanceId")));
+	}
+
+	@Test
+	public void testSyncReindexPreservesTaskIndexTemplate() throws Exception {
+		long companyId = TestPropsValues.getCompanyId();
+
+		addKaleoTaskInstanceToken("Review");
+
+		_reindex(companyId, "instance", IndexReindexer.ExecutionMode.FULL);
+
+		String taskIndexName = _getIndexName(
+			companyId, WorkflowMetricsIndexNameConstants.SUFFIX_TASK);
+
+		long baseline = _count(taskIndexName, _templateQuery("taskId"));
+
+		Assert.assertTrue(
+			"Baseline must contain the node-written taskId=0 template",
+			baseline > 0);
+
+		Thread.sleep(1100);
+
+		_reindex(companyId, "task", IndexReindexer.ExecutionMode.SYNC);
+
+		Assert.assertEquals(
+			"SYNC task reindex must not strand the node-written taskId=0 " +
+				"template",
+			baseline, _count(taskIndexName, _templateQuery("taskId")));
+	}
+
+	private long _count(String indexName, Query query) {
+		searchEngineAdapter.execute(new RefreshIndexRequest(indexName));
+
+		CountSearchRequest countSearchRequest = new CountSearchRequest();
+
+		countSearchRequest.setIndexNames(indexName);
+		countSearchRequest.setQuery(query);
+
+		CountSearchResponse countSearchResponse = searchEngineAdapter.execute(
+			countSearchRequest);
+
+		return countSearchResponse.getCount();
+	}
+
+	private String _getIndexName(long companyId, String suffix) {
+		return _indexNameBuilder.getIndexName(companyId) + suffix;
+	}
+
+	private void _reindex(
+			long companyId, String key,
+			IndexReindexer.ExecutionMode executionMode)
+		throws Exception {
+
+		WorkflowMetricsReindexer workflowMetricsReindexer =
+			_workflowMetricsReindexerRegistry.getWorkflowMetricsReindexer(key);
+
+		IndexReindexer indexReindexer =
+			(IndexReindexer)workflowMetricsReindexer;
+
+		indexReindexer.reindex(companyId, executionMode);
+	}
+
+	private Query _tasksQuery(long taskId) {
+		return QueriesUtil.nested(
+			"tasks", QueriesUtil.term("tasks.taskId", taskId));
+	}
+
+	private Query _templateQuery(String idFieldName) {
+		BooleanQuery booleanQuery = QueriesUtil.booleanQuery();
+
+		booleanQuery.addMustQueryClauses(
+			QueriesUtil.term(idFieldName, 0L),
+			QueriesUtil.term("deleted", false));
+
+		return booleanQuery;
+	}
+
+	@Inject
+	private IndexNameBuilder _indexNameBuilder;
+
+	@Inject
+	private WorkflowMetricsReindexerRegistry _workflowMetricsReindexerRegistry;
+
+}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/internal/search/index/test/WorkflowMetricsIndexerOrphanTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/internal/search/index/test/WorkflowMetricsIndexerOrphanTest.java
@@ -32,11 +32,23 @@ import org.junit.runner.RunWith;
  * @author Rodrigo Guedes de Souza
  */
 @RunWith(Arquillian.class)
-public class WorkflowMetricsReindexerOrphanReproductionTest
+public class WorkflowMetricsIndexerOrphanTest
 	extends BaseWorkflowMetricsIndexerTestCase {
 
 	@Test
 	public void testFullReindexRemovesOrphan() throws Exception {
+		_assertReindexRemovesOrphan(IndexReindexer.ExecutionMode.FULL);
+	}
+
+	@Test
+	public void testSyncReindexRemovesOrphan() throws Exception {
+		_assertReindexRemovesOrphan(IndexReindexer.ExecutionMode.SYNC);
+	}
+
+	private void _assertReindexRemovesOrphan(
+			IndexReindexer.ExecutionMode executionMode)
+		throws Exception {
+
 		long companyId = TestPropsValues.getCompanyId();
 
 		String processIndexName =
@@ -55,40 +67,17 @@ public class WorkflowMetricsReindexerOrphanReproductionTest
 			"Orphan should be present right after seeding", 1,
 			_countOrphan(processIndexName, companyId));
 
-		workflowMetricsReindexer.reindex(companyId);
-
-		Assert.assertEquals(
-			"FULL reindex must remove the orphan", 0,
-			_countOrphan(processIndexName, companyId));
-	}
-
-	@Test
-	public void testSyncReindexRemovesOrphan() throws Exception {
-		long companyId = TestPropsValues.getCompanyId();
-
-		String processIndexName =
-			_indexNameBuilder.getIndexName(companyId) +
-				WorkflowMetricsIndexNameConstants.SUFFIX_PROCESS;
+		if (executionMode == IndexReindexer.ExecutionMode.SYNC) {
+			Thread.sleep(1100);
+		}
 
 		IndexReindexer indexReindexer =
-			(IndexReindexer)
-				_workflowMetricsReindexerRegistry.getWorkflowMetricsReindexer(
-					"process");
+			(IndexReindexer)workflowMetricsReindexer;
 
-		indexReindexer.reindex(companyId, IndexReindexer.ExecutionMode.FULL);
-
-		_indexOrphan(processIndexName, companyId);
+		indexReindexer.reindex(companyId, executionMode);
 
 		Assert.assertEquals(
-			"Orphan should be present right after seeding", 1,
-			_countOrphan(processIndexName, companyId));
-
-		Thread.sleep(1100);
-
-		indexReindexer.reindex(companyId, IndexReindexer.ExecutionMode.SYNC);
-
-		Assert.assertEquals(
-			"SYNC reindex must remove the orphan", 0,
+			executionMode + " reindex must remove the orphan", 0,
 			_countOrphan(processIndexName, companyId));
 	}
 
@@ -115,14 +104,14 @@ public class WorkflowMetricsReindexerOrphanReproductionTest
 	private void _indexOrphan(String indexName, long companyId) {
 		DocumentBuilder documentBuilder = DocumentBuilderFactory.builder();
 
-		documentBuilder.setLong(
+		documentBuilder.setValue(
+			"deleted", false
+		).setLong(
 			"companyId", companyId
 		).setLong(
 			"processId", _ORPHAN_PROCESS_ID
 		).setString(
 			"uid", "orphan-" + _ORPHAN_PROCESS_ID
-		).setValue(
-			"deleted", false
 		);
 
 		Document document = documentBuilder.build();
@@ -135,7 +124,7 @@ public class WorkflowMetricsReindexerOrphanReproductionTest
 		searchEngineAdapter.execute(indexDocumentRequest);
 	}
 
-	private static final long _ORPHAN_PROCESS_ID = 999999999;
+	private static final long _ORPHAN_PROCESS_ID = 999999999L;
 
 	@Inject
 	private IndexNameBuilder _indexNameBuilder;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/internal/search/index/test/WorkflowMetricsIndexerTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/internal/search/index/test/WorkflowMetricsIndexerTest.java
@@ -1,0 +1,73 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.workflow.metrics.service.internal.search.index.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.search.engine.adapter.index.DeleteIndexRequest;
+import com.liferay.portal.search.engine.adapter.index.IndicesExistsIndexRequest;
+import com.liferay.portal.search.engine.adapter.index.IndicesExistsIndexResponse;
+import com.liferay.portal.search.index.IndexNameBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.workflow.metrics.search.index.constants.WorkflowMetricsIndexNameConstants;
+import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexer;
+import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexerRegistry;
+import com.liferay.portal.workflow.metrics.service.util.BaseWorkflowMetricsIndexerTestCase;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Felipe Lorenz
+ */
+@RunWith(Arquillian.class)
+public class WorkflowMetricsIndexerTest
+	extends BaseWorkflowMetricsIndexerTestCase {
+
+	@Test
+	public void testReindexCreatesMissingIndexes() throws Exception {
+		long companyId = TestPropsValues.getCompanyId();
+
+		String indexNamePrefix = _indexNameBuilder.getIndexName(companyId);
+
+		for (String suffix : _SUFFIXES) {
+			searchEngineAdapter.execute(
+				new DeleteIndexRequest(indexNamePrefix + suffix));
+		}
+
+		WorkflowMetricsReindexer workflowMetricsReindexer =
+			_workflowMetricsReindexerRegistry.getWorkflowMetricsReindexer(
+				"instance");
+
+		workflowMetricsReindexer.reindex(companyId);
+
+		for (String suffix : _SUFFIXES) {
+			IndicesExistsIndexResponse indicesExistsIndexResponse =
+				searchEngineAdapter.execute(
+					new IndicesExistsIndexRequest(indexNamePrefix + suffix));
+
+			Assert.assertTrue(indicesExistsIndexResponse.isExists());
+		}
+	}
+
+	private static final String[] _SUFFIXES = {
+		WorkflowMetricsIndexNameConstants.SUFFIX_INSTANCE,
+		WorkflowMetricsIndexNameConstants.SUFFIX_NODE,
+		WorkflowMetricsIndexNameConstants.SUFFIX_PROCESS,
+		WorkflowMetricsIndexNameConstants.SUFFIX_SLA_INSTANCE_RESULT,
+		WorkflowMetricsIndexNameConstants.SUFFIX_SLA_TASK_RESULT,
+		WorkflowMetricsIndexNameConstants.SUFFIX_TASK,
+		WorkflowMetricsIndexNameConstants.SUFFIX_TRANSITION
+	};
+
+	@Inject
+	private IndexNameBuilder _indexNameBuilder;
+
+	@Inject
+	private WorkflowMetricsReindexerRegistry _workflowMetricsReindexerRegistry;
+
+}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/internal/search/index/test/WorkflowMetricsReindexerOrphanReproductionTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/internal/search/index/test/WorkflowMetricsReindexerOrphanReproductionTest.java
@@ -1,0 +1,146 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.workflow.metrics.service.internal.search.index.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.search.document.Document;
+import com.liferay.portal.search.document.DocumentBuilder;
+import com.liferay.portal.search.document.DocumentBuilderFactory;
+import com.liferay.portal.search.engine.adapter.document.IndexDocumentRequest;
+import com.liferay.portal.search.engine.adapter.index.RefreshIndexRequest;
+import com.liferay.portal.search.engine.adapter.search.CountSearchRequest;
+import com.liferay.portal.search.engine.adapter.search.CountSearchResponse;
+import com.liferay.portal.search.index.IndexNameBuilder;
+import com.liferay.portal.search.query.BooleanQuery;
+import com.liferay.portal.search.query.QueriesUtil;
+import com.liferay.portal.search.spi.reindexer.IndexReindexer;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.workflow.metrics.search.index.constants.WorkflowMetricsIndexNameConstants;
+import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexer;
+import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexerRegistry;
+import com.liferay.portal.workflow.metrics.service.util.BaseWorkflowMetricsIndexerTestCase;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Rodrigo Guedes de Souza
+ */
+@RunWith(Arquillian.class)
+public class WorkflowMetricsReindexerOrphanReproductionTest
+	extends BaseWorkflowMetricsIndexerTestCase {
+
+	@Test
+	public void testFullReindexRemovesOrphan() throws Exception {
+		long companyId = TestPropsValues.getCompanyId();
+
+		String processIndexName =
+			_indexNameBuilder.getIndexName(companyId) +
+				WorkflowMetricsIndexNameConstants.SUFFIX_PROCESS;
+
+		WorkflowMetricsReindexer workflowMetricsReindexer =
+			_workflowMetricsReindexerRegistry.getWorkflowMetricsReindexer(
+				"process");
+
+		workflowMetricsReindexer.reindex(companyId);
+
+		_indexOrphan(processIndexName, companyId);
+
+		Assert.assertEquals(
+			"Orphan should be present right after seeding", 1,
+			_countOrphan(processIndexName, companyId));
+
+		workflowMetricsReindexer.reindex(companyId);
+
+		Assert.assertEquals(
+			"FULL reindex must remove the orphan", 0,
+			_countOrphan(processIndexName, companyId));
+	}
+
+	@Test
+	public void testSyncReindexRemovesOrphan() throws Exception {
+		long companyId = TestPropsValues.getCompanyId();
+
+		String processIndexName =
+			_indexNameBuilder.getIndexName(companyId) +
+				WorkflowMetricsIndexNameConstants.SUFFIX_PROCESS;
+
+		IndexReindexer indexReindexer =
+			(IndexReindexer)
+				_workflowMetricsReindexerRegistry.getWorkflowMetricsReindexer(
+					"process");
+
+		indexReindexer.reindex(companyId, IndexReindexer.ExecutionMode.FULL);
+
+		_indexOrphan(processIndexName, companyId);
+
+		Assert.assertEquals(
+			"Orphan should be present right after seeding", 1,
+			_countOrphan(processIndexName, companyId));
+
+		Thread.sleep(1100);
+
+		indexReindexer.reindex(companyId, IndexReindexer.ExecutionMode.SYNC);
+
+		Assert.assertEquals(
+			"SYNC reindex must remove the orphan", 0,
+			_countOrphan(processIndexName, companyId));
+	}
+
+	private long _countOrphan(String indexName, long companyId) {
+		searchEngineAdapter.execute(new RefreshIndexRequest(indexName));
+
+		CountSearchRequest countSearchRequest = new CountSearchRequest();
+
+		countSearchRequest.setIndexNames(indexName);
+
+		BooleanQuery booleanQuery = QueriesUtil.booleanQuery();
+
+		countSearchRequest.setQuery(
+			booleanQuery.addFilterQueryClauses(
+				QueriesUtil.term("companyId", companyId),
+				QueriesUtil.term("processId", _ORPHAN_PROCESS_ID)));
+
+		CountSearchResponse countSearchResponse = searchEngineAdapter.execute(
+			countSearchRequest);
+
+		return countSearchResponse.getCount();
+	}
+
+	private void _indexOrphan(String indexName, long companyId) {
+		DocumentBuilder documentBuilder = DocumentBuilderFactory.builder();
+
+		documentBuilder.setLong(
+			"companyId", companyId
+		).setLong(
+			"processId", _ORPHAN_PROCESS_ID
+		).setString(
+			"uid", "orphan-" + _ORPHAN_PROCESS_ID
+		).setValue(
+			"deleted", false
+		);
+
+		Document document = documentBuilder.build();
+
+		IndexDocumentRequest indexDocumentRequest = new IndexDocumentRequest(
+			indexName, document.getString("uid"), document);
+
+		indexDocumentRequest.setRefresh(true);
+
+		searchEngineAdapter.execute(indexDocumentRequest);
+	}
+
+	private static final long _ORPHAN_PROCESS_ID = 999999999;
+
+	@Inject
+	private IndexNameBuilder _indexNameBuilder;
+
+	@Inject
+	private WorkflowMetricsReindexerRegistry _workflowMetricsReindexerRegistry;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-75968

## What Is Being Fixed

When a workflow-metrics reindexer runs for the Task or Instance index, it does not only touch its own documents — Task-reindex writes into node/task/sla-task-result, and Instance-reindex writes into process/task/instance. Reindexing one of those indexes on its own therefore leaves stale cross-writer documents behind, and on a SYNC pass the sibling indexes are not exercised at all, so entries deleted from the source data outlive the reindex.

## How It Is Being Fixed

Each cross-writing reindexer now delegates to its sibling reindexers at the end of its own pass, so a SYNC reindex on Task also runs Node, and a SYNC reindex on Instance also runs Task and Process. The delegation is wired through the `postReindex` hook `BaseWorkflowMetricsReindexer` exposes, and each target reindexer is resolved by the `workflow.metrics.reindexer.key` service property. Two integration tests were added: one reproduces the orphan-document case and asserts that both FULL and SYNC reindex remove the orphans, the other asserts that cross-writer documents survive an on-topic reindex.

## PR Check

**pr-check: PASS** — tested on `45e00e066a71df35c0fc4fd3a2a1e294f46f4d9e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "45e00e066a71df35c0fc4fd3a2a1e294f46f4d9e"} -->
