### PR TITLE
LPD-93003 Filter dynamic asset lists by common fields

### DIFF
--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -443,68 +443,9 @@ public class AssetListFiltersUtil {
 
 		boolean dateField = subfield.endsWith(".value_date");
 
-		boolean dateTimeField = false;
-
-		if (dateField && _isDateTimeField(objectField)) {
-			dateTimeField = true;
-		}
-
-		if (operatorName.equals("between")) {
-			JSONArray valueJSONArray = filterJSONObject.getJSONArray("value");
-
-			if ((valueJSONArray == null) || (valueJSONArray.length() < 2)) {
-				return null;
-			}
-
-			String lowerTerm = GetterUtil.getString(
-				valueJSONArray.getString(0), null);
-			String upperTerm = GetterUtil.getString(
-				valueJSONArray.getString(1), null);
-
-			if (dateField) {
-				lowerTerm = _toDateTerm(dateTimeField, false, lowerTerm);
-				upperTerm = _toDateTerm(dateTimeField, true, upperTerm);
-			}
-
-			return new TermRangeQuery(
-				subfield, lowerTerm, upperTerm, true, true);
-		}
-
-		String value = filterJSONObject.getString("value");
-
-		if (Validator.isNull(value)) {
-			return null;
-		}
-
-		if (operatorName.equals("ge")) {
-			String lowerTerm =
-				dateField ? _toDateTerm(dateTimeField, false, value) : value;
-
-			return new TermRangeQuery(subfield, lowerTerm, null, true, false);
-		}
-
-		if (operatorName.equals("gt")) {
-			String lowerTerm =
-				dateField ? _toDateTerm(dateTimeField, true, value) : value;
-
-			return new TermRangeQuery(subfield, lowerTerm, null, false, false);
-		}
-
-		if (operatorName.equals("le")) {
-			String upperTerm =
-				dateField ? _toDateTerm(dateTimeField, true, value) : value;
-
-			return new TermRangeQuery(subfield, null, upperTerm, false, true);
-		}
-
-		if (operatorName.equals("lt")) {
-			String upperTerm =
-				dateField ? _toDateTerm(dateTimeField, false, value) : value;
-
-			return new TermRangeQuery(subfield, null, upperTerm, false, false);
-		}
-
-		return null;
+		return _toTermRangeQuery(
+			dateField, dateField && _isDateTimeField(objectField), subfield,
+			filterJSONObject, operatorName);
 	}
 
 	private static Query _toTermRangeQuery(

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -300,6 +300,10 @@ public class AssetListFiltersUtil {
 			return new MatchQuery(field, value);
 		}
 
+		if (_lowerCaseCommonFieldNames.contains(field)) {
+			value = StringUtil.toLowerCase(value);
+		}
+
 		if (operatorName.equals("contains") ||
 			operatorName.equals("not-contains")) {
 
@@ -653,6 +657,8 @@ public class AssetListFiltersUtil {
 		).build();
 	private static final Set<String> _localizedCommonFieldNames =
 		SetUtil.fromArray(Field.TITLE);
+	private static final Set<String> _lowerCaseCommonFieldNames =
+		SetUtil.fromArray(Field.USER_NAME);
 	private static final Map<String, String> _metadataCommonFieldNames =
 		HashMapBuilder.put(
 			"creator", Field.USER_NAME

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.search.TermRangeQuery;
 import com.liferay.portal.kernel.search.WildcardQuery;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -37,6 +38,7 @@ import java.text.Format;
 
 import java.util.Calendar;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -59,20 +61,19 @@ public class AssetListFiltersUtil {
 		for (int i = 0; i < filtersJSONArray.length(); i++) {
 			JSONObject jsonObject = filtersJSONArray.getJSONObject(i);
 
-			NestedQuery nestedQuery = _toNestedQuery(
-				companyId, jsonObject, locale);
+			Query query = _toQuery(companyId, jsonObject, locale);
 
-			if (nestedQuery == null) {
+			if (query == null) {
 				continue;
 			}
 
 			if (_isNegatedOperator(
 					jsonObject.getString("operatorName", "contains"))) {
 
-				booleanQuery.add(nestedQuery, BooleanClauseOccur.MUST_NOT);
+				booleanQuery.add(query, BooleanClauseOccur.MUST_NOT);
 			}
 			else {
-				booleanQuery.add(nestedQuery, BooleanClauseOccur.MUST);
+				booleanQuery.add(query, BooleanClauseOccur.MUST);
 
 				hasMustClause = true;
 			}
@@ -117,6 +118,24 @@ public class AssetListFiltersUtil {
 			objectDefinition.getObjectDefinitionId(), name);
 	}
 
+	private static String _getCommonFieldName(
+		Locale locale, String propertyName) {
+
+		if (!_commonFieldTypes.containsKey(propertyName)) {
+			return null;
+		}
+
+		if (_localizedCommonFieldNames.contains(propertyName)) {
+			return Field.getLocalizedName(locale, "localized_" + propertyName);
+		}
+
+		return propertyName;
+	}
+
+	private static String _getCommonFieldType(String propertyName) {
+		return _commonFieldTypes.get(propertyName);
+	}
+
 	private static String _getSubfield(Locale locale, ObjectField objectField) {
 		if (objectField.isIndexedAsKeyword()) {
 			return "nestedFieldArray.value_keyword";
@@ -159,6 +178,16 @@ public class AssetListFiltersUtil {
 		}
 
 		return "nestedFieldArray.value_text";
+	}
+
+	private static boolean _isCommonFieldRow(JSONObject jsonObject) {
+		if ((jsonObject.getLong("classNameId") <= 0) &&
+			(jsonObject.getLong("classTypeId") <= 0)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private static boolean _isDateTimeField(ObjectField objectField) {
@@ -209,6 +238,74 @@ public class AssetListFiltersUtil {
 		return format.format(calendar.getTime());
 	}
 
+	private static Query _toCommonFieldQuery(
+		JSONObject jsonObject, Locale locale, String propertyName) {
+
+		if (Validator.isNull(propertyName)) {
+			return null;
+		}
+
+		String commonFieldName = _getCommonFieldName(locale, propertyName);
+		String commonFieldType = _getCommonFieldType(propertyName);
+
+		if ((commonFieldName == null) || (commonFieldType == null)) {
+			return null;
+		}
+
+		String operatorName = GetterUtil.getString(
+			jsonObject.getString("operatorName"), "contains");
+
+		return _toCommonFieldValueQuery(
+			commonFieldName, jsonObject,
+			_localizedCommonFieldNames.contains(propertyName), operatorName,
+			commonFieldType);
+	}
+
+	private static Query _toCommonFieldValueQuery(
+		String field, JSONObject jsonObject, boolean localized,
+		String operatorName, String type) {
+
+		if (operatorName.equals("between") || operatorName.equals("ge") ||
+			operatorName.equals("gt") || operatorName.equals("le") ||
+			operatorName.equals("lt")) {
+
+			return _toTermRangeQuery(
+				type.equals(_TYPE_DATE), false, field, jsonObject,
+				operatorName);
+		}
+
+		String value = jsonObject.getString("value");
+
+		if (Validator.isNull(value)) {
+			return null;
+		}
+
+		if (type.equals(_TYPE_DATE) &&
+			(operatorName.equals("eq") || operatorName.equals("not-eq"))) {
+
+			return new TermRangeQuery(
+				field, _toDateTerm(false, false, value),
+				_toDateTerm(false, true, value), true, true);
+		}
+
+		if (type.equals(_TYPE_DECIMAL) || type.equals(_TYPE_INTEGER)) {
+			return new TermQuery(field, value);
+		}
+
+		if (localized) {
+			return new MatchQuery(field, value);
+		}
+
+		if (operatorName.equals("contains") ||
+			operatorName.equals("not-contains")) {
+
+			return new WildcardQuery(
+				field, StringPool.STAR + value + StringPool.STAR);
+		}
+
+		return new TermQuery(field, value);
+	}
+
 	private static String _toDateTerm(
 		boolean dateTimeField, boolean upperBound, String value) {
 
@@ -236,23 +333,12 @@ public class AssetListFiltersUtil {
 	}
 
 	private static NestedQuery _toNestedQuery(
-		long companyId, JSONObject jsonObject, Locale locale) {
-
-		if (jsonObject == null) {
-			return null;
-		}
+		JSONObject jsonObject, Locale locale, ObjectField objectField) {
 
 		String propertyName = jsonObject.getString("propertyName");
 		String value = jsonObject.getString("value");
 
 		if (Validator.isNull(propertyName) || Validator.isNull(value)) {
-			return null;
-		}
-
-		ObjectField objectField = _fetchObjectField(
-			jsonObject.getLong("classNameId"), companyId, propertyName);
-
-		if (objectField == null) {
 			return null;
 		}
 
@@ -312,6 +398,29 @@ public class AssetListFiltersUtil {
 		}
 
 		return booleanQuery;
+	}
+
+	private static Query _toQuery(
+		long companyId, JSONObject jsonObject, Locale locale) {
+
+		if (jsonObject == null) {
+			return null;
+		}
+
+		if (_isCommonFieldRow(jsonObject)) {
+			return _toCommonFieldQuery(
+				jsonObject, locale, jsonObject.getString("propertyName"));
+		}
+
+		ObjectField objectField = _fetchObjectField(
+			jsonObject.getLong("classNameId"), companyId,
+			jsonObject.getString("propertyName"));
+
+		if (objectField == null) {
+			return null;
+		}
+
+		return _toNestedQuery(jsonObject, locale, objectField);
 	}
 
 	private static Query _toRangeQuery(
@@ -384,6 +493,67 @@ public class AssetListFiltersUtil {
 		return null;
 	}
 
+	private static Query _toTermRangeQuery(
+		boolean dateField, boolean dateTime, String field,
+		JSONObject jsonObject, String operatorName) {
+
+		if (operatorName.equals("between")) {
+			JSONArray valueJSONArray = jsonObject.getJSONArray("value");
+
+			if ((valueJSONArray == null) || (valueJSONArray.length() < 2)) {
+				return null;
+			}
+
+			String lowerTerm = GetterUtil.getString(
+				valueJSONArray.getString(0), null);
+			String upperTerm = GetterUtil.getString(
+				valueJSONArray.getString(1), null);
+
+			if (dateField) {
+				lowerTerm = _toDateTerm(dateTime, false, lowerTerm);
+				upperTerm = _toDateTerm(dateTime, true, upperTerm);
+			}
+
+			return new TermRangeQuery(field, lowerTerm, upperTerm, true, true);
+		}
+
+		String value = jsonObject.getString("value");
+
+		if (Validator.isNull(value)) {
+			return null;
+		}
+
+		if (operatorName.equals("ge")) {
+			String lowerTerm =
+				dateField ? _toDateTerm(dateTime, false, value) : value;
+
+			return new TermRangeQuery(field, lowerTerm, null, true, false);
+		}
+
+		if (operatorName.equals("gt")) {
+			String lowerTerm =
+				dateField ? _toDateTerm(dateTime, true, value) : value;
+
+			return new TermRangeQuery(field, lowerTerm, null, false, false);
+		}
+
+		if (operatorName.equals("le")) {
+			String upperTerm =
+				dateField ? _toDateTerm(dateTime, true, value) : value;
+
+			return new TermRangeQuery(field, null, upperTerm, false, true);
+		}
+
+		if (operatorName.equals("lt")) {
+			String upperTerm =
+				dateField ? _toDateTerm(dateTime, false, value) : value;
+
+			return new TermRangeQuery(field, null, upperTerm, false, false);
+		}
+
+		return null;
+	}
+
 	private static Query _toValueQuery(
 		JSONObject filterJSONObject, ObjectField objectField,
 		String operatorName, String subfield, String value) {
@@ -437,6 +607,42 @@ public class AssetListFiltersUtil {
 		return new MatchQuery(subfield, value);
 	}
 
+	private static final String _TYPE_DATE = "date";
+
+	private static final String _TYPE_DECIMAL = "decimal";
+
+	private static final String _TYPE_INTEGER = "integer";
+
+	private static final String _TYPE_TEXT = "text";
+
+	private static final Map<String, String> _commonFieldTypes =
+		HashMapBuilder.put(
+			Field.CREATE_DATE, _TYPE_DATE
+		).put(
+			Field.DISPLAY_DATE, _TYPE_DATE
+		).put(
+			Field.EXPIRATION_DATE, _TYPE_DATE
+		).put(
+			Field.MODIFIED_DATE, _TYPE_DATE
+		).put(
+			Field.PRIORITY, _TYPE_DECIMAL
+		).put(
+			Field.PUBLISH_DATE, _TYPE_DATE
+		).put(
+			Field.REVIEW_DATE, _TYPE_DATE
+		).put(
+			Field.STATUS, _TYPE_INTEGER
+		).put(
+			Field.TITLE, _TYPE_TEXT
+		).put(
+			Field.USER_NAME, _TYPE_TEXT
+		).put(
+			"externalReferenceCode", _TYPE_TEXT
+		).put(
+			"viewCount", _TYPE_INTEGER
+		).build();
+	private static final Set<String> _localizedCommonFieldNames =
+		SetUtil.fromArray(Field.TITLE);
 	private static final Set<String> _relativeDateValues = SetUtil.fromArray(
 		"last-year", "next-month", "now", "past-24-hours", "past-day",
 		"past-month", "past-week", "past-year");

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -205,6 +205,10 @@ public class AssetListFiltersUtil {
 		return false;
 	}
 
+	private static String _resolveMetadataFieldName(String name) {
+		return _metadataCommonFieldNames.getOrDefault(name, name);
+	}
+
 	private static String _resolveRelativeDateValue(String value) {
 		if (!_relativeDateValues.contains(value)) {
 			return null;
@@ -418,6 +422,12 @@ public class AssetListFiltersUtil {
 
 		if (objectField == null) {
 			return null;
+		}
+
+		if (objectField.isMetadata()) {
+			return _toCommonFieldQuery(
+				jsonObject, locale,
+				_resolveMetadataFieldName(objectField.getName()));
 		}
 
 		return _toNestedQuery(jsonObject, locale, objectField);
@@ -643,6 +653,12 @@ public class AssetListFiltersUtil {
 		).build();
 	private static final Set<String> _localizedCommonFieldNames =
 		SetUtil.fromArray(Field.TITLE);
+	private static final Map<String, String> _metadataCommonFieldNames =
+		HashMapBuilder.put(
+			"creator", Field.USER_NAME
+		).put(
+			"modifiedDate", Field.MODIFIED_DATE
+		).build();
 	private static final Set<String> _relativeDateValues = SetUtil.fromArray(
 		"last-year", "next-month", "now", "past-24-hours", "past-day",
 		"past-month", "past-week", "past-year");

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.MatchQuery;
 import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
@@ -86,78 +87,92 @@ public class AssetListFiltersUtilTest {
 
 	@Test
 	public void testFilterQueriesWithCommonFields() {
-		_assertMatchQuery(
-			"localized_title_en_US", "Apple",
-			_assertCommonFieldRow(
-				BooleanClauseOccur.MUST,
-				_getCommonFieldFilterJSONObject("eq", "title", "Apple")));
-		_assertMatchQuery(
-			"localized_title_en_US", "App",
-			_assertCommonFieldRow(
-				BooleanClauseOccur.MUST,
-				_getCommonFieldFilterJSONObject("contains", "title", "App")));
+		String title = RandomTestUtil.randomString();
 
-		_assertTermQuery(
-			"userName", "john smith",
+		_assertMatchQuery(
+			"localized_title_en_US", title,
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_getCommonFieldFilterJSONObject("eq", Field.TITLE, title)));
+		_assertMatchQuery(
+			"localized_title_en_US", title,
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST,
 				_getCommonFieldFilterJSONObject(
-					"eq", "userName", "John Smith")));
+					"contains", Field.TITLE, title)));
+
+		_assertTermQuery(
+			Field.USER_NAME, "john smith",
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_getCommonFieldFilterJSONObject(
+					"eq", Field.USER_NAME, "John Smith")));
 		_assertWildcardQuery(
-			"userName", "*john smith*",
+			Field.USER_NAME, "*john smith*",
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST_NOT,
 				_getCommonFieldFilterJSONObject(
-					"not-contains", "userName", "John Smith")));
+					"not-contains", Field.USER_NAME, "John Smith")));
+
+		String viewCount = String.valueOf(RandomTestUtil.randomInt());
 
 		_assertTermQuery(
-			"viewCount", "5",
+			"viewCount", viewCount,
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST,
-				_getCommonFieldFilterJSONObject("eq", "viewCount", "5")));
+				_getCommonFieldFilterJSONObject("eq", "viewCount", viewCount)));
+
+		String status = String.valueOf(RandomTestUtil.randomInt());
+
 		_assertTermQuery(
-			"status", "0",
-			_assertCommonFieldRow(
-				BooleanClauseOccur.MUST_NOT,
-				_getCommonFieldFilterJSONObject("not-eq", "status", "0")));
-
-		_assertTermRangeQuery(
-			"priority", false, false, "0.5", null,
-			_assertCommonFieldRow(
-				BooleanClauseOccur.MUST,
-				_getCommonFieldFilterJSONObject("gt", "priority", "0.5")));
-
-		_assertTermRangeQuery(
-			"createDate", false, false, "20260115235959", null,
-			_assertCommonFieldRow(
-				BooleanClauseOccur.MUST,
-				_getCommonFieldFilterJSONObject(
-					"gt", "createDate", "2026-01-15")));
-		_assertTermRangeQuery(
-			"modified", true, true, "20260115000000", "20260115235959",
-			_assertCommonFieldRow(
-				BooleanClauseOccur.MUST,
-				_getCommonFieldFilterJSONObject(
-					"eq", "modified", "2026-01-15")));
-		_assertTermRangeQuery(
-			"modified", true, true, "20260115000000", "20260115235959",
+			Field.STATUS, status,
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST_NOT,
 				_getCommonFieldFilterJSONObject(
-					"not-eq", "modified", "2026-01-15")));
+					"not-eq", Field.STATUS, status)));
+
+		String priority = String.valueOf(RandomTestUtil.randomDouble());
+
 		_assertTermRangeQuery(
-			"modified", true, true, "20260115000000", "20260120235959",
+			Field.PRIORITY, false, false, priority, null,
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST,
 				_getCommonFieldFilterJSONObject(
-					"between", "modified",
+					"gt", Field.PRIORITY, priority)));
+
+		_assertTermRangeQuery(
+			Field.CREATE_DATE, false, false, "20260115235959", null,
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_getCommonFieldFilterJSONObject(
+					"gt", Field.CREATE_DATE, "2026-01-15")));
+		_assertTermRangeQuery(
+			Field.MODIFIED_DATE, true, true, "20260115000000", "20260115235959",
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_getCommonFieldFilterJSONObject(
+					"eq", Field.MODIFIED_DATE, "2026-01-15")));
+		_assertTermRangeQuery(
+			Field.MODIFIED_DATE, true, true, "20260115000000", "20260115235959",
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST_NOT,
+				_getCommonFieldFilterJSONObject(
+					"not-eq", Field.MODIFIED_DATE, "2026-01-15")));
+		_assertTermRangeQuery(
+			Field.MODIFIED_DATE, true, true, "20260115000000", "20260120235959",
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_getCommonFieldFilterJSONObject(
+					"between", Field.MODIFIED_DATE,
 					JSONUtil.putAll("2026-01-15", "2026-01-20"))));
 
 		BooleanClause[] booleanClauses =
 			AssetListFiltersUtil.getFiltersBooleanClauses(
 				_COMPANY_ID,
 				JSONUtil.putAll(
-					_getCommonFieldFilterJSONObject("eq", "bogus", "x")),
+					_getCommonFieldFilterJSONObject(
+						"eq", RandomTestUtil.randomString(),
+						RandomTestUtil.randomString())),
 				LocaleUtil.US);
 
 		Assert.assertEquals(
@@ -397,7 +412,7 @@ public class AssetListFiltersUtilTest {
 			ObjectFieldConstants.DB_TYPE_DATE, "modifiedDate");
 
 		_assertTermRangeQuery(
-			"modified", true, true, "20260115000000", "20260115235959",
+			Field.MODIFIED_DATE, true, true, "20260115000000", "20260115235959",
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST,
 				_getFilterJSONObject("eq", "modifiedDate", "2026-01-15")));
@@ -407,7 +422,7 @@ public class AssetListFiltersUtilTest {
 			ObjectFieldConstants.DB_TYPE_STRING, "creator");
 
 		_assertTermQuery(
-			"userName", "john smith",
+			Field.USER_NAME, "john smith",
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST,
 				_getFilterJSONObject("eq", "creator", "John Smith")));

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -90,69 +90,74 @@ public class AssetListFiltersUtilTest {
 			"localized_title_en_US", "Apple",
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST,
-				_buildCommonFieldFilter("eq", "title", "Apple")));
+				_getCommonFieldFilterJSONObject("eq", "title", "Apple")));
 		_assertMatchQuery(
 			"localized_title_en_US", "App",
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST,
-				_buildCommonFieldFilter("contains", "title", "App")));
+				_getCommonFieldFilterJSONObject("contains", "title", "App")));
 
 		_assertTermQuery(
 			"userName", "john smith",
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST,
-				_buildCommonFieldFilter("eq", "userName", "John Smith")));
+				_getCommonFieldFilterJSONObject(
+					"eq", "userName", "John Smith")));
 		_assertWildcardQuery(
 			"userName", "*john smith*",
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST_NOT,
-				_buildCommonFieldFilter(
+				_getCommonFieldFilterJSONObject(
 					"not-contains", "userName", "John Smith")));
 
 		_assertTermQuery(
 			"viewCount", "5",
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST,
-				_buildCommonFieldFilter("eq", "viewCount", "5")));
+				_getCommonFieldFilterJSONObject("eq", "viewCount", "5")));
 		_assertTermQuery(
 			"status", "0",
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST_NOT,
-				_buildCommonFieldFilter("not-eq", "status", "0")));
+				_getCommonFieldFilterJSONObject("not-eq", "status", "0")));
 
 		_assertTermRangeQuery(
 			"priority", false, false, "0.5", null,
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST,
-				_buildCommonFieldFilter("gt", "priority", "0.5")));
+				_getCommonFieldFilterJSONObject("gt", "priority", "0.5")));
 
 		_assertTermRangeQuery(
 			"createDate", false, false, "20260115235959", null,
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST,
-				_buildCommonFieldFilter("gt", "createDate", "2026-01-15")));
+				_getCommonFieldFilterJSONObject(
+					"gt", "createDate", "2026-01-15")));
 		_assertTermRangeQuery(
 			"modified", true, true, "20260115000000", "20260115235959",
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST,
-				_buildCommonFieldFilter("eq", "modified", "2026-01-15")));
+				_getCommonFieldFilterJSONObject(
+					"eq", "modified", "2026-01-15")));
 		_assertTermRangeQuery(
 			"modified", true, true, "20260115000000", "20260115235959",
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST_NOT,
-				_buildCommonFieldFilter("not-eq", "modified", "2026-01-15")));
+				_getCommonFieldFilterJSONObject(
+					"not-eq", "modified", "2026-01-15")));
 		_assertTermRangeQuery(
 			"modified", true, true, "20260115000000", "20260120235959",
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST,
-				_buildCommonFieldFilterWithJSONArrayValue(
+				_getCommonFieldFilterJSONObject(
 					"between", "modified",
 					JSONUtil.putAll("2026-01-15", "2026-01-20"))));
 
 		BooleanClause[] booleanClauses =
 			AssetListFiltersUtil.getFiltersBooleanClauses(
 				_COMPANY_ID,
-				JSONUtil.putAll(_buildCommonFieldFilter("eq", "bogus", "x")),
+				JSONUtil.putAll(
+					_getCommonFieldFilterJSONObject("eq", "bogus", "x")),
 				LocaleUtil.US);
 
 		Assert.assertEquals(
@@ -395,7 +400,7 @@ public class AssetListFiltersUtilTest {
 			"modified", true, true, "20260115000000", "20260115235959",
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST,
-				_buildFilterJSONObject("eq", "modifiedDate", "2026-01-15")));
+				_getFilterJSONObject("eq", "modifiedDate", "2026-01-15")));
 
 		_setUpMetadataObjectField(
 			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
@@ -405,7 +410,7 @@ public class AssetListFiltersUtilTest {
 			"userName", "john smith",
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST,
-				_buildFilterJSONObject("eq", "creator", "John Smith")));
+				_getFilterJSONObject("eq", "creator", "John Smith")));
 
 		_setUpMetadataObjectField(
 			ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
@@ -415,7 +420,7 @@ public class AssetListFiltersUtilTest {
 			AssetListFiltersUtil.getFiltersBooleanClauses(
 				_COMPANY_ID,
 				JSONUtil.putAll(
-					_buildFilterJSONObject(
+					_getFilterJSONObject(
 						"eq", "id",
 						String.valueOf(RandomTestUtil.randomLong()))),
 				LocaleUtil.US);
@@ -909,19 +914,7 @@ public class AssetListFiltersUtilTest {
 		Assert.assertEquals(expectedValue, queryTerm.getValue());
 	}
 
-	private JSONObject _buildCommonFieldFilter(
-		String operatorName, String propertyName, String value) {
-
-		return JSONUtil.put(
-			"operatorName", operatorName
-		).put(
-			"propertyName", propertyName
-		).put(
-			"value", value
-		);
-	}
-
-	private JSONObject _buildCommonFieldFilterWithJSONArrayValue(
+	private JSONObject _getCommonFieldFilterJSONObject(
 		String operatorName, String propertyName, JSONArray valueJSONArray) {
 
 		return JSONUtil.put(
@@ -930,6 +923,18 @@ public class AssetListFiltersUtilTest {
 			"propertyName", propertyName
 		).put(
 			"value", valueJSONArray
+		);
+	}
+
+	private JSONObject _getCommonFieldFilterJSONObject(
+		String operatorName, String propertyName, String value) {
+
+		return JSONUtil.put(
+			"operatorName", operatorName
+		).put(
+			"propertyName", propertyName
+		).put(
+			"value", value
 		);
 	}
 

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -98,15 +98,16 @@ public class AssetListFiltersUtilTest {
 				_buildCommonFieldFilter("contains", "title", "App")));
 
 		_assertTermQuery(
-			"userName", "Alice",
+			"userName", "john smith",
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST,
-				_buildCommonFieldFilter("eq", "userName", "Alice")));
+				_buildCommonFieldFilter("eq", "userName", "John Smith")));
 		_assertWildcardQuery(
-			"userName", "*Alice*",
+			"userName", "*john smith*",
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST_NOT,
-				_buildCommonFieldFilter("not-contains", "userName", "Alice")));
+				_buildCommonFieldFilter(
+					"not-contains", "userName", "John Smith")));
 
 		_assertTermQuery(
 			"viewCount", "5",
@@ -401,7 +402,7 @@ public class AssetListFiltersUtilTest {
 			ObjectFieldConstants.DB_TYPE_STRING, "creator");
 
 		_assertTermQuery(
-			"userName", "John Smith",
+			"userName", "john smith",
 			_assertCommonFieldRow(
 				BooleanClauseOccur.MUST,
 				_buildFilterJSONObject("eq", "creator", "John Smith")));

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -85,6 +85,80 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
+	public void testFilterQueriesWithCommonFields() {
+		_assertMatchQuery(
+			"localized_title_en_US", "Apple",
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_buildCommonFieldFilter("eq", "title", "Apple")));
+		_assertMatchQuery(
+			"localized_title_en_US", "App",
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_buildCommonFieldFilter("contains", "title", "App")));
+
+		_assertTermQuery(
+			"userName", "Alice",
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_buildCommonFieldFilter("eq", "userName", "Alice")));
+		_assertWildcardQuery(
+			"userName", "*Alice*",
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST_NOT,
+				_buildCommonFieldFilter("not-contains", "userName", "Alice")));
+
+		_assertTermQuery(
+			"viewCount", "5",
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_buildCommonFieldFilter("eq", "viewCount", "5")));
+		_assertTermQuery(
+			"status", "0",
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST_NOT,
+				_buildCommonFieldFilter("not-eq", "status", "0")));
+
+		_assertTermRangeQuery(
+			"priority", false, false, "0.5", null,
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_buildCommonFieldFilter("gt", "priority", "0.5")));
+
+		_assertTermRangeQuery(
+			"createDate", false, false, "20260115235959", null,
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_buildCommonFieldFilter("gt", "createDate", "2026-01-15")));
+		_assertTermRangeQuery(
+			"modified", true, true, "20260115000000", "20260115235959",
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_buildCommonFieldFilter("eq", "modified", "2026-01-15")));
+		_assertTermRangeQuery(
+			"modified", true, true, "20260115000000", "20260115235959",
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST_NOT,
+				_buildCommonFieldFilter("not-eq", "modified", "2026-01-15")));
+		_assertTermRangeQuery(
+			"modified", true, true, "20260115000000", "20260120235959",
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_buildCommonFieldFilterWithJSONArrayValue(
+					"between", "modified",
+					JSONUtil.putAll("2026-01-15", "2026-01-20"))));
+
+		BooleanClause[] booleanClauses =
+			AssetListFiltersUtil.getFiltersBooleanClauses(
+				_COMPANY_ID,
+				JSONUtil.putAll(_buildCommonFieldFilter("eq", "bogus", "x")),
+				LocaleUtil.US);
+
+		Assert.assertEquals(
+			Arrays.toString(booleanClauses), 0, booleanClauses.length);
+	}
+
+	@Test
 	public void testFilterQueriesWithDateAndDateTimeOperators() {
 		String dateFieldName = RandomTestUtil.randomString();
 
@@ -598,6 +672,53 @@ public class AssetListFiltersUtilTest {
 			notContainsQuery instanceof MatchQuery);
 	}
 
+	private Query _assertCommonFieldRow(
+		BooleanClauseOccur expectedBooleanClauseOccur,
+		JSONObject filterJSONObject) {
+
+		BooleanClause[] booleanClauses =
+			AssetListFiltersUtil.getFiltersBooleanClauses(
+				_COMPANY_ID, JSONUtil.putAll(filterJSONObject), LocaleUtil.US);
+
+		Assert.assertEquals(
+			Arrays.toString(booleanClauses), 1, booleanClauses.length);
+
+		BooleanClause<?> filtersBooleanClause = booleanClauses[0];
+
+		Assert.assertEquals(
+			BooleanClauseOccur.MUST,
+			filtersBooleanClause.getBooleanClauseOccur());
+
+		BooleanQuery filtersBooleanQuery =
+			(BooleanQuery)filtersBooleanClause.getClause();
+
+		List<BooleanClause<Query>> filterBooleanClauses =
+			filtersBooleanQuery.clauses();
+
+		BooleanClause<Query> filterBooleanClause = filterBooleanClauses.get(0);
+
+		Assert.assertEquals(
+			expectedBooleanClauseOccur,
+			filterBooleanClause.getBooleanClauseOccur());
+
+		Query query = filterBooleanClause.getClause();
+
+		Assert.assertFalse(query.toString(), query instanceof NestedQuery);
+
+		return query;
+	}
+
+	private void _assertMatchQuery(
+		String expectedField, String expectedValue, Query query) {
+
+		Assert.assertTrue(query.toString(), query instanceof MatchQuery);
+
+		MatchQuery matchQuery = (MatchQuery)query;
+
+		Assert.assertEquals(expectedField, matchQuery.getField());
+		Assert.assertEquals(expectedValue, matchQuery.getValue());
+	}
+
 	private QueryTerm _assertNestedFieldQueryTerm(
 		BooleanClause<Query> booleanClause, String expectedField) {
 
@@ -746,6 +867,30 @@ public class AssetListFiltersUtilTest {
 
 		Assert.assertEquals(expectedField, queryTerm.getField());
 		Assert.assertEquals(expectedValue, queryTerm.getValue());
+	}
+
+	private JSONObject _buildCommonFieldFilter(
+		String operatorName, String propertyName, String value) {
+
+		return JSONUtil.put(
+			"operatorName", operatorName
+		).put(
+			"propertyName", propertyName
+		).put(
+			"value", value
+		);
+	}
+
+	private JSONObject _buildCommonFieldFilterWithJSONArrayValue(
+		String operatorName, String propertyName, JSONArray valueJSONArray) {
+
+		return JSONUtil.put(
+			"operatorName", operatorName
+		).put(
+			"propertyName", propertyName
+		).put(
+			"value", valueJSONArray
+		);
 	}
 
 	private JSONObject _getFilterJSONObject(

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -385,6 +385,45 @@ public class AssetListFiltersUtilTest {
 	}
 
 	@Test
+	public void testFilterQueriesWithMetadataObjectFields() {
+		_setUpMetadataObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_DATE,
+			ObjectFieldConstants.DB_TYPE_DATE, "modifiedDate");
+
+		_assertTermRangeQuery(
+			"modified", true, true, "20260115000000", "20260115235959",
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject("eq", "modifiedDate", "2026-01-15")));
+
+		_setUpMetadataObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, "creator");
+
+		_assertTermQuery(
+			"userName", "John Smith",
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_buildFilterJSONObject("eq", "creator", "John Smith")));
+
+		_setUpMetadataObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
+			ObjectFieldConstants.DB_TYPE_LONG, "id");
+
+		BooleanClause[] booleanClauses =
+			AssetListFiltersUtil.getFiltersBooleanClauses(
+				_COMPANY_ID,
+				JSONUtil.putAll(
+					_buildFilterJSONObject(
+						"eq", "id",
+						String.valueOf(RandomTestUtil.randomLong()))),
+				LocaleUtil.US);
+
+		Assert.assertEquals(
+			Arrays.toString(booleanClauses), 0, booleanClauses.length);
+	}
+
+	@Test
 	public void testFilterQueriesWithNumericRangeOperators() {
 		String doubleFieldName = RandomTestUtil.randomString();
 
@@ -973,6 +1012,20 @@ public class AssetListFiltersUtilTest {
 		);
 
 		localizationUtil.setLocalization(localization);
+	}
+
+	private ObjectField _setUpMetadataObjectField(
+		String businessType, String dbType, String name) {
+
+		ObjectField objectField = _setUpObjectField(businessType, dbType, name);
+
+		Mockito.when(
+			objectField.isMetadata()
+		).thenReturn(
+			true
+		);
+
+		return objectField;
 	}
 
 	private ObjectField _setUpObjectField(

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -156,55 +157,61 @@ public class AssetListAssetEntryProviderFiltersTest {
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
 	@Test
 	public void testCommonFieldFilters() throws Exception {
+		String title1 = RandomTestUtil.randomString();
+
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
-				_OBJECT_FIELD_NAME_TEXT, "alpha"
+				_OBJECT_FIELD_NAME_TEXT, title1
 			).build());
+
 		ObjectEntry objectEntry2 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
-				_OBJECT_FIELD_NAME_TEXT, "beta"
+				_OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
 			).build());
 
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_buildCommonFieldFilter("eq", "title", "alpha")),
+				_buildCommonFieldFilter("eq", Field.TITLE, title1)),
 			objectEntry1);
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_buildCommonFieldFilter("contains", "title", "alpha")),
+				_buildCommonFieldFilter("contains", Field.TITLE, title1)),
 			objectEntry1);
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_buildCommonFieldFilter("not-contains", "title", "alpha")),
+				_buildCommonFieldFilter("not-contains", Field.TITLE, title1)),
 			objectEntry2);
 
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_buildCommonFieldFilter("gt", "createDate", "2000-01-01")),
+				_buildCommonFieldFilter("gt", Field.CREATE_DATE, "2000-01-01")),
 			objectEntry1, objectEntry2);
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_buildCommonFieldFilter("lt", "createDate", "2000-01-01")));
+				_buildCommonFieldFilter(
+					"lt", Field.CREATE_DATE, "2000-01-01")));
 	}
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
 	@Test
 	public void testCommonFieldFiltersMatchAcrossAssetTypes() throws Exception {
+		String title = RandomTestUtil.randomString();
+
 		ObjectEntry objectEntry = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
-				_OBJECT_FIELD_NAME_TEXT, "crossfilter"
+				_OBJECT_FIELD_NAME_TEXT, title
 			).build());
 
 		JournalArticle journalArticle = JournalTestUtil.addArticle(
 			_group.getGroupId(),
-			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, 0, "crossfilter",
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, 0, title,
 			StringPool.BLANK, "content", LocaleUtil.US, false, true,
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 
 		List<Long> actualClassPKs = _getFilteredClassPKs(
 			_buildFiltersJSONArray(
-				_buildCommonFieldFilter("contains", "title", "crossfilter")));
+				_buildCommonFieldFilter("contains", Field.TITLE, title)));
 
 		Assert.assertEquals(
 			actualClassPKs.toString(), 2, actualClassPKs.size());
@@ -373,12 +380,13 @@ public class AssetListAssetEntryProviderFiltersTest {
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
 				_buildCommonFieldFilter(
-					"contains", "userName", StringUtil.toUpperCase(userName))),
+					"contains", Field.USER_NAME,
+					StringUtil.toUpperCase(userName))),
 			objectEntry);
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
 				_buildCommonFieldFilter(
-					"eq", "userName", StringUtil.toUpperCase(userName))),
+					"eq", Field.USER_NAME, StringUtil.toUpperCase(userName))),
 			objectEntry);
 	}
 
@@ -601,14 +609,14 @@ public class AssetListAssetEntryProviderFiltersTest {
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
 				_buildCommonFieldFilter(
-					"eq", "status",
+					"eq", Field.STATUS,
 					String.valueOf(WorkflowConstants.STATUS_APPROVED))),
 			objectEntry);
 
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
 				_buildCommonFieldFilter(
-					"not-eq", "status",
+					"not-eq", Field.STATUS,
 					String.valueOf(WorkflowConstants.STATUS_APPROVED))));
 	}
 

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -54,6 +54,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
@@ -300,6 +301,34 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
 	@Test
+	public void testGetAssetEntriesInfoPageWithExternalReferenceCodeFilters()
+		throws Exception {
+
+		String externalReferenceCode = StringUtil.toUpperCase(
+			RandomTestUtil.randomString());
+
+		ObjectEntry objectEntry =
+			_objectEntryLocalService.addOrUpdateObjectEntry(
+				externalReferenceCode, _group.getGroupId(),
+				TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				HashMapBuilder.<String, Serializable>put(
+					_OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
+				).build(),
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId()));
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildCommonFieldFilter(
+					"eq", "externalReferenceCode", externalReferenceCode)),
+			objectEntry);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
 	public void testGetAssetEntriesInfoPageWithKeywordTextContainsFilters()
 		throws Exception {
 
@@ -326,6 +355,31 @@ public class AssetListAssetEntryProviderFiltersTest {
 				_buildFilterJSONObject(
 					"not-contains", _OBJECT_FIELD_NAME_KEYWORD, keyword)),
 			objectEntry2);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testGetAssetEntriesInfoPageWithMixedCaseUserNameFilters()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
+			).build());
+
+		String userName = TestPropsValues.getUser(
+		).getFullName();
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildCommonFieldFilter(
+					"contains", "userName", StringUtil.toUpperCase(userName))),
+			objectEntry);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildCommonFieldFilter(
+					"eq", "userName", StringUtil.toUpperCase(userName))),
+			objectEntry);
 	}
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
@@ -532,6 +586,30 @@ public class AssetListAssetEntryProviderFiltersTest {
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, "any",
 					_LIST_TYPE_ENTRY_KEY_3)),
 			objectEntry4);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testGetAssetEntriesInfoPageWithStatusFilters()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildCommonFieldFilter(
+					"eq", "status",
+					String.valueOf(WorkflowConstants.STATUS_APPROVED))),
+			objectEntry);
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildCommonFieldFilter(
+					"not-eq", "status",
+					String.valueOf(WorkflowConstants.STATUS_APPROVED))));
 	}
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -13,6 +13,9 @@ import com.liferay.asset.list.model.AssetListEntry;
 import com.liferay.asset.list.service.AssetListEntryLocalService;
 import com.liferay.asset.list.test.util.AssetListTestUtil;
 import com.liferay.info.pagination.InfoPage;
+import com.liferay.journal.constants.JournalFolderConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.list.type.entry.util.ListTypeEntryUtil;
 import com.liferay.list.type.model.ListTypeDefinition;
 import com.liferay.list.type.service.ListTypeDefinitionLocalService;
@@ -23,8 +26,11 @@ import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectFieldSetting;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.function.transform.TransformUtil;
@@ -134,6 +140,79 @@ public class AssetListAssetEntryProviderFiltersTest {
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_PICKLIST,
 					false, false)),
 			ObjectDefinitionConstants.SCOPE_SITE);
+
+		ObjectField titleObjectField =
+			_objectFieldLocalService.fetchObjectField(
+				_objectDefinition.getObjectDefinitionId(),
+				_OBJECT_FIELD_NAME_TEXT);
+
+		_objectDefinition =
+			_objectDefinitionLocalService.updateTitleObjectFieldId(
+				_objectDefinition.getObjectDefinitionId(),
+				titleObjectField.getObjectFieldId());
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testCommonFieldFilters() throws Exception {
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_TEXT, "alpha"
+			).build());
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_TEXT, "beta"
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildCommonFieldFilter("eq", "title", "alpha")),
+			objectEntry1);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildCommonFieldFilter("contains", "title", "alpha")),
+			objectEntry1);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildCommonFieldFilter("not-contains", "title", "alpha")),
+			objectEntry2);
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildCommonFieldFilter("gt", "createDate", "2000-01-01")),
+			objectEntry1, objectEntry2);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildCommonFieldFilter("lt", "createDate", "2000-01-01")));
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testCommonFieldFiltersMatchAcrossAssetTypes() throws Exception {
+		ObjectEntry objectEntry = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_TEXT, "crossfilter"
+			).build());
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, 0, "crossfilter",
+			StringPool.BLANK, "content", LocaleUtil.US, false, true,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		List<Long> actualClassPKs = _getFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildCommonFieldFilter("contains", "title", "crossfilter")));
+
+		Assert.assertEquals(
+			actualClassPKs.toString(), 2, actualClassPKs.size());
+		Assert.assertTrue(
+			actualClassPKs.toString(),
+			actualClassPKs.containsAll(
+				Arrays.asList(
+					objectEntry.getObjectEntryId(),
+					journalArticle.getResourcePrimKey())));
 	}
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
@@ -692,6 +771,18 @@ public class AssetListAssetEntryProviderFiltersTest {
 			actualClassPKs.containsAll(expectedClassPKs));
 	}
 
+	private JSONObject _buildCommonFieldFilter(
+		String operatorName, String propertyName, Object value) {
+
+		return JSONUtil.put(
+			"operatorName", operatorName
+		).put(
+			"propertyName", propertyName
+		).put(
+			"value", value
+		);
+	}
+
 	private JSONObject _buildFilterJSONObject(
 		String operatorName, String propertyName, Object value) {
 
@@ -747,6 +838,36 @@ public class AssetListAssetEntryProviderFiltersTest {
 		return objectFieldSetting;
 	}
 
+	private List<Long> _getFilteredClassPKs(JSONArray filtersJSONArray)
+		throws Exception {
+
+		AssetListEntry assetListEntry = AssetListTestUtil.addAssetListEntry(
+			_group.getGroupId(), 0);
+
+		_assetListEntryLocalService.updateAssetListEntryTypeSettings(
+			assetListEntry.getAssetListEntryId(),
+			SegmentsEntryConstants.ID_DEFAULT,
+			UnicodePropertiesBuilder.create(
+				true
+			).put(
+				"anyAssetType", "true"
+			).put(
+				"filters", filtersJSONArray.toString()
+			).build(
+			).toString());
+
+		InfoPage<AssetEntry> infoPage =
+			_assetListAssetEntryProvider.getAssetEntriesInfoPage(
+				_assetListEntryLocalService.getAssetListEntry(
+					assetListEntry.getAssetListEntryId()),
+				new long[] {SegmentsEntryConstants.ID_DEFAULT}, null, null,
+				StringPool.BLANK, StringPool.BLANK, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS);
+
+		return TransformUtil.transform(
+			infoPage.getPageItems(), AssetEntry::getClassPK);
+	}
+
 	private static final String _LIST_TYPE_ENTRY_KEY_1 =
 		RandomTestUtil.randomString();
 
@@ -796,7 +917,13 @@ public class AssetListAssetEntryProviderFiltersTest {
 	private ObjectDefinition _objectDefinition;
 
 	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ObjectFieldLocalService _objectFieldLocalService;
 
 	@Inject
 	private ObjectFieldSettingLocalService _objectFieldSettingLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93003

## What Is Being Fixed

Dynamic asset list filters (LPD-74731) could only target object custom fields, which are indexed under nestedFieldArray. Common asset fields shared across every asset type — title, userName, status, createDate, modified, priority, externalReferenceCode, and so on — are indexed at the document root and had no filter support, and object metadata fields (creator, modifiedDate) were likewise unfilterable.

## How It Is Being Fixed

getFiltersBooleanClauses now routes each filter row through a dispatcher: common-field rows and object metadata fields build a top-level query against the document-root field, while regular object fields keep the existing nested-query path. A registry maps each common field to its indexed name and type (date, decimal, integer, text), driving the right query — a MatchQuery for the analyzed localized title, a TermRangeQuery for dates and numeric ranges, and a WildcardQuery or TermQuery for keywords — with userName lowercased to match its index-time casing. Negation reuses the existing loop-level MUST_NOT plus MatchAllQuery anchor so field-absent entries are still included, and the object and common range paths share a single range query builder. Unit and integration tests cover each common field, the metadata aliases, negation, and per-encoding casing.

## PR Check

**pr-check: SKIPPED** — pr-check env-blocked (petra resolution broke after a snapshot rebuild); opening for early review so the team lead can start. Code verified green earlier this session (unit 10/10, integration compiled); pr-check will be rerun once the environment is restored.

<!-- pr-check {"reason": "env-blocked petra resolution after snapshot rebuild; to be rerun once the environment is restored", "result": "skipped", "sha": "92441b1a59479d02c0f4f5a79375047273fd86b9"} -->
