### PR TITLE
B2 PR3 LPD-75968 Auto-create missing workflow-metrics indexes on reindex

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/WorkflowMetricsIndex.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/WorkflowMetricsIndex.java
@@ -50,6 +50,19 @@ public enum WorkflowMetricsIndex {
 		WorkflowMetricsIndexNameConstants.SUFFIX_TRANSITION,
 		WorkflowMetricsIndexTypeConstants.TRANSITION_TYPE);
 
+	public static void createMissingIndexes(
+			SearchCapabilities searchCapabilities,
+			SearchEngineAdapter searchEngineAdapter,
+			IndexNameBuilder indexNameBuilder, long companyId)
+		throws PortalException {
+
+		for (WorkflowMetricsIndex workflowMetricsIndex : values()) {
+			workflowMetricsIndex.createIndex(
+				searchCapabilities, searchEngineAdapter, indexNameBuilder,
+				companyId);
+		}
+	}
+
 	public static String getIndexName(
 		IndexNameBuilder indexNameBuilder, String indexNameSuffix,
 		long companyId) {
@@ -92,7 +105,10 @@ public enum WorkflowMetricsIndex {
 			searchEngineAdapter.execute(createIndexRequest);
 		}
 		catch (Exception exception) {
-			_log.error(exception);
+			throw new PortalException(
+				"Unable to create index " +
+					getIndexName(indexNameBuilder, _indexNameSuffix, companyId),
+				exception);
 		}
 
 		return true;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/BaseWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/BaseWorkflowMetricsReindexer.java
@@ -50,6 +50,10 @@ public abstract class BaseWorkflowMetricsReindexer
 			return;
 		}
 
+		WorkflowMetricsIndex.createMissingIndexes(
+			searchCapabilities, searchEngineAdapter, indexNameBuilder,
+			companyId);
+
 		Date date = null;
 
 		WorkflowMetricsIndex workflowMetricsIndex =

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/SLAInstanceResultWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/SLAInstanceResultWorkflowMetricsReindexer.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.workflow.metrics.internal.search.index.reindexer;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalRunMode;
@@ -26,6 +27,7 @@ import com.liferay.portal.search.query.QueriesUtil;
 import com.liferay.portal.search.spi.reindexer.IndexReindexer;
 import com.liferay.portal.workflow.metrics.internal.background.task.WorkflowMetricsSLAProcessBackgroundTaskHelper;
 import com.liferay.portal.workflow.metrics.internal.search.index.SLAInstanceResultWorkflowMetricsIndexer;
+import com.liferay.portal.workflow.metrics.internal.search.index.WorkflowMetricsIndex;
 import com.liferay.portal.workflow.metrics.search.index.constants.WorkflowMetricsIndexNameConstants;
 import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexer;
 
@@ -46,6 +48,16 @@ public class SLAInstanceResultWorkflowMetricsReindexer
 
 	@Override
 	public void reindex(long companyId) throws PortalException {
+		if (!_searchCapabilities.isWorkflowMetricsSupported() ||
+			(companyId == CompanyConstants.SYSTEM)) {
+
+			return;
+		}
+
+		WorkflowMetricsIndex.createMissingIndexes(
+			_searchCapabilities, _searchEngineAdapter, _indexNameBuilder,
+			companyId);
+
 		_createDefaultDocuments(companyId);
 
 		WorkflowMetricsSLAProcessBackgroundTaskHelper

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/SLATaskResultWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/SLATaskResultWorkflowMetricsReindexer.java
@@ -5,6 +5,8 @@
 
 package com.liferay.portal.workflow.metrics.internal.search.index.reindexer;
 
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalRunMode;
 import com.liferay.portal.search.capabilities.SearchCapabilities;
@@ -23,6 +25,7 @@ import com.liferay.portal.search.query.BooleanQuery;
 import com.liferay.portal.search.query.QueriesUtil;
 import com.liferay.portal.search.spi.reindexer.IndexReindexer;
 import com.liferay.portal.workflow.metrics.internal.search.index.SLATaskResultWorkflowMetricsIndexer;
+import com.liferay.portal.workflow.metrics.internal.search.index.WorkflowMetricsIndex;
 import com.liferay.portal.workflow.metrics.search.background.task.WorkflowMetricsReindexStatusMessageSender;
 import com.liferay.portal.workflow.metrics.search.index.constants.WorkflowMetricsIndexNameConstants;
 import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexer;
@@ -45,7 +48,17 @@ public class SLATaskResultWorkflowMetricsReindexer
 	}
 
 	@Override
-	public void reindex(long companyId) {
+	public void reindex(long companyId) throws PortalException {
+		if (!_searchCapabilities.isWorkflowMetricsSupported() ||
+			(companyId == CompanyConstants.SYSTEM)) {
+
+			return;
+		}
+
+		WorkflowMetricsIndex.createMissingIndexes(
+			_searchCapabilities, _searchEngineAdapter, _indexNameBuilder,
+			companyId);
+
 		_createDefaultDocuments(companyId);
 	}
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/internal/search/index/test/WorkflowMetricsIndexerTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/internal/search/index/test/WorkflowMetricsIndexerTest.java
@@ -1,0 +1,73 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.workflow.metrics.service.internal.search.index.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.search.engine.adapter.index.DeleteIndexRequest;
+import com.liferay.portal.search.engine.adapter.index.IndicesExistsIndexRequest;
+import com.liferay.portal.search.engine.adapter.index.IndicesExistsIndexResponse;
+import com.liferay.portal.search.index.IndexNameBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.workflow.metrics.search.index.constants.WorkflowMetricsIndexNameConstants;
+import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexer;
+import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexerRegistry;
+import com.liferay.portal.workflow.metrics.service.util.BaseWorkflowMetricsIndexerTestCase;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Felipe Lorenz
+ */
+@RunWith(Arquillian.class)
+public class WorkflowMetricsIndexerTest
+	extends BaseWorkflowMetricsIndexerTestCase {
+
+	@Test
+	public void testReindexCreatesMissingIndexes() throws Exception {
+		long companyId = TestPropsValues.getCompanyId();
+
+		String indexNamePrefix = _indexNameBuilder.getIndexName(companyId);
+
+		for (String suffix : _SUFFIXES) {
+			searchEngineAdapter.execute(
+				new DeleteIndexRequest(indexNamePrefix + suffix));
+		}
+
+		WorkflowMetricsReindexer workflowMetricsReindexer =
+			_workflowMetricsReindexerRegistry.getWorkflowMetricsReindexer(
+				"instance");
+
+		workflowMetricsReindexer.reindex(companyId);
+
+		for (String suffix : _SUFFIXES) {
+			IndicesExistsIndexResponse indicesExistsIndexResponse =
+				searchEngineAdapter.execute(
+					new IndicesExistsIndexRequest(indexNamePrefix + suffix));
+
+			Assert.assertTrue(indicesExistsIndexResponse.isExists());
+		}
+	}
+
+	private static final String[] _SUFFIXES = {
+		WorkflowMetricsIndexNameConstants.SUFFIX_INSTANCE,
+		WorkflowMetricsIndexNameConstants.SUFFIX_NODE,
+		WorkflowMetricsIndexNameConstants.SUFFIX_PROCESS,
+		WorkflowMetricsIndexNameConstants.SUFFIX_SLA_INSTANCE_RESULT,
+		WorkflowMetricsIndexNameConstants.SUFFIX_SLA_TASK_RESULT,
+		WorkflowMetricsIndexNameConstants.SUFFIX_TASK,
+		WorkflowMetricsIndexNameConstants.SUFFIX_TRANSITION
+	};
+
+	@Inject
+	private IndexNameBuilder _indexNameBuilder;
+
+	@Inject
+	private WorkflowMetricsReindexerRegistry _workflowMetricsReindexerRegistry;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-75968

## What Is Being Fixed

When a workflow-metrics index is deleted (manual delete, template rollout, cluster reprovisioning), a subsequent reindex would fail because the SPI reindexers assumed every workflow-metrics index already existed. Recovery required a full portal restart to trigger the creation path.

## How It Is Being Fixed

`WorkflowMetricsIndex.createMissingIndexes(...)` is added as an idempotent, static helper that iterates the 7 workflow-metrics indexes and creates any that don't exist. It runs at the top of `BaseWorkflowMetricsReindexer.reindex(long, ExecutionMode)` and of the two SLA reindexers' `reindex(long, ExecutionMode)`, so any reindex path (Search Admin per-index, per-group, or programmatic) self-heals missing indexes.

`WorkflowMetricsIndexerTest.testReindexCreatesMissingIndexes` covers the recovery path end-to-end: delete every workflow-metrics index, trigger a reindex, assert every index is back. The test class name (`WorkflowMetricsIndexerTest`) matches its base `BaseWorkflowMetricsIndexerTestCase` — following Brian's naming feedback on the earlier PR #2117.

## PR Check

**pr-check: PASS** — tested on `6f804d34b21a3108406515ea5b665abbd07c803f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Portlet Title | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6f804d34b21a3108406515ea5b665abbd07c803f"} -->
