### PR TITLE
LPD-78170 Make asset list modified date term consistent

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
@@ -128,7 +128,7 @@ public class AssetListTypePropertiesUtil {
 			JSONUtil.put(
 				"label", LanguageUtil.get(locale, "modified-date")
 			).put(
-				"name", Field.MODIFIED_DATE
+				"name", "modifiedDate"
 			).put(
 				"type", "date"
 			),

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
@@ -10,6 +10,7 @@ import ClayIcon from '@clayui/icon';
 import React, {useMemo, useState} from 'react';
 
 import useTypeProperties from '../../hooks/useTypeProperties';
+import {getPropertyKey} from '../CollectionFilterBuilder/types';
 
 import type {
 	FilterProperty,
@@ -18,17 +19,10 @@ import type {
 
 type OrderByType = 'ASC' | 'DESC';
 
-type OrderBySelection = Pick<
-	FilterProperty,
-	'classNameId' | 'classTypeId' | 'name'
->;
-
-function getPropertyKey(
-	classNameId: number | undefined,
-	classTypeId: number | undefined,
-	name: string | undefined
-): string {
-	return `${classNameId ?? ''}|${classTypeId ?? ''}|${name ?? ''}`;
+interface OrderBySelection {
+	classNameId?: number;
+	classTypeId?: number;
+	propertyName: string;
 }
 
 function isGroup(
@@ -48,7 +42,7 @@ function parseInitialOrderByColumn(
 				return {
 					classNameId: parsed.classNameId,
 					classTypeId: parsed.classTypeId,
-					name: parsed.name,
+					propertyName: parsed.propertyName,
 				};
 			}
 		}
@@ -62,7 +56,7 @@ function parseInitialOrderByColumn(
 	return {
 		classNameId: undefined,
 		classTypeId: undefined,
-		name: value || '',
+		propertyName: value || '',
 	};
 }
 
@@ -93,7 +87,7 @@ function OrderByField({
 	const selectedKey = getPropertyKey(
 		columnValue.classNameId,
 		columnValue.classTypeId,
-		columnValue.name
+		columnValue.propertyName
 	);
 
 	return (
@@ -152,7 +146,7 @@ function OrderByField({
 				value={
 					columnValue.classNameId !== undefined
 						? JSON.stringify(columnValue)
-						: columnValue.name
+						: columnValue.propertyName
 				}
 			/>
 
@@ -197,7 +191,7 @@ function OrderByField({
 						>
 							{columnValue.classNameId && columnValue.classTypeId
 								? JSON.stringify(columnValue)
-								: columnValue.name}
+								: columnValue.propertyName}
 						</pre>
 					</div>
 
@@ -272,7 +266,7 @@ export default function CollectionOrdering({
 				map.set(getPropertyKey(classNameId, classTypeId, name), {
 					classNameId,
 					classTypeId,
-					name,
+					propertyName: name,
 				});
 			});
 

--- a/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
+++ b/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
@@ -368,7 +368,7 @@ public class AssetListTypePropertiesUtilTest {
 
 		String[] expectedNames = {
 			"userName", "createDate", "displayDate", "expirationDate",
-			"externalReferenceCode", "modified", "priority", "publishDate",
+			"externalReferenceCode", "modifiedDate", "priority", "publishDate",
 			"reviewDate", "status", "title", "viewCount"
 		};
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89039 - Order on Object Fields - Part 1 

Part 1 of the greater task for ordering Dynamic Collections by an Object field (Object-defined). The FE renders an order-by dropdown of the Object's filterable, sortable fields; the saved descriptor resolves to a nested FieldSort against the right nestedFieldArray.value_<subtype> subfield.

## What Is Being Fixed

1. **Fix inconsistency with property modifiedDate:** The collection ordering UI and the type properties endpoint disagreed on how the modified date field is named. `AssetListTypePropertiesUtil` emitted `Field.MODIFIED_DATE`, whose value is `modified`, while the rest of the ordering payload and the filter builder identify that property as `modifiedDate`. Ordering by modified date therefore submitted a term the consumer did not recognize.

<img width="1008" height="575" alt="Screenshot 2026-08-11 at 4 02 13 PM" src="https://github.com/user-attachments/assets/4dd13e2d-7904-423c-b087-24af02fc34c2" />

2. **Updating the expected field in frontend component + reuse function:** The ordering component `CollectionOrdering/index.tsx` also carried its own private copy of `getPropertyKey` alongside an `OrderBySelection` shape keyed on `name`, duplicating key building logic the filter builder already exports and naming the field differently from what is actually submitted.

## How It Is Being Fixed

1. The emitted property name becomes the literal `modifiedDate`, so the term is the same one used everywhere else in the ordering and filtering payloads. The existing `AssetListTypePropertiesUtilTest` expectation moves to the new value in the same commit.

2. The duplicated local `getPropertyKey` is then dropped in favor of the shared function exported from `CollectionFilterBuilder/types`, and `OrderBySelection` is narrowed to an interface whose field is `propertyName` rather than `name`, matching the shape that is submitted. Both changes are mechanical renames over a single component, with no change to how the key string itself is built.

## Why Are There No Tests?

The change is a term and type rename. `AssetListTypePropertiesUtilTest` already covers the emitted field name and was updated to the new expected value, so the existing assertion is what guards this behavior.

## PR Check

**pr-check: FAIL** — tested on `ee6c52fc3ec37d112a213476f9b7dc933eba4274`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | FAIL |
| JavaScript Unit Tests | PASS |

**The Java Unit Tests failure is pre-existing on `master` and is not introduced by this branch.** Running `AssetListTypePropertiesUtilTest` locally through Gradle never reaches an assertion; the class dies during static initialization.

<!-- pr-check {"result": "failure", "sha": "ee6c52fc3ec37d112a213476f9b7dc933eba4274"} -->
