### PR TITLE
LPD-75968 Create missing workflow metrics indexes before reindexing

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/WorkflowMetricsIndex.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/WorkflowMetricsIndex.java
@@ -50,6 +50,19 @@ public enum WorkflowMetricsIndex {
 		WorkflowMetricsIndexNameConstants.SUFFIX_TRANSITION,
 		WorkflowMetricsIndexTypeConstants.TRANSITION_TYPE);
 
+	public static void createMissingIndexes(
+			SearchCapabilities searchCapabilities,
+			SearchEngineAdapter searchEngineAdapter,
+			IndexNameBuilder indexNameBuilder, long companyId)
+		throws PortalException {
+
+		for (WorkflowMetricsIndex workflowMetricsIndex : values()) {
+			workflowMetricsIndex.createIndex(
+				searchCapabilities, searchEngineAdapter, indexNameBuilder,
+				companyId);
+		}
+	}
+
 	public static String getIndexName(
 		IndexNameBuilder indexNameBuilder, String indexNameSuffix,
 		long companyId) {
@@ -92,7 +105,10 @@ public enum WorkflowMetricsIndex {
 			searchEngineAdapter.execute(createIndexRequest);
 		}
 		catch (Exception exception) {
-			_log.error(exception);
+			throw new PortalException(
+				"Unable to create index " +
+					getIndexName(indexNameBuilder, _indexNameSuffix, companyId),
+				exception);
 		}
 
 		return true;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/BaseWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/BaseWorkflowMetricsReindexer.java
@@ -50,6 +50,10 @@ public abstract class BaseWorkflowMetricsReindexer
 			return;
 		}
 
+		WorkflowMetricsIndex.createMissingIndexes(
+			searchCapabilities, searchEngineAdapter, indexNameBuilder,
+			companyId);
+
 		Date date = null;
 
 		WorkflowMetricsIndex workflowMetricsIndex =

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/SLAInstanceResultWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/SLAInstanceResultWorkflowMetricsReindexer.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.workflow.metrics.internal.search.index.reindexer;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalRunMode;
@@ -26,6 +27,7 @@ import com.liferay.portal.search.query.QueriesUtil;
 import com.liferay.portal.search.spi.reindexer.IndexReindexer;
 import com.liferay.portal.workflow.metrics.internal.background.task.WorkflowMetricsSLAProcessBackgroundTaskHelper;
 import com.liferay.portal.workflow.metrics.internal.search.index.SLAInstanceResultWorkflowMetricsIndexer;
+import com.liferay.portal.workflow.metrics.internal.search.index.WorkflowMetricsIndex;
 import com.liferay.portal.workflow.metrics.search.index.constants.WorkflowMetricsIndexNameConstants;
 import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexer;
 
@@ -46,6 +48,16 @@ public class SLAInstanceResultWorkflowMetricsReindexer
 
 	@Override
 	public void reindex(long companyId) throws PortalException {
+		if (!_searchCapabilities.isWorkflowMetricsSupported() ||
+			(companyId == CompanyConstants.SYSTEM)) {
+
+			return;
+		}
+
+		WorkflowMetricsIndex.createMissingIndexes(
+			_searchCapabilities, _searchEngineAdapter, _indexNameBuilder,
+			companyId);
+
 		_createDefaultDocuments(companyId);
 
 		WorkflowMetricsSLAProcessBackgroundTaskHelper
@@ -66,8 +78,7 @@ public class SLAInstanceResultWorkflowMetricsReindexer
 	}
 
 	private void _createDefaultDocuments(long companyId) {
-		if (!_searchCapabilities.isWorkflowMetricsSupported() ||
-			!_hasIndex(
+		if (!_hasIndex(
 				_indexNameBuilder.getIndexName(companyId) +
 					WorkflowMetricsIndexNameConstants.SUFFIX_PROCESS)) {
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/SLATaskResultWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/SLATaskResultWorkflowMetricsReindexer.java
@@ -5,6 +5,8 @@
 
 package com.liferay.portal.workflow.metrics.internal.search.index.reindexer;
 
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalRunMode;
 import com.liferay.portal.search.capabilities.SearchCapabilities;
@@ -23,6 +25,7 @@ import com.liferay.portal.search.query.BooleanQuery;
 import com.liferay.portal.search.query.QueriesUtil;
 import com.liferay.portal.search.spi.reindexer.IndexReindexer;
 import com.liferay.portal.workflow.metrics.internal.search.index.SLATaskResultWorkflowMetricsIndexer;
+import com.liferay.portal.workflow.metrics.internal.search.index.WorkflowMetricsIndex;
 import com.liferay.portal.workflow.metrics.search.background.task.WorkflowMetricsReindexStatusMessageSender;
 import com.liferay.portal.workflow.metrics.search.index.constants.WorkflowMetricsIndexNameConstants;
 import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexer;
@@ -45,7 +48,17 @@ public class SLATaskResultWorkflowMetricsReindexer
 	}
 
 	@Override
-	public void reindex(long companyId) {
+	public void reindex(long companyId) throws PortalException {
+		if (!_searchCapabilities.isWorkflowMetricsSupported() ||
+			(companyId == CompanyConstants.SYSTEM)) {
+
+			return;
+		}
+
+		WorkflowMetricsIndex.createMissingIndexes(
+			_searchCapabilities, _searchEngineAdapter, _indexNameBuilder,
+			companyId);
+
 		_createDefaultDocuments(companyId);
 	}
 
@@ -57,8 +70,7 @@ public class SLATaskResultWorkflowMetricsReindexer
 	}
 
 	private void _createDefaultDocuments(long companyId) {
-		if (!_searchCapabilities.isWorkflowMetricsSupported() ||
-			!_hasIndex(
+		if (!_hasIndex(
 				_indexNameBuilder.getIndexName(companyId) +
 					WorkflowMetricsIndexNameConstants.SUFFIX_NODE)) {
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/util/BaseWorkflowMetricsIndexerTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/util/BaseWorkflowMetricsIndexerTestCase.java
@@ -20,6 +20,8 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.search.engine.adapter.index.DeleteIndexRequest;
+import com.liferay.portal.search.index.IndexNameBuilder;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.workflow.kaleo.definition.Node;
 import com.liferay.portal.workflow.kaleo.definition.Task;
@@ -37,6 +39,7 @@ import com.liferay.portal.workflow.kaleo.service.KaleoInstanceTokenLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoNodeLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoTaskInstanceTokenLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoTaskLocalService;
+import com.liferay.portal.workflow.metrics.search.index.constants.WorkflowMetricsIndexNameConstants;
 import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexer;
 import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexerRegistry;
 
@@ -473,6 +476,19 @@ public abstract class BaseWorkflowMetricsIndexerTestCase
 	}
 
 	private void _reindexMetricIndexes(long companyId) throws Exception {
+		String indexNamePrefix = _indexNameBuilder.getIndexName(companyId);
+
+		searchEngineAdapter.execute(
+			new DeleteIndexRequest(
+				indexNamePrefix +
+					WorkflowMetricsIndexNameConstants.SUFFIX_INSTANCE,
+				indexNamePrefix + WorkflowMetricsIndexNameConstants.SUFFIX_NODE,
+				indexNamePrefix +
+					WorkflowMetricsIndexNameConstants.SUFFIX_PROCESS,
+				indexNamePrefix + WorkflowMetricsIndexNameConstants.SUFFIX_TASK,
+				indexNamePrefix +
+					WorkflowMetricsIndexNameConstants.SUFFIX_TRANSITION));
+
 		_reindex(companyId, "instance");
 		_reindex(companyId, "node");
 		_reindex(companyId, "process");
@@ -481,6 +497,16 @@ public abstract class BaseWorkflowMetricsIndexerTestCase
 	}
 
 	private void _reindexSLAIndexes(long companyId) throws Exception {
+		String indexNamePrefix = _indexNameBuilder.getIndexName(companyId);
+
+		searchEngineAdapter.execute(
+			new DeleteIndexRequest(
+				indexNamePrefix +
+					WorkflowMetricsIndexNameConstants.
+						SUFFIX_SLA_INSTANCE_RESULT,
+				indexNamePrefix +
+					WorkflowMetricsIndexNameConstants.SUFFIX_SLA_TASK_RESULT));
+
 		_reindex(companyId, "sla-instance-result");
 		_reindex(companyId, "sla-task-result");
 	}
@@ -489,6 +515,9 @@ public abstract class BaseWorkflowMetricsIndexerTestCase
 
 	@Inject
 	private BlogsEntryLocalService _blogsEntryLocalService;
+
+	@Inject
+	private IndexNameBuilder _indexNameBuilder;
 
 	private KaleoDefinition _kaleoDefinition;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-75968

Supersedes https://github.com/liferay-search/liferay-portal/pull/2147

## What Is Being Fixed

Workflow metrics reindexing assumed the seven workflow metrics indexes already existed. When a reindex runs from scratch — a fresh search cluster, or after the indexes have been dropped — the reindexers write into indexes that are not there and the reindex quietly produces nothing. The two SLA reindexers make this worse: each one bails out of its default-document creation when the process or node index is absent, so no default SLA documents are ever written. Index creation itself hid the same class of problem, because `WorkflowMetricsIndex.createIndex` caught every failure, logged it, and still returned `true`, so a genuine failure to create an index was indistinguishable from success.

## How It Is Being Fixed

`WorkflowMetricsIndex` gains a static `createMissingIndexes`, which walks every enum constant and creates the index when it is missing. Each reindexer calls it before doing any work, so the indexes a reindex is about to write into are guaranteed to exist. `BaseWorkflowMetricsReindexer` calls it right after its existing capability and company guard. The two SLA reindexers had no such guard on `reindex` at all, so they now short-circuit on an unsupported search capability or the system company before creating the indexes, and the capability check is dropped from `_createDefaultDocuments`, where it is now redundant. `createIndex` no longer swallows failures — it throws a `PortalException` naming the index that could not be created, so a broken reindex fails loudly instead of reporting success.

`BaseWorkflowMetricsIndexerTestCase` deletes the workflow metrics indexes each reindex helper is about to populate, so the existing indexer tests now exercise the from-scratch path that was previously never covered.

## PR Check

**pr-check: PASS** — tested on `f75b60eec62b8a609a43d299656e5d1fdb99c234`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS \* |
| Java Unit Tests | PASS |

\* **Baseline (pre-existing on master, not attributable to this PR):** `EXCESSIVE VERSION INCREASE` on `modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/resource/v1_0/packageinfo` — baseline lowered `3.1.0` &rarr; `3.0.0`. Introduced by master commit `aed5313 LPD-97871 Semantic versioning`, verified an ancestor of `master`. This pull request touches only `modules/dxp/apps/portal-workflow`, so the rewrite was reverted and the working tree left clean. No baseline findings on any file this branch changed.

<!-- pr-check {"result": "success", "sha": "f75b60eec62b8a609a43d299656e5d1fdb99c234"} -->
