### PR TITLE
LPD-103858 Label a collection's missing item subtype with its ID

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
@@ -153,7 +153,7 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 						}
 					%>
 
-						<aui:option label="<%= String.valueOf(assetSelectedClassTypeId) %>" selected="<%= !anyAssetSubtype && (assetSelectedClassTypeIds.length == 1) && !noAssetSubtypeSelected %>" value="<%= assetSelectedClassTypeId %>" />
+						<aui:option label='<%= LanguageUtil.format(request, "id-x", String.valueOf(assetSelectedClassTypeId)) %>' selected="<%= !anyAssetSubtype && (assetSelectedClassTypeIds.length == 1) && !noAssetSubtypeSelected %>" value="<%= assetSelectedClassTypeId %>" />
 
 					<%
 					}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/collections/Collections.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/collections/Collections.testcase
@@ -970,10 +970,10 @@ definition {
 				locator1 = "Select#ANY",
 				value1 = "Web Content Article");
 
-			AssertSelectedLabel(
+			AssertTextEquals.assertPartialText(
 				key_selectFieldLabel = "Item Subtype",
 				locator1 = "Select#ANY",
-				value1 = "-Not Selected-");
+				value1 = "ID:");
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103858

## What Is Being Fixed

When a collection is configured with an item subtype — a web content structure, for example — and that structure is later deleted, the Item Subtype selector in the collection's source configuration still holds the now-missing subtype. It rendered as a bare number, the raw class type ID, with nothing to say what the number was, so the field read as unnamed and gave no clue which subtype had gone missing.

## How It Is Being Fixed

The option for a selected class type ID that is no longer among the available class types now runs its label through the existing `id-x` language key, so it renders as `ID: 38412` instead of `38412`, naming the value as the identifier of a subtype that no longer exists.

The functional test `Collections#ViewCollectionAfterDeleteItemSubtype` already covers this case, and its assertion is updated to match. It asserted the exact selected label through `AssertSelectedLabel`, which cannot hold here because the ID is assigned at runtime, so it now asserts partial text against the Item Subtype select and matches on the `ID:` prefix. The test was run locally against a deployed bundle and passes.

## PR Check

**pr-check: PASS** — tested on `1a682e1f446a9170713496be7b5c3ca86ef0c62d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |
| JSP Compile | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "1a682e1f446a9170713496be7b5c3ca86ef0c62d"} -->

