### PR TITLE
LPD-103180 Fix Modified Date filter for asset lists

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
@@ -128,7 +128,7 @@ public class AssetListTypePropertiesUtil {
 			JSONUtil.put(
 				"label", LanguageUtil.get(locale, "modified-date")
 			).put(
-				"name", "modifiedDate"
+				"name", Field.MODIFIED_DATE
 			).put(
 				"type", "date"
 			),

--- a/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
+++ b/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
@@ -17,8 +17,10 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -28,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -366,20 +369,17 @@ public class AssetListTypePropertiesUtilTest {
 		Assert.assertEquals(
 			itemsJSONArray.toString(), 12, itemsJSONArray.length());
 
+		Set<String> actualNames = JSONUtil.toStringSet(itemsJSONArray, "name");
+
 		String[] expectedNames = {
-			"userName", "createDate", "displayDate", "expirationDate",
-			"externalReferenceCode", "modifiedDate", "priority", "publishDate",
-			"reviewDate", "status", "title", "viewCount"
+			Field.CREATE_DATE, Field.DISPLAY_DATE, Field.EXPIRATION_DATE,
+			"externalReferenceCode", Field.MODIFIED_DATE, Field.PRIORITY,
+			Field.PUBLISH_DATE, Field.REVIEW_DATE, Field.STATUS, Field.TITLE,
+			Field.USER_NAME, "viewCount"
 		};
 
-		for (int i = 0; i < expectedNames.length; i++) {
-			Assert.assertEquals(
-				expectedNames[i],
-				itemsJSONArray.getJSONObject(
-					i
-				).getString(
-					"name"
-				));
+		for (String expectedName : expectedNames) {
+			Assert.assertTrue(expectedName, actualNames.contains(expectedName));
 		}
 	}
 

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
@@ -657,6 +657,7 @@ public class AssetHelperImpl implements AssetHelper {
 
 		if (fieldType.equals(Field.CREATE_DATE) ||
 			fieldType.equals(Field.EXPIRATION_DATE) ||
+			fieldType.equals(Field.MODIFIED_DATE) ||
 			fieldType.equals(Field.PUBLISH_DATE) ||
 			fieldType.equals("modifiedDate")) {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103180

## What Is Being Fixed

The Modified Date filter had no effect on asset lists.

## How It Is Being Fixed

`AssetListTypePropertiesUtil` published the field as `modifiedDate`, but `AssetListFiltersUtil` keys its common field types map on `Field.MODIFIED_DATE` ("modified") and drops any property missing from that map. Using the constant on both sides makes the filter resolve.

Supersedes #2149.

## PR Check

**pr-check: PASS** — tested on `8a304f60f6153c42d8ec9034b374b852ae65f522`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Java Unit Tests, Source Format, and Transaction Usage were run against this head — `AssetListTypePropertiesUtilTest`: tests=6, skipped=0, failures=0, errors=0. The remaining validations ran earlier on this branch and are carried forward, as no main source, exported package, or module descriptor has changed since.

Baseline surfaced a pre-existing `EXCESSIVE VERSION INCREASE` on `headless-cms-api` (`packageinfo` 3.1.0 → 3.0.0). It is present on master and unrelated to this diff, which touches no exported package.

<!-- pr-check {"result": "success", "sha": "8a304f60f6153c42d8ec9034b374b852ae65f522"} -->
