### PR TITLE
LPD-103633 Stop decompressing OpenSearch responses twice

### DIFF
--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/connection/OpenSearchConnection.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/connection/OpenSearchConnection.java
@@ -348,6 +348,8 @@ public class OpenSearchConnection {
 							_proxyConfig.getPort()));
 				}
 
+				httpClientBuilder.disableContentCompression();
+
 				return httpClientBuilder.setConnectionManager(
 					poolingAsyncClientConnectionManagerBuilder.build());
 			}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/connection/OpenSearchConnectionContentCompressionTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/connection/OpenSearchConnectionContentCompressionTest.java
@@ -1,0 +1,166 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.opensearch2.internal.connection;
+
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpContext;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import java.net.InetSocketAddress;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.zip.GZIPOutputStream;
+
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpStatus;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.core.CountResponse;
+
+/**
+ * @author Selena Aungst
+ */
+public class OpenSearchConnectionContentCompressionTest {
+
+	@ClassRule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		_httpServer = HttpServer.create(new InetSocketAddress(0), 0);
+
+		HttpContext httpContext = _httpServer.createContext("/");
+
+		httpContext.setHandler(this::_handle);
+
+		_httpServer.start();
+	}
+
+	@After
+	public void tearDown() {
+		if (_openSearchConnection != null) {
+			_openSearchConnection.close();
+		}
+
+		_httpServer.stop(0);
+	}
+
+	@Test
+	public void testConnectWithCompressionDisabled() throws Exception {
+		_testConnect(false, null);
+	}
+
+	@Test
+	public void testConnectWithCompressionEnabled() throws Exception {
+		_testConnect(true, _GZIP);
+	}
+
+	private String _getCountJSON() {
+		return JSONUtil.put(
+			"_shards",
+			JSONUtil.put(
+				"failed", 0
+			).put(
+				"successful", 1
+			).put(
+				"total", 1
+			)
+		).put(
+			"count", _COUNT
+		).toString();
+	}
+
+	private byte[] _gzip(byte[] bytes) throws IOException {
+		ByteArrayOutputStream byteArrayOutputStream =
+			new ByteArrayOutputStream();
+
+		try (GZIPOutputStream gzipOutputStream = new GZIPOutputStream(
+				byteArrayOutputStream)) {
+
+			gzipOutputStream.write(bytes);
+		}
+
+		return byteArrayOutputStream.toByteArray();
+	}
+
+	private void _handle(HttpExchange httpExchange) throws IOException {
+		Headers requestHeaders = httpExchange.getRequestHeaders();
+
+		_acceptEncoding = requestHeaders.getFirst(HttpHeaders.ACCEPT_ENCODING);
+
+		Headers responseHeaders = httpExchange.getResponseHeaders();
+
+		byte[] bytes = _getCountJSON().getBytes(StandardCharsets.UTF_8);
+
+		if ((_acceptEncoding != null) && _acceptEncoding.contains(_GZIP)) {
+			bytes = _gzip(bytes);
+
+			responseHeaders.set(HttpHeaders.CONTENT_ENCODING, _GZIP);
+		}
+
+		responseHeaders.set(HttpHeaders.CONTENT_TYPE, "application/json");
+
+		httpExchange.sendResponseHeaders(HttpStatus.SC_OK, bytes.length);
+
+		try (OutputStream outputStream = httpExchange.getResponseBody()) {
+			outputStream.write(bytes);
+		}
+	}
+
+	private void _testConnect(
+			boolean compressionEnabled, String expectedAcceptEncoding)
+		throws Exception {
+
+		InetSocketAddress inetSocketAddress = _httpServer.getAddress();
+
+		String networkHostAddress =
+			"http://localhost:" + inetSocketAddress.getPort();
+
+		OpenSearchConnection.Builder openSearchConnectionBuilder =
+			new OpenSearchConnection.Builder();
+
+		openSearchConnectionBuilder.compressionEnabled(compressionEnabled);
+		openSearchConnectionBuilder.networkHostAddresses(
+			new String[] {networkHostAddress});
+
+		_openSearchConnection = openSearchConnectionBuilder.build();
+
+		_openSearchConnection.connect();
+
+		OpenSearchClient openSearchClient =
+			_openSearchConnection.getOpenSearchClient();
+
+		CountResponse countResponse = openSearchClient.count();
+
+		Assert.assertEquals(expectedAcceptEncoding, _acceptEncoding);
+		Assert.assertEquals(_COUNT, countResponse.count());
+	}
+
+	private static final long _COUNT = 7;
+
+	private static final String _GZIP = "gzip";
+
+	private String _acceptEncoding;
+	private HttpServer _httpServer;
+	private OpenSearchConnection _openSearchConnection;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103633

## What Is Being Fixed

Every request the OpenSearch 2 connector makes was gunzipped twice, so the connection failed before it could serve a single search. `httpclient5` inflated the gzipped response body but left the `Content-Encoding: gzip` header in place. `opensearch-java` then read that header off the raw response, stamped it onto a `ByteArrayEntity` that already held plain JSON, and inflated it a second time, throwing `jakarta.json.JsonException`.

The regression came from LPD-101741, which bumped `httpclient5` from 5.4.4 to 5.6.3. Version 5.4.4 had no content compression stage in the async execution chain at all, and its `HttpAsyncClientBuilder` does not even expose `disableContentCompression()`. Version 5.6.3 adds `ContentCompressionAsyncExec` to the default chain and enables it unless it is explicitly turned off.

Elasticsearch is not affected and needs no change. `RestClientTransportFactory` has disabled content compression at the HTTP layer since LPD-11789, and the Elasticsearch connector uses no `httpclient5` class at all: its transport is `RestClientTransport` on `httpclient` 4.x, which strips `Content-Encoding` after inflating rather than leaving it for the client to act on again.

## How It Is Being Fixed

The OpenSearch connector now mirrors what the Elasticsearch connector already does: compression is negotiated at the search client layer and disabled at the HTTP client layer, so exactly one layer inflates the body. That is a single `disableContentCompression()` call inside the existing `setHttpClientConfigCallback` lambda in `OpenSearchConnection`.

Compression still happens on the wire. `opensearch-java` sends its own `Accept-Encoding: gzip` header whenever `compressionEnabled` is set, which is the default, so responses stay compressed and are inflated exactly once by the OpenSearch client.

`OpenSearchConnectionContentCompressionTest` drives a real `count()` request against a stub `HttpServer` that gzips its response when the client accepts gzip. It asserts that the response parses and that the only `Accept-Encoding` reaching the server is the one the OpenSearch client sends, so no header arrives at all when compression is disabled. Reverting the one line fix makes both cases fail with the reported `jakarta.json.JsonException`.

The test is a separate class rather than a method on `OpenSearchConnectionTest` for two reasons: that class carries `OpenSearchTestRule`, which gates on a system property only the opt-in `run.opensearch2.unit.tests` batch sets, and its setup builds a connection against a fixed port while this test needs the stub server's ephemeral one. `ElasticsearchConnectionHttpTest` sits beside `ElasticsearchConnectionTest` in the sibling module for the same reason.

## PR Check

**pr-check: PASS** — tested on `fb983d58d6536fb2f517a3afcc7e3e6fde5aba34`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "fb983d58d6536fb2f517a3afcc7e3e6fde5aba34"} -->
