### PR TITLE
LPD-103930 Add a per-request track total hits limit to the search API

### DIFF
--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/ElasticsearchIndexSearcher.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/ElasticsearchIndexSearcher.java
@@ -490,6 +490,17 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 		return _searchResponseBuilderFactory.builder(searchContext);
 	}
 
+	private Integer _getTrackTotalHitsLimit(Integer trackTotalHitsLimit) {
+		int connectorTrackTotalHitsLimit =
+			_elasticsearchConfigurationWrapper.trackTotalHitsLimit();
+
+		if (trackTotalHitsLimit == null) {
+			return connectorTrackTotalHitsLimit;
+		}
+
+		return Math.min(trackTotalHitsLimit, connectorTrackTotalHitsLimit);
+	}
+
 	private boolean _isEnableDeepPagination(long companyId) {
 		DeepPaginationConfiguration deepPaginationConfiguration =
 			_getDeepPaginationConfiguration(companyId);
@@ -544,7 +555,7 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 		baseSearchRequest.setRescores(searchRequest.getRescores());
 		baseSearchRequest.setStatsRequests(searchRequest.getStatsRequests());
 		baseSearchRequest.setTrackTotalHitsLimit(
-			_elasticsearchConfigurationWrapper.trackTotalHitsLimit());
+			_getTrackTotalHitsLimit(searchRequest.getTrackTotalHitsLimit()));
 
 		_setAggregations(baseSearchRequest, searchRequest);
 		_setConnectionId(baseSearchRequest, searchRequest);

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/ElasticsearchIndexSearcherTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/ElasticsearchIndexSearcherTest.java
@@ -122,6 +122,58 @@ public class ElasticsearchIndexSearcherTest {
 			searchContext, Mockito.mock(Query.class));
 	}
 
+	@Test
+	public void testTrackTotalHitsLimit() {
+		_assertTrackTotalHitsLimit(null, 11000);
+	}
+
+	@Test
+	public void testTrackTotalHitsLimitAboveConnectorLimit() {
+		_assertTrackTotalHitsLimit(50000, 11000);
+	}
+
+	@Test
+	public void testTrackTotalHitsLimitBelowConnectorLimit() {
+		_assertTrackTotalHitsLimit(1000, 1000);
+	}
+
+	@Test
+	public void testTrackTotalHitsLimitZero() {
+		_assertTrackTotalHitsLimit(0, 0);
+	}
+
+	private void _assertTrackTotalHitsLimit(
+		Integer trackTotalHitsLimit, int expectedTrackTotalHitsLimit) {
+
+		Mockito.when(
+			_elasticsearchConfigurationWrapper.indexMaxResultWindow()
+		).thenReturn(
+			10000
+		);
+
+		Mockito.when(
+			_elasticsearchConfigurationWrapper.trackTotalHitsLimit()
+		).thenReturn(
+			11000
+		);
+
+		SearchContext searchContext = new SearchContext();
+
+		SearchRequest searchRequest = _searchRequestBuilderFactory.builder(
+			searchContext
+		).trackTotalHitsLimit(
+			trackTotalHitsLimit
+		).build();
+
+		SearchSearchRequest searchSearchRequest =
+			_elasticsearchIndexSearcher.createSearchSearchRequest(
+				searchRequest, searchContext, Mockito.mock(Query.class));
+
+		Assert.assertEquals(
+			Integer.valueOf(expectedTrackTotalHitsLimit),
+			searchSearchRequest.getTrackTotalHitsLimit());
+	}
+
 	private ElasticsearchIndexSearcher _createElasticsearchIndexSearcher(
 		IndexNameBuilder indexNameBuilder,
 		SearchRequestBuilderFactory searchRequestBuilderFactory) {

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/OpenSearchIndexSearcher.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/OpenSearchIndexSearcher.java
@@ -507,6 +507,17 @@ public class OpenSearchIndexSearcher extends BaseIndexSearcher {
 		return _searchResponseBuilderFactory.builder(searchContext);
 	}
 
+	private Integer _getTrackTotalHitsLimit(Integer trackTotalHitsLimit) {
+		int connectorTrackTotalHitsLimit =
+			_openSearchConfigurationWrapper.trackTotalHitsLimit();
+
+		if (trackTotalHitsLimit == null) {
+			return connectorTrackTotalHitsLimit;
+		}
+
+		return Math.min(trackTotalHitsLimit, connectorTrackTotalHitsLimit);
+	}
+
 	private void _populateResponse(
 		BaseSearchResponse baseSearchResponse,
 		SearchResponseBuilder searchResponseBuilder) {
@@ -554,7 +565,7 @@ public class OpenSearchIndexSearcher extends BaseIndexSearcher {
 		baseSearchRequest.setRescores(searchRequest.getRescores());
 		baseSearchRequest.setStatsRequests(searchRequest.getStatsRequests());
 		baseSearchRequest.setTrackTotalHitsLimit(
-			_openSearchConfigurationWrapper.trackTotalHitsLimit());
+			_getTrackTotalHitsLimit(searchRequest.getTrackTotalHitsLimit()));
 
 		_setAggregations(baseSearchRequest, searchRequest);
 		_setConnectionId(baseSearchRequest, searchRequest);

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/OpenSearchIndexSearcherTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/OpenSearchIndexSearcherTest.java
@@ -100,6 +100,27 @@ public class OpenSearchIndexSearcherTest {
 
 	@Test
 	public void testTrackTotalHitsLimit() {
+		_assertTrackTotalHitsLimit(null, 11000);
+	}
+
+	@Test
+	public void testTrackTotalHitsLimitAboveConnectorLimit() {
+		_assertTrackTotalHitsLimit(50000, 11000);
+	}
+
+	@Test
+	public void testTrackTotalHitsLimitBelowConnectorLimit() {
+		_assertTrackTotalHitsLimit(1000, 1000);
+	}
+
+	@Test
+	public void testTrackTotalHitsLimitZero() {
+		_assertTrackTotalHitsLimit(0, 0);
+	}
+
+	private void _assertTrackTotalHitsLimit(
+		Integer trackTotalHitsLimit, int expectedTrackTotalHitsLimit) {
+
 		Mockito.when(
 			_openSearchConfigurationWrapper.indexMaxResultWindow()
 		).thenReturn(
@@ -122,6 +143,8 @@ public class OpenSearchIndexSearcherTest {
 
 		SearchRequest searchRequest = _searchRequestBuilderFactory.builder(
 			searchContext
+		).trackTotalHitsLimit(
+			trackTotalHitsLimit
 		).build();
 
 		SearchSearchRequest searchSearchRequest =
@@ -129,7 +152,7 @@ public class OpenSearchIndexSearcherTest {
 				Mockito.mock(Query.class), searchContext, searchRequest);
 
 		Assert.assertEquals(
-			Integer.valueOf(11000),
+			Integer.valueOf(expectedTrackTotalHitsLimit),
 			searchSearchRequest.getTrackTotalHitsLimit());
 	}
 

--- a/modules/apps/portal-search/portal-search-api/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search API
 Bundle-SymbolicName: com.liferay.portal.search.api
-Bundle-Version: 22.1.2
+Bundle-Version: 22.2.0
 Export-Package:\
 	com.liferay.portal.search.aggregation,\
 	com.liferay.portal.search.aggregation.bucket,\

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/searcher/SearchRequest.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/searcher/SearchRequest.java
@@ -116,6 +116,15 @@ public interface SearchRequest {
 
 	public String[] getStoredFields();
 
+	/**
+	 * Provides the upper limit for counting the total number of hits. Above
+	 * this limit the total is a lower bound rather than an exact count.
+	 *
+	 * @return the limit, or <code>null</code> to use the search engine
+	 *         connector's limit
+	 */
+	public Integer getTrackTotalHitsLimit();
+
 	public boolean isBasicFacetSelection();
 
 	public boolean isEmptySearchEnabled();

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/searcher/SearchRequestBuilder.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/searcher/SearchRequestBuilder.java
@@ -188,6 +188,19 @@ public interface SearchRequestBuilder {
 
 	public SearchRequestBuilder storedFields(String... storedFields);
 
+	/**
+	 * Sets the upper limit for counting the total number of hits. Above this
+	 * limit the total is a lower bound rather than an exact count. The search
+	 * engine connector's limit is used when this is <code>null</code>, and
+	 * caps this value when it is lower.
+	 *
+	 * @param  trackTotalHitsLimit the limit, or <code>null</code> to use the
+	 *         search engine connector's limit
+	 * @return the search request builder
+	 */
+	public SearchRequestBuilder trackTotalHitsLimit(
+		Integer trackTotalHitsLimit);
+
 	public SearchRequestBuilder withFacetContext(
 		Consumer<FacetContext> facetContextConsumer);
 

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/searcher/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/searcher/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 2.4.0

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/legacy/searcher/SearchRequestBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/legacy/searcher/SearchRequestBuilderImpl.java
@@ -509,6 +509,17 @@ public class SearchRequestBuilderImpl implements SearchRequestBuilder {
 	}
 
 	@Override
+	public SearchRequestBuilder trackTotalHitsLimit(
+		Integer trackTotalHitsLimit) {
+
+		_withSearchRequestImpl(
+			searchRequestImpl -> searchRequestImpl.setTrackTotalHitsLimit(
+				trackTotalHitsLimit));
+
+		return this;
+	}
+
+	@Override
 	public SearchRequestBuilder withFacetContext(
 		Consumer<FacetContext> facetContextConsumer) {
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/SearchRequestImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/SearchRequestImpl.java
@@ -79,6 +79,7 @@ public class SearchRequestImpl implements SearchRequest, Serializable {
 		_size = searchRequestImpl._size;
 		_sorts.addAll(searchRequestImpl._sorts);
 		_statsRequests.addAll(searchRequestImpl._statsRequests);
+		_trackTotalHitsLimit = searchRequestImpl._trackTotalHitsLimit;
 	}
 
 	public void addAggregation(Aggregation aggregation) {
@@ -306,6 +307,11 @@ public class SearchRequestImpl implements SearchRequest, Serializable {
 	}
 
 	@Override
+	public Integer getTrackTotalHitsLimit() {
+		return _trackTotalHitsLimit;
+	}
+
+	@Override
 	public boolean isBasicFacetSelection() {
 		return _basicFacetSelection;
 	}
@@ -488,6 +494,10 @@ public class SearchRequestImpl implements SearchRequest, Serializable {
 		_storedFields = storedFields;
 	}
 
+	public void setTrackTotalHitsLimit(Integer trackTotalHitsLimit) {
+		_trackTotalHitsLimit = trackTotalHitsLimit;
+	}
+
 	private final Map<String, Aggregation> _aggregationsMap =
 		new LinkedHashMap<>();
 	private boolean _basicFacetSelection;
@@ -524,5 +534,6 @@ public class SearchRequestImpl implements SearchRequest, Serializable {
 	private final List<Sort> _sorts = new ArrayList<>();
 	private final List<StatsRequest> _statsRequests = new ArrayList<>();
 	private String[] _storedFields;
+	private Integer _trackTotalHitsLimit;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103930

## What Is Being Fixed

The track total hits limit could only be set globally, on the search engine connector in System Settings. Nothing above the connector could ask for a cheaper count on a single search, because `ElasticsearchIndexSearcher._prepare()` and its OpenSearch twin copied the connector's value onto every request, overriding whatever the caller wanted.

This blocks the Search Results widget and the headless search API from applying their own accurate count limits, which is what LPD-98858 needs.

## How It Is Being Fixed

`SearchRequest` and `SearchRequestBuilder` gain a `trackTotalHitsLimit` of type `Integer`. The wrapper type is deliberate: `null` means the caller did not opine, which keeps the connector's value in place, so every existing search behaves exactly as before and no feature flag is needed.

No intermediate plumbing had to change. The search request already travels down to the engine inside the search context, under the `search.request` attribute, and `_prepare()` already receives it — that is how `getSize()` and `getRescores()` reach the engine today. Only the copy constructor of `SearchRequestImpl` needed the new field, or federated searches and rebuilt requests would silently lose it.

Both engines now reconcile the two values instead of overriding: when the request carries no limit they keep the connector default, and otherwise they take the lower of the two. This is the natural choke point, since the connector cap is already read right there.

## PR Check

**pr-check: PASS** — tested on `c59ce1f0043c88071c36a9382bad65ea278d6981`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c59ce1f0043c88071c36a9382bad65ea278d6981"} -->
