### PR TITLE
LPD-102613 asset-list-test: Lowercase the negated text filter value

### DIFF
--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -450,7 +450,7 @@ public class AssetListAssetEntryProviderFiltersTest {
 	public void testGetAssetEntriesInfoPageWithNegationFiltersIncludeFieldAbsentEntries()
 		throws Exception {
 
-		String title = RandomTestUtil.randomString();
+		String title = StringUtil.toLowerCase(RandomTestUtil.randomString());
 
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102613

## What Is Being Fixed

`AssetListAssetEntryProviderFiltersTest.testGetAssetEntriesInfoPageWithNegationFiltersIncludeFieldAbsentEntries` has failed on every EE Development Acceptance (master) run since it was added.

```
testGetAssetEntriesInfoPageWithNegationFiltersIncludeFieldAbsentEntries:
java.lang.AssertionError: [39185, 39189] expected:<1> but was:<2>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:647)
```

Commit `7f5dac0339b66` ("LPD-88609 asset-list-service: Add picklist multi-value filter query handling") added the test and moved negation handling from inside the nested query to a top level `MUST_NOT` clause. The test builds a `not-eq` filter on a plain text object field using `RandomTestUtil.randomString()`, which draws from digits and both letter cases.

A plain text field is indexed into `nestedFieldArray.value_text`, mapped as `"type": "text"`, so the stored token is analyzed and lowercased. `AssetListFiltersUtil._toValueQuery` turns `not-eq` into a `TermQuery`, which is not analyzed, and it lowercases only the `.value_keyword` subfields. A mixed case value therefore never matches the indexed token, the negated nested query matches nothing, the `MUST_NOT` clause excludes nothing, and the entry carrying the field is returned alongside the field absent one.

Instrumenting the assertion against a local portal shows the mechanism directly. The first line is the failing filter, the second is the same operator with an already lowercased value from `testGetAssetEntriesInfoPageWithEqualityFilters`, and the third is `not-contains`, which is unaffected because it falls through to an analyzed `MatchQuery`:

```
not-eq       value="lx00kSYA"  expected=[42781]  actual=[42777, 42781]
not-eq       value="wxr1aqr1"  expected=[42373]  actual=[42373]
not-contains value="b94qmuCc"  expected=[43296]  actual=[43296]
```

## How It Is Being Fixed

Lowercase the value before handing it to the filter, which is the convention `testGetAssetEntriesInfoPageWithEqualityFilters` already follows for the same `eq` and `not-eq` operators on this field.

Reviewers should note that the underlying product behavior is arguably also wrong: a user typing a capitalized value into an `eq` or `not-eq` collection filter on a plain text field gets no matches, because the query never reaches the analyzed token. The index already carries a `nestedFieldArray.value_keyword_lowercase` subfield that would serve exact matching correctly. That code path predates LPD-88609 and changing it would alter `eq` semantics too, so it is left for a separate ticket rather than widened into this fix.

- `modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java`

## Why Are There No Tests?

The change is itself a fix to an existing integration test, so there is no product code to cover.

## PR Check

**pr-check: PARTIAL** — tested on `c518144f5f0ebfa85c2b684449767bf47159d15e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Integration Test Compile | PASS |
| Per-Module Compile | NOT RUN |
| Java Unit Tests | NOT RUN |

The failing test was additionally run against a local portal, before and after the change, on a warm server:

| Run | Code | Result |
| --- | --- | --- |
| With the fix | `c518144f5` | 12 of 12 passed |
| Fix reverted | baseline | `testGetAssetEntriesInfoPageWithNegationFiltersIncludeFieldAbsentEntries` failed, other 11 passed |

Per-Module Compile and Java Unit Tests were not run because the machine ran out of memory partway through the session. They are the two remaining gaps in this record.

<!-- pr-check {"reason": "Per-Module Compile and Java Unit Tests not run; host out of memory", "result": "skipped", "sha": "c518144f5f0ebfa85c2b684449767bf47159d15e"} -->
