### PR TITLE
LPD-102698 Synchronize and fix the batch mode logic in both connectors

### DIFF
--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterImpl.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterImpl.java
@@ -108,16 +108,16 @@ public class ElasticsearchSearchEngineAdapterImpl
 
 				SearchContext.registerBatchModeSyncCallable(
 					() -> {
-						List<BulkableDocumentRequest<?>>
-							bulkableDocumentRequests =
-								finalBulkDocumentRequest.
-									getBulkableDocumentRequests();
-
-						if (bulkableDocumentRequests.isEmpty()) {
-							return null;
-						}
-
 						try {
+							List<BulkableDocumentRequest<?>>
+								bulkableDocumentRequests =
+									finalBulkDocumentRequest.
+										getBulkableDocumentRequests();
+
+							if (bulkableDocumentRequests.isEmpty()) {
+								return null;
+							}
+
 							_documentRequestExecutor.executeBulkDocumentRequest(
 								finalBulkDocumentRequest);
 						}

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterDocumentRequestTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterDocumentRequestTest.java
@@ -17,6 +17,7 @@ import co.elastic.clients.elasticsearch.indices.DeleteIndexRequest;
 import co.elastic.clients.elasticsearch.indices.ElasticsearchIndicesClient;
 import co.elastic.clients.json.JsonData;
 
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -26,6 +27,9 @@ import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchEngineHelperUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Validator;
@@ -73,6 +77,9 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
 /**
  * @author Dylan Rebelak
  */
@@ -113,6 +120,62 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		_deleteIndex();
 
 		_documentFixture.tearDown();
+	}
+
+	@Test
+	public void testExecuteBatchModeAfterExactMultipleFlush() throws Exception {
+		try (MockedStatic<SearchEngineHelperUtil>
+				searchEngineHelperUtilMockedStatic = Mockito.mockStatic(
+					SearchEngineHelperUtil.class)) {
+
+			ExecutorService executorService = Mockito.mock(
+				ExecutorService.class);
+
+			Mockito.doAnswer(
+				invocation -> {
+					Runnable runnable = invocation.getArgument(0);
+
+					runnable.run();
+
+					return null;
+				}
+			).when(
+				executorService
+			).execute(
+				Mockito.any(Runnable.class)
+			);
+
+			searchEngineHelperUtilMockedStatic.when(
+				SearchEngineHelperUtil::getDocumentsConsumerExecutorService
+			).thenReturn(
+				executorService
+			);
+
+			try (SafeCloseable safeCloseable = SearchContext.openBatchMode(
+					false)) {
+
+				for (int i = 0; i < Indexer.DEFAULT_INTERVAL; i++) {
+					_searchEngineAdapter.execute(
+						_createIndexDocumentRequest(String.valueOf(i)));
+				}
+			}
+
+			GetResponse getResponse1 = _getDocument("0");
+
+			Assert.assertTrue(getResponse1.found());
+
+			String id = "remainder";
+
+			try (SafeCloseable safeCloseable = SearchContext.openBatchMode(
+					false)) {
+
+				_searchEngineAdapter.execute(_createIndexDocumentRequest(id));
+			}
+
+			GetResponse getResponse2 = _getDocument(id);
+
+			Assert.assertTrue(getResponse2.found());
+		}
 	}
 
 	@Test
@@ -729,6 +792,20 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
 		}
+	}
+
+	private IndexDocumentRequest _createIndexDocumentRequest(String uid) {
+		Document document = new DocumentImpl();
+
+		document.addKeyword(Field.UID, uid);
+
+		IndexDocumentRequest indexDocumentRequest = new IndexDocumentRequest(
+			_INDEX_NAME, document);
+
+		indexDocumentRequest.setType(
+			IndexMappingsConstants.LIFERAY_DOCUMENT_TYPE);
+
+		return indexDocumentRequest;
 	}
 
 	private void _deleteIndex() {

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/build.gradle
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
+	compileOnly project(":core:petra:petra-concurrent")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-reflect")

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/OpenSearchSearchEngineAdapterImpl.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/OpenSearchSearchEngineAdapterImpl.java
@@ -109,16 +109,16 @@ public class OpenSearchSearchEngineAdapterImpl implements SearchEngineAdapter {
 
 				SearchContext.registerBatchModeSyncCallable(
 					() -> {
-						List<BulkableDocumentRequest<?>>
-							bulkableDocumentRequests =
-								finalBulkDocumentRequest.
-									getBulkableDocumentRequests();
-
-						if (bulkableDocumentRequests.isEmpty()) {
-							return null;
-						}
-
 						try {
+							List<BulkableDocumentRequest<?>>
+								bulkableDocumentRequests =
+									finalBulkDocumentRequest.
+										getBulkableDocumentRequests();
+
+							if (bulkableDocumentRequests.isEmpty()) {
+								return null;
+							}
+
 							_documentRequestExecutor.executeBulkDocumentRequest(
 								finalBulkDocumentRequest);
 						}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/OpenSearchSearchEngineAdapterImpl.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/OpenSearchSearchEngineAdapterImpl.java
@@ -5,8 +5,13 @@
 
 package com.liferay.portal.search.opensearch2.internal.search.engine.adapter;
 
+import com.liferay.petra.concurrent.DefaultNoticeableFuture;
+import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchEngineHelperUtil;
 import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
 import com.liferay.portal.search.engine.adapter.ccr.CCRRequest;
 import com.liferay.portal.search.engine.adapter.ccr.CCRRequestExecutor;
@@ -14,6 +19,8 @@ import com.liferay.portal.search.engine.adapter.ccr.CCRResponse;
 import com.liferay.portal.search.engine.adapter.cluster.ClusterRequest;
 import com.liferay.portal.search.engine.adapter.cluster.ClusterRequestExecutor;
 import com.liferay.portal.search.engine.adapter.cluster.ClusterResponse;
+import com.liferay.portal.search.engine.adapter.document.BulkDocumentRequest;
+import com.liferay.portal.search.engine.adapter.document.BulkableDocumentRequest;
 import com.liferay.portal.search.engine.adapter.document.DocumentRequest;
 import com.liferay.portal.search.engine.adapter.document.DocumentRequestExecutor;
 import com.liferay.portal.search.engine.adapter.document.DocumentResponse;
@@ -37,7 +44,9 @@ import com.liferay.portal.search.opensearch2.internal.search.engine.adapter.sear
 import com.liferay.portal.search.opensearch2.internal.search.engine.adapter.snapshot.OpenSearchSnapshotRequestExecutor;
 import com.liferay.portal.search.opensearch2.internal.util.JsonpUtil;
 
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.query_dsl.QueryVariant;
@@ -82,6 +91,93 @@ public class OpenSearchSearchEngineAdapterImpl implements SearchEngineAdapter {
 	@Override
 	public <S extends DocumentResponse> S execute(
 		DocumentRequest<S> documentRequest) {
+
+		if (SearchContext.isBatchMode() &&
+			(documentRequest instanceof BulkableDocumentRequest ||
+			 documentRequest instanceof BulkDocumentRequest)) {
+
+			BulkDocumentRequest bulkDocumentRequest =
+				_bulkDocumentRequest.get();
+
+			if (bulkDocumentRequest == null) {
+				bulkDocumentRequest = new BulkDocumentRequest();
+
+				_bulkDocumentRequest.set(bulkDocumentRequest);
+
+				BulkDocumentRequest finalBulkDocumentRequest =
+					bulkDocumentRequest;
+
+				SearchContext.registerBatchModeSyncCallable(
+					() -> {
+						List<BulkableDocumentRequest<?>>
+							bulkableDocumentRequests =
+								finalBulkDocumentRequest.
+									getBulkableDocumentRequests();
+
+						if (bulkableDocumentRequests.isEmpty()) {
+							return null;
+						}
+
+						try {
+							_documentRequestExecutor.executeBulkDocumentRequest(
+								finalBulkDocumentRequest);
+						}
+						catch (RuntimeException runtimeException) {
+							throw _getRuntimeException(runtimeException);
+						}
+						finally {
+							_bulkDocumentRequest.remove();
+						}
+
+						return null;
+					});
+			}
+
+			if (documentRequest instanceof BulkDocumentRequest) {
+				BulkDocumentRequest incomingBulkDocumentRequest =
+					(BulkDocumentRequest)documentRequest;
+
+				for (BulkableDocumentRequest<?> bulkableDocumentRequest :
+						incomingBulkDocumentRequest.
+							getBulkableDocumentRequests()) {
+
+					bulkDocumentRequest.addBulkableDocumentRequest(
+						bulkableDocumentRequest);
+				}
+			}
+			else {
+				bulkDocumentRequest.addBulkableDocumentRequest(
+					(BulkableDocumentRequest)documentRequest);
+			}
+
+			List<BulkableDocumentRequest<?>> bulkableDocumentRequests =
+				bulkDocumentRequest.getBulkableDocumentRequests();
+
+			if (bulkableDocumentRequests.size() < Indexer.DEFAULT_INTERVAL) {
+				return null;
+			}
+
+			ExecutorService executorService =
+				SearchEngineHelperUtil.getDocumentsConsumerExecutorService();
+
+			BulkDocumentRequest transferCopyBulkDocumentRequest =
+				bulkDocumentRequest.transferCopy();
+
+			DefaultNoticeableFuture<Void> defaultNoticeableFuture =
+				new DefaultNoticeableFuture<>(
+					() -> {
+						_documentRequestExecutor.executeBulkDocumentRequest(
+							transferCopyBulkDocumentRequest);
+
+						return null;
+					});
+
+			SearchContext.registerBatchModeSyncFuture(defaultNoticeableFuture);
+
+			executorService.execute(defaultNoticeableFuture);
+
+			return null;
+		}
 
 		try {
 			return documentRequest.accept(_documentRequestExecutor);
@@ -198,6 +294,11 @@ public class OpenSearchSearchEngineAdapterImpl implements SearchEngineAdapter {
 
 		return runtimeException1;
 	}
+
+	private static final ThreadLocal<BulkDocumentRequest> _bulkDocumentRequest =
+		new CentralizedThreadLocal<>(
+			OpenSearchSearchEngineAdapterImpl.class.getName() +
+				"._bulkDocumentRequest");
 
 	private CCRRequestExecutor _ccrRequestExecutor;
 	private ClusterRequestExecutor _clusterRequestExecutor;

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/OpenSearchSearchEngineAdapterDocumentRequestTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/OpenSearchSearchEngineAdapterDocumentRequestTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.search.opensearch2.internal.search.engine.adapter;
 
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -14,6 +15,9 @@ import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchEngineHelperUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Validator;
@@ -58,6 +62,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.OpenSearchClient;
@@ -104,6 +111,62 @@ public class OpenSearchSearchEngineAdapterDocumentRequestTest
 		_deleteIndex();
 
 		_documentFixture.tearDown();
+	}
+
+	@Test
+	public void testExecuteBatchModeAfterExactMultipleFlush() throws Exception {
+		try (MockedStatic<SearchEngineHelperUtil>
+				searchEngineHelperUtilMockedStatic = Mockito.mockStatic(
+					SearchEngineHelperUtil.class)) {
+
+			ExecutorService executorService = Mockito.mock(
+				ExecutorService.class);
+
+			Mockito.doAnswer(
+				invocation -> {
+					Runnable runnable = invocation.getArgument(0);
+
+					runnable.run();
+
+					return null;
+				}
+			).when(
+				executorService
+			).execute(
+				Mockito.any(Runnable.class)
+			);
+
+			searchEngineHelperUtilMockedStatic.when(
+				SearchEngineHelperUtil::getDocumentsConsumerExecutorService
+			).thenReturn(
+				executorService
+			);
+
+			try (SafeCloseable safeCloseable = SearchContext.openBatchMode(
+					false)) {
+
+				for (int i = 0; i < Indexer.DEFAULT_INTERVAL; i++) {
+					_searchEngineAdapter.execute(
+						_createIndexDocumentRequest(String.valueOf(i)));
+				}
+			}
+
+			GetResponse<JsonData> getResponse1 = _getDocument("0");
+
+			Assert.assertTrue(getResponse1.found());
+
+			String id = "remainder";
+
+			try (SafeCloseable safeCloseable = SearchContext.openBatchMode(
+					false)) {
+
+				_searchEngineAdapter.execute(_createIndexDocumentRequest(id));
+			}
+
+			GetResponse<JsonData> getResponse2 = _getDocument(id);
+
+			Assert.assertTrue(getResponse2.found());
+		}
 	}
 
 	@Test
@@ -686,6 +749,14 @@ public class OpenSearchSearchEngineAdapterDocumentRequestTest
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
 		}
+	}
+
+	private IndexDocumentRequest _createIndexDocumentRequest(String uid) {
+		Document document = new DocumentImpl();
+
+		document.addKeyword(Field.UID, uid);
+
+		return new IndexDocumentRequest(TEST_INDEX_NAME, document);
 	}
 
 	private void _deleteIndex() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102698
https://liferay.atlassian.net/browse/LPD-101532

## What Is Being Fixed

The batch mode document logic in the two search connectors was out of sync. `ElasticsearchSearchEngineAdapterImpl` coalesces bulkable document requests into bulk requests during a full reindex, while `OpenSearchSearchEngineAdapterImpl` had no batch mode handling at all and passed every request straight to its document request executor.

The Elasticsearch implementation also carries a defect. When a batch scope's last write triggers a flush, the buffer ends empty, so the close callable returns before releasing its thread local. That callable is only registered while the thread local is null, so no later scope on the same thread registers one, and documents accumulate in an orphaned buffer that only ever empties on a threshold crossing. Whatever remains when the reindex ends is discarded without surfacing an error, which gives the signature `indexed = total - (total mod index.interval)`.

## How It Is Being Fixed

The OpenSearch adapter is first brought to parity, so that `execute(DocumentRequest)` is identical in both connectors. The same fix is then applied to each, moving the empty check inside the `try` so the `finally` always releases the buffer.

Separating the synchronization from the fix is deliberate. It keeps the two fix commits byte identical, which is what makes the parity verifiable, and it lets a backport take the regression fix on its own without pulling the new OpenSearch coalescing onto a release branch.

Both connectors were verified against a live OpenSearch 2.19.0 cluster and the Elasticsearch sidecar, with all adapter document request tests passing in each. Reverting the fix fails the new test in both connectors, so it catches the defect rather than passing vacuously.

## PR Check

**pr-check: PASS** — tested on `2d43b03f7b989a7513ebec6cc006f827bc2dc93f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "2d43b03f7b989a7513ebec6cc006f827bc2dc93f"} -->
