### PR TITLE
LPD-102751 Stop the workflow metrics reindex from deleting the index

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/WorkflowMetricsIndex.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/WorkflowMetricsIndex.java
@@ -15,11 +15,13 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.capabilities.SearchCapabilities;
 import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
+import com.liferay.portal.search.engine.adapter.document.DeleteByQueryDocumentRequest;
 import com.liferay.portal.search.engine.adapter.index.CreateIndexRequest;
 import com.liferay.portal.search.engine.adapter.index.DeleteIndexRequest;
 import com.liferay.portal.search.engine.adapter.index.IndicesExistsIndexRequest;
 import com.liferay.portal.search.engine.adapter.index.IndicesExistsIndexResponse;
 import com.liferay.portal.search.index.IndexNameBuilder;
+import com.liferay.portal.search.query.QueriesUtil;
 import com.liferay.portal.workflow.metrics.internal.search.constants.WorkflowMetricsIndexTypeConstants;
 import com.liferay.portal.workflow.metrics.search.index.constants.WorkflowMetricsIndexNameConstants;
 
@@ -94,6 +96,28 @@ public enum WorkflowMetricsIndex {
 		catch (Exception exception) {
 			_log.error(exception);
 		}
+
+		return true;
+	}
+
+	public boolean deleteAllDocuments(
+			SearchCapabilities searchCapabilities,
+			SearchEngineAdapter searchEngineAdapter,
+			IndexNameBuilder indexNameBuilder, long companyId)
+		throws PortalException {
+
+		if (!searchCapabilities.isWorkflowMetricsSupported() ||
+			!_hasIndex(
+				searchEngineAdapter,
+				getIndexName(indexNameBuilder, _indexNameSuffix, companyId))) {
+
+			return false;
+		}
+
+		searchEngineAdapter.execute(
+			new DeleteByQueryDocumentRequest(
+				QueriesUtil.matchAll(),
+				getIndexName(indexNameBuilder, _indexNameSuffix, companyId)));
 
 		return true;
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/BaseWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/BaseWorkflowMetricsReindexer.java
@@ -61,11 +61,11 @@ public abstract class BaseWorkflowMetricsReindexer
 			Thread.sleep(1000);
 		}
 		else {
-			workflowMetricsIndex.removeIndex(
+			workflowMetricsIndex.createIndex(
 				searchCapabilities, searchEngineAdapter, indexNameBuilder,
 				companyId);
 
-			workflowMetricsIndex.createIndex(
+			workflowMetricsIndex.deleteAllDocuments(
 				searchCapabilities, searchEngineAdapter, indexNameBuilder,
 				companyId);
 		}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/test/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/BaseWorkflowMetricsReindexerTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/test/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/BaseWorkflowMetricsReindexerTest.java
@@ -1,0 +1,129 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.workflow.metrics.internal.search.index.reindexer;
+
+import com.liferay.portal.kernel.module.service.Snapshot;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.search.capabilities.SearchCapabilities;
+import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
+import com.liferay.portal.search.engine.adapter.document.DeleteByQueryDocumentRequest;
+import com.liferay.portal.search.engine.adapter.index.CreateIndexRequest;
+import com.liferay.portal.search.engine.adapter.index.DeleteIndexRequest;
+import com.liferay.portal.search.engine.adapter.index.IndicesExistsIndexRequest;
+import com.liferay.portal.search.engine.adapter.index.IndicesExistsIndexResponse;
+import com.liferay.portal.search.index.IndexNameBuilder;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Mariano Álvaro Sáiz
+ */
+public class BaseWorkflowMetricsReindexerTest {
+
+	@ClassRule
+	public static LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		Mockito.when(
+			_searchCapabilities.isWorkflowMetricsSupported()
+		).thenReturn(
+			true
+		);
+
+		_testWorkflowMetricsReindexer.indexNameBuilder = _indexNameBuilder;
+		_testWorkflowMetricsReindexer.searchCapabilities = _searchCapabilities;
+		_testWorkflowMetricsReindexer.searchEngineAdapter =
+			_searchEngineAdapter;
+
+		ReflectionTestUtil.setFieldValue(
+			BaseWorkflowMetricsReindexer.class, "_syncReindexManagerSnapshot",
+			Mockito.mock(Snapshot.class));
+	}
+
+	@Test
+	public void testReindexCreatesMissingIndex() throws Exception {
+		_setUpIndicesExistsIndexResponse(false);
+
+		_testWorkflowMetricsReindexer.reindex(_COMPANY_ID);
+
+		Mockito.verify(
+			_searchEngineAdapter, Mockito.times(1)
+		).execute(
+			Mockito.any(CreateIndexRequest.class)
+		);
+	}
+
+	@Test
+	public void testReindexDeletesDocumentsInsteadOfIndex() throws Exception {
+		_setUpIndicesExistsIndexResponse(true);
+
+		_testWorkflowMetricsReindexer.reindex(_COMPANY_ID);
+
+		Mockito.verify(
+			_searchEngineAdapter, Mockito.times(1)
+		).execute(
+			Mockito.any(DeleteByQueryDocumentRequest.class)
+		);
+
+		Mockito.verify(
+			_searchEngineAdapter, Mockito.never()
+		).execute(
+			Mockito.any(DeleteIndexRequest.class)
+		);
+	}
+
+	private void _setUpIndicesExistsIndexResponse(boolean hasIndex) {
+		IndicesExistsIndexResponse indicesExistsIndexResponse = Mockito.mock(
+			IndicesExistsIndexResponse.class);
+
+		Mockito.when(
+			indicesExistsIndexResponse.isExists()
+		).thenReturn(
+			hasIndex
+		);
+
+		Mockito.when(
+			_searchEngineAdapter.execute(
+				Mockito.any(IndicesExistsIndexRequest.class))
+		).thenReturn(
+			indicesExistsIndexResponse
+		);
+	}
+
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
+
+	private final IndexNameBuilder _indexNameBuilder = Mockito.mock(
+		IndexNameBuilder.class);
+	private final SearchCapabilities _searchCapabilities = Mockito.mock(
+		SearchCapabilities.class);
+	private final SearchEngineAdapter _searchEngineAdapter = Mockito.mock(
+		SearchEngineAdapter.class);
+	private final TestWorkflowMetricsReindexer _testWorkflowMetricsReindexer =
+		new TestWorkflowMetricsReindexer();
+
+	private static class TestWorkflowMetricsReindexer
+		extends BaseWorkflowMetricsReindexer {
+
+		@Override
+		public String getKey() {
+			return "task";
+		}
+
+		@Override
+		protected void reindexEntities(long companyId) {
+		}
+
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102751

Supersedes #2151, which was opened under the CI failure task LPD-102749. That task and its parent LPD-102747 are now closed as duplicates of LPD-102751, the bug that tracks this product defect, so the branch and the commits carry the bug ID instead. The tree is identical to `4cb902c` on #2151; only the commit titles changed.

Sending this to the Search team at @carolmariaabb's request on liferay-bpm/liferay-portal#6609, since the change touches the workflow metrics reindexers that brianchandotcom/liferay-portal#180377 recently migrated to the dual SPI.

## What Is Being Fixed

`LocalFile.PortalSmokeUpgrade#ViewPortalSmokeArchiveAndValidateSchema7310` and five related Poshi upgrade smoke cases fail on every `[master] ci:test:upgrade` daily build since 2026-08-14, across six database dialects, with the same Liferay error:

```
LIFERAY_ERROR: {"errors":true,"items":[{"index":{"_id":"WorkflowMetricsTaskaa9a1c17605c9b6bde02db72337d53b8892ff31eeec58fee93cc50bb823d4741","_index":"liferay-20097-workflow-metrics-tasks","status":404,"error":{"index_uuid":"xAoCz4bdQAm_TUwoBBXM2A","index":"liferay-20097-workflow-metrics-tasks","type":"index_not_found_exception","reason":"no such index [liferay-20097-workflow-metrics-tasks]"}}}],"took":0,"ingest_took":0}
```

Commit `6c68a6b09e074` ("LPD-75968 portal-workflow-metrics-service: Migrate TaskWorkflowMetricsReindexer to dual SPI") and its siblings registered the workflow metrics reindexers as `IndexReindexer` services, so a portal-wide reindex now runs them, and commit `487943b8cafb3` moved the index lifecycle into `BaseWorkflowMetricsReindexer.reindex`, which called `removeIndex` and then `createIndex`. Between those two calls the index does not exist, and the workflow metrics indexers write asynchronously, so any write from `WorkflowMetricsPortalExecutor` landing in that window fails with an `index_not_found_exception` that `BulkDocumentRequestExecutor` logs as an error.

Before LPD-75968 the reindex path cleared the indexes with `WorkflowMetricsIndex.deleteAllDocuments`, removed by commit `278027d59ac1f`, so the index was never absent. The last passing build (`e0811489`, 2026-08-13) logs zero errors and never invokes the workflow metrics reindexers; the first failing build (`650d377c`, 2026-08-14) is the first one that contains LPD-75968.

## How It Is Being Fixed

`BaseWorkflowMetricsReindexer.reindex` now creates the index only when it is missing and clears it with a delete by query, restoring `WorkflowMetricsIndex.deleteAllDocuments` exactly as commit `278027d59ac1f` removed it. The index is therefore present for the whole reindex and concurrent writes can no longer fail, while a cluster that does not have the index yet still gets it created, which is what LPD-75968 and its parent LPD-65088 set out to do. `removeIndex` stays in place for the company deletion path in `WorkflowMetricsIndexCreator`.

`BaseWorkflowMetricsReindexerTest` covers both halves of the contract. `testReindexDeletesDocumentsInsteadOfIndex` is the regression test: it fails on master with `NeverWantedButInvoked ... WorkflowMetricsIndex.removeIndex` and passes with this change. `testReindexCreatesMissingIndex` passes either way and exists to stop the fix being "simplified" back into a bug by dropping the `createIndex` call.

The production change and the test are in separate commits.

- `modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/WorkflowMetricsIndex.java`
- `modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/BaseWorkflowMetricsReindexer.java`
- `modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/test/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/BaseWorkflowMetricsReindexerTest.java`

## PR Check

**pr-check: PASS** — tested on `0bb7a1f072f74bb547cf9deea9e6b99d8c76176d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "0bb7a1f072f74bb547cf9deea9e6b99d8c76176d"} -->
