### PR TITLE
LPD-93003 Match userName filter casing to the index

### DIFF
--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -222,6 +222,10 @@ public class AssetListFiltersUtil {
 			return new MatchQuery(field, value);
 		}
 
+		if (Objects.equals(field, Field.USER_NAME)) {
+			value = StringUtil.toLowerCase(value);
+		}
+
 		if (operatorName.equals("contains") ||
 			operatorName.equals("not-contains")) {
 

--- a/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
+++ b/modules/apps/asset/asset-list-service/src/test/java/com/liferay/asset/list/internal/util/AssetListFiltersUtilTest.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.util.FastDateFormatFactoryImpl;
 
@@ -123,13 +124,14 @@ public class AssetListFiltersUtilTest {
 		String userName = RandomTestUtil.randomString();
 
 		_assertTermQuery(
-			Field.USER_NAME, userName,
+			Field.USER_NAME, StringUtil.toLowerCase(userName),
 			_assertCommonFieldQuery(
 				BooleanClauseOccur.MUST,
 				_getCommonFieldFilterJSONObject(
 					"eq", Field.USER_NAME, userName)));
 		_assertWildcardQuery(
-			Field.USER_NAME, StringBundler.concat("*", userName, "*"),
+			Field.USER_NAME,
+			StringBundler.concat("*", StringUtil.toLowerCase(userName), "*"),
 			_assertCommonFieldQuery(
 				BooleanClauseOccur.MUST_NOT,
 				_getCommonFieldFilterJSONObject(

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -404,6 +405,32 @@ public class AssetListAssetEntryProviderFiltersTest {
 				_getFilterJSONObject(
 					"not-contains", _OBJECT_FIELD_NAME_KEYWORD, keyword)),
 			objectEntry2);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
+	public void testGetAssetEntriesInfoPageWithMixedCaseUserNameFilters()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
+			).build());
+
+		User user = TestPropsValues.getUser();
+
+		String upperCaseUserName = StringUtil.toUpperCase(user.getFullName());
+
+		_assertFilteredClassPKs(
+			_getFiltersJSONArray(
+				_getCommonFieldFilterJSONObject(
+					"contains", Field.USER_NAME, upperCaseUserName)),
+			objectEntry);
+		_assertFilteredClassPKs(
+			_getFiltersJSONArray(
+				_getCommonFieldFilterJSONObject(
+					"eq", Field.USER_NAME, upperCaseUserName)),
+			objectEntry);
 	}
 
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93003

## What Is Being Fixed

Asset list Common Field filters on `userName` never matched when the value carried uppercase characters — which a full name almost always does.

## How It Is Being Fixed

`AssetListFiltersUtil` now lowercases the filter value for `Field.USER_NAME` before building the term or wildcard query. `userName` is a special case: it is the one Common Field the indexer stores lowercased, because `AuditedModelDocumentContributor` adds it with `document.addKeyword(Field.USER_NAME, ..., true)`, and that `lowerCase` flag routes the value through `StringUtil.toLowerCase` in `DocumentImpl.createKeywordField`. Every other Common Field is indexed as entered, so the adjustment is scoped to this field rather than made a general rule.

Unit coverage asserts the lowercased term and wildcard queries; an integration test filters with an upper-cased user name end to end.

## PR Check

**pr-check: PASS** — tested on `5888b0d90fbd8cfc5843d28b00fd5354b0199111`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

Scoped run. This branch was rebased onto `upstream/master` (`0a25b719`), and the only change since the prior run is in `AssetListAssetEntryProviderFiltersTest`, so pr-check was limited to the validations that change exercises. Integration Test Compile also compiled `asset-list-service` transitively. The remaining validations (Transaction Usage, Per-Module Compile, Cross-Module Compile, Baseline, Java Unit Tests) passed on `c5719c458f5ca649b220910ca2c2fbeac1875396` in the superseded PR liferay-search#2173, against the older `e99b34bf` base.

<!-- pr-check {"result": "success", "sha": "5888b0d90fbd8cfc5843d28b00fd5354b0199111"} -->
