### PR TITLE
LPD-93003 Match userName filter casing to the index

### DIFF
--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -296,6 +296,10 @@ public class AssetListFiltersUtil {
 			return new MatchQuery(field, value);
 		}
 
+		if (Objects.equals(field, Field.USER_NAME)) {
+			value = StringUtil.toLowerCase(value);
+		}
+
 		if (operatorName.equals("contains") ||
 			operatorName.equals("not-contains")) {
 

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.util.FastDateFormatFactoryImpl;
 
@@ -123,13 +124,14 @@ public class AssetListFiltersUtilTest {
 		String userName = RandomTestUtil.randomString();
 
 		_assertTermQuery(
-			Field.USER_NAME, userName,
+			Field.USER_NAME, StringUtil.toLowerCase(userName),
 			_assertCommonFieldQuery(
 				BooleanClauseOccur.MUST,
 				_getCommonFieldFilterJSONObject(
 					"eq", Field.USER_NAME, userName)));
 		_assertWildcardQuery(
-			Field.USER_NAME, StringBundler.concat("*", userName, "*"),
+			Field.USER_NAME,
+			StringBundler.concat("*", StringUtil.toLowerCase(userName), "*"),
 			_assertCommonFieldQuery(
 				BooleanClauseOccur.MUST_NOT,
 				_getCommonFieldFilterJSONObject(

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -408,6 +408,32 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
 	@Test
+	public void testGetAssetEntriesInfoPageWithMixedCaseUserNameFilters()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
+			).build());
+
+		String userName = TestPropsValues.getUser(
+		).getFullName();
+
+		_assertFilteredClassPKs(
+			_getFiltersJSONArray(
+				_getCommonFieldFilterJSONObject(
+					"contains", Field.USER_NAME,
+					StringUtil.toUpperCase(userName))),
+			objectEntry);
+		_assertFilteredClassPKs(
+			_getFiltersJSONArray(
+				_getCommonFieldFilterJSONObject(
+					"eq", Field.USER_NAME, StringUtil.toUpperCase(userName))),
+			objectEntry);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
 	public void testGetAssetEntriesInfoPageWithMultipleFiltersJoinedWithMust()
 		throws Exception {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93003

## What Is Being Fixed

Asset list Common Field filters on `userName` never matched when the value carried uppercase characters — which a full name almost always does.

## How It Is Being Fixed

`AssetListFiltersUtil` now lowercases the filter value for `Field.USER_NAME` before building the term or wildcard query. `userName` is a special case: it is the one Common Field the indexer stores lowercased, because `AuditedModelDocumentContributor` adds it with `document.addKeyword(Field.USER_NAME, ..., true)`, and that `lowerCase` flag routes the value through `StringUtil.toLowerCase` in `DocumentImpl.createKeywordField`. Every other Common Field is indexed as entered, so the adjustment is scoped to this field rather than made a general rule.

Unit coverage asserts the lowercased term and wildcard queries; an integration test filters with an upper-cased user name end to end.

## PR Check

**pr-check: PASS** — tested on `c5719c458f5ca649b220910ca2c2fbeac1875396`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c5719c458f5ca649b220910ca2c2fbeac1875396"} -->
