### PR TITLE
PR1 LPD-93003 Build common-field filtering for asset list filters

### DIFF
--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.search.TermRangeQuery;
 import com.liferay.portal.kernel.search.WildcardQuery;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -37,6 +38,7 @@ import java.text.Format;
 
 import java.util.Calendar;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -59,20 +61,19 @@ public class AssetListFiltersUtil {
 		for (int i = 0; i < filtersJSONArray.length(); i++) {
 			JSONObject jsonObject = filtersJSONArray.getJSONObject(i);
 
-			NestedQuery nestedQuery = _toNestedQuery(
-				companyId, jsonObject, locale);
+			Query query = _toQuery(companyId, jsonObject, locale);
 
-			if (nestedQuery == null) {
+			if (query == null) {
 				continue;
 			}
 
 			if (_isNegatedOperator(
 					jsonObject.getString("operatorName", "contains"))) {
 
-				booleanQuery.add(nestedQuery, BooleanClauseOccur.MUST_NOT);
+				booleanQuery.add(query, BooleanClauseOccur.MUST_NOT);
 			}
 			else {
-				booleanQuery.add(nestedQuery, BooleanClauseOccur.MUST);
+				booleanQuery.add(query, BooleanClauseOccur.MUST);
 
 				hasMustClause = true;
 			}
@@ -89,6 +90,24 @@ public class AssetListFiltersUtil {
 		return new BooleanClause[] {
 			new BooleanClause<>(booleanQuery, BooleanClauseOccur.MUST)
 		};
+	}
+
+	private static String _fetchCommonFieldName(
+		Locale locale, String propertyName) {
+
+		if (!_commonFieldTypesMap.containsKey(propertyName)) {
+			return null;
+		}
+
+		if (_localizedCommonFieldNames.contains(propertyName)) {
+			return Field.getLocalizedName(locale, "localized_" + propertyName);
+		}
+
+		return propertyName;
+	}
+
+	private static String _fetchCommonFieldType(String propertyName) {
+		return _commonFieldTypesMap.get(propertyName);
 	}
 
 	private static ObjectDefinition _fetchObjectDefinition(
@@ -161,6 +180,16 @@ public class AssetListFiltersUtil {
 		return "nestedFieldArray.value_text";
 	}
 
+	private static boolean _isCommonFieldRow(JSONObject jsonObject) {
+		if ((jsonObject.getLong("classNameId") <= 0) &&
+			(jsonObject.getLong("classTypeId") <= 0)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	private static boolean _isDateTimeField(ObjectField objectField) {
 		return ObjectFieldConstants.DB_TYPE_DATE_TIME.equals(
 			objectField.getDBType());
@@ -209,6 +238,74 @@ public class AssetListFiltersUtil {
 		return format.format(calendar.getTime());
 	}
 
+	private static Query _toCommonFieldQuery(
+		JSONObject jsonObject, Locale locale, String propertyName) {
+
+		if (Validator.isNull(propertyName)) {
+			return null;
+		}
+
+		String commonFieldName = _fetchCommonFieldName(locale, propertyName);
+		String commonFieldType = _fetchCommonFieldType(propertyName);
+
+		if ((commonFieldName == null) || (commonFieldType == null)) {
+			return null;
+		}
+
+		String operatorName = GetterUtil.getString(
+			jsonObject.getString("operatorName"), "contains");
+
+		return _toCommonFieldValueQuery(
+			commonFieldName, jsonObject,
+			_localizedCommonFieldNames.contains(propertyName), operatorName,
+			commonFieldType);
+	}
+
+	private static Query _toCommonFieldValueQuery(
+		String field, JSONObject jsonObject, boolean localized,
+		String operatorName, String type) {
+
+		if (operatorName.equals("between") || operatorName.equals("ge") ||
+			operatorName.equals("gt") || operatorName.equals("le") ||
+			operatorName.equals("lt")) {
+
+			return _toTermRangeQuery(
+				type.equals(_TYPE_DATE), false, field, jsonObject,
+				operatorName);
+		}
+
+		String value = jsonObject.getString("value");
+
+		if (Validator.isNull(value)) {
+			return null;
+		}
+
+		if (type.equals(_TYPE_DATE) &&
+			(operatorName.equals("eq") || operatorName.equals("not-eq"))) {
+
+			return new TermRangeQuery(
+				field, _toDateTerm(false, false, value),
+				_toDateTerm(false, true, value), true, true);
+		}
+
+		if (type.equals(_TYPE_DECIMAL) || type.equals(_TYPE_INTEGER)) {
+			return new TermQuery(field, value);
+		}
+
+		if (localized) {
+			return new MatchQuery(field, value);
+		}
+
+		if (operatorName.equals("contains") ||
+			operatorName.equals("not-contains")) {
+
+			return new WildcardQuery(
+				field, StringPool.STAR + value + StringPool.STAR);
+		}
+
+		return new TermQuery(field, value);
+	}
+
 	private static String _toDateTerm(
 		boolean dateTimeField, boolean upperBound, String value) {
 
@@ -237,10 +334,6 @@ public class AssetListFiltersUtil {
 
 	private static NestedQuery _toNestedQuery(
 		long companyId, JSONObject jsonObject, Locale locale) {
-
-		if (jsonObject == null) {
-			return null;
-		}
 
 		String propertyName = jsonObject.getString("propertyName");
 		String value = jsonObject.getString("value");
@@ -314,20 +407,38 @@ public class AssetListFiltersUtil {
 		return booleanQuery;
 	}
 
+	private static Query _toQuery(
+		long companyId, JSONObject jsonObject, Locale locale) {
+
+		if (jsonObject == null) {
+			return null;
+		}
+
+		if (_isCommonFieldRow(jsonObject)) {
+			return _toCommonFieldQuery(
+				jsonObject, locale, jsonObject.getString("propertyName"));
+		}
+
+		return _toNestedQuery(companyId, jsonObject, locale);
+	}
+
 	private static Query _toRangeQuery(
 		JSONObject filterJSONObject, ObjectField objectField,
 		String operatorName, String subfield) {
 
 		boolean dateField = subfield.endsWith(".value_date");
 
-		boolean dateTimeField = false;
+		return _toTermRangeQuery(
+			dateField, dateField && _isDateTimeField(objectField), subfield,
+			filterJSONObject, operatorName);
+	}
 
-		if (dateField && _isDateTimeField(objectField)) {
-			dateTimeField = true;
-		}
+	private static Query _toTermRangeQuery(
+		boolean dateField, boolean dateTime, String field,
+		JSONObject jsonObject, String operatorName) {
 
 		if (operatorName.equals("between")) {
-			JSONArray valueJSONArray = filterJSONObject.getJSONArray("value");
+			JSONArray valueJSONArray = jsonObject.getJSONArray("value");
 
 			if ((valueJSONArray == null) || (valueJSONArray.length() < 2)) {
 				return null;
@@ -339,15 +450,14 @@ public class AssetListFiltersUtil {
 				valueJSONArray.getString(1), null);
 
 			if (dateField) {
-				lowerTerm = _toDateTerm(dateTimeField, false, lowerTerm);
-				upperTerm = _toDateTerm(dateTimeField, true, upperTerm);
+				lowerTerm = _toDateTerm(dateTime, false, lowerTerm);
+				upperTerm = _toDateTerm(dateTime, true, upperTerm);
 			}
 
-			return new TermRangeQuery(
-				subfield, lowerTerm, upperTerm, true, true);
+			return new TermRangeQuery(field, lowerTerm, upperTerm, true, true);
 		}
 
-		String value = filterJSONObject.getString("value");
+		String value = jsonObject.getString("value");
 
 		if (Validator.isNull(value)) {
 			return null;
@@ -355,30 +465,30 @@ public class AssetListFiltersUtil {
 
 		if (operatorName.equals("ge")) {
 			String lowerTerm =
-				dateField ? _toDateTerm(dateTimeField, false, value) : value;
+				dateField ? _toDateTerm(dateTime, false, value) : value;
 
-			return new TermRangeQuery(subfield, lowerTerm, null, true, false);
+			return new TermRangeQuery(field, lowerTerm, null, true, false);
 		}
 
 		if (operatorName.equals("gt")) {
 			String lowerTerm =
-				dateField ? _toDateTerm(dateTimeField, true, value) : value;
+				dateField ? _toDateTerm(dateTime, true, value) : value;
 
-			return new TermRangeQuery(subfield, lowerTerm, null, false, false);
+			return new TermRangeQuery(field, lowerTerm, null, false, false);
 		}
 
 		if (operatorName.equals("le")) {
 			String upperTerm =
-				dateField ? _toDateTerm(dateTimeField, true, value) : value;
+				dateField ? _toDateTerm(dateTime, true, value) : value;
 
-			return new TermRangeQuery(subfield, null, upperTerm, false, true);
+			return new TermRangeQuery(field, null, upperTerm, false, true);
 		}
 
 		if (operatorName.equals("lt")) {
 			String upperTerm =
-				dateField ? _toDateTerm(dateTimeField, false, value) : value;
+				dateField ? _toDateTerm(dateTime, false, value) : value;
 
-			return new TermRangeQuery(subfield, null, upperTerm, false, false);
+			return new TermRangeQuery(field, null, upperTerm, false, false);
 		}
 
 		return null;
@@ -437,6 +547,42 @@ public class AssetListFiltersUtil {
 		return new MatchQuery(subfield, value);
 	}
 
+	private static final String _TYPE_DATE = "date";
+
+	private static final String _TYPE_DECIMAL = "decimal";
+
+	private static final String _TYPE_INTEGER = "integer";
+
+	private static final String _TYPE_TEXT = "text";
+
+	private static final Map<String, String> _commonFieldTypesMap =
+		HashMapBuilder.put(
+			Field.CREATE_DATE, _TYPE_DATE
+		).put(
+			Field.DISPLAY_DATE, _TYPE_DATE
+		).put(
+			Field.EXPIRATION_DATE, _TYPE_DATE
+		).put(
+			Field.MODIFIED_DATE, _TYPE_DATE
+		).put(
+			Field.PRIORITY, _TYPE_DECIMAL
+		).put(
+			Field.PUBLISH_DATE, _TYPE_DATE
+		).put(
+			Field.REVIEW_DATE, _TYPE_DATE
+		).put(
+			Field.STATUS, _TYPE_INTEGER
+		).put(
+			Field.TITLE, _TYPE_TEXT
+		).put(
+			Field.USER_NAME, _TYPE_TEXT
+		).put(
+			"externalReferenceCode", _TYPE_TEXT
+		).put(
+			"viewCount", _TYPE_INTEGER
+		).build();
+	private static final Set<String> _localizedCommonFieldNames =
+		SetUtil.fromArray(Field.TITLE);
 	private static final Set<String> _relativeDateValues = SetUtil.fromArray(
 		"last-year", "next-month", "now", "past-24-hours", "past-day",
 		"past-month", "past-week", "past-year");

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -269,6 +269,10 @@ public class AssetListFiltersUtil {
 			operatorName.equals("gt") || operatorName.equals("le") ||
 			operatorName.equals("lt")) {
 
+			if (type.equals(_TYPE_ENUM)) {
+				return null;
+			}
+
 			return _toTermRangeQuery(
 				type.equals(_TYPE_DATE), false, field, jsonObject,
 				operatorName);
@@ -551,6 +555,8 @@ public class AssetListFiltersUtil {
 
 	private static final String _TYPE_DECIMAL = "decimal";
 
+	private static final String _TYPE_ENUM = "enum";
+
 	private static final String _TYPE_INTEGER = "integer";
 
 	private static final String _TYPE_TEXT = "text";
@@ -571,7 +577,7 @@ public class AssetListFiltersUtil {
 		).put(
 			Field.REVIEW_DATE, _TYPE_DATE
 		).put(
-			Field.STATUS, _TYPE_INTEGER
+			Field.STATUS, _TYPE_ENUM
 		).put(
 			Field.TITLE, _TYPE_TEXT
 		).put(

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -10,6 +10,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldLocalServiceUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -17,6 +18,7 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.MatchQuery;
 import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
@@ -82,6 +84,102 @@ public class AssetListFiltersUtilTest {
 		_portalUtilMockedStatic.reset();
 
 		_setUpLocalizationUtil();
+	}
+
+	@Test
+	public void testFilterQueriesWithCommonFields() {
+		String userName = RandomTestUtil.randomString();
+
+		_assertTermQuery(
+			Field.USER_NAME, userName,
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_getCommonFieldFilterJSONObject(
+					"eq", Field.USER_NAME, userName)));
+		_assertWildcardQuery(
+			Field.USER_NAME, StringBundler.concat("*", userName, "*"),
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST_NOT,
+				_getCommonFieldFilterJSONObject(
+					"not-contains", Field.USER_NAME, userName)));
+
+		String status = String.valueOf(RandomTestUtil.randomInt());
+
+		_assertTermQuery(
+			Field.STATUS, status,
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST_NOT,
+				_getCommonFieldFilterJSONObject(
+					"not-eq", Field.STATUS, status)));
+
+		String priority = String.valueOf(RandomTestUtil.randomDouble());
+
+		_assertTermRangeQuery(
+			Field.PRIORITY, false, false, priority, null,
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_getCommonFieldFilterJSONObject(
+					"gt", Field.PRIORITY, priority)));
+
+		String title = RandomTestUtil.randomString();
+
+		_assertMatchQuery(
+			"localized_title_en_US", title,
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_getCommonFieldFilterJSONObject("eq", Field.TITLE, title)));
+		_assertMatchQuery(
+			"localized_title_en_US", title,
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_getCommonFieldFilterJSONObject(
+					"contains", Field.TITLE, title)));
+
+		String viewCount = String.valueOf(RandomTestUtil.randomInt());
+
+		_assertTermQuery(
+			"viewCount", viewCount,
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_getCommonFieldFilterJSONObject("eq", "viewCount", viewCount)));
+
+		_assertTermRangeQuery(
+			Field.CREATE_DATE, false, false, "20260115235959", null,
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_getCommonFieldFilterJSONObject(
+					"gt", Field.CREATE_DATE, "2026-01-15")));
+		_assertTermRangeQuery(
+			Field.MODIFIED_DATE, true, true, "20260115000000", "20260120235959",
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_getCommonFieldFilterJSONObject(
+					"between", Field.MODIFIED_DATE,
+					JSONUtil.putAll("2026-01-15", "2026-01-20"))));
+		_assertTermRangeQuery(
+			Field.MODIFIED_DATE, true, true, "20260115000000", "20260115235959",
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST,
+				_getCommonFieldFilterJSONObject(
+					"eq", Field.MODIFIED_DATE, "2026-01-15")));
+		_assertTermRangeQuery(
+			Field.MODIFIED_DATE, true, true, "20260115000000", "20260115235959",
+			_assertCommonFieldRow(
+				BooleanClauseOccur.MUST_NOT,
+				_getCommonFieldFilterJSONObject(
+					"not-eq", Field.MODIFIED_DATE, "2026-01-15")));
+
+		BooleanClause[] booleanClauses =
+			AssetListFiltersUtil.getFiltersBooleanClauses(
+				_COMPANY_ID,
+				JSONUtil.putAll(
+					_getCommonFieldFilterJSONObject(
+						"eq", RandomTestUtil.randomString(),
+						RandomTestUtil.randomString())),
+				LocaleUtil.US);
+
+		Assert.assertEquals(
+			Arrays.toString(booleanClauses), 0, booleanClauses.length);
 	}
 
 	@Test
@@ -598,6 +696,53 @@ public class AssetListFiltersUtilTest {
 			notContainsQuery instanceof MatchQuery);
 	}
 
+	private Query _assertCommonFieldRow(
+		BooleanClauseOccur expectedBooleanClauseOccur,
+		JSONObject filterJSONObject) {
+
+		BooleanClause[] booleanClauses =
+			AssetListFiltersUtil.getFiltersBooleanClauses(
+				_COMPANY_ID, JSONUtil.putAll(filterJSONObject), LocaleUtil.US);
+
+		Assert.assertEquals(
+			Arrays.toString(booleanClauses), 1, booleanClauses.length);
+
+		BooleanClause<?> filtersBooleanClause = booleanClauses[0];
+
+		Assert.assertEquals(
+			BooleanClauseOccur.MUST,
+			filtersBooleanClause.getBooleanClauseOccur());
+
+		BooleanQuery filtersBooleanQuery =
+			(BooleanQuery)filtersBooleanClause.getClause();
+
+		List<BooleanClause<Query>> filterBooleanClauses =
+			filtersBooleanQuery.clauses();
+
+		BooleanClause<Query> filterBooleanClause = filterBooleanClauses.get(0);
+
+		Assert.assertEquals(
+			expectedBooleanClauseOccur,
+			filterBooleanClause.getBooleanClauseOccur());
+
+		Query query = filterBooleanClause.getClause();
+
+		Assert.assertFalse(query.toString(), query instanceof NestedQuery);
+
+		return query;
+	}
+
+	private void _assertMatchQuery(
+		String expectedField, String expectedValue, Query query) {
+
+		Assert.assertTrue(query.toString(), query instanceof MatchQuery);
+
+		MatchQuery matchQuery = (MatchQuery)query;
+
+		Assert.assertEquals(expectedField, matchQuery.getField());
+		Assert.assertEquals(expectedValue, matchQuery.getValue());
+	}
+
 	private QueryTerm _assertNestedFieldQueryTerm(
 		BooleanClause<Query> booleanClause, String expectedField) {
 
@@ -746,6 +891,30 @@ public class AssetListFiltersUtilTest {
 
 		Assert.assertEquals(expectedField, queryTerm.getField());
 		Assert.assertEquals(expectedValue, queryTerm.getValue());
+	}
+
+	private JSONObject _getCommonFieldFilterJSONObject(
+		String operatorName, String propertyName, JSONArray valueJSONArray) {
+
+		return JSONUtil.put(
+			"operatorName", operatorName
+		).put(
+			"propertyName", propertyName
+		).put(
+			"value", valueJSONArray
+		);
+	}
+
+	private JSONObject _getCommonFieldFilterJSONObject(
+		String operatorName, String propertyName, String value) {
+
+		return JSONUtil.put(
+			"operatorName", operatorName
+		).put(
+			"propertyName", propertyName
+		).put(
+			"value", value
+		);
 	}
 
 	private JSONObject _getFilterJSONObject(

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -180,6 +180,15 @@ public class AssetListFiltersUtilTest {
 
 		Assert.assertEquals(
 			Arrays.toString(booleanClauses), 0, booleanClauses.length);
+
+		booleanClauses = AssetListFiltersUtil.getFiltersBooleanClauses(
+			_COMPANY_ID,
+			JSONUtil.putAll(
+				_getCommonFieldFilterJSONObject("gt", Field.STATUS, status)),
+			LocaleUtil.US);
+
+		Assert.assertEquals(
+			Arrays.toString(booleanClauses), 0, booleanClauses.length);
 	}
 
 	@Test

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -424,7 +424,7 @@ public class AssetListAssetEntryProviderFiltersTest {
 		_assertFilteredClassPKs(
 			_buildFiltersJSONArray(
 				_buildFilterJSONObject(
-					"not-eq", _OBJECT_FIELD_NAME_TEXT, title)),
+					"not-contains", _OBJECT_FIELD_NAME_TEXT, title)),
 			objectEntry2);
 
 		String keyword = RandomTestUtil.randomString();

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -13,6 +13,9 @@ import com.liferay.asset.list.model.AssetListEntry;
 import com.liferay.asset.list.service.AssetListEntryLocalService;
 import com.liferay.asset.list.test.util.AssetListTestUtil;
 import com.liferay.info.pagination.InfoPage;
+import com.liferay.journal.constants.JournalFolderConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.list.type.entry.util.ListTypeEntryUtil;
 import com.liferay.list.type.model.ListTypeDefinition;
 import com.liferay.list.type.service.ListTypeDefinitionLocalService;
@@ -23,8 +26,11 @@ import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectFieldSetting;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.function.transform.TransformUtil;
@@ -34,6 +40,7 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -48,6 +55,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
@@ -134,6 +142,86 @@ public class AssetListAssetEntryProviderFiltersTest {
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_PICKLIST,
 					false, false)),
 			ObjectDefinitionConstants.SCOPE_SITE);
+
+		ObjectField titleObjectField =
+			_objectFieldLocalService.fetchObjectField(
+				_objectDefinition.getObjectDefinitionId(),
+				_OBJECT_FIELD_NAME_TEXT);
+
+		_objectDefinition =
+			_objectDefinitionLocalService.updateTitleObjectFieldId(
+				_objectDefinition.getObjectDefinitionId(),
+				titleObjectField.getObjectFieldId());
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testCommonFieldFilters() throws Exception {
+		String title = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_TEXT, title
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildCommonFieldFilter("contains", Field.TITLE, title)),
+			objectEntry1);
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildCommonFieldFilter("eq", Field.TITLE, title)),
+			objectEntry1);
+
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildCommonFieldFilter("gt", Field.CREATE_DATE, "2000-01-01")),
+			objectEntry1, objectEntry2);
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildCommonFieldFilter(
+					"lt", Field.CREATE_DATE, "2000-01-01")));
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildCommonFieldFilter("not-contains", Field.TITLE, title)),
+			objectEntry2);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testCommonFieldFiltersMatchAcrossAssetTypes() throws Exception {
+		String title = RandomTestUtil.randomString();
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, 0, title,
+			StringPool.BLANK, "content", LocaleUtil.US, false, true,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_TEXT, title
+			).build());
+
+		List<Long> actualClassPKs = _getFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildCommonFieldFilter("contains", Field.TITLE, title)));
+
+		Assert.assertEquals(
+			actualClassPKs.toString(), 2, actualClassPKs.size());
+		Assert.assertTrue(
+			actualClassPKs.toString(),
+			actualClassPKs.containsAll(
+				Arrays.asList(
+					objectEntry.getObjectEntryId(),
+					journalArticle.getResourcePrimKey())));
 	}
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
@@ -217,6 +305,34 @@ public class AssetListAssetEntryProviderFiltersTest {
 					"not-eq", _OBJECT_FIELD_NAME_INTEGER,
 					String.valueOf(priority))),
 			objectEntry2);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testGetAssetEntriesInfoPageWithExternalReferenceCodeFilters()
+		throws Exception {
+
+		String externalReferenceCode = StringUtil.toUpperCase(
+			RandomTestUtil.randomString());
+
+		ObjectEntry objectEntry =
+			_objectEntryLocalService.addOrUpdateObjectEntry(
+				externalReferenceCode, _group.getGroupId(),
+				TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				HashMapBuilder.<String, Serializable>put(
+					_OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
+				).build(),
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId()));
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildCommonFieldFilter(
+					"eq", "externalReferenceCode", externalReferenceCode)),
+			objectEntry);
 	}
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
@@ -457,6 +573,30 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
 	@Test
+	public void testGetAssetEntriesInfoPageWithStatusFilters()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
+			).build());
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildCommonFieldFilter(
+					"eq", Field.STATUS,
+					String.valueOf(WorkflowConstants.STATUS_APPROVED))),
+			objectEntry);
+
+		_assertFilteredClassPKs(
+			_buildFiltersJSONArray(
+				_buildCommonFieldFilter(
+					"not-eq", Field.STATUS,
+					String.valueOf(WorkflowConstants.STATUS_APPROVED))));
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
 	public void testGetAssetEntriesInfoPageWithTextContainsFilters()
 		throws Exception {
 
@@ -692,6 +832,18 @@ public class AssetListAssetEntryProviderFiltersTest {
 			actualClassPKs.containsAll(expectedClassPKs));
 	}
 
+	private JSONObject _buildCommonFieldFilter(
+		String operatorName, String propertyName, Object value) {
+
+		return JSONUtil.put(
+			"operatorName", operatorName
+		).put(
+			"propertyName", propertyName
+		).put(
+			"value", value
+		);
+	}
+
 	private JSONObject _buildFilterJSONObject(
 		String operatorName, String propertyName, Object value) {
 
@@ -747,6 +899,36 @@ public class AssetListAssetEntryProviderFiltersTest {
 		return objectFieldSetting;
 	}
 
+	private List<Long> _getFilteredClassPKs(JSONArray filtersJSONArray)
+		throws Exception {
+
+		AssetListEntry assetListEntry = AssetListTestUtil.addAssetListEntry(
+			_group.getGroupId(), 0);
+
+		_assetListEntryLocalService.updateAssetListEntryTypeSettings(
+			assetListEntry.getAssetListEntryId(),
+			SegmentsEntryConstants.ID_DEFAULT,
+			UnicodePropertiesBuilder.create(
+				true
+			).put(
+				"anyAssetType", "true"
+			).put(
+				"filters", filtersJSONArray.toString()
+			).build(
+			).toString());
+
+		InfoPage<AssetEntry> infoPage =
+			_assetListAssetEntryProvider.getAssetEntriesInfoPage(
+				_assetListEntryLocalService.getAssetListEntry(
+					assetListEntry.getAssetListEntryId()),
+				new long[] {SegmentsEntryConstants.ID_DEFAULT}, null, null,
+				StringPool.BLANK, StringPool.BLANK, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS);
+
+		return TransformUtil.transform(
+			infoPage.getPageItems(), AssetEntry::getClassPK);
+	}
+
 	private static final String _LIST_TYPE_ENTRY_KEY_1 =
 		RandomTestUtil.randomString();
 
@@ -796,7 +978,13 @@ public class AssetListAssetEntryProviderFiltersTest {
 	private ObjectDefinition _objectDefinition;
 
 	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ObjectFieldLocalService _objectFieldLocalService;
 
 	@Inject
 	private ObjectFieldSettingLocalService _objectFieldSettingLocalService;

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
@@ -158,7 +158,7 @@ public class AssetListTypePropertiesUtil {
 			).put(
 				"name", Field.STATUS
 			).put(
-				"type", "integer"
+				"type", "enum"
 			),
 			JSONUtil.put(
 				"label", LanguageUtil.get(locale, "title")

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionFilterBuilder/operators.tsx
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionFilterBuilder/operators.tsx
@@ -26,6 +26,11 @@ const DEFAULT_OPERATORS: FilterOperator[] = [
 	{label: Liferay.Language.get('does-not-contain'), value: 'not-contains'},
 ];
 
+const EQUALITY_OPERATORS: FilterOperator[] = [
+	{label: Liferay.Language.get('equals'), value: 'eq'},
+	{label: Liferay.Language.get('not-equals'), value: 'not-eq'},
+];
+
 export function getCollectionOperators(
 	property: FilterProperty
 ): FilterOperator[] {
@@ -38,6 +43,8 @@ export function getCollectionOperators(
 		case 'integer':
 		case 'numeric':
 			return COMPARISON_OPERATORS;
+		case 'enum':
+			return EQUALITY_OPERATORS;
 		case 'picklist':
 		case 'text':
 		default:

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionFilterBuilder/types.ts
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionFilterBuilder/types.ts
@@ -10,6 +10,7 @@ export type PropertyType =
 	| 'date'
 	| 'date-time'
 	| 'decimal'
+	| 'enum'
 	| 'integer'
 	| 'numeric'
 	| 'picklist'


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93003

## What Is Being Fixed

Asset list (Dynamic Collection) filters could target object fields but not the entry's common fields — title, userName, status, createDate, modified, priority, externalReferenceCode, and viewCount — so a collection could not be filtered by those top-level fields.

## How It Is Being Fixed

This is the first of three stacked PRs splitting LPD-93003. It adds the core path: a `_toQuery` dispatcher routes common-field filter rows (rows with no classNameId/classTypeId) to a new `_toCommonFieldQuery` / `_toCommonFieldValueQuery`, which maps each supported field to its indexed type (text, integer, decimal, date) and builds the matching term, range, wildcard, or match query. The object-field path is left unchanged. A shared `_toTermRangeQuery` is extracted so the object range builder and the new common range builder use one implementation. Unit and integration coverage exercises each common field, including negation and cross-asset-type matching.

The follow-ups, stacked on this PR, are metadata object-field routing and userName casing alignment.

## Note: One LPD-88609 Commit Included

The final commit is prefixed LPD-88609, not LPD-93003. The pre-existing object-field test `testGetAssetEntriesInfoPageWithNegationFiltersIncludeFieldAbsentEntries` asserted a `not-eq` filter on a text object field — a combination the collection filter UI cannot produce (text properties expose only "contains" / "does not contain"; equals / not-equals are offered for date and numeric types only). That unreachable path builds a `TermQuery` against the analyzed `value_text` subfield and over-matches, so the test failed when actually run. The commit switches the assertion to the reachable `not-contains` operator, which is how text-field negation is issued in the product. There is no production change; it keeps the integration suite green while this branch is delivered.

## PR Check

**pr-check: PASS** — tested on `964a39823e7faeecd5735a5cd515c1458effc8b7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "964a39823e7faeecd5735a5cd515c1458effc8b7"} -->
