### PR TITLE
LPD-78170 LPD-89039 Order on Object Fields - Part 3

### DIFF
--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
@@ -264,16 +264,15 @@ public class AssetListAssetEntryProviderImpl
 
 		assetEntryQuery.setOrderByCol1(
 			_getOrderByColumn(
-				assetListEntry.getCompanyId(), "priority",
-				GetterUtil.getString(
-					unicodeProperties.getProperty(
-						"orderByColumn1", "priority"))));
-		assetEntryQuery.setOrderByCol2(
-			_getOrderByColumn(
 				assetListEntry.getCompanyId(), Field.MODIFIED_DATE,
 				GetterUtil.getString(
 					unicodeProperties.getProperty(
-						"orderByColumn2", Field.MODIFIED_DATE))));
+						"orderByColumn1", Field.MODIFIED_DATE))));
+		assetEntryQuery.setOrderByCol2(
+			_getOrderByColumn(
+				assetListEntry.getCompanyId(), "title",
+				GetterUtil.getString(
+					unicodeProperties.getProperty("orderByColumn2", "title"))));
 
 		assetEntryQuery.setOrderByType1(
 			GetterUtil.getString(

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
@@ -270,10 +270,10 @@ public class AssetListAssetEntryProviderImpl
 						"orderByColumn1", "priority"))));
 		assetEntryQuery.setOrderByCol2(
 			_getOrderByColumn(
-				assetListEntry.getCompanyId(), "modifiedDate",
+				assetListEntry.getCompanyId(), Field.MODIFIED_DATE,
 				GetterUtil.getString(
 					unicodeProperties.getProperty(
-						"orderByColumn2", "modifiedDate"))));
+						"orderByColumn2", Field.MODIFIED_DATE))));
 
 		assetEntryQuery.setOrderByType1(
 			GetterUtil.getString(
@@ -980,7 +980,7 @@ public class AssetListAssetEntryProviderImpl
 		long companyId, String defaultOrderByColumn, String orderByColumn) {
 
 		if (!orderByColumn.startsWith(StringPool.OPEN_CURLY_BRACE)) {
-			return orderByColumn;
+			return _toAssetEntryQueryOrderByColumn(orderByColumn);
 		}
 
 		if (FeatureFlagManagerUtil.isEnabled(companyId, "LPD-74731")) {
@@ -989,7 +989,7 @@ public class AssetListAssetEntryProviderImpl
 		}
 
 		if (orderByColumn.startsWith(StringPool.OPEN_CURLY_BRACE)) {
-			return defaultOrderByColumn;
+			return _toAssetEntryQueryOrderByColumn(defaultOrderByColumn);
 		}
 
 		return orderByColumn;
@@ -1181,6 +1181,14 @@ public class AssetListAssetEntryProviderImpl
 				Comparator.comparing(
 					AssetListEntrySegmentsEntryRel::getPriority)),
 			AssetListEntrySegmentsEntryRel::getSegmentsEntryId);
+	}
+
+	private String _toAssetEntryQueryOrderByColumn(String orderByColumn) {
+		if (orderByColumn.equals(Field.MODIFIED_DATE)) {
+			return "modifiedDate";
+		}
+
+		return orderByColumn;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderOrderByTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderOrderByTest.java
@@ -1,0 +1,285 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.list.asset.entry.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.list.asset.entry.provider.AssetListAssetEntryProvider;
+import com.liferay.asset.list.model.AssetListEntry;
+import com.liferay.asset.list.service.AssetListEntryLocalService;
+import com.liferay.asset.list.test.util.AssetListTestUtil;
+import com.liferay.info.pagination.InfoPage;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.segments.constants.SegmentsEntryConstants;
+
+import java.io.Serializable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Olivia Yu
+ */
+@RunWith(Arquillian.class)
+public class AssetListAssetEntryProviderOrderByTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
+			Arrays.asList(
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_DATE,
+					ObjectFieldConstants.DB_TYPE_DATE, true, false, null,
+					RandomTestUtil.randomString(), "dueDate", false),
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+					RandomTestUtil.randomString(), "learnDocumentation", false),
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
+					ObjectFieldConstants.DB_TYPE_INTEGER, true, false, null,
+					RandomTestUtil.randomString(), "priority", false),
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+					RandomTestUtil.randomString(), "title", false)),
+			ObjectDefinitionConstants.SCOPE_SITE);
+
+		ObjectField titleObjectField =
+			_objectFieldLocalService.fetchObjectField(
+				_objectDefinition.getObjectDefinitionId(), "title");
+
+		_objectDefinition =
+			_objectDefinitionLocalService.updateTitleObjectFieldId(
+				_objectDefinition.getObjectDefinitionId(),
+				titleObjectField.getObjectFieldId());
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testGetAssetEntriesInfoPageOrderedByObjectFieldDate()
+		throws Exception {
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"dueDate", "2026-03-01"
+			).build());
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"dueDate", "2026-01-01"
+			).build());
+		ObjectEntry objectEntry3 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"dueDate", "2026-02-01"
+			).build());
+
+		_assertOrderedObjectEntries(
+			_buildOrderByColumn("dueDate"), "ASC", objectEntry2, objectEntry3,
+			objectEntry1);
+		_assertOrderedObjectEntries(
+			_buildOrderByColumn("dueDate"), "DESC", objectEntry1, objectEntry3,
+			objectEntry2);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testGetAssetEntriesInfoPageOrderedByObjectFieldInteger()
+		throws Exception {
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"priority", 30
+			).build());
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"priority", 10
+			).build());
+		ObjectEntry objectEntry3 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"priority", 20
+			).build());
+
+		_assertOrderedObjectEntries(
+			_buildOrderByColumn("priority"), "ASC", objectEntry2, objectEntry3,
+			objectEntry1);
+		_assertOrderedObjectEntries(
+			_buildOrderByColumn("priority"), "DESC", objectEntry1, objectEntry3,
+			objectEntry2);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testGetAssetEntriesInfoPageOrderedByObjectFieldText()
+		throws Exception {
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"learnDocumentation", "charlie"
+			).build());
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"learnDocumentation", "alpha"
+			).build());
+		ObjectEntry objectEntry3 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"learnDocumentation", "bravo"
+			).build());
+
+		_assertOrderedObjectEntries(
+			_buildOrderByColumn("learnDocumentation"), "ASC", objectEntry2,
+			objectEntry3, objectEntry1);
+		_assertOrderedObjectEntries(
+			_buildOrderByColumn("learnDocumentation"), "DESC", objectEntry1,
+			objectEntry3, objectEntry2);
+	}
+
+	private AssetListEntry _addDynamicAssetListEntryWithOrderBy(
+			String orderByColumn, String orderByType)
+		throws Exception {
+
+		AssetListEntry assetListEntry = AssetListTestUtil.addAssetListEntry(
+			_group.getGroupId(), 0);
+
+		_assetListEntryLocalService.updateAssetListEntryTypeSettings(
+			assetListEntry.getAssetListEntryId(),
+			SegmentsEntryConstants.ID_DEFAULT,
+			UnicodePropertiesBuilder.create(
+				true
+			).put(
+				"anyAssetType",
+				String.valueOf(
+					_portal.getClassNameId(_objectDefinition.getClassName()))
+			).put(
+				"orderByColumn1", orderByColumn
+			).put(
+				"orderByType1", orderByType
+			).build(
+			).toString());
+
+		return _assetListEntryLocalService.getAssetListEntry(
+			assetListEntry.getAssetListEntryId());
+	}
+
+	private ObjectEntry _addObjectEntry(Map<String, Serializable> values)
+		throws Exception {
+
+		return _objectEntryLocalService.addObjectEntry(
+			_group.getGroupId(), TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null, values,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private void _assertOrderedObjectEntries(
+			String orderByColumn, String orderByType,
+			ObjectEntry... expectedObjectEntries)
+		throws Exception {
+
+		AssetListEntry assetListEntry = _addDynamicAssetListEntryWithOrderBy(
+			orderByColumn, orderByType);
+
+		InfoPage<AssetEntry> infoPage =
+			_assetListAssetEntryProvider.getAssetEntriesInfoPage(
+				assetListEntry, new long[] {SegmentsEntryConstants.ID_DEFAULT},
+				null, null, StringPool.BLANK, StringPool.BLANK,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		List<Long> actualClassPKs = TransformUtil.transform(
+			infoPage.getPageItems(), AssetEntry::getClassPK);
+
+		List<Long> expectedClassPKs = TransformUtil.transformToList(
+			expectedObjectEntries, ObjectEntry::getObjectEntryId);
+
+		Assert.assertEquals(
+			actualClassPKs.toString(), expectedClassPKs, actualClassPKs);
+	}
+
+	private String _buildOrderByColumn(String propertyName) {
+		return JSONUtil.put(
+			"classNameId",
+			_portal.getClassNameId(_objectDefinition.getClassName())
+		).put(
+			"classTypeId", _objectDefinition.getObjectDefinitionId()
+		).put(
+			"propertyName", propertyName
+		).toString();
+	}
+
+	@Inject
+	private AssetListAssetEntryProvider _assetListAssetEntryProvider;
+
+	@Inject
+	private AssetListEntryLocalService _assetListEntryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ObjectFieldLocalService _objectFieldLocalService;
+
+	@Inject
+	private Portal _portal;
+
+}

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
@@ -47,6 +47,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
@@ -2110,7 +2111,7 @@ public class AssetListAssetEntryProviderTest {
 		).put(
 			"groupIds", String.valueOf(_group.getGroupId())
 		).put(
-			"orderByColumn1", "modifiedDate"
+			"orderByColumn1", Field.MODIFIED_DATE
 		).put(
 			"orderByColumn2", "title"
 		).put(
@@ -2151,7 +2152,7 @@ public class AssetListAssetEntryProviderTest {
 		).put(
 			"groupIds", String.valueOf(_group.getGroupId())
 		).put(
-			"orderByColumn1", "modifiedDate"
+			"orderByColumn1", Field.MODIFIED_DATE
 		).put(
 			"orderByColumn2", "title"
 		).put(

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
@@ -65,6 +65,7 @@ import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -784,8 +785,8 @@ public class EditAssetListDisplayContext {
 			return _orderByColumn1;
 		}
 
-		_orderByColumn1 = GetterUtil.getString(
-			_unicodeProperties.getProperty("orderByColumn1", "modifiedDate"));
+		_orderByColumn1 = _getOrderByColumn(
+			"orderByColumn1", Field.MODIFIED_DATE);
 
 		return _orderByColumn1;
 	}
@@ -795,8 +796,7 @@ public class EditAssetListDisplayContext {
 			return _orderByColumn2;
 		}
 
-		_orderByColumn2 = GetterUtil.getString(
-			_unicodeProperties.getProperty("orderByColumn2", "title"));
+		_orderByColumn2 = _getOrderByColumn("orderByColumn2", "title");
 
 		return _orderByColumn2;
 	}
@@ -1374,6 +1374,17 @@ public class EditAssetListDisplayContext {
 			"segmentsEntryId",
 			assetListEntrySegmentsEntryRel.getSegmentsEntryId()
 		).buildString();
+	}
+
+	private String _getOrderByColumn(String key, String defaultOrderByColumn) {
+		String orderByColumn = GetterUtil.getString(
+			_unicodeProperties.getProperty(key, defaultOrderByColumn));
+
+		if (orderByColumn.equals("modifiedDate")) {
+			return Field.MODIFIED_DATE;
+		}
+
+		return orderByColumn;
 	}
 
 	private String _getTypeSettings() {

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/ordering.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/ordering.jsp
@@ -43,6 +43,10 @@
 
 					<%
 					String orderByColumn1 = editAssetListDisplayContext.getOrderByColumn1();
+
+					if (orderByColumn1.startsWith(StringPool.OPEN_CURLY_BRACE)) {
+						orderByColumn1 = "modified";
+					}
 					%>
 
 					<div class="h5"><liferay-ui:message key="order-by" /></div>
@@ -94,6 +98,10 @@
 
 					<%
 					String orderByColumn2 = editAssetListDisplayContext.getOrderByColumn2();
+
+					if (orderByColumn2.startsWith(StringPool.OPEN_CURLY_BRACE)) {
+						orderByColumn2 = "title";
+					}
 					%>
 
 					<div class="h5">

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/ordering.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/ordering.jsp
@@ -52,7 +52,7 @@
 
 						<aui:option label="create-date" selected='<%= Objects.equals(orderByColumn1, "createDate") %>' value="createDate" />
 
-						<aui:option label="modified-date" selected='<%= Objects.equals(orderByColumn1, "modifiedDate") %>' value="modifiedDate" />
+						<aui:option label="modified-date" selected='<%= Objects.equals(orderByColumn1, "modified") %>' value="modified" />
 
 						<aui:option label="publish-date" selected='<%= Objects.equals(orderByColumn1, "publishDate") %>' value="publishDate" />
 
@@ -105,7 +105,7 @@
 
 						<aui:option label="create-date" selected='<%= Objects.equals(orderByColumn2, "createDate") %>' value="createDate" />
 
-						<aui:option label="modified-date" selected='<%= Objects.equals(orderByColumn2, "modifiedDate") %>' value="modifiedDate" />
+						<aui:option label="modified-date" selected='<%= Objects.equals(orderByColumn2, "modified") %>' value="modified" />
 
 						<aui:option label="publish-date" selected='<%= Objects.equals(orderByColumn2, "publishDate") %>' value="publishDate" />
 

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/CollectionOrdering/index.tsx
@@ -17,7 +17,7 @@ import type {
 	FilterPropertyGroup,
 } from '../CollectionFilterBuilder/types';
 
-const DEFAULT_ORDER_BY_COLUMN_1 = 'modifiedDate';
+const DEFAULT_ORDER_BY_COLUMN_1 = 'modified';
 const DEFAULT_ORDER_BY_COLUMN_2 = 'title';
 
 type OrderByType = 'ASC' | 'DESC';

--- a/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContextTest.java
+++ b/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContextTest.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.module.service.Snapshot;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -207,6 +208,36 @@ public class EditAssetListDisplayContextTest {
 					RandomTestUtil.randomLong(), RandomTestUtil.randomLong(),
 					RandomTestUtil.randomLong()
 				}));
+	}
+
+	@Test
+	public void testGetOrderByColumnsWhenLegacyModifiedDateIsSaved() {
+		EditAssetListDisplayContext editAssetListDisplayContext =
+			_getEditAssetListDisplayContext(
+				UnicodePropertiesBuilder.put(
+					"orderByColumn1", "modifiedDate"
+				).put(
+					"orderByColumn2", "modifiedDate"
+				).build());
+
+		Assert.assertEquals(
+			Field.MODIFIED_DATE,
+			editAssetListDisplayContext.getOrderByColumn1());
+		Assert.assertEquals(
+			Field.MODIFIED_DATE,
+			editAssetListDisplayContext.getOrderByColumn2());
+	}
+
+	@Test
+	public void testGetOrderByColumnsWhenUnset() {
+		EditAssetListDisplayContext editAssetListDisplayContext =
+			_getEditAssetListDisplayContext(new UnicodeProperties());
+
+		Assert.assertEquals(
+			Field.MODIFIED_DATE,
+			editAssetListDisplayContext.getOrderByColumn1());
+		Assert.assertEquals(
+			"title", editAssetListDisplayContext.getOrderByColumn2());
 	}
 
 	@Test

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
@@ -682,9 +682,11 @@ public class AssetHelperImpl implements AssetHelper {
 		int sortType = Sort.STRING_TYPE;
 
 		if (fieldType.equals(Field.CREATE_DATE) ||
+			fieldType.equals(Field.DISPLAY_DATE) ||
 			fieldType.equals(Field.EXPIRATION_DATE) ||
 			fieldType.equals(Field.MODIFIED_DATE) ||
 			fieldType.equals(Field.PUBLISH_DATE) ||
+			fieldType.equals(Field.REVIEW_DATE) ||
 			fieldType.equals("modifiedDate")) {
 
 			sortType = Sort.LONG_TYPE;
@@ -692,7 +694,9 @@ public class AssetHelperImpl implements AssetHelper {
 		else if (fieldType.equals(Field.PRIORITY)) {
 			sortType = Sort.DOUBLE_TYPE;
 		}
-		else if (fieldType.equals("viewCount")) {
+		else if (fieldType.equals(Field.STATUS) ||
+				 fieldType.equals("viewCount")) {
+
 			sortType = Sort.INT_TYPE;
 		}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89039
https://liferay.atlassian.net/browse/LPD-103180

Part 3 of epic to filter by object fields

On top of changes from Part 2 (in review): https://github.com/brianchandotcom/liferay-portal/pull/180822

## What Is Being Fixed

Dynamic Collections could not be ordered by object fields. The ordering dropdown offered only asset-level columns, and when a collection's type settings did name an object field, the provider handed the raw JSON straight to `AssetEntryQuery`, which rejected the column and silently fell back to a default — so the collection came back in an arbitrary order with no indication anything had gone wrong.

Two gaps sat underneath that. The collection's default ordering did not match what the edit screen showed, so a collection whose ordering had never been touched displayed one thing and returned another. And `AssetHelperImpl` never listed display date, review date, or status among its sort types, so all three fell through to `Sort.STRING_TYPE` and ordered lexicographically on the raw field instead of on the sortable doc value.

## How It Is Being Fixed

Two strands, kept as separate commit runs.

**Ordering by object field (LPD-89039).** `asset-list-web` falls back to the previous `orderByColumn` values when FF-74731 is off, and `AssetListAssetEntryProviderImpl` defaults ordering to modified date then title so the provider agrees with `EditAssetListDisplayContext`. `AssetHelperImpl` gains the sort types it was missing: display date, review date, and status. The sort type decides the field name, and `SortFieldBuilder` appends the sortable suffix only for numeric types, so without this those three ordered on the raw field rather than on the sortable doc value.

**Modified vs. modified date (LPD-103180).** The collection ordering UI and the provider now speak `Field.MODIFIED_DATE` consistently, matching the rest of the search vocabulary. `AssetEntryQuery` accepts only the column names in `ORDER_BY_COLUMNS`, so the provider translates back to `"modifiedDate"` on the way out rather than teaching the kernel a second spelling for the same column — which keeps `portal-impl` and `portal-kernel` out of this strand entirely.

## PR Check

**pr-check: PASS** — tested on `65b8da5cf74b291df62c49e4cfe23b8913f71215`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| JSP Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

Java Unit Tests ran `EditAssetListDisplayContextTest` (7 tests, 0 failures). `AssetHelperImpl` and `AssetListAssetEntryProviderImpl` have no unit-test counterparts, so those two changes are exercised only by `AssetListAssetEntryProviderOrderByTest`, an integration test outside pr-check's scope.

JavaScript Unit Tests ran the module's only suite, `VariationsNav.test.js` (14 tests, 0 failures). The changed `CollectionOrdering/index.tsx` has no test of its own.

<!-- pr-check {"result": "success", "sha": "65b8da5cf74b291df62c49e4cfe23b8913f71215"} -->
