### PR TITLE
LPD-102470 Index workflow tasks when no workflow handler is registered

### DIFF
--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/connection/ElasticsearchConnectionManager.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/connection/ElasticsearchConnectionManager.java
@@ -178,12 +178,12 @@ public class ElasticsearchConnectionManager
 		Supplier<ElasticsearchConnection> elasticsearchConnectionSupplier =
 			_elasticsearchConnectionSuppliers.get(connectionId);
 
-		if (_log.isInfoEnabled()) {
+		if (_log.isDebugEnabled()) {
 			if (elasticsearchConnectionSupplier != null) {
-				_log.info("Returning connection with ID: " + connectionId);
+				_log.debug("Returning connection with ID: " + connectionId);
 			}
 			else {
-				_log.info(
+				_log.debug(
 					"Connection not found. Returning null for ID: " +
 						connectionId);
 			}
@@ -366,21 +366,21 @@ public class ElasticsearchConnectionManager
 	protected ElasticsearchConnection getElasticsearchConnection(
 		String connectionId, boolean preferLocalCluster) {
 
-		if (_log.isInfoEnabled()) {
-			_log.info("Connection requested for ID: " + connectionId);
+		if (_log.isDebugEnabled()) {
+			_log.debug("Connection requested for ID: " + connectionId);
 		}
 
 		if (!Validator.isBlank(connectionId)) {
-			if (_log.isInfoEnabled()) {
-				_log.info("Getting connection with ID: " + connectionId);
+			if (_log.isDebugEnabled()) {
+				_log.debug("Getting connection with ID: " + connectionId);
 			}
 
 			return getElasticsearchConnection(connectionId);
 		}
 
 		if (!elasticsearchConfigurationWrapper.productionModeEnabled()) {
-			if (_log.isInfoEnabled()) {
-				_log.info(
+			if (_log.isDebugEnabled()) {
+				_log.debug(
 					"Getting " + ConnectionConstants.SIDECAR_CONNECTION_ID +
 						" connection");
 			}
@@ -393,8 +393,8 @@ public class ElasticsearchConnectionManager
 			String localClusterConnectionId = getLocalClusterConnectionId();
 
 			if (localClusterConnectionId != null) {
-				if (_log.isInfoEnabled()) {
-					_log.info(
+				if (_log.isDebugEnabled()) {
+					_log.debug(
 						"Getting local cluster connection with ID: " +
 							localClusterConnectionId);
 				}
@@ -411,8 +411,8 @@ public class ElasticsearchConnectionManager
 				ConnectionConstants.REMOTE_CONNECTION_ID;
 		}
 
-		if (_log.isInfoEnabled()) {
-			_log.info(
+		if (_log.isDebugEnabled()) {
+			_log.debug(
 				"Getting remote cluster connection with ID: " +
 					remoteClusterConnectionId);
 		}

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/connection/RestClientTransportFactory.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/connection/RestClientTransportFactory.java
@@ -66,7 +66,9 @@ public class RestClientTransportFactory {
 
 				@Override
 				public void onFailure(Node node) {
-					_log.error(new Exception("Unable to connect to " + node));
+					if (_log.isWarnEnabled()) {
+						_log.warn("Marked node as unavailable: " + node);
+					}
 				}
 
 			}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/connection/OpenSearchConnection.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/connection/OpenSearchConnection.java
@@ -39,7 +39,9 @@ import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.transport.OpenSearchTransport;
+import org.opensearch.client.transport.httpclient5.ApacheHttpClient5Transport;
 import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
+import org.opensearch.client.transport.httpclient5.internal.Node;
 
 /**
  * @author Michael C. Han
@@ -303,6 +305,17 @@ public class OpenSearchConnection {
 	private OpenSearchTransport _createTransport() {
 		return ApacheHttpClient5TransportBuilder.builder(
 			_getHttpHosts()
+		).setFailureListener(
+			new ApacheHttpClient5Transport.FailureListener() {
+
+				@Override
+				public void onFailure(Node node) {
+					if (_log.isWarnEnabled()) {
+						_log.warn("Marked node as unavailable: " + node);
+					}
+				}
+
+			}
 		).setCompressionEnabled(
 			_compressionEnabled
 		).setMapper(

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/connection/OpenSearchConnectionManagerImpl.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/connection/OpenSearchConnectionManagerImpl.java
@@ -180,8 +180,8 @@ public class OpenSearchConnectionManagerImpl
 			openSearchConnectionsHolder.getOpenSearchConnection(connectionId);
 
 		if (openSearchConnection != null) {
-			if (_log.isInfoEnabled()) {
-				_log.info("Returning connection with ID: " + connectionId);
+			if (_log.isDebugEnabled()) {
+				_log.debug("Returning connection with ID: " + connectionId);
 			}
 
 			return openSearchConnection;
@@ -233,13 +233,13 @@ public class OpenSearchConnectionManagerImpl
 	protected OpenSearchConnection getOpenSearchConnection(
 		String connectionId, boolean preferLocalCluster) {
 
-		if (_log.isInfoEnabled()) {
-			_log.info("Connection requested for ID: " + connectionId);
+		if (_log.isDebugEnabled()) {
+			_log.debug("Connection requested for ID: " + connectionId);
 		}
 
 		if (!Validator.isBlank(connectionId)) {
-			if (_log.isInfoEnabled()) {
-				_log.info("Getting connection with ID: " + connectionId);
+			if (_log.isDebugEnabled()) {
+				_log.debug("Getting connection with ID: " + connectionId);
 			}
 
 			return getOpenSearchConnection(connectionId);
@@ -249,8 +249,8 @@ public class OpenSearchConnectionManagerImpl
 			String localClusterConnectionId = getLocalClusterConnectionId();
 
 			if (localClusterConnectionId != null) {
-				if (_log.isInfoEnabled()) {
-					_log.info(
+				if (_log.isDebugEnabled()) {
+					_log.debug(
 						"Getting local cluster connection with ID: " +
 							localClusterConnectionId);
 				}
@@ -262,8 +262,8 @@ public class OpenSearchConnectionManagerImpl
 		String remoteClusterConnectionId =
 			openSearchConfigurationWrapper.remoteClusterConnectionId();
 
-		if (_log.isInfoEnabled()) {
-			_log.info(
+		if (_log.isDebugEnabled()) {
+			_log.debug(
 				"Getting remote cluster connection with ID: " +
 					remoteClusterConnectionId);
 		}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/search/spi/model/index/contributor/KaleoTaskInstanceTokenModelDocumentContributor.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/search/spi/model/index/contributor/KaleoTaskInstanceTokenModelDocumentContributor.java
@@ -13,15 +13,12 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
-import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 import com.liferay.portal.workflow.kaleo.internal.search.KaleoTaskInstanceTokenField;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion;
 import com.liferay.portal.workflow.kaleo.model.KaleoTaskAssignmentInstance;
 import com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceToken;
-import com.liferay.portal.workflow.kaleo.runtime.util.WorkflowContextUtil;
 import com.liferay.portal.workflow.kaleo.service.KaleoDefinitionVersionLocalService;
 
 import java.util.HashSet;
@@ -104,14 +101,6 @@ public class KaleoTaskInstanceTokenModelDocumentContributor
 			document.addKeyword(
 				KaleoTaskInstanceTokenField.KALEO_DEFINITION_ID,
 				kaleoDefinition.getKaleoDefinitionId());
-
-			WorkflowHandler<?> workflowHandler =
-				WorkflowHandlerRegistryUtil.getWorkflowHandler(
-					kaleoTaskInstanceToken.getClassName());
-
-			workflowHandler.contributeWorkflowContext(
-				WorkflowContextUtil.convert(
-					kaleoTaskInstanceToken.getWorkflowContext()));
 		}
 		catch (PortalException portalException) {
 			if (_log.isWarnEnabled()) {

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/build.gradle
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:object:object-test-util")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
+	testIntegrationImplementation project(":apps:portal-search:portal-search-spi")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:portal-security:portal-security-script-management-api")
 	testIntegrationImplementation project(":apps:portal-security:portal-security-script-management-test-util")

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/search/spi/model/index/contributor/test/KaleoTaskInstanceTokenModelDocumentContributorTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/search/spi/model/index/contributor/test/KaleoTaskInstanceTokenModelDocumentContributorTest.java
@@ -8,13 +8,18 @@ package com.liferay.portal.workflow.kaleo.internal.search.spi.model.index.contri
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentImpl;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.workflow.constants.WorkflowDefinitionConstants;
+import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
+import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion;
 import com.liferay.portal.workflow.kaleo.model.KaleoInstance;
 import com.liferay.portal.workflow.kaleo.model.KaleoInstanceToken;
 import com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceToken;
+import com.liferay.portal.workflow.kaleo.service.KaleoInstanceLocalService;
 import com.liferay.portal.workflow.kaleo.service.test.BaseKaleoLocalServiceTestCase;
 
 import java.io.Serializable;
@@ -36,18 +41,37 @@ public class KaleoTaskInstanceTokenModelDocumentContributorTest
 	public void testContributeWhenWorkflowHandlerIsNotRegistered()
 		throws Exception {
 
-		KaleoInstance kaleoInstance = addKaleoInstance();
+		KaleoDefinition kaleoDefinition = addKaleoDefinition(
+			WorkflowDefinitionConstants.SCOPE_ALL);
+
+		KaleoDefinitionVersion kaleoDefinitionVersion =
+			getLatestKaleoDefinitionVersion(kaleoDefinition);
+
+		String className = RandomTestUtil.randomString();
+
+		KaleoInstance kaleoInstance =
+			_kaleoInstanceLocalService.addKaleoInstance(
+				kaleoDefinition.getKaleoDefinitionId(),
+				kaleoDefinitionVersion.getKaleoDefinitionVersionId(),
+				kaleoDefinition.getName(), 1,
+				HashMapBuilder.<String, Serializable>put(
+					WorkflowConstants.CONTEXT_ENTRY_CLASS_NAME, className
+				).put(
+					WorkflowConstants.CONTEXT_ENTRY_CLASS_PK, "1"
+				).build(),
+				serviceContext);
 
 		KaleoInstanceToken kaleoInstanceToken = addKaleoInstanceToken(
 			kaleoInstance);
 
+		String taskName = RandomTestUtil.randomString();
+
 		KaleoTaskInstanceToken kaleoTaskInstanceToken =
 			kaleoTaskInstanceTokenLocalService.addKaleoTaskInstanceToken(
-				kaleoInstanceToken.getKaleoInstanceTokenId(), 1, _TASK_NAME,
+				kaleoInstanceToken.getKaleoInstanceTokenId(), 1, taskName,
 				Collections.emptyList(), null,
 				HashMapBuilder.<String, Serializable>put(
-					WorkflowConstants.CONTEXT_ENTRY_CLASS_NAME,
-					_UNREGISTERED_CLASS_NAME
+					WorkflowConstants.CONTEXT_ENTRY_CLASS_NAME, className
 				).put(
 					WorkflowConstants.CONTEXT_ENTRY_CLASS_PK, "1"
 				).build(),
@@ -57,15 +81,15 @@ public class KaleoTaskInstanceTokenModelDocumentContributorTest
 
 		_modelDocumentContributor.contribute(document, kaleoTaskInstanceToken);
 
+		Assert.assertEquals(className, document.get("className"));
 		Assert.assertEquals(
-			_UNREGISTERED_CLASS_NAME, document.get("className"));
-		Assert.assertEquals(_TASK_NAME, document.get("taskName"));
+			String.valueOf(kaleoDefinition.getKaleoDefinitionId()),
+			document.get("kaleoDefinitionId"));
+		Assert.assertEquals(taskName, document.get("taskName"));
 	}
 
-	private static final String _TASK_NAME = "task";
-
-	private static final String _UNREGISTERED_CLASS_NAME =
-		"com.liferay.portal.workflow.kaleo.test.NoWorkflowHandlerModel";
+	@Inject
+	private KaleoInstanceLocalService _kaleoInstanceLocalService;
 
 	@Inject(
 		filter = "component.name=com.liferay.portal.workflow.kaleo.internal.search.spi.model.index.contributor.KaleoTaskInstanceTokenModelDocumentContributor"

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/search/spi/model/index/contributor/test/KaleoTaskInstanceTokenModelDocumentContributorTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/search/spi/model/index/contributor/test/KaleoTaskInstanceTokenModelDocumentContributorTest.java
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.workflow.kaleo.internal.search.spi.model.index.contributor.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentImpl;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.workflow.kaleo.model.KaleoInstance;
+import com.liferay.portal.workflow.kaleo.model.KaleoInstanceToken;
+import com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceToken;
+import com.liferay.portal.workflow.kaleo.service.test.BaseKaleoLocalServiceTestCase;
+
+import java.io.Serializable;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Selena Aungst
+ */
+@RunWith(Arquillian.class)
+public class KaleoTaskInstanceTokenModelDocumentContributorTest
+	extends BaseKaleoLocalServiceTestCase {
+
+	@Test
+	public void testContributeWhenWorkflowHandlerIsNotRegistered()
+		throws Exception {
+
+		KaleoInstance kaleoInstance = addKaleoInstance();
+
+		KaleoInstanceToken kaleoInstanceToken = addKaleoInstanceToken(
+			kaleoInstance);
+
+		KaleoTaskInstanceToken kaleoTaskInstanceToken =
+			kaleoTaskInstanceTokenLocalService.addKaleoTaskInstanceToken(
+				kaleoInstanceToken.getKaleoInstanceTokenId(), 1, _TASK_NAME,
+				Collections.emptyList(), null,
+				HashMapBuilder.<String, Serializable>put(
+					WorkflowConstants.CONTEXT_ENTRY_CLASS_NAME,
+					_UNREGISTERED_CLASS_NAME
+				).put(
+					WorkflowConstants.CONTEXT_ENTRY_CLASS_PK, "1"
+				).build(),
+				serviceContext);
+
+		Document document = new DocumentImpl();
+
+		_modelDocumentContributor.contribute(document, kaleoTaskInstanceToken);
+
+		Assert.assertEquals(
+			_UNREGISTERED_CLASS_NAME, document.get("className"));
+		Assert.assertEquals(_TASK_NAME, document.get("taskName"));
+	}
+
+	private static final String _TASK_NAME = "task";
+
+	private static final String _UNREGISTERED_CLASS_NAME =
+		"com.liferay.portal.workflow.kaleo.test.NoWorkflowHandlerModel";
+
+	@Inject(
+		filter = "component.name=com.liferay.portal.workflow.kaleo.internal.search.spi.model.index.contributor.KaleoTaskInstanceTokenModelDocumentContributor"
+	)
+	private ModelDocumentContributor<KaleoTaskInstanceToken>
+		_modelDocumentContributor;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102470

## What Is Being Fixed

A full reindex drops every KaleoTaskInstanceToken document when a workflow task references an entity whose WorkflowHandler is not registered — a retired module, a bundle stopped for maintenance, or a module absent from an environment. KaleoTaskInstanceTokenModelDocumentContributor dereferences the result of WorkflowHandlerRegistryUtil.getWorkflowHandler without a null check, and the surrounding catch (PortalException) does not catch the resulting NullPointerException, so the exception aborts the entire entity pass and the entity ends at zero documents rather than partially indexed. Index-backed read paths then return nothing while the database still holds the tasks.

This is a regression from LPD-55366, which added the dereference.

## How It Is Being Fixed

The block is removed rather than null-guarded. WorkflowContextUtil.convert returns a freshly deserialized map, so contributeWorkflowContext mutates a throwaway copy and nothing it does reaches the Document — the call has no effect in the indexing path. LPD-55366 needed that behavior on the workflow submission path, where CompleteTaskMVCActionCommand already performs it. Copying the null check from BaseKaleoModelDocumentContributor would have been wrong here: that return is safe because nothing follows it, whereas the rest of the document is built after the try block, so an early return would silently produce incomplete documents.

Two unrelated logging cleanups found in the same investigation are included. RestClientTransportFactory logged node blacklisting at ERROR and fabricated an Exception purely to emit a stack trace, which made a recoverable node-state notification read as an operation failure; it now logs a warning with no synthetic exception. ElasticsearchConnectionManager emitted three INFO lines per connection lookup, which accounted for 11,098 of 12,455 lines in a sample reindex log; those are now debug.

## PR Check

**pr-check: PASS** — tested on `939ba0426929959315be2e9bc6af103bd08b3f05`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "939ba0426929959315be2e9bc6af103bd08b3f05"} -->
