### PR TITLE
LPD-78170 LPD-89039 Order on Object Fields - Part 2

### DIFF
--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
@@ -19,6 +19,7 @@ import com.liferay.asset.list.asset.entry.provider.AssetListAssetEntryProvider;
 import com.liferay.asset.list.constants.AssetListEntryTypeConstants;
 import com.liferay.asset.list.internal.configuration.AssetListConfiguration;
 import com.liferay.asset.list.internal.util.AssetListFiltersUtil;
+import com.liferay.asset.list.internal.util.AssetListOrderByColumnUtil;
 import com.liferay.asset.list.model.AssetListEntry;
 import com.liferay.asset.list.model.AssetListEntryAssetEntryRel;
 import com.liferay.asset.list.model.AssetListEntryAssetEntryRelModel;
@@ -261,15 +262,19 @@ public class AssetListAssetEntryProviderImpl
 			}
 		}
 
-		String orderByColumn1 = GetterUtil.getString(
-			unicodeProperties.getProperty("orderByColumn1", "priority"));
+		assetEntryQuery.setOrderByCol1(
+			_getOrderByColumn(
+				assetListEntry.getCompanyId(), "priority",
+				GetterUtil.getString(
+					unicodeProperties.getProperty(
+						"orderByColumn1", "priority"))));
 
-		assetEntryQuery.setOrderByCol1(orderByColumn1);
-
-		String orderByColumn2 = GetterUtil.getString(
-			unicodeProperties.getProperty("orderByColumn2", "modifiedDate"));
-
-		assetEntryQuery.setOrderByCol2(orderByColumn2);
+		assetEntryQuery.setOrderByCol2(
+			_getOrderByColumn(
+				assetListEntry.getCompanyId(), "modifiedDate",
+				GetterUtil.getString(
+					unicodeProperties.getProperty(
+						"orderByColumn2", "modifiedDate"))));
 
 		assetEntryQuery.setOrderByType1(
 			GetterUtil.getString(
@@ -970,6 +975,25 @@ public class AssetListAssetEntryProviderImpl
 		searchContext.setKeywords(keywords);
 
 		return searchContext;
+	}
+
+	private String _getOrderByColumn(
+		long companyId, String defaultOrderByColumn, String orderByColumn) {
+
+		if (!orderByColumn.startsWith(StringPool.OPEN_CURLY_BRACE)) {
+			return orderByColumn;
+		}
+
+		if (FeatureFlagManagerUtil.isEnabled(companyId, "LPD-74731")) {
+			orderByColumn = AssetListOrderByColumnUtil.toOrderByColumn(
+				companyId, orderByColumn);
+		}
+
+		if (orderByColumn.startsWith(StringPool.OPEN_CURLY_BRACE)) {
+			return defaultOrderByColumn;
+		}
+
+		return orderByColumn;
 	}
 
 	private long[] _getReferencedModelsGroupIds(long[] groupIds) {

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
@@ -268,7 +268,6 @@ public class AssetListAssetEntryProviderImpl
 				GetterUtil.getString(
 					unicodeProperties.getProperty(
 						"orderByColumn1", "priority"))));
-
 		assetEntryQuery.setOrderByCol2(
 			_getOrderByColumn(
 				assetListEntry.getCompanyId(), "modifiedDate",

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -6,10 +6,7 @@
 package com.liferay.asset.list.internal.util;
 
 import com.liferay.object.constants.ObjectFieldConstants;
-import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
-import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
-import com.liferay.object.service.ObjectFieldLocalServiceUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -29,7 +26,6 @@ import com.liferay.portal.kernel.search.WildcardQuery;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -92,32 +88,6 @@ public class AssetListFiltersUtil {
 		};
 	}
 
-	private static ObjectDefinition _fetchObjectDefinition(
-		long classNameId, long companyId) {
-
-		if (classNameId <= 0) {
-			return null;
-		}
-
-		return ObjectDefinitionLocalServiceUtil.
-			fetchObjectDefinitionByClassName(
-				companyId, PortalUtil.getClassName(classNameId));
-	}
-
-	private static ObjectField _fetchObjectField(
-		long classNameId, long companyId, String name) {
-
-		ObjectDefinition objectDefinition = _fetchObjectDefinition(
-			classNameId, companyId);
-
-		if (objectDefinition == null) {
-			return null;
-		}
-
-		return ObjectFieldLocalServiceUtil.fetchObjectField(
-			objectDefinition.getObjectDefinitionId(), name);
-	}
-
 	private static String _getCommonFieldName(
 		Locale locale, String propertyName) {
 
@@ -134,50 +104,6 @@ public class AssetListFiltersUtil {
 
 	private static String _getCommonFieldType(String propertyName) {
 		return _commonFieldTypesMap.get(propertyName);
-	}
-
-	private static String _getSubfield(Locale locale, ObjectField objectField) {
-		if (objectField.isIndexedAsKeyword()) {
-			return "nestedFieldArray.value_keyword";
-		}
-
-		String dbType = objectField.getDBType();
-
-		if (ObjectFieldConstants.DB_TYPE_BIG_DECIMAL.equals(dbType) ||
-			ObjectFieldConstants.DB_TYPE_DOUBLE.equals(dbType)) {
-
-			return "nestedFieldArray.value_double";
-		}
-
-		if (ObjectFieldConstants.DB_TYPE_BOOLEAN.equals(dbType)) {
-			return "nestedFieldArray.value_boolean";
-		}
-
-		if (ObjectFieldConstants.DB_TYPE_DATE.equals(dbType) ||
-			ObjectFieldConstants.DB_TYPE_DATE_TIME.equals(dbType)) {
-
-			return "nestedFieldArray.value_date";
-		}
-
-		if (ObjectFieldConstants.DB_TYPE_INTEGER.equals(dbType)) {
-			return "nestedFieldArray.value_integer";
-		}
-
-		if (ObjectFieldConstants.DB_TYPE_LONG.equals(dbType)) {
-			return "nestedFieldArray.value_long";
-		}
-
-		if (objectField.isLocalized()) {
-			return Field.getLocalizedName(locale, "nestedFieldArray.value");
-		}
-
-		String indexedLanguageId = objectField.getIndexedLanguageId();
-
-		if (Validator.isNotNull(indexedLanguageId)) {
-			return "nestedFieldArray.value_" + indexedLanguageId;
-		}
-
-		return "nestedFieldArray.value_text";
 	}
 
 	private static boolean _isCommonFieldRow(JSONObject jsonObject) {
@@ -342,7 +268,7 @@ public class AssetListFiltersUtil {
 			return null;
 		}
 
-		ObjectField objectField = _fetchObjectField(
+		ObjectField objectField = AssetListObjectFieldUtil.fetchObjectField(
 			jsonObject.getLong("classNameId"), companyId, propertyName);
 
 		if (objectField == null) {
@@ -351,7 +277,8 @@ public class AssetListFiltersUtil {
 
 		String operatorName = jsonObject.getString("operatorName", "contains");
 
-		String subfield = _getSubfield(locale, objectField);
+		String subfield = AssetListObjectFieldUtil.getFilterSubfield(
+			locale, objectField);
 
 		Query query = _toValueQuery(
 			jsonObject, objectField, operatorName, subfield, value);

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListObjectFieldUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListObjectFieldUtil.java
@@ -1,0 +1,115 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.list.internal.util;
+
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
+import com.liferay.object.service.ObjectFieldLocalServiceUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Locale;
+
+/**
+ * @author Joshua Cords
+ * @author Olivia Yu
+ */
+public class AssetListObjectFieldUtil {
+
+	public static ObjectField fetchObjectField(
+		long classNameId, long companyId, String name) {
+
+		if (classNameId <= 0) {
+			return null;
+		}
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionLocalServiceUtil.fetchObjectDefinitionByClassName(
+				companyId, PortalUtil.getClassName(classNameId));
+
+		if (objectDefinition == null) {
+			return null;
+		}
+
+		return ObjectFieldLocalServiceUtil.fetchObjectField(
+			objectDefinition.getObjectDefinitionId(), name);
+	}
+
+	public static String getFilterSubfield(
+		Locale locale, ObjectField objectField) {
+
+		String subfieldSuffix = _getTypedSubfieldSuffix(objectField);
+
+		if (subfieldSuffix != null) {
+			return "nestedFieldArray." + subfieldSuffix;
+		}
+
+		if (objectField.isLocalized()) {
+			return "nestedFieldArray." +
+				Field.getLocalizedName(locale, "value");
+		}
+
+		String indexedLanguageId = objectField.getIndexedLanguageId();
+
+		if (Validator.isNotNull(indexedLanguageId)) {
+			return "nestedFieldArray.value_" + indexedLanguageId;
+		}
+
+		return "nestedFieldArray.value_text";
+	}
+
+	public static String getSortSubfield(ObjectField objectField) {
+		String subfieldSuffix = _getTypedSubfieldSuffix(objectField);
+
+		if (subfieldSuffix == null) {
+			subfieldSuffix = "value_keyword_lowercase";
+		}
+
+		return StringBundler.concat(
+			"nestedFieldArray.", objectField.getName(), StringPool.PERIOD,
+			subfieldSuffix);
+	}
+
+	private static String _getTypedSubfieldSuffix(ObjectField objectField) {
+		if (objectField.isIndexedAsKeyword()) {
+			return "value_keyword";
+		}
+
+		String dbType = objectField.getDBType();
+
+		if (ObjectFieldConstants.DB_TYPE_BIG_DECIMAL.equals(dbType) ||
+			ObjectFieldConstants.DB_TYPE_DOUBLE.equals(dbType)) {
+
+			return "value_double";
+		}
+
+		if (ObjectFieldConstants.DB_TYPE_BOOLEAN.equals(dbType)) {
+			return "value_boolean";
+		}
+
+		if (ObjectFieldConstants.DB_TYPE_DATE.equals(dbType) ||
+			ObjectFieldConstants.DB_TYPE_DATE_TIME.equals(dbType)) {
+
+			return "value_date";
+		}
+
+		if (ObjectFieldConstants.DB_TYPE_INTEGER.equals(dbType)) {
+			return "value_integer";
+		}
+
+		if (ObjectFieldConstants.DB_TYPE_LONG.equals(dbType)) {
+			return "value_long";
+		}
+
+		return null;
+	}
+
+}

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListOrderByColumnUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListOrderByColumnUtil.java
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.list.internal.util;
+
+import com.liferay.object.model.ObjectField;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+/**
+ * @author Joshua Cords
+ * @author Olivia Yu
+ */
+public class AssetListOrderByColumnUtil {
+
+	public static String toOrderByColumn(long companyId, String orderByColumn) {
+		if (Validator.isNull(orderByColumn) ||
+			!orderByColumn.startsWith(StringPool.OPEN_CURLY_BRACE)) {
+
+			return orderByColumn;
+		}
+
+		JSONObject jsonObject = null;
+
+		try {
+			jsonObject = JSONFactoryUtil.createJSONObject(orderByColumn);
+		}
+		catch (JSONException jsonException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to parse order by column: " + orderByColumn,
+					jsonException);
+			}
+
+			return orderByColumn;
+		}
+
+		ObjectField objectField = AssetListObjectFieldUtil.fetchObjectField(
+			jsonObject.getLong("classNameId"), companyId,
+			jsonObject.getString("propertyName"));
+
+		if (objectField == null) {
+			return orderByColumn;
+		}
+
+		return AssetListObjectFieldUtil.getSortSubfield(objectField);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AssetListOrderByColumnUtil.class);
+
+}

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListOrderByColumnUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListOrderByColumnUtilTest.java
@@ -1,0 +1,192 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.list.internal.util;
+
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
+import com.liferay.object.service.ObjectFieldLocalServiceUtil;
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Joshua Cords
+ * @author Olivia Yu
+ */
+public class AssetListOrderByColumnUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
+
+		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_objectDefinitionLocalServiceUtilMockedStatic.close();
+		_objectFieldLocalServiceUtilMockedStatic.close();
+		_portalUtilMockedStatic.close();
+	}
+
+	@Before
+	public void setUp() {
+		_objectDefinitionLocalServiceUtilMockedStatic.reset();
+		_objectFieldLocalServiceUtilMockedStatic.reset();
+		_portalUtilMockedStatic.reset();
+	}
+
+	@Test
+	public void testToOrderByColumnIgnoresUnresolvableObjectField() {
+		String orderByColumn = _buildOrderByColumn("dueDate");
+
+		Assert.assertEquals(
+			orderByColumn,
+			AssetListOrderByColumnUtil.toOrderByColumn(
+				_COMPANY_ID, orderByColumn));
+	}
+
+	@Test
+	public void testToOrderByColumnWithKeywordTextField() {
+		ObjectField objectField = _setUpObjectField(
+			ObjectFieldConstants.DB_TYPE_STRING, "name");
+
+		Mockito.when(
+			objectField.isIndexedAsKeyword()
+		).thenReturn(
+			true
+		);
+
+		Assert.assertEquals(
+			"nestedFieldArray.name.value_keyword",
+			AssetListOrderByColumnUtil.toOrderByColumn(
+				_COMPANY_ID, _buildOrderByColumn("name")));
+	}
+
+	@Test
+	public void testToOrderByColumnWithLegacyColumn() {
+		Assert.assertEquals(
+			"priority",
+			AssetListOrderByColumnUtil.toOrderByColumn(
+				_COMPANY_ID, "priority"));
+	}
+
+	@Test
+	public void testToOrderByColumnWithNumericField() {
+		_setUpObjectField(ObjectFieldConstants.DB_TYPE_DOUBLE, "amount");
+
+		Assert.assertEquals(
+			"nestedFieldArray.amount.value_double",
+			AssetListOrderByColumnUtil.toOrderByColumn(
+				_COMPANY_ID, _buildOrderByColumn("amount")));
+	}
+
+	@Test
+	public void testToOrderByColumnWithTextField() {
+		_setUpObjectField(ObjectFieldConstants.DB_TYPE_STRING, "description");
+
+		Assert.assertEquals(
+			"nestedFieldArray.description.value_keyword_lowercase",
+			AssetListOrderByColumnUtil.toOrderByColumn(
+				_COMPANY_ID, _buildOrderByColumn("description")));
+	}
+
+	private String _buildOrderByColumn(String propertyName) {
+		return JSONUtil.put(
+			"classNameId", _CLASS_NAME_ID
+		).put(
+			"classTypeId", _CLASS_TYPE_ID
+		).put(
+			"propertyName", propertyName
+		).toString();
+	}
+
+	private ObjectField _setUpObjectField(String dbType, String name) {
+		ObjectField objectField = Mockito.mock(ObjectField.class);
+
+		Mockito.when(
+			objectField.getDBType()
+		).thenReturn(
+			dbType
+		);
+
+		Mockito.when(
+			objectField.getName()
+		).thenReturn(
+			name
+		);
+
+		ObjectDefinition objectDefinition = Mockito.mock(
+			ObjectDefinition.class);
+
+		Mockito.when(
+			objectDefinition.getObjectDefinitionId()
+		).thenReturn(
+			_CLASS_TYPE_ID
+		);
+
+		_objectDefinitionLocalServiceUtilMockedStatic.when(
+			() ->
+				ObjectDefinitionLocalServiceUtil.
+					fetchObjectDefinitionByClassName(
+						_COMPANY_ID, "com.liferay.test.Class" + _CLASS_NAME_ID)
+		).thenReturn(
+			objectDefinition
+		);
+
+		_objectFieldLocalServiceUtilMockedStatic.when(
+			() -> ObjectFieldLocalServiceUtil.fetchObjectField(
+				_CLASS_TYPE_ID, name)
+		).thenReturn(
+			objectField
+		);
+
+		_portalUtilMockedStatic.when(
+			() -> PortalUtil.getClassName(_CLASS_NAME_ID)
+		).thenReturn(
+			"com.liferay.test.Class" + _CLASS_NAME_ID
+		);
+
+		return objectField;
+	}
+
+	private static final long _CLASS_NAME_ID = RandomTestUtil.randomLong();
+
+	private static final long _CLASS_TYPE_ID = RandomTestUtil.randomLong();
+
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
+
+	private static final MockedStatic<ObjectDefinitionLocalServiceUtil>
+		_objectDefinitionLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			ObjectDefinitionLocalServiceUtil.class);
+	private static final MockedStatic<ObjectFieldLocalServiceUtil>
+		_objectFieldLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			ObjectFieldLocalServiceUtil.class);
+	private static final MockedStatic<PortalUtil> _portalUtilMockedStatic =
+		Mockito.mockStatic(PortalUtil.class);
+
+}

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
@@ -199,6 +199,18 @@ public class AssetListTypePropertiesUtil {
 			_log);
 	}
 
+	private static boolean _isSortable(String businessType) {
+		if (businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_LONG_TEXT) ||
+			businessType.equals(
+				ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST) ||
+			businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT)) {
+
+			return false;
+		}
+
+		return true;
+	}
+
 	private static JSONObject _toPropertyJSONObject(
 		long classNameId, long classTypeId, Locale locale,
 		ObjectField objectField, String type) {
@@ -230,6 +242,8 @@ public class AssetListTypePropertiesUtil {
 					),
 					_log);
 			}
+		).put(
+			"sortable", _isSortable(objectField.getBusinessType())
 		).put(
 			"type", type
 		);

--- a/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
+++ b/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
@@ -164,6 +164,66 @@ public class AssetListTypePropertiesUtilTest {
 	}
 
 	@Test
+	public void testGetTypePropertiesJSONArrayEmitsSortableFlag() {
+		_setUpObjectDefinition(
+			_CLASS_NAME_ID_1, _LABEL_1, _CLASS_TYPE_ID_1,
+			Arrays.asList(
+				_mockObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN, false,
+					"active"),
+				_mockObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_DATE, false, "due"),
+				_mockObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_INTEGER, false, "rank"),
+				_mockObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_LONG_TEXT, false,
+					"summary"),
+				_mockObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST,
+					false, "labels"),
+				_mockObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_PICKLIST, false,
+					"category"),
+				_mockObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT, false,
+					"body"),
+				_mockObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT, false, "title")));
+
+		JSONArray jsonArray =
+			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
+				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
+				_COMPANY_ID, LocaleUtil.US);
+
+		JSONArray itemsJSONArray = jsonArray.getJSONObject(
+			1
+		).getJSONArray(
+			"items"
+		);
+
+		Assert.assertEquals(
+			itemsJSONArray.toString(), 8, itemsJSONArray.length());
+
+		for (int i = 0; i < itemsJSONArray.length(); i++) {
+			JSONObject itemJSONObject = itemsJSONArray.getJSONObject(i);
+
+			String name = itemJSONObject.getString("name");
+
+			boolean expectedSortable = true;
+
+			if (name.equals("body") || name.equals("labels") ||
+				name.equals("summary")) {
+
+				expectedSortable = false;
+			}
+
+			Assert.assertEquals(
+				itemJSONObject.toString(), expectedSortable,
+				itemJSONObject.getBoolean("sortable"));
+		}
+	}
+
+	@Test
 	public void testGetTypePropertiesJSONArrayEmitsTypeGroupWithEmptyItemsWhenNoFieldsFilterable() {
 		_setUpObjectDefinition(
 			_CLASS_NAME_ID_1, _LABEL_1, _CLASS_TYPE_ID_1,

--- a/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
+++ b/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
@@ -195,11 +195,8 @@ public class AssetListTypePropertiesUtilTest {
 				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
 				_COMPANY_ID, LocaleUtil.US);
 
-		JSONArray itemsJSONArray = jsonArray.getJSONObject(
-			1
-		).getJSONArray(
-			"items"
-		);
+		JSONArray itemsJSONArray = JSONUtil.getValueAsJSONArray(
+			jsonArray, "JSONObject/1", "JSONArray/items");
 
 		Assert.assertEquals(
 			itemsJSONArray.toString(), 8, itemsJSONArray.length());
@@ -270,11 +267,8 @@ public class AssetListTypePropertiesUtilTest {
 
 		Assert.assertEquals(jsonArray.toString(), 2, jsonArray.length());
 
-		JSONArray itemsJSONArray = jsonArray.getJSONObject(
-			1
-		).getJSONArray(
-			"items"
-		);
+		JSONArray itemsJSONArray = JSONUtil.getValueAsJSONArray(
+			jsonArray, "JSONObject/1", "JSONArray/items");
 
 		Assert.assertEquals(
 			itemsJSONArray.toString(), 1, itemsJSONArray.length());

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
@@ -21,6 +21,7 @@ import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
 import com.liferay.asset.util.AssetHelper;
 import com.liferay.asset.util.AssetPublisherAddItemHolder;
 import com.liferay.dynamic.data.mapping.util.DDMIndexer;
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -64,9 +65,11 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.hits.SearchHit;
 import com.liferay.portal.search.hits.SearchHits;
 import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.query.QueriesUtil;
 import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.portal.search.sort.FieldSort;
+import com.liferay.portal.search.sort.NestedSort;
 import com.liferay.portal.search.sort.SortOrder;
 import com.liferay.portal.search.sort.Sorts;
 
@@ -613,16 +616,29 @@ public class AssetHelperImpl implements AssetHelper {
 		throws Exception {
 
 		if (sortField.startsWith(DDMIndexer.DDM_FIELD_PREFIX)) {
-			SortOrder sortOrder = SortOrder.ASC;
-
-			if (Validator.isNotNull(orderByType) &&
-				!StringUtil.equalsIgnoreCase(orderByType, "asc")) {
-
-				sortOrder = SortOrder.DESC;
-			}
-
 			return _ddmIndexer.createDDMStructureFieldSort(
-				sortField, locale, sortOrder);
+				sortField, locale, _getSortOrder(orderByType));
+		}
+
+		if (sortField.startsWith("nestedFieldArray.")) {
+			String[] sortFieldParts = StringUtil.split(
+				sortField, CharPool.PERIOD);
+
+			if (sortFieldParts.length == 3) {
+				FieldSort fieldSort = _sorts.field(
+					sortFieldParts[0] + StringPool.PERIOD + sortFieldParts[2],
+					_getSortOrder(orderByType));
+
+				NestedSort nestedSort = _sorts.nested(sortFieldParts[0]);
+
+				nestedSort.setFilterQuery(
+					QueriesUtil.term(
+						sortFieldParts[0] + ".fieldName", sortFieldParts[1]));
+
+				fieldSort.setNestedSort(nestedSort);
+
+				return fieldSort;
+			}
 		}
 
 		Sort sort = SortFactoryUtil.getSort(
@@ -650,6 +666,16 @@ public class AssetHelperImpl implements AssetHelper {
 			locale);
 
 		return new com.liferay.portal.search.sort.Sort[] {sort1, sort2};
+	}
+
+	private SortOrder _getSortOrder(String orderByType) {
+		if (Validator.isNotNull(orderByType) &&
+			!StringUtil.equalsIgnoreCase(orderByType, "asc")) {
+
+			return SortOrder.DESC;
+		}
+
+		return SortOrder.ASC;
 	}
 
 	private int _getSortType(String fieldType) {

--- a/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetEntryQuery.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetEntryQuery.java
@@ -44,8 +44,9 @@ public class AssetEntryQuery {
 	public static String checkOrderByCol(String orderByCol) {
 		if (ArrayUtil.contains(ORDER_BY_COLUMNS, orderByCol) ||
 			((orderByCol != null) &&
-			 orderByCol.startsWith(
-				 DDMStructureManager.STRUCTURE_INDEXER_FIELD_PREFIX))) {
+			 (orderByCol.startsWith(
+				 DDMStructureManager.STRUCTURE_INDEXER_FIELD_PREFIX) ||
+			  orderByCol.startsWith("nestedFieldArray.")))) {
 
 			return orderByCol;
 		}


### PR DESCRIPTION
Resent from https://github.com/brianchandotcom/liferay-portal/pull/180822

https://liferay.atlassian.net/browse/LPD-78170
https://liferay.atlassian.net/browse/LPD-89039

Part 2 of the greater task for ordering Dynamic Collections by an Object field (Object-defined). The FE renders an order-by dropdown of the Object's filterable, sortable fields; the saved descriptor resolves to a nested FieldSort against the right nestedFieldArray.value_ subfield.

This is the liferay-search#2121 work rebased onto current master, plus two review fixes: line removal + `AssetListTypePropertiesUtilTest` now reads the items array with `JSONUtil.getValue`.

## What Is Being Fixed

- Dynamic collections could only be ordered by a fixed set of flat asset columns — title, create date, modified date, publish date, expiration date, and priority.
- Object fields on CMS and Site-scoped object definitions were not offered as ordering options, so a collection could not be ordered by the object data it displays.
- The query layer had no way to sort on an object field, which is indexed as a nested `nestedFieldArray` document rather than a flat asset column.

## How It Is Being Fixed

- **asset-list-web: Emit sortable flag on object field properties** — Each property in the type-properties JSON now carries a `sortable` flag. Long text, rich text, and multiselect picklist fields are marked non-sortable so the ordering picker can exclude them.
- **asset-list-service: Extract shared object field resolution** — `fetchObjectField`, `getFilterSubfield`, and `getSortSubfield` move out of `AssetListFiltersUtil` into a new `AssetListObjectFieldUtil`, so filtering and ordering resolve object fields and index subfields through one path.
- **asset-list-service: Order collections by object field** — A new `AssetListOrderByColumnUtil` converts a JSON order-by column into a `nestedFieldArray.<name>.<subfield>` sort field. `AssetListAssetEntryProviderImpl` calls it behind feature flag `LPD-74731` and falls back to the default column when the value cannot be resolved.
- **asset-service: Build nested field sort for object field ordering** — `AssetHelperImpl` recognizes a nested field name and builds a `FieldSort` carrying a `NestedSort` filtered on that field name, instead of falling through to the flat-column path.
- **portal-kernel: Let nestedFieldArray-prefixed columns** — Updates portal-kernel in order to allow those `nestedFieldArray.<name>.<subfield>` as part of orderByCol.

## PR Check

**pr-check: PASS** — tested on `cdfc994841ffec997438bf2ab0d3f944068f99fe`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "cdfc994841ffec997438bf2ab0d3f944068f99fe"} -->
