### PR TITLE
LPD-103180 Fix Modified Date filter for asset lists

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
@@ -128,7 +128,7 @@ public class AssetListTypePropertiesUtil {
 			JSONUtil.put(
 				"label", LanguageUtil.get(locale, "modified-date")
 			).put(
-				"name", "modifiedDate"
+				"name", Field.MODIFIED_DATE
 			).put(
 				"type", "date"
 			),

--- a/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
+++ b/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
@@ -368,7 +368,7 @@ public class AssetListTypePropertiesUtilTest {
 
 		String[] expectedNames = {
 			"userName", "createDate", "displayDate", "expirationDate",
-			"externalReferenceCode", "modifiedDate", "priority", "publishDate",
+			"externalReferenceCode", "modified", "priority", "publishDate",
 			"reviewDate", "status", "title", "viewCount"
 		};
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103180

## What Is Being Fixed

The Modified Date filter had no effect on asset lists.

## How It Is Being Fixed

`AssetListTypePropertiesUtil` published the field as `modifiedDate`, but `AssetListFiltersUtil` keys its common field types map on `Field.MODIFIED_DATE` ("modified") and drops any property missing from that map. Using the constant on both sides makes the filter resolve.

## PR Check

Superseded — the branch was amended after this PR was opened. The current pr-check run for head `8a304f6` is recorded in a comment on this PR.
