### PR TITLE
LPD-75968 Create missing workflow metrics indexes before reindexing

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/WorkflowMetricsIndex.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/WorkflowMetricsIndex.java
@@ -50,6 +50,19 @@ public enum WorkflowMetricsIndex {
 		WorkflowMetricsIndexNameConstants.SUFFIX_TRANSITION,
 		WorkflowMetricsIndexTypeConstants.TRANSITION_TYPE);
 
+	public static void createMissingIndexes(
+			SearchCapabilities searchCapabilities,
+			SearchEngineAdapter searchEngineAdapter,
+			IndexNameBuilder indexNameBuilder, long companyId)
+		throws PortalException {
+
+		for (WorkflowMetricsIndex workflowMetricsIndex : values()) {
+			workflowMetricsIndex.createIndex(
+				searchCapabilities, searchEngineAdapter, indexNameBuilder,
+				companyId);
+		}
+	}
+
 	public static String getIndexName(
 		IndexNameBuilder indexNameBuilder, String indexNameSuffix,
 		long companyId) {
@@ -92,7 +105,10 @@ public enum WorkflowMetricsIndex {
 			searchEngineAdapter.execute(createIndexRequest);
 		}
 		catch (Exception exception) {
-			_log.error(exception);
+			throw new PortalException(
+				"Unable to create index " +
+					getIndexName(indexNameBuilder, _indexNameSuffix, companyId),
+				exception);
 		}
 
 		return true;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/BaseWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/BaseWorkflowMetricsReindexer.java
@@ -50,6 +50,10 @@ public abstract class BaseWorkflowMetricsReindexer
 			return;
 		}
 
+		WorkflowMetricsIndex.createMissingIndexes(
+			searchCapabilities, searchEngineAdapter, indexNameBuilder,
+			companyId);
+
 		Date date = null;
 
 		WorkflowMetricsIndex workflowMetricsIndex =

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/SLAInstanceResultWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/SLAInstanceResultWorkflowMetricsReindexer.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.workflow.metrics.internal.search.index.reindexer;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalRunMode;
@@ -26,6 +27,7 @@ import com.liferay.portal.search.query.QueriesUtil;
 import com.liferay.portal.search.spi.reindexer.IndexReindexer;
 import com.liferay.portal.workflow.metrics.internal.background.task.WorkflowMetricsSLAProcessBackgroundTaskHelper;
 import com.liferay.portal.workflow.metrics.internal.search.index.SLAInstanceResultWorkflowMetricsIndexer;
+import com.liferay.portal.workflow.metrics.internal.search.index.WorkflowMetricsIndex;
 import com.liferay.portal.workflow.metrics.search.index.constants.WorkflowMetricsIndexNameConstants;
 import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexer;
 
@@ -46,6 +48,16 @@ public class SLAInstanceResultWorkflowMetricsReindexer
 
 	@Override
 	public void reindex(long companyId) throws PortalException {
+		if (!_searchCapabilities.isWorkflowMetricsSupported() ||
+			(companyId == CompanyConstants.SYSTEM)) {
+
+			return;
+		}
+
+		WorkflowMetricsIndex.createMissingIndexes(
+			_searchCapabilities, _searchEngineAdapter, _indexNameBuilder,
+			companyId);
+
 		_createDefaultDocuments(companyId);
 
 		WorkflowMetricsSLAProcessBackgroundTaskHelper
@@ -66,8 +78,7 @@ public class SLAInstanceResultWorkflowMetricsReindexer
 	}
 
 	private void _createDefaultDocuments(long companyId) {
-		if (!_searchCapabilities.isWorkflowMetricsSupported() ||
-			!_hasIndex(
+		if (!_hasIndex(
 				_indexNameBuilder.getIndexName(companyId) +
 					WorkflowMetricsIndexNameConstants.SUFFIX_PROCESS)) {
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/SLATaskResultWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/SLATaskResultWorkflowMetricsReindexer.java
@@ -5,6 +5,8 @@
 
 package com.liferay.portal.workflow.metrics.internal.search.index.reindexer;
 
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalRunMode;
 import com.liferay.portal.search.capabilities.SearchCapabilities;
@@ -23,6 +25,7 @@ import com.liferay.portal.search.query.BooleanQuery;
 import com.liferay.portal.search.query.QueriesUtil;
 import com.liferay.portal.search.spi.reindexer.IndexReindexer;
 import com.liferay.portal.workflow.metrics.internal.search.index.SLATaskResultWorkflowMetricsIndexer;
+import com.liferay.portal.workflow.metrics.internal.search.index.WorkflowMetricsIndex;
 import com.liferay.portal.workflow.metrics.search.background.task.WorkflowMetricsReindexStatusMessageSender;
 import com.liferay.portal.workflow.metrics.search.index.constants.WorkflowMetricsIndexNameConstants;
 import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexer;
@@ -45,7 +48,17 @@ public class SLATaskResultWorkflowMetricsReindexer
 	}
 
 	@Override
-	public void reindex(long companyId) {
+	public void reindex(long companyId) throws PortalException {
+		if (!_searchCapabilities.isWorkflowMetricsSupported() ||
+			(companyId == CompanyConstants.SYSTEM)) {
+
+			return;
+		}
+
+		WorkflowMetricsIndex.createMissingIndexes(
+			_searchCapabilities, _searchEngineAdapter, _indexNameBuilder,
+			companyId);
+
 		_createDefaultDocuments(companyId);
 	}
 
@@ -57,8 +70,7 @@ public class SLATaskResultWorkflowMetricsReindexer
 	}
 
 	private void _createDefaultDocuments(long companyId) {
-		if (!_searchCapabilities.isWorkflowMetricsSupported() ||
-			!_hasIndex(
+		if (!_hasIndex(
 				_indexNameBuilder.getIndexName(companyId) +
 					WorkflowMetricsIndexNameConstants.SUFFIX_NODE)) {
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/util/BaseWorkflowMetricsIndexerTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/util/BaseWorkflowMetricsIndexerTestCase.java
@@ -20,6 +20,8 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.search.engine.adapter.index.DeleteIndexRequest;
+import com.liferay.portal.search.index.IndexNameBuilder;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.workflow.kaleo.definition.Node;
 import com.liferay.portal.workflow.kaleo.definition.Task;
@@ -37,6 +39,7 @@ import com.liferay.portal.workflow.kaleo.service.KaleoInstanceTokenLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoNodeLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoTaskInstanceTokenLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoTaskLocalService;
+import com.liferay.portal.workflow.metrics.search.index.constants.WorkflowMetricsIndexNameConstants;
 import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexer;
 import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexerRegistry;
 
@@ -465,6 +468,15 @@ public abstract class BaseWorkflowMetricsIndexerTestCase
 		}
 	}
 
+	private void _deleteWorkflowMetricsIndexes(long companyId) {
+		String indexNamePrefix = _indexNameBuilder.getIndexName(companyId);
+
+		for (String indexNameSuffix : _INDEX_NAME_SUFFIXES) {
+			searchEngineAdapter.execute(
+				new DeleteIndexRequest(indexNamePrefix + indexNameSuffix));
+		}
+	}
+
 	private void _reindex(long companyId, String key) throws Exception {
 		WorkflowMetricsReindexer reindexer =
 			_workflowMetricsReindexerRegistry.getWorkflowMetricsReindexer(key);
@@ -473,6 +485,7 @@ public abstract class BaseWorkflowMetricsIndexerTestCase
 	}
 
 	private void _reindexMetricIndexes(long companyId) throws Exception {
+		_deleteWorkflowMetricsIndexes(companyId);
 		_reindex(companyId, "instance");
 		_reindex(companyId, "node");
 		_reindex(companyId, "process");
@@ -481,14 +494,28 @@ public abstract class BaseWorkflowMetricsIndexerTestCase
 	}
 
 	private void _reindexSLAIndexes(long companyId) throws Exception {
+		_deleteWorkflowMetricsIndexes(companyId);
 		_reindex(companyId, "sla-instance-result");
 		_reindex(companyId, "sla-task-result");
 	}
+
+	private static final String[] _INDEX_NAME_SUFFIXES = {
+		WorkflowMetricsIndexNameConstants.SUFFIX_INSTANCE,
+		WorkflowMetricsIndexNameConstants.SUFFIX_NODE,
+		WorkflowMetricsIndexNameConstants.SUFFIX_PROCESS,
+		WorkflowMetricsIndexNameConstants.SUFFIX_SLA_INSTANCE_RESULT,
+		WorkflowMetricsIndexNameConstants.SUFFIX_SLA_TASK_RESULT,
+		WorkflowMetricsIndexNameConstants.SUFFIX_TASK,
+		WorkflowMetricsIndexNameConstants.SUFFIX_TRANSITION
+	};
 
 	private final List<BlogsEntry> _blogsEntries = new ArrayList<>();
 
 	@Inject
 	private BlogsEntryLocalService _blogsEntryLocalService;
+
+	@Inject
+	private IndexNameBuilder _indexNameBuilder;
 
 	private KaleoDefinition _kaleoDefinition;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-75968

Previous pull requests:

- https://github.com/brianchandotcom/liferay-portal/pull/180377
- https://github.com/liferay-search/liferay-portal/pull/2140

## What Is Being Fixed

Reindexing workflow metrics from scratch produced nothing when the indexes did not yet exist. The reindexers assumed the indexes were already in place, and `WorkflowMetricsIndex.createIndex` only logged creation failures, so the problem stayed silent.

## How It Is Being Fixed

`WorkflowMetricsIndex.createMissingIndexes` creates every workflow metrics index for a company, and `BaseWorkflowMetricsReindexer` plus both SLA reindexers now call it before indexing anything. `createIndex` throws a `PortalException` instead of logging, so a real failure surfaces. The SLA reindexers move their search capability and system company guards up into `reindex`, ahead of index creation. The integration test base case deletes the indexes before reindexing so the tests actually exercise the from-scratch path.

## PR Check

**pr-check: PASS** — tested on `e2f804e82d1573d27ae3c1c219b9428220912bb8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e2f804e82d1573d27ae3c1c219b9428220912bb8"} -->
