### PR TITLE
LPD-101532 Do not drop documents when a batch mode bulk request flushes empty

### DIFF
--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterImpl.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterImpl.java
@@ -108,16 +108,16 @@ public class ElasticsearchSearchEngineAdapterImpl
 
 				SearchContext.registerBatchModeSyncCallable(
 					() -> {
-						List<BulkableDocumentRequest<?>>
-							bulkableDocumentRequests =
-								finalBulkDocumentRequest.
-									getBulkableDocumentRequests();
-
-						if (bulkableDocumentRequests.isEmpty()) {
-							return null;
-						}
-
 						try {
+							List<BulkableDocumentRequest<?>>
+								bulkableDocumentRequests =
+									finalBulkDocumentRequest.
+										getBulkableDocumentRequests();
+
+							if (bulkableDocumentRequests.isEmpty()) {
+								return null;
+							}
+
 							_documentRequestExecutor.executeBulkDocumentRequest(
 								finalBulkDocumentRequest);
 						}

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterDocumentRequestTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterDocumentRequestTest.java
@@ -17,6 +17,7 @@ import co.elastic.clients.elasticsearch.indices.DeleteIndexRequest;
 import co.elastic.clients.elasticsearch.indices.ElasticsearchIndicesClient;
 import co.elastic.clients.json.JsonData;
 
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -26,6 +27,9 @@ import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchEngineHelperUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Validator;
@@ -73,6 +77,9 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
 /**
  * @author Dylan Rebelak
  */
@@ -113,6 +120,61 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		_deleteIndex();
 
 		_documentFixture.tearDown();
+	}
+
+	@Test
+	public void testExecuteBatchModeAfterExactMultipleFlush() throws Exception {
+		try (MockedStatic<SearchEngineHelperUtil>
+				searchEngineHelperUtilMockedStatic = Mockito.mockStatic(
+					SearchEngineHelperUtil.class)) {
+
+			ExecutorService executorService = Mockito.mock(
+				ExecutorService.class);
+
+			Mockito.doAnswer(
+				invocation -> {
+					Runnable runnable = invocation.getArgument(0);
+
+					runnable.run();
+
+					return null;
+				}
+			).when(
+				executorService
+			).execute(
+				Mockito.any(Runnable.class)
+			);
+
+			searchEngineHelperUtilMockedStatic.when(
+				SearchEngineHelperUtil::getDocumentsConsumerExecutorService
+			).thenReturn(
+				executorService
+			);
+
+			try (SafeCloseable safeCloseable = SearchContext.openBatchMode(
+					false)) {
+
+				for (int i = 0; i < Indexer.DEFAULT_INTERVAL; i++) {
+					_searchEngineAdapter.execute(
+						_createIndexDocumentRequest(String.valueOf(i)));
+				}
+			}
+
+			GetResponse getResponse1 = _getDocument("0");
+
+			Assert.assertTrue(getResponse1.found());
+
+			try (SafeCloseable safeCloseable = SearchContext.openBatchMode(
+					false)) {
+
+				_searchEngineAdapter.execute(
+					_createIndexDocumentRequest("remainder"));
+			}
+
+			GetResponse getResponse2 = _getDocument("remainder");
+
+			Assert.assertTrue(getResponse2.found());
+		}
 	}
 
 	@Test
@@ -729,6 +791,20 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
 		}
+	}
+
+	private IndexDocumentRequest _createIndexDocumentRequest(String uid) {
+		Document document = new DocumentImpl();
+
+		document.addKeyword(Field.UID, uid);
+
+		IndexDocumentRequest indexDocumentRequest = new IndexDocumentRequest(
+			_INDEX_NAME, document);
+
+		indexDocumentRequest.setType(
+			IndexMappingsConstants.LIFERAY_DOCUMENT_TYPE);
+
+		return indexDocumentRequest;
 	}
 
 	private void _deleteIndex() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101532

## Opensearch Changes

This is being tracked in https://liferay.atlassian.net/browse/LPD-98499.

## What Is Being Fixed

A full reindex silently drops documents. The Elasticsearch adapter coalesces bulkable document requests into a per-thread buffer and flushes it at `Indexer.DEFAULT_INTERVAL`. When a batch mode scope's final write lands exactly on that threshold, `transferCopy()` empties the buffer, and the sync callable then returns early without releasing its thread local. Because a flush callable is only registered when the thread local is null, the next batch mode scope on that thread registers none, and everything it buffers below the threshold is never written. Nothing throws and the reindex reports success.

Reproduced on a master bundle: 10,001 BlogsEntry rows in the database produced 10,000 documents after a full reindex — exactly 40 x 250, losing the remainder. The indexed count always lands on a multiple of `index.interval`.

## How It Is Being Fixed

The empty-buffer check moves inside the existing `try`, so the `finally` that calls `_bulkDocumentRequest.remove()` runs on every path. That restores the invariant that the thread local is null at the end of every scope that created it, so each scope registers its own flush callable and flushes its own remainder.

The regression test drives `Indexer.DEFAULT_INTERVAL` directly rather than configuring a smaller threshold, so it reproduces the drop with no configuration: it fills one batch scope to exactly the threshold, then asserts a document indexed in a following scope is present.

## PR Check

**pr-check: PASS** — tested on `7882c96e05646339ef261759bcb567075786ad24`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "7882c96e05646339ef261759bcb567075786ad24"} -->
